### PR TITLE
chore(deploy): Update service to use testnet and persistent identity

### DIFF
--- a/deploy/zhtp.service
+++ b/deploy/zhtp.service
@@ -4,14 +4,13 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/opt/zhtp/zhtp node start
+ExecStart=/opt/zhtp/zhtp node start --network testnet
 WorkingDirectory=/opt/zhtp
 Restart=always
 RestartSec=5
 StandardOutput=journal
 StandardError=journal
 Environment=RUST_LOG=info
-Environment=ZHTP_AUTO_WALLET=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Changes
- Add `--network testnet` flag to ExecStart
- Remove `ZHTP_AUTO_WALLET=1` to enable keystore persistence

## Why
CI deploys this service file, which was overwriting manual changes on the server.