### PR TITLE
fix(identity): Properly load node identity with private key

### DIFF
--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -2233,20 +2233,61 @@ pub async fn create_or_load_node_identity(
 
     let identity_file = keystore_path.join("node_identity.json");
 
-    // Try to load existing identity from keystore
-    if identity_file.exists() {
-        if let Ok(data) = tokio::fs::read_to_string(&identity_file).await {
-            if let Ok(identity) = serde_json::from_str::<lib_identity::ZhtpIdentity>(&data) {
-                info!("✓ Loaded existing node identity from keystore");
-                return Ok(identity);
-            } else {
-                warn!("⚠ Node identity file exists but failed to parse - creating new identity");
+    // Try to load existing identity from keystore (requires private key)
+    let private_key_file = keystore_path.join("node_private_key.json");
+
+    if identity_file.exists() && private_key_file.exists() {
+        if let (Ok(identity_data), Ok(key_data)) = (
+            tokio::fs::read_to_string(&identity_file).await,
+            tokio::fs::read_to_string(&private_key_file).await,
+        ) {
+            // Parse private key
+            if let Ok(key_json) = serde_json::from_str::<serde_json::Value>(&key_data) {
+                if let (Some(dilithium), Some(kyber), Some(seed)) = (
+                    key_json.get("dilithium_sk").and_then(|v| serde_json::from_value::<Vec<u8>>(v.clone()).ok()),
+                    key_json.get("kyber_sk").and_then(|v| serde_json::from_value::<Vec<u8>>(v.clone()).ok()),
+                    key_json.get("master_seed").and_then(|v| serde_json::from_value::<Vec<u8>>(v.clone()).ok()),
+                ) {
+                    let private_key = lib_crypto::PrivateKey {
+                        dilithium_sk: dilithium,
+                        kyber_sk: kyber,
+                        master_seed: seed,
+                    };
+
+                    match lib_identity::ZhtpIdentity::from_serialized(&identity_data, &private_key) {
+                        Ok(identity) => {
+                            info!("✓ Loaded existing node identity from keystore: {}", identity.did);
+                            return Ok(identity);
+                        }
+                        Err(e) => {
+                            // FATAL: Do NOT overwrite - require manual recovery
+                            return Err(anyhow::anyhow!(
+                                "FATAL: Failed to load node identity from keystore: {}\n\
+                                The keystore file may be corrupted. Manual recovery required.",
+                                e
+                            ));
+                        }
+                    }
+                }
             }
+            // Private key parse failed - FATAL
+            return Err(anyhow::anyhow!(
+                "FATAL: Failed to parse node private key from keystore.\n\
+                The keystore may be corrupted. Manual recovery required."
+            ));
         }
     }
 
+    // Only create new identity if keystore doesn't exist at all
+    if identity_file.exists() {
+        return Err(anyhow::anyhow!(
+            "FATAL: Node identity file exists but private key is missing.\n\
+            Cannot load identity without private key. Manual recovery required."
+        ));
+    }
+
     // Create new identity using P1-7 architecture
-    info!("Creating new node identity...");
+    info!("Creating new node identity (no existing keystore found)...");
     let node_identity = lib_identity::ZhtpIdentity::new_unified(
         lib_identity::types::IdentityType::Device,
         None, // No age for device


### PR DESCRIPTION
## Summary
Fix `create_or_load_node_identity()` silently overwriting existing identities.

**Bug**: `serde_json::from_str::<ZhtpIdentity>` fails because ZhtpIdentity requires `from_serialized()` with private key.

**Before**: File exists → parse fails → creates new identity → OVERWRITES  
**After**: File exists → load with private key → if fails → FATAL error (no overwrite)

## Test Plan
- [ ] Existing identity loads successfully
- [ ] Corrupted identity returns FATAL error (no overwrite)
- [ ] Missing keystore creates new identity