### PR TITLE
fix(cli): Add ALPN protocols and separate keystore for QUIC clients

### DIFF
--- a/lib-network/src/web4/client.rs
+++ b/lib-network/src/web4/client.rs
@@ -320,10 +320,19 @@ impl Web4Client {
 
     /// Configure QUIC client with trust verifier
     fn configure_client(verifier: Arc<ZhtpTrustVerifier>) -> Result<ClientConfig> {
-        let crypto = rustls::ClientConfig::builder()
+        // Install crypto provider for rustls 0.23+
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let mut crypto = rustls::ClientConfig::builder()
             .dangerous()
             .with_custom_certificate_verifier(verifier)
             .with_no_client_auth();
+
+        // Configure ALPN protocols to match server (required for QUIC handshake)
+        crypto.alpn_protocols = vec![
+            b"zhtp/1.0".to_vec(),  // ZHTP native protocol
+            b"h3".to_vec(),        // HTTP/3 fallback
+        ];
 
         let mut config = ClientConfig::new(Arc::new(
             quinn::crypto::rustls::QuicClientConfig::try_from(crypto)?


### PR DESCRIPTION
## Summary
- Add ALPN protocols (`zhtp/1.0`, `h3`) to Web4Client and ZhtpClient for QUIC handshake compatibility
- Install rustls crypto provider before TLS config (fixes panic on rustls 0.23+)
- Implement separate private key storage in keystore (`identity.json` + `private_key.json`)

## Security
- Private keys stored with 0600 permissions
- Identity public data separated from secret keys (standard practice: SSH, GPG, wallets)

## Test plan
- [ ] CLI can connect to QUIC node with ALPN
- [ ] Identity create saves separate keystore files
- [ ] Deploy command loads identity from separate keystore