### PR TITLE
fix: Install rustls crypto provider at startup

### DIFF
--- a/zhtp/src/main.rs
+++ b/zhtp/src/main.rs
@@ -25,6 +25,10 @@ use zhtp::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install rustls crypto provider before any TLS/QUIC operations
+    // This MUST be done before any rustls usage to avoid panic
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     // Initialize logging system with INFO level by default.
     // Add explicit filter directives to silence noisy third-party targets
     // (mdns_sd) and to suppress firewall rule WARNs from network_isolation.


### PR DESCRIPTION
## Summary
- Install rustls crypto provider at the very beginning of main() before any TLS/QUIC operations

## Problem
The node was panicking with:
```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually
```

## Solution
Call `rustls::crypto::ring::default_provider().install_default()` at the start of main() before logging initialization.

## Test plan
- Node should start without rustls panic
- QUIC connections should work normally