### PR TITLE
fix: Resolve compilation errors in guardian and DAO handlers

### DIFF
--- a/zhtp/src/api/handlers/dao/mod.rs
+++ b/zhtp/src/api/handlers/dao/mod.rs
@@ -880,7 +880,7 @@ impl DaoHandler {
         )?;
 
         // Use authenticated identity as proposer (not first identity!)
-        let proposer_id = authenticated_identity_id;
+        let proposer_id = hex::encode(authenticated_identity_id.as_bytes());
 
         // Create treasury allocation proposal
         let create_request = CreateProposalRequest {


### PR DESCRIPTION
## Summary
- Fix borrow of moved value for `req.guardian_did` by cloning before move
- Fix borrow of moved value for `client_ip` by cloning before move
- Fix mutable borrow conflict in recovery completion by scoping properly
- Fix borrow after move for `identity_id` by converting to hex before move
- Fix reference lifetime issue by cloning recovery requests
- Fix type mismatch by converting `Hash` to hex `String` for `proposer_id`

## Test plan
- [x] Build completes successfully with `cargo build --release --workspace`
- [ ] Run node with `./target/release/zhtp node start --config zhtp/configs/test-node1.toml`
- [ ] Verify guardian and DAO API endpoints still function correctly