### PR TITLE
feat(node): Add persistent identity keystore for node startup

### DIFF
--- a/zhtp/src/cli/mod.rs
+++ b/zhtp/src/cli/mod.rs
@@ -117,6 +117,10 @@ pub enum NodeAction {
         /// Maximum headers to store in edge mode (default: 500 = ~100KB)
         #[arg(long, default_value = "500")]
         edge_max_headers: usize,
+        /// Path to identity keystore directory (default: ~/.zhtp/keystore)
+        /// Stores node identity and wallet for persistence across restarts.
+        #[arg(long)]
+        keystore: Option<String>,
     },
     /// Stop the orchestrator node
     Stop,


### PR DESCRIPTION
## Summary
- Add secure identity persistence across node restarts via keystore
- Add `--keystore` CLI flag to `zhtp node start`
- Implement explicit error handling (NotFound vs Corrupt vs PermissionDenied)
- Never silently create new identity on corruption - abort with recovery instructions

## Changes
- `KeystoreError` enum with explicit error types
- Pure `save_to_keystore()` / `load_from_keystore()` helpers
- Modified `handle_startup_wallet_flow()` to load first, save after creation
- 0600 permissions enforced on all keystore files
- Proper `~` expansion via `dirs::home_dir()`

## Keystore Files
```
~/.zhtp/keystore/
├── user_identity.json
├── user_private_key.json (0600)
├── node_identity.json
├── node_private_key.json (0600)
└── wallet_data.json
```

## Usage
```bash
# First run - creates identity interactively
zhtp node start --port 9333 --network testnet

# Subsequent runs - loads existing identity
zhtp node start --port 9333 --network testnet
# Output: ✓ Loaded existing identity from ~/.zhtp/keystore

# Custom keystore location
zhtp node start --keystore ~/my-node-keystore --network testnet
```

## Test plan
- [ ] First run creates identity and saves to keystore
- [ ] Subsequent run loads existing identity
- [ ] Corrupt keystore file aborts with clear error message
- [ ] Missing keystore proceeds to interactive creation
- [ ] `--keystore` flag overrides default path
- [ ] File permissions are 0600 on private key files