### PR TITLE
fix: Use PublicKey.dilithium_pk field for hex encoding in multi_wallet

### DIFF
--- a/lib-economy/src/wallets/multi_wallet.rs
+++ b/lib-economy/src/wallets/multi_wallet.rs
@@ -467,7 +467,7 @@ impl MultiWalletManager {
         Ok(serde_json::json!({
             "identity": {
                 "node_id": hex::encode(self.identity.id.clone()),
-                "public_key": hex::encode(&self.identity.public_key),
+                "public_key": hex::encode(&self.identity.public_key.dilithium_pk),
                 "identity_type": format!("{:?}", self.identity.identity_type)
             },
             "total_balance": total_balance,


### PR DESCRIPTION
## Summary

Fixes compilation error in lib-economy where PublicKey struct was being passed to hex::encode which expects AsRef<[u8]>.

## Problem

```
error[E0277]: the trait bound `PublicKey: AsRef<[u8]>` is not satisfied
   --> lib-economy/src/wallets/multi_wallet.rs:470:44
    |
470 |                 "public_key": hex::encode(&self.identity.public_key),
    |                               -----------  ^^^^^^^^^^^^^^^^^^^^^^^^ 
    |                               the trait `AsRef<[u8]>` is not implemented for `PublicKey`
```

## Root Cause

`PublicKey` is a struct containing multiple fields:
- `dilithium_pk: Vec<u8>` - CRYSTALS-Dilithium public key
- `kyber_pk: Vec<u8>` - CRYSTALS-Kyber public key  
- `key_id: [u8; 32]` - Key identifier

The code was attempting to hex-encode the entire struct, but `hex::encode()` requires a type that implements `AsRef<[u8]>`.

## Solution

Encode the specific field (Dilithium public key) instead of the entire struct:

```rust
// Before (doesn't compile)
"public_key": hex::encode(&self.identity.public_key),

// After (compiles)
"public_key": hex::encode(&self.identity.public_key.dilithium_pk),
```

## Changes

**File:** `lib-economy/src/wallets/multi_wallet.rs`
- Line 470: Use `.dilithium_pk` field for hex encoding

## Impact

✅ **lib-economy now compiles successfully**
✅ **No behavior change** - Dilithium public key is the primary signing key
✅ **Unblocks workspace builds** - lib-economy was blocking downstream crates

## Testing

- ✅ `cargo build -p lib-economy` succeeds
- ✅ No warnings introduced
- ⚠️ Full workspace build still blocked by lib-blockchain errors (separate issue)

## Related

This is one of several build errors discovered during alpha release preparation. Other errors in lib-blockchain will be addressed in separate PRs.