### PR TITLE
fix: Blockchain and DHT persistence paths

### DIFF
--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -287,6 +287,7 @@ impl BlockchainComponent {
         blockchain: Arc<RwLock<Option<Blockchain>>>,
         validator_manager_arc: Arc<RwLock<Option<Arc<RwLock<ValidatorManager>>>>>,
         node_identity_arc: Arc<RwLock<Option<IdentityId>>>,
+        env_for_persist: crate::config::Environment,
     ) {
         info!(" Mining loop started - waiting 2 seconds for consensus to wire...");
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -371,9 +372,9 @@ impl BlockchainComponent {
                                     blockchain_guard.increment_persist_counter();
                                     const PERSIST_INTERVAL: u64 = 5; // Save every 5 blocks
                                     if blockchain_guard.should_auto_persist(PERSIST_INTERVAL) {
-                                        // Use development environment path for now
-                                        // TODO: Pass environment from component config
-                                        let persist_path = std::path::Path::new("./data/dev/blockchain.dat");
+                                        // Use environment-specific path
+                                        let persist_path_str = env_for_persist.blockchain_data_path();
+                                        let persist_path = std::path::Path::new(&persist_path_str);
                                         match blockchain_guard.save_to_file(persist_path) {
                                             Ok(()) => {
                                                 blockchain_guard.mark_persisted();
@@ -477,14 +478,15 @@ impl Component for BlockchainComponent {
         // This ensures the mining loop always sees the latest state from Genesis/Sync
         let validator_manager_arc = self.validator_manager.clone();
         let node_identity_arc = self.node_identity.clone();
-        
+        let env_for_persist = self.environment.clone();
+
         // We pass a new empty Arc for the local fallback, effectively disabling it
         // The mining loop prefers the global provider anyway
         let dummy_local_blockchain = Arc::new(RwLock::new(None));
-        
+
         let mining_handle = tokio::spawn(async move {
             info!(" Mining task spawned, starting mining loop...");
-            Self::real_mining_loop(dummy_local_blockchain, validator_manager_arc, node_identity_arc).await;
+            Self::real_mining_loop(dummy_local_blockchain, validator_manager_arc, node_identity_arc, env_for_persist).await;
         });
         
         *self.mining_handle.write().await = Some(mining_handle);
@@ -502,9 +504,10 @@ impl Component for BlockchainComponent {
         // Persist blockchain before shutdown
         if let Ok(shared_blockchain) = crate::runtime::blockchain_provider::get_global_blockchain().await {
             let blockchain_guard = shared_blockchain.read().await;
-            let persist_path = std::path::Path::new("./data/dev/blockchain.dat");
+            let persist_path_str = self.environment.blockchain_data_path();
+            let persist_path = std::path::Path::new(&persist_path_str);
             match blockchain_guard.save_to_file(persist_path) {
-                Ok(()) => info!("💾 Blockchain persisted to disk before shutdown"),
+                Ok(()) => info!("💾 Blockchain persisted to {} before shutdown", persist_path_str),
                 Err(e) => warn!("⚠️ Failed to persist blockchain on shutdown: {}", e),
             }
         }


### PR DESCRIPTION
## Summary
- Blockchain now uses environment-specific path (testnet/dev/mainnet) instead of hardcoded `./data/dev/`
- MeshRouter DHT now loads persisted data from `~/.zhtp/storage/dht_storage.bin` on startup

## Problem
- Blockchain was saving to `./data/dev/blockchain.dat` but loading from `./data/testnet/blockchain.dat` (path mismatch)
- MeshRouter created fresh in-memory DHT instead of loading persisted domains/content

## Result
User data (identities, wallets, domains, websites) now survives node restarts.

## Test plan
- [ ] Create identity via app
- [ ] Restart node
- [ ] Verify identity persists (check `Identities: 2` in logs)
- [ ] Deploy website
- [ ] Restart node
- [ ] Verify website accessible