### PR TITLE
feat(blockchain-sync): Add security improvements from PR #420

### DIFF
--- a/lib-network/src/blockchain_sync/chunk_buffer.rs
+++ b/lib-network/src/blockchain_sync/chunk_buffer.rs
@@ -1,0 +1,143 @@
+//! Blockchain chunk buffer for reassembly
+//!
+//! Buffers received chunks until complete, with timeout and size tracking.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use lib_crypto::PublicKey;
+
+/// Buffer for reassembling blockchain chunks
+#[derive(Debug)]
+pub struct BlockchainChunkBuffer {
+    /// Received chunks indexed by chunk_index
+    pub chunks: HashMap<u32, Vec<u8>>,
+    /// Total expected chunks
+    pub total_chunks: u32,
+    /// Hash of complete data for verification
+    pub complete_data_hash: [u8; 32],
+    /// Original requester for sender validation
+    pub requester: PublicKey,
+    /// When buffer was created (for timeout)
+    pub created_at: Instant,
+    /// Total bytes received so far
+    pub total_bytes: usize,
+}
+
+impl BlockchainChunkBuffer {
+    pub fn new(
+        total_chunks: u32,
+        complete_data_hash: [u8; 32],
+        requester: PublicKey,
+    ) -> Self {
+        Self {
+            chunks: HashMap::new(),
+            total_chunks,
+            complete_data_hash,
+            requester,
+            created_at: Instant::now(),
+            total_bytes: 0,
+        }
+    }
+
+    /// Check if all chunks received
+    pub fn is_complete(&self) -> bool {
+        self.chunks.len() as u32 == self.total_chunks
+    }
+
+    /// Get age of buffer
+    pub fn age(&self) -> Duration {
+        self.created_at.elapsed()
+    }
+
+    /// Add a chunk to the buffer
+    pub fn add_chunk(&mut self, chunk_index: u32, data: Vec<u8>) {
+        self.total_bytes += data.len();
+        self.chunks.insert(chunk_index, data);
+    }
+
+    /// Reassemble chunks in order
+    pub fn reassemble(&self) -> Option<Vec<u8>> {
+        if !self.is_complete() {
+            return None;
+        }
+
+        let mut complete_data = Vec::with_capacity(self.total_bytes);
+        for i in 0..self.total_chunks {
+            if let Some(chunk) = self.chunks.get(&i) {
+                complete_data.extend_from_slice(chunk);
+            } else {
+                return None;
+            }
+        }
+
+        Some(complete_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chunk_buffer_creation() {
+        let buffer = BlockchainChunkBuffer::new(
+            3,
+            [0u8; 32],
+            PublicKey::new(vec![1, 2, 3]),
+        );
+
+        assert_eq!(buffer.total_chunks, 3);
+        assert!(!buffer.is_complete());
+        assert_eq!(buffer.total_bytes, 0);
+    }
+
+    #[test]
+    fn test_chunk_buffer_add_and_complete() {
+        let mut buffer = BlockchainChunkBuffer::new(
+            3,
+            [0u8; 32],
+            PublicKey::new(vec![1, 2, 3]),
+        );
+
+        buffer.add_chunk(0, vec![1, 2, 3]);
+        assert!(!buffer.is_complete());
+
+        buffer.add_chunk(1, vec![4, 5, 6]);
+        assert!(!buffer.is_complete());
+
+        buffer.add_chunk(2, vec![7, 8, 9]);
+        assert!(buffer.is_complete());
+        assert_eq!(buffer.total_bytes, 9);
+    }
+
+    #[test]
+    fn test_chunk_buffer_reassemble() {
+        let mut buffer = BlockchainChunkBuffer::new(
+            3,
+            [0u8; 32],
+            PublicKey::new(vec![1, 2, 3]),
+        );
+
+        buffer.add_chunk(0, vec![1, 2, 3]);
+        buffer.add_chunk(1, vec![4, 5, 6]);
+        buffer.add_chunk(2, vec![7, 8, 9]);
+
+        let data = buffer.reassemble().unwrap();
+        assert_eq!(data, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    #[test]
+    fn test_chunk_buffer_reassemble_incomplete() {
+        let mut buffer = BlockchainChunkBuffer::new(
+            3,
+            [0u8; 32],
+            PublicKey::new(vec![1, 2, 3]),
+        );
+
+        buffer.add_chunk(0, vec![1, 2, 3]);
+        buffer.add_chunk(2, vec![7, 8, 9]);
+        // Missing chunk 1
+
+        assert!(buffer.reassemble().is_none());
+    }
+}

--- a/lib-network/src/blockchain_sync/mod.rs
+++ b/lib-network/src/blockchain_sync/mod.rs
@@ -2,10 +2,19 @@
 //!
 //! Provides peer-to-peer blockchain synchronization using bincode messages
 //! over any mesh protocol (Bluetooth, WiFi Direct, LoRaWAN, etc.)
+//!
+//! # Security Features
+//! - Authenticated peer validation
+//! - Rate limiting per peer (DoS protection)
+//! - Sender/requester validation
+//! - Buffer size limits
+//! - Chunk timeout cleanup
 
 pub mod edge_sync;
 pub mod blockchain_provider;
 pub mod sync_coordinator;
+pub mod chunk_buffer;
+pub mod rate_limiter;
 
 use anyhow::{Result, anyhow};
 use lib_crypto::PublicKey;
@@ -14,18 +23,27 @@ use crate::protocols::NetworkProtocol;
 use sha2::{Sha256, Digest};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
-use tracing::{info, debug};
+use tracing::{info, debug, warn, error};
 
 pub use edge_sync::EdgeNodeSyncManager;
 pub use blockchain_provider::{BlockchainProvider, NullBlockchainProvider};
 pub use sync_coordinator::{SyncCoordinator, PeerSyncState, SyncStats, SyncType};
+pub use chunk_buffer::BlockchainChunkBuffer;
+pub use rate_limiter::ChunkRateLimiter;
 
 /// Chunk sizes based on protocol capabilities
 pub const BLE_CHUNK_SIZE: usize = 200;       // Conservative for BLE GATT (247-byte MTU)
 pub const CLASSIC_CHUNK_SIZE: usize = 1000;  // Bluetooth Classic RFCOMM (larger MTU)
 pub const WIFI_CHUNK_SIZE: usize = 1400;     // WiFi Direct (can handle more)
 pub const DEFAULT_CHUNK_SIZE: usize = 200;   // Safe fallback
+
+/// Security constraints
+pub const MAX_CHUNK_BUFFER_SIZE: usize = 10_000_000;  // 10MB max buffer per request
+pub const MAX_PENDING_REQUESTS: usize = 100;          // Max concurrent sync requests
+pub const CHUNK_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
+pub const MAX_CHUNKS_PER_SECOND: u32 = 100;           // Rate limit per peer
 
 /// Get optimal chunk size for protocol
 pub fn get_chunk_size_for_protocol(protocol: &NetworkProtocol) -> usize {
@@ -38,24 +56,43 @@ pub fn get_chunk_size_for_protocol(protocol: &NetworkProtocol) -> usize {
     }
 }
 
-/// Blockchain sync request/response coordinator
-#[derive(Debug)]
+/// Sync strategy trait for pluggable sync modes (full node vs edge node)
+#[async_trait::async_trait]
+pub trait SyncStrategy: Send + Sync {
+    /// Create a sync request message based on current state
+    async fn create_sync_request(&mut self, requester: PublicKey, request_id: u64, from_height: Option<u64>) -> Result<ZhtpMeshMessage>;
+
+    /// Process sync response data
+    async fn process_sync_response(&mut self, message: &ZhtpMeshMessage) -> Result<()>;
+
+    /// Check if sync is needed
+    async fn should_sync(&self) -> bool;
+
+    /// Get current blockchain height
+    async fn get_current_height(&self) -> u64;
+}
+
+/// Blockchain sync request/response coordinator with security features
 pub struct BlockchainSyncManager {
     /// Pending blockchain requests (request_id -> requester)
     pending_requests: Arc<RwLock<HashMap<u64, PublicKey>>>,
-    /// Received chunks for reassembly (request_id -> chunks)
+    /// Received chunks for reassembly (request_id -> buffer)
     received_chunks: Arc<RwLock<HashMap<u64, BlockchainChunkBuffer>>>,
     /// Next request ID
     next_request_id: Arc<RwLock<u64>>,
+    /// Authenticated peers (peer_key_id -> allowed)
+    authenticated_peers: Arc<RwLock<HashMap<Vec<u8>, bool>>>,
+    /// Rate limiters per peer (peer_key_id -> limiter)
+    chunk_rate_limiters: Arc<RwLock<HashMap<Vec<u8>, ChunkRateLimiter>>>,
 }
 
-/// Buffer for reassembling blockchain chunks
-#[derive(Debug)]
-struct BlockchainChunkBuffer {
-    chunks: HashMap<u32, Vec<u8>>,
-    total_chunks: u32,
-    complete_data_hash: [u8; 32],
-    requester: PublicKey,
+impl std::fmt::Debug for BlockchainSyncManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlockchainSyncManager")
+            .field("pending_requests", &"<locked>")
+            .field("received_chunks", &"<locked>")
+            .finish()
+    }
 }
 
 impl BlockchainSyncManager {
@@ -64,7 +101,23 @@ impl BlockchainSyncManager {
             pending_requests: Arc::new(RwLock::new(HashMap::new())),
             received_chunks: Arc::new(RwLock::new(HashMap::new())),
             next_request_id: Arc::new(RwLock::new(1)),
+            authenticated_peers: Arc::new(RwLock::new(HashMap::new())),
+            chunk_rate_limiters: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Register a peer as authenticated (allowed to send chunks)
+    pub async fn register_authenticated_peer(&self, peer: &PublicKey) {
+        let peer_key_id = peer.key_id.to_vec();
+        self.authenticated_peers.write().await.insert(peer_key_id, true);
+        debug!("Registered authenticated peer for sync");
+    }
+
+    /// Unregister an authenticated peer
+    pub async fn unregister_peer(&self, peer: &PublicKey) {
+        let peer_key_id = peer.key_id.to_vec();
+        self.authenticated_peers.write().await.remove(&peer_key_id);
+        self.chunk_rate_limiters.write().await.remove(&peer_key_id);
     }
 
     /// Create a blockchain request message
@@ -88,7 +141,7 @@ impl BlockchainSyncManager {
             request_type,
         };
 
-        info!(" Created blockchain request (ID: {})", request_id);
+        info!("📤 Created blockchain request (ID: {})", request_id);
         Ok((request_id, message))
     }
 
@@ -126,7 +179,7 @@ impl BlockchainSyncManager {
         let mut complete_data_hash = [0u8; 32];
         complete_data_hash.copy_from_slice(&hash_result);
 
-        info!(" Chunking blockchain data: {} bytes into {} chunks ({} bytes each)", 
+        info!("📦 Chunking blockchain data: {} bytes into {} chunks ({} bytes each)",
             total_size, total_chunks, chunk_size);
 
         let mut messages = Vec::new();
@@ -145,8 +198,114 @@ impl BlockchainSyncManager {
         Ok(messages)
     }
 
-    /// Add received chunk to buffer
+    /// Add received chunk to buffer with security checks
+    ///
+    /// # Security Features
+    /// - Verifies sender is authenticated peer
+    /// - Enforces rate limiting per peer
+    /// - Checks buffer size limits
+    /// - Validates sender matches original requester
+    /// - SHA256 hash verification on complete data
     pub async fn add_chunk(
+        &self,
+        sender: &PublicKey,
+        request_id: u64,
+        chunk_index: u32,
+        total_chunks: u32,
+        data: Vec<u8>,
+        complete_data_hash: [u8; 32],
+    ) -> Result<Option<Vec<u8>>> {
+        let sender_key_id = sender.key_id.to_vec();
+
+        // SECURITY CHECK 1: Verify sender is authenticated
+        {
+            let auth_peers = self.authenticated_peers.read().await;
+            if !auth_peers.get(&sender_key_id).unwrap_or(&false) {
+                error!("🚫 SECURITY: Chunk from unauthenticated peer rejected (request_id: {})", request_id);
+                return Err(anyhow!("Chunk from unauthenticated peer"));
+            }
+        }
+
+        // SECURITY CHECK 2: Rate limiting
+        {
+            let mut rate_limiters = self.chunk_rate_limiters.write().await;
+            let rate_limiter = rate_limiters
+                .entry(sender_key_id.clone())
+                .or_insert_with(ChunkRateLimiter::new);
+
+            if !rate_limiter.check_and_increment(MAX_CHUNKS_PER_SECOND) {
+                warn!("⚠️ SECURITY: Chunk rate limit exceeded for peer (request_id: {})", request_id);
+                return Err(anyhow!("Chunk rate limit exceeded"));
+            }
+        }
+
+        // SECURITY CHECK 3: Verify sender matches original requester
+        {
+            let pending = self.pending_requests.read().await;
+            if let Some(expected_sender) = pending.get(&request_id) {
+                if expected_sender.key_id != sender.key_id {
+                    error!("🚫 SECURITY: Chunk sender doesn't match requester (request_id: {})", request_id);
+                    return Err(anyhow!("Chunk sender mismatch"));
+                }
+            }
+            // Allow chunks for unknown request_id - might be late arrival
+        }
+
+        // SECURITY CHECK 4: Check max pending requests
+        let mut buffers = self.received_chunks.write().await;
+        if buffers.len() >= MAX_PENDING_REQUESTS && !buffers.contains_key(&request_id) {
+            warn!("⚠️ SECURITY: Max pending requests limit reached ({})", MAX_PENDING_REQUESTS);
+            return Err(anyhow!("Max pending requests limit reached"));
+        }
+
+        let buffer = buffers.entry(request_id).or_insert_with(|| {
+            BlockchainChunkBuffer::new(total_chunks, complete_data_hash, sender.clone())
+        });
+
+        // SECURITY CHECK 5: Buffer size limit
+        if buffer.total_bytes + data.len() > MAX_CHUNK_BUFFER_SIZE {
+            error!("🚫 SECURITY: Chunk buffer size limit exceeded ({} bytes)", MAX_CHUNK_BUFFER_SIZE);
+            return Err(anyhow!("Chunk buffer size limit exceeded"));
+        }
+
+        // Add chunk
+        buffer.add_chunk(chunk_index, data);
+        debug!("Added chunk {}/{} for request {}", chunk_index + 1, total_chunks, request_id);
+
+        // Check if all chunks received
+        if buffer.is_complete() {
+            info!("✅ All chunks received for request {}, reassembling...", request_id);
+
+            // Reassemble
+            let complete_data = buffer.reassemble()
+                .ok_or_else(|| anyhow!("Failed to reassemble chunks"))?;
+
+            // Verify hash
+            let mut hasher = Sha256::new();
+            hasher.update(&complete_data);
+            let hash_result = hasher.finalize();
+            let mut computed_hash = [0u8; 32];
+            computed_hash.copy_from_slice(&hash_result);
+
+            if computed_hash != complete_data_hash {
+                error!("🚫 SECURITY: Blockchain data hash mismatch - data corrupted");
+                return Err(anyhow!("Blockchain data hash mismatch - data corrupted"));
+            }
+
+            info!("✅ Blockchain data verified: {} bytes", complete_data.len());
+
+            // Remove from buffers
+            buffers.remove(&request_id);
+
+            return Ok(Some(complete_data));
+        }
+
+        Ok(None)
+    }
+
+    /// Legacy add_chunk without sender validation (for backward compatibility)
+    /// Prefer add_chunk with sender parameter for new code
+    pub async fn add_chunk_legacy(
         &self,
         request_id: u64,
         chunk_index: u32,
@@ -155,35 +314,19 @@ impl BlockchainSyncManager {
         complete_data_hash: [u8; 32],
     ) -> Result<Option<Vec<u8>>> {
         let mut buffers = self.received_chunks.write().await;
-        
+
         let buffer = buffers.entry(request_id).or_insert_with(|| {
-            // Get requester from pending requests
-            let requester = PublicKey::new(vec![0; 32]); // Placeholder
-            BlockchainChunkBuffer {
-                chunks: HashMap::new(),
-                total_chunks,
-                complete_data_hash,
-                requester,
-            }
+            BlockchainChunkBuffer::new(total_chunks, complete_data_hash, PublicKey::new(vec![0; 32]))
         });
 
-        // Add chunk
-        buffer.chunks.insert(chunk_index, data);
+        buffer.add_chunk(chunk_index, data);
         debug!("Added chunk {}/{} for request {}", chunk_index + 1, total_chunks, request_id);
 
-        // Check if all chunks received
-        if buffer.chunks.len() as u32 == total_chunks {
-            info!(" All chunks received for request {}, reassembling...", request_id);
-            
-            // Reassemble in order
-            let mut complete_data = Vec::new();
-            for i in 0..total_chunks {
-                if let Some(chunk) = buffer.chunks.get(&i) {
-                    complete_data.extend_from_slice(chunk);
-                } else {
-                    return Err(anyhow!("Missing chunk {} during reassembly", i));
-                }
-            }
+        if buffer.is_complete() {
+            info!("✅ All chunks received for request {}, reassembling...", request_id);
+
+            let complete_data = buffer.reassemble()
+                .ok_or_else(|| anyhow!("Failed to reassemble chunks"))?;
 
             // Verify hash
             let mut hasher = Sha256::new();
@@ -196,15 +339,29 @@ impl BlockchainSyncManager {
                 return Err(anyhow!("Blockchain data hash mismatch - data corrupted"));
             }
 
-            info!(" Blockchain data verified: {} bytes", complete_data.len());
-            
-            // Remove from buffers
+            info!("✅ Blockchain data verified: {} bytes", complete_data.len());
             buffers.remove(&request_id);
-            
+
             return Ok(Some(complete_data));
         }
 
         Ok(None)
+    }
+
+    /// Cleanup stale chunk buffers (call periodically)
+    pub async fn cleanup_stale_buffers(&self) -> usize {
+        let mut buffers = self.received_chunks.write().await;
+        let initial_count = buffers.len();
+
+        buffers.retain(|_request_id, buffer| {
+            buffer.age() < CHUNK_TIMEOUT
+        });
+
+        let cleaned = initial_count - buffers.len();
+        if cleaned > 0 {
+            info!("🧹 Cleaned up {} stale chunk buffers", cleaned);
+        }
+        cleaned
     }
 
     /// Check if a request is pending
@@ -218,6 +375,22 @@ impl BlockchainSyncManager {
         self.received_chunks.write().await.remove(&request_id);
         info!("Request {} completed and cleaned up", request_id);
     }
+
+    /// Get number of pending requests
+    pub async fn pending_count(&self) -> usize {
+        self.pending_requests.read().await.len()
+    }
+
+    /// Get number of authenticated peers
+    pub async fn authenticated_peer_count(&self) -> usize {
+        self.authenticated_peers.read().await.len()
+    }
+}
+
+impl Default for BlockchainSyncManager {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]
@@ -229,26 +402,25 @@ mod tests {
         let sync_manager = BlockchainSyncManager::new();
         let requester = PublicKey::new(vec![1, 2, 3]);
 
+        // Register peer as authenticated
+        sync_manager.register_authenticated_peer(&requester).await;
+
         // Create request
-        let (request_id, _message) = sync_manager.create_blockchain_request(requester, None).await.unwrap();
+        let (request_id, _message) = sync_manager.create_blockchain_request(requester.clone(), None).await.unwrap();
 
         // Create test data
         let test_data = vec![0u8; 500]; // 500 bytes should create 3 chunks
-        
-        // Create test sender
-        let sender_keypair = lib_crypto::KeyPair::generate().unwrap();
-        let sender_pubkey = sender_keypair.public_key.clone();
-        
+
         // Chunk the data
-        let chunks = BlockchainSyncManager::chunk_blockchain_data(sender_pubkey, request_id, test_data.clone()).unwrap();
-        
+        let chunks = BlockchainSyncManager::chunk_blockchain_data(requester.clone(), request_id, test_data.clone()).unwrap();
+
         assert_eq!(chunks.len(), 3); // 500 bytes / 200 = 3 chunks
 
         // Simulate receiving chunks
         for message in chunks {
             if let ZhtpMeshMessage::BlockchainData { sender: _, request_id, chunk_index, total_chunks, data, complete_data_hash } = message {
-                let result = sync_manager.add_chunk(request_id, chunk_index, total_chunks, data, complete_data_hash).await.unwrap();
-                
+                let result = sync_manager.add_chunk(&requester, request_id, chunk_index, total_chunks, data, complete_data_hash).await.unwrap();
+
                 // Last chunk should return complete data
                 if chunk_index == total_chunks - 1 {
                     assert!(result.is_some());
@@ -257,5 +429,83 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_unauthenticated_peer_rejected() {
+        let sync_manager = BlockchainSyncManager::new();
+        let requester = PublicKey::new(vec![1, 2, 3]);
+
+        // Create request but DON'T register peer
+        let (request_id, _message) = sync_manager.create_blockchain_request(requester.clone(), None).await.unwrap();
+
+        let test_data = vec![0u8; 100];
+        let chunks = BlockchainSyncManager::chunk_blockchain_data(requester.clone(), request_id, test_data).unwrap();
+
+        if let ZhtpMeshMessage::BlockchainData { sender: _, request_id, chunk_index, total_chunks, data, complete_data_hash } = &chunks[0] {
+            let result = sync_manager.add_chunk(&requester, *request_id, *chunk_index, *total_chunks, data.clone(), *complete_data_hash).await;
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("unauthenticated"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiting() {
+        let sync_manager = BlockchainSyncManager::new();
+        let requester = PublicKey::new(vec![1, 2, 3]);
+
+        sync_manager.register_authenticated_peer(&requester).await;
+        let (request_id, _message) = sync_manager.create_blockchain_request(requester.clone(), None).await.unwrap();
+
+        // Try to send more than MAX_CHUNKS_PER_SECOND chunks
+        for i in 0..(MAX_CHUNKS_PER_SECOND + 10) {
+            let test_data = vec![i as u8; 10];
+            let mut hasher = Sha256::new();
+            hasher.update(&test_data);
+            let hash_result = hasher.finalize();
+            let mut complete_data_hash = [0u8; 32];
+            complete_data_hash.copy_from_slice(&hash_result);
+
+            let result = sync_manager.add_chunk(
+                &requester,
+                request_id,
+                i,
+                MAX_CHUNKS_PER_SECOND + 10,
+                test_data,
+                complete_data_hash
+            ).await;
+
+            if i >= MAX_CHUNKS_PER_SECOND {
+                assert!(result.is_err(), "Expected rate limit error at chunk {}", i);
+                assert!(result.unwrap_err().to_string().contains("rate limit"));
+                break;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_buffer_size_limit() {
+        let sync_manager = BlockchainSyncManager::new();
+        let requester = PublicKey::new(vec![1, 2, 3]);
+
+        sync_manager.register_authenticated_peer(&requester).await;
+        let (request_id, _message) = sync_manager.create_blockchain_request(requester.clone(), None).await.unwrap();
+
+        // Try to send chunks that exceed MAX_CHUNK_BUFFER_SIZE
+        let large_chunk = vec![0u8; MAX_CHUNK_BUFFER_SIZE / 2 + 1];
+        let mut hasher = Sha256::new();
+        hasher.update(&large_chunk);
+        let hash_result = hasher.finalize();
+        let mut complete_data_hash = [0u8; 32];
+        complete_data_hash.copy_from_slice(&hash_result);
+
+        // First chunk should succeed
+        let result1 = sync_manager.add_chunk(&requester, request_id, 0, 3, large_chunk.clone(), complete_data_hash).await;
+        assert!(result1.is_ok());
+
+        // Second chunk should exceed buffer limit
+        let result2 = sync_manager.add_chunk(&requester, request_id, 1, 3, large_chunk, complete_data_hash).await;
+        assert!(result2.is_err());
+        assert!(result2.unwrap_err().to_string().contains("buffer size limit"));
     }
 }

--- a/lib-network/src/blockchain_sync/rate_limiter.rs
+++ b/lib-network/src/blockchain_sync/rate_limiter.rs
@@ -1,0 +1,87 @@
+//! Rate limiting for chunk reception per peer
+//!
+//! Prevents DoS attacks by limiting the number of chunks a peer can send per second.
+
+use std::time::{Duration, Instant};
+
+/// Rate limiter for chunk reception per peer
+#[derive(Debug)]
+pub struct ChunkRateLimiter {
+    chunks_received: u32,
+    window_start: Instant,
+}
+
+impl ChunkRateLimiter {
+    pub fn new() -> Self {
+        Self {
+            chunks_received: 0,
+            window_start: Instant::now(),
+        }
+    }
+
+    /// Check if chunk is allowed and increment counter
+    /// Returns false if rate limit exceeded
+    pub fn check_and_increment(&mut self, max_per_second: u32) -> bool {
+        let elapsed = self.window_start.elapsed();
+
+        // Reset window every second
+        if elapsed >= Duration::from_secs(1) {
+            self.chunks_received = 0;
+            self.window_start = Instant::now();
+        }
+
+        if self.chunks_received >= max_per_second {
+            return false;
+        }
+
+        self.chunks_received += 1;
+        true
+    }
+}
+
+impl Default for ChunkRateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rate_limiter_allows_within_limit() {
+        let mut limiter = ChunkRateLimiter::new();
+
+        for _ in 0..10 {
+            assert!(limiter.check_and_increment(10));
+        }
+    }
+
+    #[test]
+    fn test_rate_limiter_blocks_over_limit() {
+        let mut limiter = ChunkRateLimiter::new();
+
+        for _ in 0..10 {
+            assert!(limiter.check_and_increment(10));
+        }
+
+        assert!(!limiter.check_and_increment(10));
+    }
+
+    #[test]
+    fn test_rate_limiter_resets_after_window() {
+        let mut limiter = ChunkRateLimiter::new();
+
+        for _ in 0..5 {
+            assert!(limiter.check_and_increment(5));
+        }
+
+        assert!(!limiter.check_and_increment(5));
+
+        // Wait for window to expire
+        std::thread::sleep(Duration::from_millis(1100));
+
+        assert!(limiter.check_and_increment(5));
+    }
+}

--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -827,18 +827,18 @@ impl MeshMessageHandler {
     /// Handle incoming blockchain data chunks
     pub async fn handle_blockchain_data(
         &self,
-        _sender: &PublicKey,
+        sender: &PublicKey,
         request_id: u64,
         chunk_index: u32,
         total_chunks: u32,
         data: Vec<u8>,
         complete_data_hash: [u8; 32],
     ) -> Result<()> {
-        info!(" Blockchain data chunk {}/{} received ({} bytes, request_id: {})", 
+        info!(" Blockchain data chunk {}/{} received ({} bytes, request_id: {})",
               chunk_index + 1, total_chunks, data.len(), request_id);
-        
+
         // Add chunk to sync manager for reassembly
-        match self.sync_manager.add_chunk(request_id, chunk_index, total_chunks, data, complete_data_hash).await {
+        match self.sync_manager.add_chunk(sender, request_id, chunk_index, total_chunks, data, complete_data_hash).await {
             Ok(Some(complete_data)) => {
                 info!(" All blockchain chunks received and verified! Total: {} bytes", complete_data.len());
                 info!("   Hash: {}", hex::encode(complete_data_hash));


### PR DESCRIPTION
## Summary
Extracts useful security improvements from PR #420 without the regressions.

### Changes
- **rate_limiter.rs** - Per-peer rate limiting to prevent DoS attacks (100 chunks/second)
- **chunk_buffer.rs** - Better buffer struct with `created_at`, `total_bytes`, `age()` for timeout tracking
- **Security checks in add_chunk()**:
  1. Authenticated peer validation
  2. Rate limiting per peer
  3. Sender/requester match verification
  4. Max pending requests limit (100)
  5. Buffer size limit (10MB)
- **SyncStrategy trait** - Clean abstraction for full vs edge node sync
- **cleanup_stale_buffers()** - Timeout-based buffer cleanup (5 min)

### Test plan
- [x] All blockchain_sync tests pass (17 passed, 3 ignored)
- [x] Rate limiter tests verify allow/block/reset behavior
- [x] Chunk buffer tests verify creation, add, reassembly
- [x] Security check tests verify unauthenticated rejection, rate limiting, buffer size limits

## Related
- Extracts useful code from PR #420