### PR TITLE
feat(web4): Allow .sov TLD in domain registration

### DIFF
--- a/lib-network/src/web4/domain_registry.rs
+++ b/lib-network/src/web4/domain_registry.rs
@@ -454,17 +454,21 @@ impl DomainRegistry {
 
     /// Validate domain name format
     fn validate_domain_name(&self, domain: &str) -> Result<()> {
-        // Must end with .zhtp
-        if !domain.ends_with(".zhtp") {
-            return Err(anyhow!("Domain must end with .zhtp"));
-        }
+        // Must end with .zhtp or .sov
+        let tld_len = if domain.ends_with(".zhtp") {
+            5
+        } else if domain.ends_with(".sov") {
+            4
+        } else {
+            return Err(anyhow!("Domain must end with .zhtp or .sov"));
+        };
 
-        // Extract the name part (before .zhtp)
-        let name = &domain[..domain.len() - 5]; // Remove ".zhtp"
+        // Extract the name part (before TLD)
+        let name = &domain[..domain.len() - tld_len];
         
         // Must be 3-63 characters
         if name.len() < 3 || name.len() > 63 {
-            return Err(anyhow!("Domain name must be 3-63 characters (excluding .zhtp)"));
+            return Err(anyhow!("Domain name must be 3-63 characters (excluding TLD)"));
         }
 
         // Must contain only valid characters


### PR DESCRIPTION
## Summary
- Update domain validation to accept both `.zhtp` and `.sov` top-level domains
- The `.sov` namespace is the primary open registry for the Sovereign Network with semantic sub-namespaces for governance

## Changes
- Fix `validate_domain_name()` in `lib-network/src/web4/domain_registry.rs` to accept `.sov` in addition to `.zhtp`
- Dynamically calculate TLD length for name extraction (5 for `.zhtp`, 4 for `.sov`)
- Update error messages to reference both TLDs

## Test plan
- Deploy site with `--domain centralhub.sov` should succeed
- Domain validation accepts both `.zhtp` and `.sov` suffixes