### PR TITLE
fix(handshake): Use consistent node ID for master key derivation

### DIFF
--- a/lib-network/src/protocols/quic_handshake.rs
+++ b/lib-network/src/protocols/quic_handshake.rs
@@ -530,11 +530,14 @@ pub async fn handshake_as_responder(
         // Phase 3: Master Key Derivation
         // ================================================================
 
+        // Use responder's (server's) node ID for key derivation
+        // NOTE: Both initiator and responder must use the SAME node ID (responder's)
+        // to derive matching master keys and session IDs
         let master_key = derive_quic_master_key(
             &uhp_session_key,
             &pqc_shared_secret,
             &uhp_transcript_hash,
-            client_hello.identity.node_id.as_bytes(),
+            server_hello.identity.node_id.as_bytes(),
         )?;
 
         // Zeroize intermediate keys


### PR DESCRIPTION
## Summary
- Fixes session ID mismatch causing "401 Invalid session" errors
- Both initiator and responder now use the same node ID (responder's) when deriving master key

## Problem
During QUIC handshake, the master key (and thus session ID) was derived differently on each side:
- **Initiator**: used `server_hello.identity.node_id` ✅
- **Responder**: used `client_hello.identity.node_id` ❌

This caused different master keys and session IDs:
- Client session_id: `61667a9d38484cd2`
- Server session_id: `ea8fd181794d68cb`

When the client sent requests with its auth_context containing its session_id, the server rejected them with "Invalid session" because the IDs didn't match.

## Solution
Both sides now use the responder's (server's) node ID for key derivation. This is the standard convention since the responder is the party being connected to.

## Test plan
- [ ] Deploy to node 77.42.37.161:9334
- [ ] Verify session IDs match on both sides
- [ ] Test CLI deployment succeeds