### PR TITLE
fix: add node start command and auto-wallet to systemd service

### DIFF
--- a/deploy/zhtp.service
+++ b/deploy/zhtp.service
@@ -4,13 +4,14 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/opt/zhtp/zhtp
+ExecStart=/opt/zhtp/zhtp node start
 WorkingDirectory=/opt/zhtp
 Restart=always
 RestartSec=5
 StandardOutput=journal
 StandardError=journal
 Environment=RUST_LOG=info
+Environment=ZHTP_AUTO_WALLET=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Add `node start` subcommand to ExecStart (binary requires it)
- Add `ZHTP_AUTO_WALLET=1` for headless operation

## Problem
The service file was missing:
1. The `node start` subcommand - binary exits with status 2 (shows help)
2. The auto-wallet env var - node hangs waiting for interactive input