### PR TITLE
159 arch d 25 implement protocol trait for all 6 protocols

### DIFF
--- a/lib-network/src/protocols/mod.rs
+++ b/lib-network/src/protocols/mod.rs
@@ -1363,6 +1363,61 @@ pub trait Protocol: Send + Sync {
 }
 
 // ============================================================================
+// Protocol Helper Functions (DRY utilities to reduce duplication)
+// ============================================================================
+
+/// Derive a MAC key for session validation using SHA256
+/// 
+/// This function provides a standardized way to derive MAC keys across all protocols,
+/// reducing code duplication.
+pub fn derive_protocol_mac_key(protocol_name: &str, node_id: &[u8]) -> [u8; 32] {
+    use sha2::{Sha256, Digest};
+    let mut hasher = Sha256::new();
+    hasher.update(protocol_name.as_bytes());
+    hasher.update(b"_SESSION_MAC");
+    hasher.update(node_id);
+    let result = hasher.finalize();
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&result);
+    key
+}
+
+/// Derive a session encryption key using SHA256
+///
+/// This function provides a standardized way to derive session keys across all protocols,
+/// reducing code duplication.
+pub fn derive_protocol_session_key(protocol_name: &str, node_id: &[u8], peer_id: &[u8]) -> [u8; 32] {
+    use sha2::{Sha256, Digest};
+    let mut hasher = Sha256::new();
+    hasher.update(protocol_name.as_bytes());
+    hasher.update(b"_SESSION_KEY");
+    hasher.update(node_id);
+    hasher.update(peer_id);
+    let result = hasher.finalize();
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&result);
+    key
+}
+
+/// Derive a rekeyed session key using SHA256 with message count
+///
+/// This function provides a standardized way to derive rekey keys across all protocols,
+/// reducing code duplication.
+pub fn derive_protocol_rekey(protocol_name: &str, node_id: &[u8], peer_id: &[u8], message_count: u64) -> [u8; 32] {
+    use sha2::{Sha256, Digest};
+    let mut hasher = Sha256::new();
+    hasher.update(protocol_name.as_bytes());
+    hasher.update(b"_REKEY");
+    hasher.update(node_id);
+    hasher.update(peer_id);
+    hasher.update(&message_count.to_le_bytes());
+    let result = hasher.finalize();
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&result);
+    key
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 

--- a/lib-network/src/protocols/wifi_direct.rs
+++ b/lib-network/src/protocols/wifi_direct.rs
@@ -3538,29 +3538,14 @@ const WIFI_DIRECT_LATENCY_MS: u32 = 10;
 const WIFI_DIRECT_RANGE_METERS: u32 = 200;
 
 impl WiFiDirectMeshProtocol {
-    /// MAC key for session validation (derived from node_id)
+    /// MAC key for session validation (uses shared helper)
     fn get_mac_key(&self) -> [u8; 32] {
-        use sha2::{Sha256, Digest};
-        let mut hasher = Sha256::new();
-        hasher.update(b"WIFI_DIRECT_SESSION_MAC");
-        hasher.update(&self.node_id);
-        let result = hasher.finalize();
-        let mut key = [0u8; 32];
-        key.copy_from_slice(&result);
-        key
+        super::derive_protocol_mac_key("WIFI_DIRECT", &self.node_id)
     }
 
-    /// Derive session encryption key from peer MAC and node_id
+    /// Derive session encryption key (uses shared helper)
     fn derive_session_key(&self, peer_mac: &str) -> [u8; 32] {
-        use sha2::{Sha256, Digest};
-        let mut hasher = Sha256::new();
-        hasher.update(b"WIFI_DIRECT_SESSION_KEY");
-        hasher.update(&self.node_id);
-        hasher.update(peer_mac.as_bytes());
-        let result = hasher.finalize();
-        let mut key = [0u8; 32];
-        key.copy_from_slice(&result);
-        key
+        super::derive_protocol_session_key("WIFI_DIRECT", &self.node_id, peer_mac.as_bytes())
     }
 }
 
@@ -3660,19 +3645,13 @@ impl Protocol for WiFiDirectMeshProtocol {
             _ => return Err(anyhow!("Invalid peer address type")),
         };
 
-        // Functional Core: Generate new session key with ratcheting
-        let new_key = {
-            use sha2::{Sha256, Digest};
-            let mut hasher = Sha256::new();
-            hasher.update(b"WIFI_DIRECT_REKEY");
-            hasher.update(&self.node_id);
-            hasher.update(peer_mac.as_bytes());
-            hasher.update(&session.lifecycle().message_count().to_le_bytes());
-            let result = hasher.finalize();
-            let mut key = [0u8; 32];
-            key.copy_from_slice(&result);
-            key
-        };
+        // Functional Core: Generate new session key with ratcheting (uses shared helper)
+        let new_key = super::derive_protocol_rekey(
+            "WIFI_DIRECT",
+            &self.node_id,
+            peer_mac.as_bytes(),
+            session.lifecycle().message_count()
+        );
 
         // Imperative Shell: Update session state
         session.session_keys_mut().set_encryption_key(new_key)?;


### PR DESCRIPTION
"feat(network): Add production-ready is_available() and comprehensive Protocol trait tests

Production-ready is_available() implementations:
- Bluetooth: Check platform-specific hardware state (Windows BLE advertiser/GATT, macOS CoreBluetooth, Linux BlueZ)
- QUIC: Check if endpoint is not closed
- WiFi Direct: Check enabled state via Arc<RwLock<bool>>
- LoRaWAN: Check for SPI/UART device paths on Linux
- Satellite: Validate terminal_id initialization

Comprehensive test coverage for all 6 protocols:
- test_*_protocol_capabilities: Verify MTU, throughput, latency, power profile
- test_*_protocol_type: Verify correct NetworkProtocol enum
- test_*_is_available: Verify availability checks work correctly
- test_*_connect_creates_session: Verify session creation
- test_*_session_validation: Verify session validation succeeds
- test_*_key_derivation: Verify unique keys per node_id
- test_*_fragmentation (BLE/LoRa): Verify fragmentation logic

All tests verify:
- Security properties (replay protection, identity binding, encryption)
- Functional Core/Imperative Shell compliance
- No hardcoded keys (all derived from node_id)

Total: 36 new tests covering all Protocol trait functionality"