### PR TITLE
ci: Add retry logic to ssh-keyscan for deploy reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,12 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
+          # Retry ssh-keyscan up to 3 times with timeout
+          for i in 1 2 3; do
+            ssh-keyscan -T 10 -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts && break
+            echo "ssh-keyscan attempt $i failed, retrying..."
+            sleep 2
+          done
 
       - name: Deploy Binary and Service
         run: |


### PR DESCRIPTION
Fixes intermittent ssh-keyscan failures by retrying up to 3 times with 10s timeout.