### PR TITLE
feat: implement TCP bootstrap adapter for UHP (ticket #139)

### DIFF
--- a/PROOF_OF_PERSONHOOD_ROADMAP.md
+++ b/PROOF_OF_PERSONHOOD_ROADMAP.md
@@ -1,0 +1,376 @@
+# Proof of Personhood (PoP) Implementation Roadmap
+
+**Status:** Phase 1 Issues Created ✅
+**Date:** 2025-12-07
+**Total Work:** 109 GitHub Issues across 5 phases
+**Timeline:** 18 weeks (post-alpha)
+
+---
+
+## 📋 Executive Summary
+
+This roadmap implements a **Sybil-resistant identity verification system** for the Sovereign Network, combining:
+1. **Social vouching** (web of trust)
+2. **Economic staking** (skin in the game)
+3. **Biometric verification** (uniqueness proof)
+4. **Behavioral analysis** (bot detection)
+5. **Anti-collusion detection** (coordinated attack prevention)
+
+Additionally, it resolves **7 critical contradictions** between existing systems (PoP, UHP, SOV Swap).
+
+---
+
+## 🎯 What Was Created Today
+
+### ✅ Phase 1: Critical Architecture Fixes (COMPLETE)
+
+**17 GitHub Issues Created** ([#223](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/223) - [#239](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/239))
+
+**Fixes 4 critical contradictions:**
+1. **Tier terminology conflicts** → Renamed to CitizenshipStatus/NetworkParticipationLevel/AccessLevel
+2. **Stake amount confusion** → Clear hierarchy: 500/2000/10,000 SOV
+3. **Access control chaos** → Unified permission system
+4. **Privacy violations** → Privacy-preserving SID unlinkable to DID
+
+**Key Components:**
+- `CitizenshipStatus` enum (Visitor → Provisional → Verified → Trusted)
+- `UnifiedAccessControl` with Permission enum
+- `UnifiedStake` with progressive tier unlocking
+- `PrivacyPreservingIdentity` with ZK proofs
+
+---
+
+## 📊 Full Implementation Plan
+
+### Phase 1: Critical Architecture Fixes ✅ (2 weeks, 17 issues)
+**Status:** GitHub issues created
+
+| Group | Issues | Focus |
+|-------|--------|-------|
+| 1.1 Terminology | 5 | Rename tier systems |
+| 1.2 Access Control | 3 | Unified permissions |
+| 1.3 Stake Hierarchy | 4 | 500/2000/10,000 SOV |
+| 1.4 Privacy SID | 5 | ZK proofs for biometric |
+
+### Phase 2: Proof of Personhood Core ⏳ (6 weeks, 33 issues)
+**Status:** Not yet created - see `docs/ZHTPPM/DID/IMPLEMENTATION_PLAN.md`
+
+| Group | Issues | Focus |
+|-------|--------|-------|
+| 2.1 Citizenship Staking | 6 | 500 SOV stake, 180-day lock |
+| 2.2 Social Vouching | 8 | 3 vouchers required |
+| 2.3 Behavioral Analysis | 7 | Bot detection ML |
+| 2.4 Anti-Collusion | 6 | DAO-coordinated attack detection |
+| 2.5 Biometric Verification | 6 | Iris/facial/gov ID |
+
+### Phase 3: Integration & Distribution ⏳ (4 weeks, 19 issues)
+**Status:** Not yet created
+
+| Group | Issues | Focus |
+|-------|--------|-------|
+| 3.1 UBI Distribution | 8 | Monthly distribution to citizens |
+| 3.2 Token Class Enforcement | 5 | FP↔NP blocking |
+| 3.3 Access Contracts | 6 | Auto-issuance to VerifiedCitizens |
+
+### Phase 4: Testing & Validation ⏳ (4 weeks, 30 issues)
+**Status:** Not yet created
+
+| Group | Issues | Focus |
+|-------|--------|-------|
+| 4.1 Unit Testing | 10 | Component tests |
+| 4.2 Integration Testing | 8 | End-to-end flows |
+| 4.3 Security Testing | 7 | Sybil attack prevention |
+| 4.4 Performance Testing | 5 | Scalability benchmarks |
+
+### Phase 5: Documentation & Migration ⏳ (2 weeks, 10 issues)
+**Status:** Not yet created
+
+| Group | Issues | Focus |
+|-------|--------|-------|
+| 5.1 Documentation | 6 | API docs, guides |
+| 5.2 Migration Tools | 4 | Data migration scripts |
+
+---
+
+## 📁 Documentation Structure
+
+### Created Today
+- ✅ `docs/ZHTPPM/DID/PROOF_OF_PERSONHOOD.md` (50+ pages) - Complete PoP specification
+- ✅ `docs/ZHTPPM/DID/PROOF_OF_PERSONHOOD_DEPENDENCIES.md` - Lib-* dependency analysis
+- ✅ `docs/ZHTPPM/DID/PROOF_OF_PERSONHOOD_SYSTEM_INTEGRATION.md` - System-wide integration
+- ✅ `docs/ZHTPPM/SOV/SYSTEM_INTEGRATION_CONTRADICTIONS.md` (56 pages) - Contradiction resolutions
+- ✅ `docs/ZHTPPM/DID/IMPLEMENTATION_PLAN.md` - Detailed 109-issue breakdown
+- ✅ `docs/ZHTPPM/DID/GITHUB_ISSUES_CREATED.md` - Issue tracking document
+
+### Repository
+```
+docs/ZHTPPM/
+├── DID/
+│   ├── PROOF_OF_PERSONHOOD.md                        ⭐ Core spec
+│   ├── PROOF_OF_PERSONHOOD_DEPENDENCIES.md           ⭐ Lib dependencies
+│   ├── PROOF_OF_PERSONHOOD_SYSTEM_INTEGRATION.md     ⭐ System integration
+│   ├── IMPLEMENTATION_PLAN.md                        ⭐ 109 issues detailed
+│   └── GITHUB_ISSUES_CREATED.md                      ⭐ Status tracking
+├── SOV/
+│   ├── SYSTEM_INTEGRATION_CONTRADICTIONS.md          ⭐ 7 contradictions resolved
+│   └── SOV_SWAP_DAO_SPEC.md                          (existing)
+└── DHT/
+    └── 08-complete-system-architecture.md            (existing, UHP spec)
+```
+
+---
+
+## 🔑 Key Metrics & Targets
+
+### Security Targets
+| Metric | Target | Current | Gap |
+|--------|--------|---------|-----|
+| False Positive Rate | < 0.1% | N/A | ❌ Not implemented |
+| False Negative Rate | < 1% | 100% | ❌ Zero protection |
+| Cost per Sybil Attack | > $1000 | $0 | ❌ Free |
+| Time to Citizenship | < 7 days | 0 seconds | ❌ Instant |
+
+### Implementation Progress
+| Phase | Issues | Created | Remaining |
+|-------|--------|---------|-----------|
+| Phase 1 | 17 | ✅ 17 | 0 |
+| Phase 2 | 33 | ⏳ 0 | 33 |
+| Phase 3 | 19 | ⏳ 0 | 19 |
+| Phase 4 | 30 | ⏳ 0 | 30 |
+| Phase 5 | 10 | ⏳ 0 | 10 |
+| **TOTAL** | **109** | **17** | **92** |
+| **Progress** | **100%** | **16%** | **84%** |
+
+---
+
+## 🚀 Quick Start for Developers
+
+### 1. Review Phase 1 Issues
+```bash
+# View all Phase 1 (P0-Critical) issues
+gh issue list --repo SOVEREIGN-NET/The-Sovereign-Network --label "phase-1,post-alpha"
+
+# Filter by component
+gh issue list --repo SOVEREIGN-NET/The-Sovereign-Network --label "architecture,post-alpha"
+gh issue list --repo SOVEREIGN-NET/The-Sovereign-Network --label "cryptography,post-alpha"
+```
+
+### 2. Read Specifications
+Start with these documents in order:
+1. `docs/ZHTPPM/DID/PROOF_OF_PERSONHOOD.md` - Understand PoP system
+2. `docs/ZHTPPM/SOV/SYSTEM_INTEGRATION_CONTRADICTIONS.md` - Understand fixes needed
+3. `docs/ZHTPPM/DID/IMPLEMENTATION_PLAN.md` - See detailed issue breakdown
+
+### 3. Start with Critical Issues
+Recommended order:
+1. **DID-001**: Rename tier systems (blocks everything else)
+2. **DID-002**: Create SovereignIdentity (central type)
+3. **DID-006**: Implement UnifiedAccessControl (security critical)
+4. **DID-013**: Privacy-preserving SID (privacy critical)
+
+### 4. Implementation Path
+```
+Week 1-2:  Phase 1 (DID-001 to DID-017) - Critical fixes
+Week 3-8:  Phase 2 (DID-018 to DID-050) - Core PoP
+Week 9-12: Phase 3 (DID-051 to DID-069) - Integration
+Week 13-16: Phase 4 (DID-070 to DID-099) - Testing
+Week 17-18: Phase 5 (DID-100 to DID-109) - Documentation
+```
+
+---
+
+## 🔗 GitHub Repository
+
+**Main Repository:** https://github.com/SOVEREIGN-NET/The-Sovereign-Network
+
+**Phase 1 Issues:**
+- DID-001: https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/223
+- DID-002: https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/224
+- ...
+- DID-017: https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/239
+
+**Labels Used:**
+- `post-alpha` - All PoP issues (109 total)
+- `P0-Critical` - Phase 1 (17 issues)
+- `P1-High` - Phases 2-3 (52 issues)
+- `P2-Medium` - Phases 4-5 (40 issues)
+- `phase-1`, `phase-2`, `phase-3`, `phase-4` - Phasing labels
+- Domain: `architecture`, `security`, `cryptography`, `blockchain`, `testing`, `documentation`
+
+---
+
+## 🎓 Citizenship Tier System
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                 CITIZENSHIP PROGRESSION                   │
+├──────────────────────────────────────────────────────────┤
+│                                                           │
+│  VISITOR (Tier 0)                                        │
+│  └─> 0 votes, 0 UBI, read-only access                   │
+│       │                                                   │
+│       ↓ [3 vouchers + 500 SOV stake + pass bot check]   │
+│                                                           │
+│  PROVISIONAL CITIZEN (Tier 1)                            │
+│  └─> 1 vote, 500 SOV/month UBI, limited access          │
+│       │ (30-day probation)                               │
+│       ↓ [Biometric verification OR 180 days + good rep]  │
+│                                                           │
+│  VERIFIED CITIZEN (Tier 2)                               │
+│  └─> 10 votes, 1000 SOV/month UBI, full access          │
+│       │ (stake returned)                                 │
+│       ↓ [1 year + reputation ≥8.0 + vouch 5+ citizens]  │
+│                                                           │
+│  TRUSTED CITIZEN (Tier 3)                                │
+│  └─> 15 votes, 1500 SOV/month UBI, admin privileges     │
+│       (Can substitute for biometric verification)        │
+│                                                           │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 💰 Stake Hierarchy
+
+```
+┌────────────────────────────────────────────────────┐
+│           PROGRESSIVE STAKE PATH                   │
+├────────────────────────────────────────────────────┤
+│                                                     │
+│  500 SOV (180 days)                                │
+│  └─> Citizenship → ProvisionalCitizen              │
+│       Benefit: 1 vote, 500 SOV/month UBI           │
+│                                                     │
+│  2,000 SOV (365 days)                              │
+│  └─> DAO Founder → Can launch DAOs                 │
+│       Benefit: Create DAOs, 10 votes, 1000 SOV/mo  │
+│                                                     │
+│  10,000 SOV (730 days)                             │
+│  └─> Validator → Block production                  │
+│       Benefit: Validator rewards, 15 votes         │
+│                                                     │
+└────────────────────────────────────────────────────┘
+
+Example Journey:
+Day 0:    Stake 500 SOV → ProvisionalCitizen
+Month 6:  Earned 3000 SOV UBI (6×500), total: 3500 SOV
+Month 6:  Stake 2000 SOV → DaoFounder, total staked: 2500 SOV
+Month 18: Earned 12000 SOV UBI (12×1000), total: 13,500 SOV
+Month 18: Stake 10,000 SOV → Validator, total staked: 12,500 SOV
+```
+
+---
+
+## 🔒 Privacy Architecture
+
+```
+┌────────────────────────────────────────────────────┐
+│          PRIVACY-PRESERVING IDENTITY                │
+├────────────────────────────────────────────────────┤
+│                                                     │
+│  PRIVATE (Never leaves device):                    │
+│  ├─ DID: did:zhtp:abc123...                       │
+│  ├─ Salt: random 32 bytes                         │
+│  └─ Biometric data: iris scan / facial            │
+│                                                     │
+│  PUBLIC (On-chain):                                │
+│  ├─ SID: Blake3(DID || salt)  ← unlinkable!      │
+│  ├─ Citizenship NFT: proves tier, not identity    │
+│  ├─ Biometric commitment: Hash(biometric_hash)    │
+│  └─ Nullifier: prevents biometric reuse           │
+│                                                     │
+│  SEMI-PUBLIC (Access contracts):                   │
+│  ├─ AccessContract: bound to SID, not DID         │
+│  └─ ZK eligibility proof: proves tier w/o reveal  │
+│                                                     │
+│  OBSERVER SEES:                                    │
+│  ✓ SID "xyz789" is VerifiedCitizen                │
+│  ✓ SID "xyz789" voted in DAO proposal #5          │
+│  ✗ CANNOT link SID to DID or biometric            │
+│                                                     │
+└────────────────────────────────────────────────────┘
+```
+
+---
+
+## 🛡️ Anti-Sybil Defense Stack
+
+```
+┌────────────────────────────────────────────────────┐
+│       PARALLEL DEFENSE LAYERS (Not Sequential)     │
+├────────────────────────────────────────────────────┤
+│                                                     │
+│  1️⃣ BEHAVIORAL ANALYSIS (25% confidence)           │
+│     └─> ML bot detection, transaction patterns    │
+│         Output: Bot probability 0.0-1.0            │
+│                                                     │
+│  2️⃣ SOCIAL VERIFICATION (20% confidence)           │
+│     └─> 3 vouchers from independent VerifiedCitizens│
+│         Output: Social trust score 0.0-1.0         │
+│                                                     │
+│  3️⃣ ECONOMIC DETERRENT (15% confidence)            │
+│     └─> 500 SOV stake, slashed if fraud           │
+│         Output: Economic commitment score          │
+│                                                     │
+│  4️⃣ BIOMETRIC UNIQUENESS (40% confidence)          │
+│     └─> Iris/facial/gov ID verification            │
+│         Output: Uniqueness score (ZK proof)        │
+│                                                     │
+│  TOTAL CONFIDENCE = Σ(layer × weight)              │
+│  ├─ 0-30%:  ❌ Rejected (bot/Sybil)               │
+│  ├─ 50-70%: 🟢 Provisional Citizen                │
+│  ├─ 70-85%: 🔵 Verified Citizen                   │
+│  └─ 85%+:   ⭐ Fast-track Verified                │
+│                                                     │
+└────────────────────────────────────────────────────┘
+```
+
+---
+
+## 📞 Next Actions
+
+### For Project Managers
+1. Review Phase 1 issues (#223-#239)
+2. Assign developers to critical path issues
+3. Track progress on GitHub project board
+4. Plan Phase 2 issue creation (33 issues)
+
+### For Developers
+1. Read `PROOF_OF_PERSONHOOD.md` for full context
+2. Read `SYSTEM_INTEGRATION_CONTRADICTIONS.md` for fixes needed
+3. Start with DID-001 (rename tier systems)
+4. Follow implementation order in `IMPLEMENTATION_PLAN.md`
+
+### For Creating Remaining Issues
+```bash
+# See docs/ZHTPPM/DID/IMPLEMENTATION_PLAN.md for:
+# - Phase 2: Issues DID-018 to DID-050 (33 issues)
+# - Phase 3: Issues DID-051 to DID-069 (19 issues)
+# - Phase 4: Issues DID-070 to DID-099 (30 issues)
+# - Phase 5: Issues DID-100 to DID-109 (10 issues)
+
+# Use the same gh issue create pattern from batch scripts
+```
+
+---
+
+## ✅ Success Criteria
+
+### Phase 1 Complete When:
+- ✅ No tier terminology conflicts in codebase
+- ✅ UnifiedAccessControl passing all permission checks
+- ✅ Stake hierarchy with 500/2000/10,000 SOV working
+- ✅ Privacy-preserving SID unlinkable to DID
+
+### Full System Complete When:
+- ✅ Sybil attack cost > $1000 per fake identity
+- ✅ False negative rate < 1% (blocks 99% of bots)
+- ✅ False positive rate < 0.1% (0.1% legitimate users blocked)
+- ✅ UBI distribution automated monthly
+- ✅ All 109 issues closed and tested
+
+---
+
+**Ready to Start:** Phase 1 issues are created and ready for implementation! 🚀
+
+**Questions?** See documentation in `docs/ZHTPPM/DID/` or open a discussion in the GitHub repo.

--- a/lib-network/src/constants.rs
+++ b/lib-network/src/constants.rs
@@ -1,0 +1,20 @@
+//! Protocol constants for lib-network
+//!
+//! This module defines shared protocol constants used across the network layer.
+
+/// Maximum handshake message size (1 MB)
+///
+/// This provides sufficient space for:
+/// - Identity metadata: ~2-5 KB typical
+/// - Large capabilities: ~100 KB
+/// - Extensive custom fields: up to 1 MB
+///
+/// While preventing DoS attacks via memory exhaustion.
+///
+/// # Security (P1-2 FIX)
+/// Consistent limit enforced across all UHP implementations:
+/// - `lib-network/src/bootstrap/handshake.rs` - TCP bootstrap adapter
+/// - `lib-network/src/handshake/core.rs` - Core UHP implementation
+///
+/// Previously bootstrap used 10 MB (too large, DoS risk) while core used 1 MB.
+pub const MAX_HANDSHAKE_MESSAGE_SIZE: usize = 1024 * 1024; // 1 MB

--- a/lib-network/src/handshake/blockchain.rs
+++ b/lib-network/src/handshake/blockchain.rs
@@ -732,7 +732,7 @@ mod tests {
         let validator_id = Hash::from_bytes(&[3u8; 32]);
         let validator_stake = 2_000_000_000; // 2000 ZHTP
         
-        verifier.add_validator_stake(validator_id.clone(), validator_stake);
+        verifier.add_validator_stake(validator_id.clone(), validator_stake, 1);
         
         let mut peer_ctx = create_test_context();
         peer_ctx.validator_stake = Some(validator_stake);
@@ -748,7 +748,7 @@ mod tests {
         let mut verifier = BlockchainHandshakeVerifier::new(local_ctx);
         
         let validator_id = Hash::from_bytes(&[3u8; 32]);
-        verifier.add_validator_stake(validator_id.clone(), 2_000_000_000);
+        verifier.add_validator_stake(validator_id.clone(), 2_000_000_000, 1);
         
         let mut peer_ctx = create_test_context();
         peer_ctx.validator_stake = Some(3_000_000_000); // Claimed stake doesn't match
@@ -781,7 +781,7 @@ mod tests {
         let node_id = Hash::from_bytes(&[4u8; 32]);
         let node_stake = 500_000_000; // 500 ZHTP (above StakedNode threshold)
         
-        verifier.add_validator_stake(node_id.clone(), node_stake);
+        verifier.add_validator_stake(node_id.clone(), node_stake, 1);
         
         let mut peer_ctx = create_test_context();
         peer_ctx.validator_stake = Some(node_stake);

--- a/lib-network/src/lib.rs
+++ b/lib-network/src/lib.rs
@@ -55,6 +55,7 @@ pub mod protocols;
 pub mod bootstrap;
 pub mod identity; // Unified peer identity system
 pub mod handshake; // Unified Handshake Protocol (UHP)
+pub mod constants; // Protocol constants
 pub mod monitoring;
 pub mod zk_integration;
 pub mod testing;
@@ -62,6 +63,9 @@ pub mod platform;
 pub mod dht; // Native binary DHT protocol with lib-storage backend
 pub mod web4; // Web4 domain registry and content publishing
 pub mod blockchain_sync; // Blockchain synchronization over mesh protocols
+
+// Re-export protocol constants for convenience
+pub use constants::*;
 
 // Mobile FFI bindings for Android (JNI) and iOS (C FFI)
 // Available for all platforms to allow compilation, but only functional on mobile


### PR DESCRIPTION
Replaces deprecated perform_lib_handshake() with production-ready UHP implementation for TCP bootstrap connections.

Key Features:

- handshake_as_initiator(): Client-side 3-way UHP handshake over TCP

- handshake_as_responder(): Server-side 3-way UHP handshake over TCP

- Length-prefix message framing with 10 MB size limit

- Mutual authentication with signature verification on all messages

- Replay protection via nonce cache

- 30-second handshake timeout

Integration Tests:

- test_tcp_bootstrap_handshake: End-to-end verification

- test_replay_attack_prevention: Nonce cache validation

- test_message_framing: Protocol correctness

- test_oversized_message_rejection: Size limits

Acceptance Criteria Met:

- TCP bootstrap uses UHP and verifies signatures

- Integration test verifies only authenticated peers accepted

- Zero placeholder code - all production-ready