### PR TITLE
feat(quic): ALPN-based protocol routing for UHP control plane

### DIFF
--- a/lib-network/src/client/zhtp_client.rs
+++ b/lib-network/src/client/zhtp_client.rs
@@ -263,11 +263,9 @@ impl ZhtpClient {
             .with_custom_certificate_verifier(verifier)
             .with_no_client_auth();
 
-        // Configure ALPN protocols to match server (required for QUIC handshake)
-        crypto.alpn_protocols = vec![
-            b"zhtp/1.0".to_vec(),  // ZHTP native protocol
-            b"h3".to_vec(),        // HTTP/3 fallback
-        ];
+        // Configure ALPN for control plane operations (UHP handshake required)
+        // This tells the server to expect UHP handshake before API requests
+        crypto.alpn_protocols = crate::constants::client_control_plane_alpns();
 
         let mut config = ClientConfig::new(Arc::new(
             quinn::crypto::rustls::QuicClientConfig::try_from(crypto)?

--- a/lib-network/src/constants.rs
+++ b/lib-network/src/constants.rs
@@ -2,6 +2,72 @@
 //!
 //! This module defines shared protocol constants used across the network layer.
 
+// =============================================================================
+// ALPN Protocol Identifiers
+// =============================================================================
+//
+// ALPN (Application-Layer Protocol Negotiation) is used to select the protocol
+// mode at connection time. This allows the server to handle different client
+// types appropriately:
+//
+// - zhtp-uhp/1: Control plane with UHP handshake (CLI, Web4 deploy, admin)
+// - zhtp-http/1: HTTP-only mode (mobile apps, browsers)
+// - zhtp-mesh/1: Mesh peer-to-peer protocol
+//
+// Security: ALPN selection determines the initial protocol flow, but actual
+// security comes from UHP authentication for control plane operations.
+
+/// ALPN for control plane connections (CLI, Web4 deploy, admin APIs)
+/// These connections perform UHP handshake FIRST, then send authenticated requests.
+pub const ALPN_CONTROL_PLANE: &[u8] = b"zhtp-uhp/1";
+
+/// ALPN for HTTP-compatible connections (mobile apps, browsers)
+/// These connections send HTTP requests directly without UHP handshake.
+/// Mutations require session tokens or other auth mechanisms.
+pub const ALPN_HTTP_COMPAT: &[u8] = b"zhtp-http/1";
+
+/// ALPN for mesh peer-to-peer connections (node-to-node)
+/// These connections perform UHP handshake for peer authentication.
+pub const ALPN_MESH: &[u8] = b"zhtp-mesh/1";
+
+/// Legacy ALPN for backward compatibility
+/// Treated as HTTP-compat mode for mobile app compatibility.
+pub const ALPN_LEGACY: &[u8] = b"zhtp/1.0";
+
+/// HTTP/3 ALPN for browser compatibility
+pub const ALPN_H3: &[u8] = b"h3";
+
+/// All supported server ALPNs (ordered by preference)
+pub fn server_alpns() -> Vec<Vec<u8>> {
+    vec![
+        ALPN_CONTROL_PLANE.to_vec(),  // Preferred: control plane with UHP
+        ALPN_MESH.to_vec(),            // Mesh protocol
+        ALPN_HTTP_COMPAT.to_vec(),     // HTTP-compat mode
+        ALPN_LEGACY.to_vec(),          // Legacy (treated as HTTP-compat)
+        ALPN_H3.to_vec(),              // HTTP/3 browsers
+    ]
+}
+
+/// Client ALPNs for control plane operations (CLI, Web4 deploy)
+pub fn client_control_plane_alpns() -> Vec<Vec<u8>> {
+    vec![
+        ALPN_CONTROL_PLANE.to_vec(),   // Primary: control plane with UHP
+    ]
+}
+
+/// Client ALPNs for HTTP-only operations (mobile apps)
+pub fn client_http_alpns() -> Vec<Vec<u8>> {
+    vec![
+        ALPN_HTTP_COMPAT.to_vec(),     // HTTP-compat mode
+        ALPN_LEGACY.to_vec(),          // Legacy fallback
+        ALPN_H3.to_vec(),              // HTTP/3 fallback
+    ]
+}
+
+// =============================================================================
+// Handshake Constants
+// =============================================================================
+
 /// Maximum handshake message size (1 MB)
 ///
 /// This provides sufficient space for:

--- a/lib-network/src/web4/client.rs
+++ b/lib-network/src/web4/client.rs
@@ -328,11 +328,9 @@ impl Web4Client {
             .with_custom_certificate_verifier(verifier)
             .with_no_client_auth();
 
-        // Configure ALPN protocols to match server (required for QUIC handshake)
-        crypto.alpn_protocols = vec![
-            b"zhtp/1.0".to_vec(),  // ZHTP native protocol
-            b"h3".to_vec(),        // HTTP/3 fallback
-        ];
+        // Configure ALPN for control plane operations (UHP handshake required)
+        // This tells the server to expect UHP handshake before API requests
+        crypto.alpn_protocols = crate::constants::client_control_plane_alpns();
 
         let mut config = ClientConfig::new(Arc::new(
             quinn::crypto::rustls::QuicClientConfig::try_from(crypto)?

--- a/zhtp/src/server/zhtp/compatibility.rs
+++ b/zhtp/src/server/zhtp/compatibility.rs
@@ -177,6 +177,75 @@ impl HttpCompatibilityLayer {
         Ok(())
     }
 
+    /// Handle authenticated HTTP stream from control plane connection
+    /// The session contains authentication context from UHP+Kyber handshake
+    pub async fn handle_authenticated_http_stream(
+        &self,
+        buffered: &mut crate::server::quic_handler::BufferedStream,
+        mut send: SendStream,
+        session: &crate::server::quic_handler::ControlPlaneSession,
+    ) -> Result<()> {
+        debug!("🔄 Processing authenticated HTTP request from {} (compatibility mode)", session.peer_did);
+
+        // Read HTTP request from buffered stream
+        let buffer = buffered.read_to_end(10 * 1024 * 1024).await
+            .map_err(|e| anyhow::anyhow!("Failed to read HTTP request from buffered stream: {}", e))?;
+
+        if buffer.is_empty() {
+            return Ok(());
+        }
+
+        // Parse HTTP request
+        let http_data = String::from_utf8_lossy(&buffer);
+        let mut request = match self.parse_http_request(&http_data) {
+            Ok(req) => req,
+            Err(e) => {
+                warn!("❌ Failed to parse HTTP request from {}: {}", session.peer_did, e);
+                let error_response = self.create_http_error_response(400, "Bad Request");
+                send.write_all(&error_response).await
+                    .map_err(|e| anyhow::anyhow!("Write error: {}", e))?;
+                send.finish()
+                    .map_err(|e| anyhow::anyhow!("Finish error: {}", e))?;
+                return Ok(());
+            }
+        };
+
+        // Add authenticated requester identity to request context
+        // IdentityId is a Hash of the DID
+        request.requester = Some(lib_crypto::Hash(lib_crypto::hash_blake3(session.peer_did.as_bytes())));
+
+        info!("🔄 Authenticated HTTP {} {} → ZHTP from {}",
+            match request.method {
+                ZhtpMethod::Get => "GET",
+                ZhtpMethod::Post => "POST",
+                ZhtpMethod::Put => "PUT",
+                ZhtpMethod::Delete => "DELETE",
+                _ => "UNKNOWN",
+            },
+            request.uri,
+            session.peer_did
+        );
+
+        // Route through ZHTP router
+        let router = self.router.read().await;
+        let response = router.route_request(request).await
+            .unwrap_or_else(|e| {
+                warn!("Handler error for authenticated request: {}", e);
+                ZhtpResponse::error(ZhtpStatus::InternalServerError, e.to_string())
+            });
+
+        // Convert ZHTP response back to HTTP
+        let http_response = self.zhtp_to_http_response(&response);
+
+        send.write_all(&http_response).await
+            .map_err(|e| anyhow::anyhow!("Write error: {}", e))?;
+        send.finish()
+            .map_err(|e| anyhow::anyhow!("Finish error: {}", e))?;
+
+        debug!("✅ Authenticated HTTP response sent to {}", session.peer_did);
+        Ok(())
+    }
+
     /// Parse HTTP/1.1 request into ZHTP request
     fn parse_http_request(&self, http_data: &str) -> Result<ZhtpRequest> {
         let lines: Vec<&str> = http_data.lines().collect();


### PR DESCRIPTION
## Summary
- Implements ALPN-based protocol routing for QUIC connections
- Adds UHP+Kyber handshake support for control plane connections (CLI, Web4 deploy)
- Routes different client types to appropriate handlers based on negotiated ALPN

## Problem
CLI commands and Web4 deployment were failing because the QUIC-only node didn't recognize UHP handshake as a valid connection type. The server was treating UHP handshake data as "mesh messages" and rejecting them.

## Solution
Use ALPN (Application-Layer Protocol Negotiation) to select the appropriate connection mode at connection time:

| ALPN | Mode | Description |
|------|------|-------------|
| `zhtp-uhp/1` | Control Plane | UHP handshake → authenticated API requests |
| `zhtp-mesh/1` | Mesh | UHP handshake → encrypted mesh messages |
| `zhtp-http/1`, `h3` | HTTP-compat | Direct HTTP requests (no UHP) |

## Changes
- **lib-network/src/constants.rs**: New ALPN protocol constants
- **lib-network/src/protocols/quic_mesh.rs**: Updated server QUIC config with ALPNs
- **lib-network/src/web4/client.rs**: Updated Web4Client to use `zhtp-uhp/1`
- **lib-network/src/client/zhtp_client.rs**: Updated ZhtpClient to use `zhtp-uhp/1`
- **zhtp/src/server/quic_handler.rs**: 
  - Added `ConnectionMode` enum
  - Added `ControlPlaneSession` struct
  - Implemented `handle_control_plane_connection()` with UHP+Kyber handshake
  - Added ALPN-based connection dispatcher
- **zhtp/src/server/zhtp/router.rs**: Added `handle_authenticated_zhtp_stream()`
- **zhtp/src/server/zhtp/compatibility.rs**: Added `handle_authenticated_http_stream()`

## Test plan
- [x] Run `cargo check` - compiles without errors
- [x] Test mobile app still works (uses HTTP-compat mode)
- [x] Test CLI deployment works (uses control plane mode)
- [x] Run integration tests