### PR TITLE
ci: Add systemd service for auto-start and restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/development'
     steps:
+      - name: Checkout (for service file)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: deploy
+
       - name: Download Release Artifact
         uses: actions/download-artifact@v4
         with:
@@ -85,13 +90,19 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
 
-      - name: Deploy Binary
+      - name: Deploy Binary and Service
         run: |
           scp -i ~/.ssh/deploy_key ./zhtp ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/zhtp/zhtp.new
+          scp -i ~/.ssh/deploy_key ./deploy/zhtp.service ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/zhtp.service
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} '
             cd /opt/zhtp &&
+            systemctl stop zhtp 2>/dev/null || true &&
             if [ -f zhtp ]; then mv zhtp zhtp.old; fi &&
             mv zhtp.new zhtp &&
             chmod +x zhtp &&
-            echo "Deployed successfully at $(date)"
+            mv /tmp/zhtp.service /etc/systemd/system/zhtp.service &&
+            systemctl daemon-reload &&
+            systemctl enable zhtp &&
+            systemctl start zhtp &&
+            echo "Deployed and started at $(date)"
           '

--- a/deploy/zhtp.service
+++ b/deploy/zhtp.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ZHTP Node
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/opt/zhtp/zhtp
+WorkingDirectory=/opt/zhtp
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+Environment=RUST_LOG=info
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Add zhtp.service systemd unit file
- Deploy service file alongside binary
- Auto-restart on crash (RestartSec=5)
- Enable service on boot
- Logs to journald (`journalctl -u zhtp`)

## Commands after deploy
```bash
# Check status
systemctl status zhtp

# View logs
journalctl -u zhtp -f

# Restart manually
systemctl restart zhtp
```