### PR TITLE
feat: Implement unified peer registry (Ticket #147)

### DIFF
--- a/lib-network/src/lib.rs
+++ b/lib-network/src/lib.rs
@@ -29,6 +29,8 @@ pub use crate::peer_registry::{
     PeerRegistry, PeerEntry, SharedPeerRegistry, new_shared_registry,
     PeerEndpoint, ConnectionMetrics, NodeCapabilities, GeographicLocation,
     DhtPeerInfo, DiscoveryMethod, PeerTier, RegistryStats,
+    // New security features
+    RegistryConfig, DEFAULT_MAX_PEERS, DEFAULT_PEER_TTL_SECS,
 };
 
 // Unified Handshake Protocol exports

--- a/lib-network/src/peer_registry/mod.rs
+++ b/lib-network/src/peer_registry/mod.rs
@@ -15,16 +15,24 @@
 //! - **Atomic Updates**: Prevent race conditions across components
 //! - **Multi-Key Lookup**: Find peers by NodeId, PublicKey, or DID
 //! - **Comprehensive Metadata**: All connection, routing, and capability data in one place
+//! - **Memory Bounded**: Max peers limit with eviction policy prevents memory exhaustion
+//! - **TTL-Based Expiration**: Stale peers automatically expire
+//!
+//! ## Security Features
+//!
+//! - **DID Validation**: All DIDs validated before indexing
+//! - **Index Consistency**: Atomic updates prevent stale index entries
+//! - **Audit Logging**: All peer changes logged for security monitoring
+//! - **Sybil Resistance**: Max peers limit + eviction policy
 //!
 //! ## Acceptance Criteria Verification
 //!
 //! ✅ **Single peer registry structure defined**
-//!    - PeerRegistry struct at line 33
-//!    - HashMap<UnifiedPeerId, PeerEntry> primary storage
+//!    - PeerRegistry struct with HashMap<UnifiedPeerId, PeerEntry> primary storage
 //!    - Secondary indexes for NodeId, PublicKey, DID
 //!
 //! ✅ **Consolidates metadata from all 6 existing stores**
-//!    - PeerEntry struct at line 50
+//!    - PeerEntry struct with all metadata
 //!    - Connection metadata (from MeshConnection): endpoints, protocols, metrics, auth
 //!    - Routing metadata (from RouteInfo): next_hop, hop_count, quality
 //!    - Topology metadata (from NetworkNode): capabilities, location, reliability
@@ -33,44 +41,83 @@
 //!    - Trust/tier metadata: trust_score, tier classification
 //!
 //! ✅ **Thread-safe wrapper using Arc<RwLock<>>**
-//!    - SharedPeerRegistry type alias at line 359
-//!    - new_shared_registry() constructor at line 362
+//!    - SharedPeerRegistry type alias
+//!    - new_shared_registry() constructor
 //!    - All methods use RwLock for concurrent access
 //!
 //! ✅ **Lookup methods for all identifier types**
-//!    - find_by_node_id() at line 261
-//!    - find_by_public_key() at line 267
-//!    - find_by_did() at line 273
+//!    - find_by_node_id()
+//!    - find_by_public_key()
+//!    - find_by_did()
 //!
 //! ✅ **Atomic update operations**
-//!    - upsert() at line 219 (atomically updates all indexes)
-//!    - remove() at line 233 (atomically removes from all indexes)
-//!    - update_metrics() at line 304
-//!    - update_trust() at line 315
+//!    - upsert() atomically updates all indexes (with stale entry cleanup)
+//!    - remove() atomically removes from all indexes
+//!    - update_metrics()
+//!    - update_trust()
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 use serde::{Serialize, Deserialize};
 use anyhow::{Result, anyhow};
+use tracing::{info, warn, debug};
 
 use crate::identity::unified_peer::UnifiedPeerId;
 use crate::protocols::NetworkProtocol;
 use lib_crypto::PublicKey;
 use lib_identity::NodeId;
 
+/// Default maximum peers (prevents memory exhaustion / Sybil attacks)
+pub const DEFAULT_MAX_PEERS: usize = 10_000;
+
+/// Default peer TTL in seconds (24 hours)
+pub const DEFAULT_PEER_TTL_SECS: u64 = 86_400;
+
+/// Registry configuration
+#[derive(Debug, Clone)]
+pub struct RegistryConfig {
+    /// Maximum number of peers (Sybil resistance)
+    pub max_peers: usize,
+    /// Peer TTL in seconds (peers not seen within TTL are eligible for eviction)
+    pub peer_ttl_secs: u64,
+    /// Enable audit logging
+    pub audit_logging: bool,
+}
+
+impl Default for RegistryConfig {
+    fn default() -> Self {
+        Self {
+            max_peers: DEFAULT_MAX_PEERS,
+            peer_ttl_secs: DEFAULT_PEER_TTL_SECS,
+            audit_logging: true,
+        }
+    }
+}
+
 /// Unified peer registry - single source of truth for all peer data
 ///
 /// Replaces 6 separate peer stores with one atomic, thread-safe registry
+///
+/// ## Security Features
+/// - **Memory bounded**: max_peers limit prevents Sybil attacks
+/// - **TTL expiration**: Stale peers automatically eligible for eviction
+/// - **DID validation**: All DIDs validated before indexing
+/// - **Index consistency**: Atomic updates prevent stale entries
+/// - **Audit logging**: All changes logged for security monitoring
 #[derive(Debug, Clone)]
 pub struct PeerRegistry {
     /// Primary storage: UnifiedPeerId → PeerEntry
     peers: HashMap<UnifiedPeerId, PeerEntry>,
-    
+
     /// Secondary indexes for fast lookup
     by_node_id: HashMap<NodeId, UnifiedPeerId>,
     by_public_key: HashMap<PublicKey, UnifiedPeerId>,
     by_did: HashMap<String, UnifiedPeerId>,
+
+    /// Configuration
+    config: RegistryConfig,
 }
 
 /// Complete peer metadata - consolidates all data from 6 existing registries
@@ -240,33 +287,185 @@ pub enum PeerTier {
 }
 
 impl PeerRegistry {
-    /// Create a new empty peer registry
+    /// Create a new empty peer registry with default configuration
     pub fn new() -> Self {
+        Self::with_config(RegistryConfig::default())
+    }
+
+    /// Create a new peer registry with custom configuration
+    pub fn with_config(config: RegistryConfig) -> Self {
         Self {
             peers: HashMap::new(),
             by_node_id: HashMap::new(),
             by_public_key: HashMap::new(),
             by_did: HashMap::new(),
+            config,
         }
     }
-    
+
+    /// Validate DID format before indexing
+    ///
+    /// # Security
+    /// Prevents malicious DIDs like "admin" or "system" from being indexed
+    fn validate_did(did: &str) -> Result<()> {
+        // DID must start with "did:zhtp:" and have sufficient length
+        if !did.starts_with("did:zhtp:") {
+            return Err(anyhow!("Invalid DID format: must start with 'did:zhtp:'"));
+        }
+
+        // DID must have content after the prefix (at least 16 chars for the hash)
+        if did.len() < 25 {
+            return Err(anyhow!("Invalid DID format: too short (expected at least 25 chars)"));
+        }
+
+        // Check for valid hex characters after prefix
+        let hash_part = &did[9..]; // After "did:zhtp:"
+        if !hash_part.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(anyhow!("Invalid DID format: hash must be hexadecimal"));
+        }
+
+        Ok(())
+    }
+
+    /// Get current timestamp in seconds
+    fn current_timestamp() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
     /// Insert or update a peer entry
+    ///
+    /// # Security
+    /// - Validates DID format before indexing
+    /// - Removes stale index entries to prevent index poisoning
+    /// - Enforces max_peers limit with eviction policy
+    /// - Logs all changes for audit trail
     ///
     /// This is an atomic operation that updates all indexes
     pub fn upsert(&mut self, entry: PeerEntry) -> Result<()> {
         let peer_id = entry.peer_id.clone();
-        
+        let did = peer_id.did().to_string();
+
+        // SECURITY: Validate DID format before indexing
+        Self::validate_did(&did)?;
+
+        // SECURITY: Check if we need to evict peers (max_peers limit)
+        if !self.peers.contains_key(&peer_id) && self.peers.len() >= self.config.max_peers {
+            self.evict_stale_peer()?;
+        }
+
+        // SECURITY: Remove stale index entries if peer exists with different identity fields
+        // This prevents index poisoning attacks
+        if let Some(existing) = self.peers.get(&peer_id) {
+            // If identity fields changed, remove old index entries
+            if existing.peer_id.node_id() != peer_id.node_id() {
+                self.by_node_id.remove(existing.peer_id.node_id());
+                warn!(
+                    old_node_id = %hex::encode(existing.peer_id.node_id().as_bytes()),
+                    new_node_id = %hex::encode(peer_id.node_id().as_bytes()),
+                    "Peer NodeId changed - removed stale index"
+                );
+            }
+            if existing.peer_id.public_key() != peer_id.public_key() {
+                self.by_public_key.remove(existing.peer_id.public_key());
+                warn!(
+                    peer_did = %did,
+                    "Peer PublicKey changed - removed stale index"
+                );
+            }
+            if existing.peer_id.did() != peer_id.did() {
+                self.by_did.remove(existing.peer_id.did());
+                warn!(
+                    old_did = %existing.peer_id.did(),
+                    new_did = %did,
+                    "Peer DID changed - removed stale index"
+                );
+            }
+        }
+
         // Update secondary indexes
         self.by_node_id.insert(peer_id.node_id().clone(), peer_id.clone());
         self.by_public_key.insert(peer_id.public_key().clone(), peer_id.clone());
-        self.by_did.insert(peer_id.did().to_string(), peer_id.clone());
-        
+        self.by_did.insert(did.clone(), peer_id.clone());
+
         // Insert into primary storage
-        self.peers.insert(peer_id, entry);
-        
+        let is_new = !self.peers.contains_key(&peer_id);
+        self.peers.insert(peer_id.clone(), entry);
+
+        // AUDIT: Log peer changes
+        if self.config.audit_logging {
+            if is_new {
+                info!(
+                    peer_did = %did,
+                    peer_count = self.peers.len(),
+                    "Peer added to registry"
+                );
+            } else {
+                debug!(
+                    peer_did = %did,
+                    "Peer updated in registry"
+                );
+            }
+        }
+
         Ok(())
     }
-    
+
+    /// Evict the most stale peer to make room for new peers
+    ///
+    /// # Eviction Policy
+    /// 1. First, try to evict expired peers (TTL exceeded)
+    /// 2. If no expired peers, evict lowest-tier peer
+    /// 3. Among same tier, evict least-recently-seen peer
+    fn evict_stale_peer(&mut self) -> Result<()> {
+        let now = Self::current_timestamp();
+        let ttl = self.config.peer_ttl_secs;
+
+        // Strategy 1: Find expired peer (TTL exceeded)
+        let expired_peer = self.peers.iter()
+            .filter(|(_, entry)| now.saturating_sub(entry.last_seen) > ttl)
+            .min_by_key(|(_, entry)| entry.last_seen)
+            .map(|(id, _)| id.clone());
+
+        if let Some(peer_id) = expired_peer {
+            let _entry = self.remove(&peer_id);
+            if self.config.audit_logging {
+                info!(
+                    peer_did = %peer_id.did(),
+                    reason = "TTL_EXPIRED",
+                    "Peer evicted from registry"
+                );
+            }
+            return Ok(());
+        }
+
+        // Strategy 2: Evict lowest-tier, least-recently-seen peer
+        let victim = self.peers.iter()
+            .max_by(|(_, a), (_, b)| {
+                // Higher tier (worse) = evict first
+                // Among same tier, older last_seen = evict first
+                a.tier.cmp(&b.tier)
+                    .then_with(|| b.last_seen.cmp(&a.last_seen))
+            })
+            .map(|(id, _)| id.clone());
+
+        if let Some(peer_id) = victim {
+            let _entry = self.remove(&peer_id);
+            if self.config.audit_logging {
+                info!(
+                    peer_did = %peer_id.did(),
+                    reason = "MAX_PEERS_EVICTION",
+                    "Peer evicted from registry"
+                );
+            }
+            return Ok(());
+        }
+
+        Err(anyhow!("Cannot evict peer: registry empty"))
+    }
+
     /// Remove a peer entry
     ///
     /// Atomically removes from all indexes
@@ -275,9 +474,48 @@ impl PeerRegistry {
         self.by_node_id.remove(peer_id.node_id());
         self.by_public_key.remove(peer_id.public_key());
         self.by_did.remove(peer_id.did());
-        
+
         // Remove from primary storage
-        self.peers.remove(peer_id)
+        let removed = self.peers.remove(peer_id);
+
+        // AUDIT: Log removal
+        if self.config.audit_logging && removed.is_some() {
+            info!(
+                peer_did = %peer_id.did(),
+                peer_count = self.peers.len(),
+                "Peer removed from registry"
+            );
+        }
+
+        removed
+    }
+
+    /// Cleanup expired peers based on TTL
+    ///
+    /// Returns the number of peers removed
+    pub fn cleanup_expired(&mut self) -> usize {
+        let now = Self::current_timestamp();
+        let ttl = self.config.peer_ttl_secs;
+
+        let expired: Vec<UnifiedPeerId> = self.peers.iter()
+            .filter(|(_, entry)| now.saturating_sub(entry.last_seen) > ttl)
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        let count = expired.len();
+        for peer_id in expired {
+            self.remove(&peer_id);
+        }
+
+        if count > 0 && self.config.audit_logging {
+            info!(
+                expired_count = count,
+                remaining_peers = self.peers.len(),
+                "Expired peers cleaned up"
+            );
+        }
+
+        count
     }
     
     /// Get peer by UnifiedPeerId
@@ -554,17 +792,258 @@ mod tests {
     #[tokio::test]
     async fn test_shared_registry() {
         let registry = new_shared_registry();
-        
+
         {
             let mut reg = registry.write().await;
             let peer_id = create_test_peer_id();
             let entry = create_test_entry(peer_id);
             reg.upsert(entry).expect("Failed to upsert");
         }
-        
+
         {
             let reg = registry.read().await;
             assert_eq!(reg.peers.len(), 1);
         }
+    }
+
+    // ========== NEW SECURITY TESTS ==========
+
+    #[test]
+    fn test_did_validation_rejects_invalid_format() {
+        // Test that invalid DIDs are rejected
+        assert!(PeerRegistry::validate_did("admin").is_err());
+        assert!(PeerRegistry::validate_did("system").is_err());
+        assert!(PeerRegistry::validate_did("did:other:abc123").is_err());
+        assert!(PeerRegistry::validate_did("did:zhtp:").is_err()); // Too short
+        assert!(PeerRegistry::validate_did("did:zhtp:xyz!@#").is_err()); // Invalid chars
+    }
+
+    #[test]
+    fn test_did_validation_accepts_valid_format() {
+        // Valid DIDs should pass
+        assert!(PeerRegistry::validate_did("did:zhtp:1234567890abcdef1234567890abcdef").is_ok());
+        assert!(PeerRegistry::validate_did("did:zhtp:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab").is_ok());
+    }
+
+    #[test]
+    fn test_max_peers_eviction() {
+        // Create a registry with max 3 peers
+        let config = RegistryConfig {
+            max_peers: 3,
+            peer_ttl_secs: 86400,
+            audit_logging: false, // Disable logging for test
+        };
+        let mut registry = PeerRegistry::with_config(config);
+
+        // Add 3 peers
+        for i in 0..3 {
+            let peer_id = create_test_peer_id();
+            let mut entry = create_test_entry(peer_id);
+            entry.tier = PeerTier::Tier3;
+            entry.last_seen = i as u64; // Different last_seen times
+            registry.upsert(entry).expect("Failed to upsert");
+        }
+
+        assert_eq!(registry.peers.len(), 3);
+
+        // Add 4th peer - should trigger eviction
+        let peer_id = create_test_peer_id();
+        let mut entry = create_test_entry(peer_id.clone());
+        entry.tier = PeerTier::Tier1; // Higher tier = less likely to be evicted
+        entry.last_seen = 100;
+        registry.upsert(entry).expect("Failed to upsert");
+
+        // Should still have 3 peers (one was evicted)
+        assert_eq!(registry.peers.len(), 3);
+
+        // The new Tier1 peer should be present
+        assert!(registry.get(&peer_id).is_some());
+    }
+
+    #[test]
+    fn test_cleanup_expired_peers() {
+        let config = RegistryConfig {
+            max_peers: 100,
+            peer_ttl_secs: 60, // 60 second TTL
+            audit_logging: false,
+        };
+        let mut registry = PeerRegistry::with_config(config);
+
+        // Add peer with old last_seen (expired)
+        let peer1 = create_test_peer_id();
+        let mut entry1 = create_test_entry(peer1.clone());
+        entry1.last_seen = 0; // Very old
+        registry.upsert(entry1).expect("Failed to upsert");
+
+        // Add peer with recent last_seen (not expired)
+        let peer2 = create_test_peer_id();
+        let mut entry2 = create_test_entry(peer2.clone());
+        entry2.last_seen = PeerRegistry::current_timestamp(); // Now
+        registry.upsert(entry2).expect("Failed to upsert");
+
+        assert_eq!(registry.peers.len(), 2);
+
+        // Cleanup expired peers
+        let removed = registry.cleanup_expired();
+
+        // One peer should be removed (the expired one)
+        assert_eq!(removed, 1);
+        assert_eq!(registry.peers.len(), 1);
+        assert!(registry.get(&peer1).is_none()); // Expired peer gone
+        assert!(registry.get(&peer2).is_some()); // Recent peer remains
+    }
+
+    #[test]
+    fn test_update_metrics() {
+        let mut registry = PeerRegistry::new();
+        let peer_id = create_test_peer_id();
+        let entry = create_test_entry(peer_id.clone());
+
+        registry.upsert(entry).expect("Failed to upsert");
+
+        let new_metrics = ConnectionMetrics {
+            signal_strength: 0.95,
+            bandwidth_capacity: 2_000_000,
+            latency_ms: 25,
+            stability_score: 0.99,
+            connected_at: 12345,
+        };
+
+        registry.update_metrics(&peer_id, new_metrics.clone()).expect("Failed to update");
+
+        let updated = registry.get(&peer_id).unwrap();
+        assert_eq!(updated.connection_metrics.signal_strength, 0.95);
+        assert_eq!(updated.connection_metrics.bandwidth_capacity, 2_000_000);
+    }
+
+    #[test]
+    fn test_update_trust_clamping() {
+        let mut registry = PeerRegistry::new();
+        let peer_id = create_test_peer_id();
+        let entry = create_test_entry(peer_id.clone());
+
+        registry.upsert(entry).expect("Failed to upsert");
+
+        // Test trust score clamping to 0.0-1.0 range
+        registry.update_trust(&peer_id, 1.5).expect("Failed to update");
+        assert_eq!(registry.get(&peer_id).unwrap().trust_score, 1.0);
+
+        registry.update_trust(&peer_id, -0.5).expect("Failed to update");
+        assert_eq!(registry.get(&peer_id).unwrap().trust_score, 0.0);
+
+        registry.update_trust(&peer_id, 0.75).expect("Failed to update");
+        assert_eq!(registry.get(&peer_id).unwrap().trust_score, 0.75);
+    }
+
+    #[test]
+    fn test_registry_stats() {
+        let mut registry = PeerRegistry::new();
+
+        // Add peers with different tiers
+        let peer1 = create_test_peer_id();
+        let mut entry1 = create_test_entry(peer1);
+        entry1.tier = PeerTier::Tier1;
+        entry1.authenticated = true;
+
+        let peer2 = create_test_peer_id();
+        let mut entry2 = create_test_entry(peer2);
+        entry2.tier = PeerTier::Tier2;
+        entry2.authenticated = true;
+
+        let peer3 = create_test_peer_id();
+        let mut entry3 = create_test_entry(peer3);
+        entry3.tier = PeerTier::Untrusted;
+        entry3.authenticated = false;
+
+        registry.upsert(entry1).expect("Failed to upsert");
+        registry.upsert(entry2).expect("Failed to upsert");
+        registry.upsert(entry3).expect("Failed to upsert");
+
+        let stats = registry.stats();
+        assert_eq!(stats.total_peers, 3);
+        assert_eq!(stats.tier1_count, 1);
+        assert_eq!(stats.tier2_count, 1);
+        assert_eq!(stats.untrusted_count, 1);
+        assert_eq!(stats.authenticated_count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_access() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let registry = new_shared_registry();
+        let success_count = Arc::new(AtomicUsize::new(0));
+        let mut handles = vec![];
+
+        // Spawn 10 concurrent writers
+        for i in 0..10 {
+            let registry_clone = registry.clone();
+            let success_clone = success_count.clone();
+            handles.push(tokio::spawn(async move {
+                let peer_id = create_test_peer_id();
+                let mut entry = create_test_entry(peer_id);
+                entry.tier = if i % 2 == 0 { PeerTier::Tier1 } else { PeerTier::Tier2 };
+
+                let mut reg = registry_clone.write().await;
+                if reg.upsert(entry).is_ok() {
+                    success_clone.fetch_add(1, Ordering::SeqCst);
+                }
+            }));
+        }
+
+        // Spawn 10 concurrent readers
+        for _ in 0..10 {
+            let registry_clone = registry.clone();
+            handles.push(tokio::spawn(async move {
+                let reg = registry_clone.read().await;
+                let _ = reg.stats();
+            }));
+        }
+
+        // Wait for all tasks
+        for handle in handles {
+            handle.await.expect("Task panicked");
+        }
+
+        // All writes should succeed
+        assert_eq!(success_count.load(Ordering::SeqCst), 10);
+
+        // Verify registry state
+        let reg = registry.read().await;
+        assert_eq!(reg.peers.len(), 10);
+    }
+
+    #[test]
+    fn test_with_custom_config() {
+        let config = RegistryConfig {
+            max_peers: 500,
+            peer_ttl_secs: 3600,
+            audit_logging: false,
+        };
+
+        let registry = PeerRegistry::with_config(config.clone());
+        assert_eq!(registry.config.max_peers, 500);
+        assert_eq!(registry.config.peer_ttl_secs, 3600);
+        assert!(!registry.config.audit_logging);
+    }
+
+    #[test]
+    fn test_empty_registry_operations() {
+        let mut registry = PeerRegistry::new();
+
+        // Remove from empty registry should return None
+        let peer_id = create_test_peer_id();
+        assert!(registry.remove(&peer_id).is_none());
+
+        // Find operations on empty registry
+        assert!(registry.find_by_did("did:zhtp:nonexistent").is_none());
+        assert!(registry.find_by_node_id(&lib_identity::NodeId::from_bytes([0u8; 32])).is_none());
+
+        // Stats on empty registry
+        let stats = registry.stats();
+        assert_eq!(stats.total_peers, 0);
+
+        // Cleanup on empty registry
+        assert_eq!(registry.cleanup_expired(), 0);
     }
 }


### PR DESCRIPTION
Single source of truth for all peer data, replacing 6 separate registries:
- mesh_connections (server)
- direct_routes (router)
- TopologyGraph.nodes (multi-hop)
- mesh_connections (handler)
- discovered_peers (bootstrap)
- dht_routing_table (DHT)

Implementation:
- Created PeerRegistry with HashMap<UnifiedPeerId, PeerEntry>
- PeerEntry consolidates all metadata from 6 existing stores
- Thread-safe Arc<RwLock<PeerRegistry>> wrapper
- Multi-key lookups: NodeId, PublicKey, DID
- Atomic updates prevent race conditions

Files:
- lib-network/src/peer_registry/mod.rs (new, 571 lines)
- lib-network/src/lib.rs (exports added)

Tests:
- test_registry_creation
- test_upsert_and_get
- test_find_by_node_id
- test_find_by_public_key
- test_find_by_did
- test_remove (atomic)
- test_peers_by_tier
- test_shared_registry (thread-safe)

Acceptance Criteria:
 Single registry replaces all 6 existing peer stores
 Atomic updates prevent race conditions

Depends on: Tickets #145, #146
Phase: 1 - P0-Critical
Category: Unified Peer Registry