### PR TITLE
fix(crypto): Fix Kyber KDF info mismatch causing session ID divergence

### DIFF
--- a/lib-crypto/src/post_quantum/kyber.rs
+++ b/lib-crypto/src/post_quantum/kyber.rs
@@ -17,19 +17,21 @@ pub fn kyber512_keypair() -> (Vec<u8>, Vec<u8>) {
 }
 
 /// Encapsulate shared secret with Kyber512
-pub fn kyber512_encapsulate(public_key: &[u8]) -> Result<(Vec<u8>, [u8; 32])> {
+///
+/// Note: kdf_info must match the info used in kyber512_decapsulate for the
+/// shared secrets to be identical on both sides.
+pub fn kyber512_encapsulate(public_key: &[u8], kdf_info: &[u8]) -> Result<(Vec<u8>, [u8; 32])> {
     let pk = kyber512::PublicKey::from_bytes(public_key)
         .map_err(|_| anyhow::anyhow!("Invalid Kyber512 public key"))?;
-    
+
     let (shared_secret_bytes, ciphertext) = kyber512::encapsulate(&pk);
-    
+
     // Derive a 32-byte key using HKDF-SHA3
     let hk = Hkdf::<Sha3_256>::new(None, shared_secret_bytes.as_bytes());
     let mut shared_secret = [0u8; 32];
-    let kdf_info = b"ZHTP-KEM-v1.0";
     hk.expand(kdf_info, &mut shared_secret)
         .map_err(|_| anyhow::anyhow!("HKDF expansion failed"))?;
-    
+
     Ok((ciphertext.as_bytes().to_vec(), shared_secret))
 }
 
@@ -58,18 +60,20 @@ mod tests {
     #[test]
     fn test_kyber512_kem() -> Result<()> {
         let (pk, sk) = kyber512_keypair();
-        
+
+        // Both sides must use the same kdf_info
+        let kdf_info = b"ZHTP-QUIC-KEM-v1.0";
+
         // Encapsulate
-        let (ciphertext, shared_secret1) = kyber512_encapsulate(&pk)?;
-        
+        let (ciphertext, shared_secret1) = kyber512_encapsulate(&pk, kdf_info)?;
+
         // Decapsulate
-        let kdf_info = b"ZHTP-KEM-v1.0";
         let shared_secret2 = kyber512_decapsulate(&ciphertext, &sk, kdf_info)?;
-        
+
         // Should match
         assert_eq!(shared_secret1, shared_secret2);
         assert_eq!(shared_secret1.len(), 32);
-        
+
         Ok(())
     }
 }

--- a/lib-network/src/protocols/quic_handshake.rs
+++ b/lib-network/src/protocols/quic_handshake.rs
@@ -271,6 +271,7 @@ pub async fn handshake_as_initiator(
             &client_hello_bytes,
             &server_hello_bytes,
             &client_finish_bytes,
+            "INITIATOR",
         );
 
         // ================================================================
@@ -487,6 +488,7 @@ pub async fn handshake_as_responder(
             &client_hello_bytes,
             &server_hello_bytes,
             &client_finish_bytes,
+            "RESPONDER",
         );
 
         // ================================================================
@@ -517,8 +519,11 @@ pub async fn handshake_as_responder(
         debug!("QUIC handshake: KyberRequest received and verified");
 
         // Encapsulate shared secret using client's public key
-        let (ciphertext, mut pqc_shared_secret) = kyber512_encapsulate(&kyber_request.kyber_pubkey)
-            .context("Failed to encapsulate Kyber shared secret")?;
+        // NOTE: kdf_info must match the one used in decapsulate by the initiator
+        let (ciphertext, mut pqc_shared_secret) = kyber512_encapsulate(
+            &kyber_request.kyber_pubkey,
+            b"ZHTP-QUIC-KEM-v1.0",
+        ).context("Failed to encapsulate Kyber shared secret")?;
 
         // Send KyberResponse
         let kyber_response = KyberResponse {
@@ -650,7 +655,20 @@ fn compute_uhp_transcript_hash(
     client_hello_bytes: &[u8],
     server_hello_bytes: &[u8],
     client_finish_bytes: &[u8],
+    role: &str,
 ) -> [u8; 32] {
+    // DEBUG: Log byte lengths and first 16 bytes of each message
+    debug!(
+        role = %role,
+        client_hello_len = client_hello_bytes.len(),
+        server_hello_len = server_hello_bytes.len(),
+        client_finish_len = client_finish_bytes.len(),
+        client_hello_head = %hex::encode(&client_hello_bytes[..std::cmp::min(16, client_hello_bytes.len())]),
+        server_hello_head = %hex::encode(&server_hello_bytes[..std::cmp::min(16, server_hello_bytes.len())]),
+        client_finish_head = %hex::encode(&client_finish_bytes[..std::cmp::min(16, client_finish_bytes.len())]),
+        "Transcript hash inputs"
+    );
+
     let mut transcript = Vec::with_capacity(
         client_hello_bytes.len() + server_hello_bytes.len() + client_finish_bytes.len()
     );
@@ -658,7 +676,16 @@ fn compute_uhp_transcript_hash(
     transcript.extend_from_slice(server_hello_bytes);
     transcript.extend_from_slice(client_finish_bytes);
 
-    hash_blake3(&transcript)
+    let hash = hash_blake3(&transcript);
+
+    debug!(
+        role = %role,
+        transcript_len = transcript.len(),
+        transcript_hash = %hex::encode(&hash[..8]),
+        "Transcript hash computed"
+    );
+
+    hash
 }
 
 // ============================================================================

--- a/lib-network/src/protocols/zhtp_encryption.rs
+++ b/lib-network/src/protocols/zhtp_encryption.rs
@@ -110,7 +110,9 @@ impl ZhtpEncryptionSession {
         info!(" Responding to Kyber key exchange for session: {}", &init.session_id[..8]);
         
         // Encapsulate shared secret with peer's public key
-        let (ciphertext, shared_secret) = kyber512_encapsulate(&init.kyber_public_key)?;
+        // NOTE: kdf_info must match the one used in complete_key_exchange by the initiator
+        let kdf_info = b"ZHTP-KEM-v1.0";
+        let (ciphertext, shared_secret) = kyber512_encapsulate(&init.kyber_public_key, kdf_info)?;
         
         debug!("Encapsulated shared secret (ciphertext: {} bytes)", ciphertext.len());
         


### PR DESCRIPTION
## Summary

Fixes the "401 Invalid session" error during Web4 deployment that was caused by client and server deriving different session IDs from the same UHP+Kyber handshake.

## Root Cause

The `kyber512_encapsulate()` function was hardcoded to use `kdf_info = "ZHTP-KEM-v1.0"` internally, while `kyber512_decapsulate()` accepted `kdf_info` as a parameter. The QUIC handshake passed `"ZHTP-QUIC-KEM-v1.0"` to decapsulate, causing an HKDF mismatch.

This meant that even though the underlying Kyber shared secret was identical on both sides, the HKDF expansion produced different derived keys due to different info strings.

## Changes

### lib-crypto/src/post_quantum/kyber.rs
- Add `kdf_info: &[u8]` parameter to `kyber512_encapsulate()` to ensure both sides use matching KDF info strings
- Update test to use consistent kdf_info

### lib-network/src/protocols/quic_handshake.rs  
- Update encapsulate call to pass `"ZHTP-QUIC-KEM-v1.0"` (matching decapsulate)
- Add debug logging for transcript hash computation and master key derivation inputs

### lib-network/src/protocols/zhtp_encryption.rs
- Update encapsulate call to pass `"ZHTP-KEM-v1.0"` (matching its decapsulate)

### zhtp/src/api/handlers/web4/domains.rs
- Add `ManifestDomainRegistrationRequest` struct for CLI deploy command
- Add `register_domain_from_manifest()` handler to support manifest-based registration
- Update `register_domain_simple()` to try manifest format first, falling back to inline content format

## Testing

Local testing confirms:
- Session IDs now match between client and server
- All 4 master key derivation inputs now match:
  - `uhp_session_key` ✅
  - `pqc_shared_secret` ✅ (was different before fix)
  - `uhp_transcript_hash` ✅
  - `server_node_id` ✅
- File uploads succeed with status 200
- Manifest-based domain registration works

## Related Issues

Fixes the session ID mismatch discovered during Web4 deployment debugging.