### PR TITLE
feat(quic): Add zhtp-public/1 ALPN for unauthenticated public content access

### DIFF
--- a/lib-network/src/constants.rs
+++ b/lib-network/src/constants.rs
@@ -21,7 +21,13 @@
 /// These connections perform UHP handshake FIRST, then send authenticated requests.
 pub const ALPN_CONTROL_PLANE: &[u8] = b"zhtp-uhp/1";
 
-/// ALPN for HTTP-compatible connections (mobile apps, browsers)
+/// ALPN for public read-only connections (mobile apps, browsers reading public content)
+/// These connections do NOT perform UHP handshake.
+/// Only allows: domain resolution, manifest fetch, content/blob retrieval.
+/// Rejects: deploy, domain registration, admin operations, any mutations.
+pub const ALPN_PUBLIC: &[u8] = b"zhtp-public/1";
+
+/// ALPN for HTTP-compatible connections (legacy mobile apps, browsers)
 /// These connections send HTTP requests directly without UHP handshake.
 /// Mutations require session tokens or other auth mechanisms.
 pub const ALPN_HTTP_COMPAT: &[u8] = b"zhtp-http/1";
@@ -40,9 +46,10 @@ pub const ALPN_H3: &[u8] = b"h3";
 /// All supported server ALPNs (ordered by preference)
 pub fn server_alpns() -> Vec<Vec<u8>> {
     vec![
-        ALPN_CONTROL_PLANE.to_vec(),  // Preferred: control plane with UHP
+        ALPN_PUBLIC.to_vec(),          // Public read-only (mobile apps, browsers)
+        ALPN_CONTROL_PLANE.to_vec(),   // Control plane with UHP (CLI, deploy)
         ALPN_MESH.to_vec(),            // Mesh protocol
-        ALPN_HTTP_COMPAT.to_vec(),     // HTTP-compat mode
+        ALPN_HTTP_COMPAT.to_vec(),     // HTTP-compat mode (legacy)
         ALPN_LEGACY.to_vec(),          // Legacy (treated as HTTP-compat)
         ALPN_H3.to_vec(),              // HTTP/3 browsers
     ]
@@ -55,7 +62,14 @@ pub fn client_control_plane_alpns() -> Vec<Vec<u8>> {
     ]
 }
 
-/// Client ALPNs for HTTP-only operations (mobile apps)
+/// Client ALPNs for public read-only operations (mobile apps reading content)
+pub fn client_public_alpns() -> Vec<Vec<u8>> {
+    vec![
+        ALPN_PUBLIC.to_vec(),          // Public read-only (preferred)
+    ]
+}
+
+/// Client ALPNs for HTTP-only operations (legacy mobile apps)
 pub fn client_http_alpns() -> Vec<Vec<u8>> {
     vec![
         ALPN_HTTP_COMPAT.to_vec(),     // HTTP-compat mode


### PR DESCRIPTION
## Summary
Separates public read traffic from authenticated control-plane traffic at the ALPN level.

## Problem
Mobile clients were being routed to `ControlPlane` mode which requires UHP+Kyber handshake, even when just trying to read public websites. This caused handshake timeouts and prevented access to public content.

## Solution
Two explicit ALPNs:

| ALPN | Purpose | Handshake |
|------|---------|-----------|
| `zhtp-public/1` | Read-only public content | None |
| `zhtp-uhp/1` | Authenticated control plane | UHP+Kyber required |

### Changes
- Add `ALPN_PUBLIC` constant (`zhtp-public/1`)
- Add `ConnectionMode::Public` variant
- Implement `handle_public_connection()` - accepts streams without handshake
- Only allows GET requests on public connections (rejects POST/PUT/DELETE)
- Default unknown ALPNs to `Public` (safe default)

## Mobile Client Update Required
Change ALPN from:
```
["zhtp-uhp/1"]
```
To:
```
["zhtp-public/1"]
```

## Test plan
- [ ] Mobile client connects with `zhtp-public/1` ALPN
- [ ] GET requests to public domains work without handshake
- [ ] POST/PUT/DELETE requests are rejected with 403
- [ ] CLI deploy still works with `zhtp-uhp/1` ALPN