### PR TITLE
feat: add manual workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [development, main]
   pull_request:
     branches: [development, main]
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Deploy after build'
+        required: false
+        default: 'true'
+        type: boolean
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to CI workflow
- Enables manual triggering from GitHub UI or CLI
- Includes optional `deploy` input parameter

## Usage
After merge:
- **UI**: Actions → CI → "Run workflow" button
- **CLI**: `gh workflow run ci.yml --ref development`