### PR TITLE
feat(network): Add persistent TLS certificates for Android Cronet compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,6 +2465,7 @@ dependencies = [
  "regex",
  "rocksdb",
  "rustls",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "serialport",
@@ -3914,7 +3915,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4087,6 +4088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/lib-network/Cargo.toml
+++ b/lib-network/Cargo.toml
@@ -94,6 +94,7 @@ mdns-sd = "0.16"                                  # mDNS service discovery (Bonj
 # NOTE: QUIC integration ready but commented out until cmake/NASM dependencies resolved
 quinn = "0.11"                                    # Production-ready QUIC implementation (used by Google, Cloudflare)
 rustls = { version = "0.23", default-features = false, features = ["ring"] } # TLS 1.3 library (used by quinn)
+rustls-pemfile = "2.1"                              # PEM file parsing for persistent TLS certificates
 rcgen = "0.14.5"                                    # Certificate generation for QUIC
 #To enable: Install cmake and NASM, then uncomment above lines
 


### PR DESCRIPTION
## Summary

Android's Cronet (the only production-ready QUIC library for Android) cannot bypass TLS certificate verification like iOS's Network.framework. This prevented Android clients from connecting to ZHTP nodes that generated ephemeral self-signed certificates on each startup.

### The Problem
- **iOS**: Can use `sec_protocol_options_set_verify_block` to accept any certificate ✅
- **Android Cronet**: Has NO equivalent - requires trusted or pinned certificates ❌

### The Solution
TLS certificates are now persisted to disk, enabling Android apps to pin the certificate hash:

- On **first startup**: generates certificate and saves to disk (`./data/tls/server.crt` and `server.key`)
- On **subsequent startups**: loads existing certificate from disk
- **Mobile apps** can now pin the certificate hash for secure connections

### Node-to-Node Connections Unaffected
Other ZHTP nodes continue to use `SkipServerVerification` and rely on PQC (Kyber + Dilithium) for security. The persistent cert only affects mobile client connections.

### Certificate Pinning for Android
After server first startup, extract the hash:
```bash
openssl x509 -in ./data/tls/server.crt -pubkey -noout | \
  openssl pkey -pubin -outform der | \
  openssl dgst -sha256 -binary | base64
```

Configure Cronet:
```kotlin
val engine = CronetEngine.Builder(context)
    .addPublicKeyPins(
        "your-server-hostname",
        setOf("sha256/YOUR_BASE64_HASH_HERE"),
        includeSubdomains = false,
        expirationDate = Date(...)
    )
    .build()
```

## Changes
- Added `rustls-pemfile` dependency for PEM parsing
- Added `load_or_generate_cert()` function that persists certificates
- Added `new_with_cert_paths()` for custom certificate locations
- Added `DEFAULT_TLS_CERT_PATH` and `DEFAULT_TLS_KEY_PATH` constants

## Test Plan
- [ ] Node starts and generates certificate on first run
- [ ] Node loads existing certificate on subsequent runs
- [ ] Node-to-node mesh connections still work
- [ ] Android Cronet client can connect with pinned certificate