### PR TITLE
fix: Add 'quic' to all node configuration protocol lists

### DIFF
--- a/zhtp/configs/dev-node.toml
+++ b/zhtp/configs/dev-node.toml
@@ -39,7 +39,7 @@ pricing_tier = "hot"
 [network_config]
 mesh_port = 33444
 max_peers = 20  # Small network for development
-protocols = ["tcp"]  # TCP only for simplicity
+protocols = ["tcp", "quic"]  # TCP and QUIC (required for mesh mode)
 bootstrap_peers = ["127.0.0.1:9333"]  # Localhost bootstrap
 long_range_relays = false
 

--- a/zhtp/configs/edge-node.toml
+++ b/zhtp/configs/edge-node.toml
@@ -44,7 +44,7 @@ pricing_tier = "warm"
 [network_config]
 mesh_port = 33444
 max_peers = 50  # Optimized for mesh routing
-protocols = ["bluetooth_le", "wifi_direct", "lorawan"]  # BLE only (not classic) - Pure mesh
+protocols = ["bluetooth_le", "wifi_direct", "lorawan", "quic"]  # BLE only (not classic) - Pure mesh with QUIC required
 bootstrap_peers = []  # Mesh discovery only
 long_range_relays = true  # CRITICAL for pure mesh mode
 

--- a/zhtp/configs/full-node.toml
+++ b/zhtp/configs/full-node.toml
@@ -44,7 +44,7 @@ pricing_tier = "hot"
 [network_config]
 mesh_port = 33444
 max_peers = 150  # Higher peer count for full nodes
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = ["100.94.204.6:9333", "bootstrap.sovereign.net:9333"]
 long_range_relays = false
 

--- a/zhtp/configs/mainnet-edge-node.toml
+++ b/zhtp/configs/mainnet-edge-node.toml
@@ -39,7 +39,7 @@ pricing_tier = "archive"  # Cheapest tier
 [network_config]
 mesh_port = 33446  # Mainnet mesh port
 max_peers = 30    # Low peer count for edge devices
-protocols = ["bluetooth", "wifi_direct"]  # Mesh protocols only
+protocols = ["bluetooth", "wifi_direct", "quic"]  # Mesh protocols with required QUIC
 bootstrap_peers = [
     "mainnet-seed1.sovereign.net:9333",
     "mainnet-seed2.sovereign.net:9333"

--- a/zhtp/configs/mainnet-full-node.toml
+++ b/zhtp/configs/mainnet-full-node.toml
@@ -62,7 +62,7 @@ pricing_tier = "warm"        # Balanced storage tier
 [network_config]
 mesh_port = 33444            # Standard mainnet mesh port
 max_peers = 200              # High peer count for production
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = [
     "mainnet-seed1.sovereign.net:9333",
     "mainnet-seed2.sovereign.net:9333",

--- a/zhtp/configs/mainnet-storage-node.toml
+++ b/zhtp/configs/mainnet-storage-node.toml
@@ -39,7 +39,7 @@ pricing_tier = "cold"  # Cost-effective storage
 [network_config]
 mesh_port = 33446  # Mainnet mesh port
 max_peers = 150
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = [
     "mainnet-seed1.sovereign.net:9333",
     "mainnet-seed2.sovereign.net:9333"

--- a/zhtp/configs/mainnet-validator-node.toml
+++ b/zhtp/configs/mainnet-validator-node.toml
@@ -39,7 +39,7 @@ pricing_tier = "hot"  # Fast storage for validators
 [network_config]
 mesh_port = 33446  # Mainnet mesh port
 max_peers = 200    # Higher peer count for mainnet
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = [
     "mainnet-seed1.sovereign.net:9333",
     "mainnet-seed2.sovereign.net:9333"

--- a/zhtp/configs/storage-node.toml
+++ b/zhtp/configs/storage-node.toml
@@ -44,7 +44,7 @@ pricing_tier = "cold"  # Optimized for bulk storage
 [network_config]
 mesh_port = 33444
 max_peers = 100  # Moderate peer count, focus on storage
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = ["100.94.204.6:9333", "storage.sovereign.net:9333"]
 long_range_relays = false
 

--- a/zhtp/configs/test-node1.toml
+++ b/zhtp/configs/test-node1.toml
@@ -37,7 +37,7 @@ pricing_tier = "hot"
 [network_config]
 mesh_port = 9334
 max_peers = 50
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = ["127.0.0.1:9335", "localhost:9335"]  # Node 2 on same machine
 long_range_relays = false
 

--- a/zhtp/configs/test-node2.toml
+++ b/zhtp/configs/test-node2.toml
@@ -37,7 +37,7 @@ pricing_tier = "hot"
 [network_config]
 mesh_port = 9002
 max_peers = 50
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = ["127.0.0.1:9001", "localhost:9001"]  # Node 1 on same machine
 long_range_relays = false
 

--- a/zhtp/configs/test-node3.toml
+++ b/zhtp/configs/test-node3.toml
@@ -37,7 +37,7 @@ pricing_tier = "hot"
 [network_config]
 mesh_port = 9003
 max_peers = 50
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = ["127.0.0.1:9001"]  # Connect to Node 1
 long_range_relays = false
 

--- a/zhtp/configs/test-node4.toml
+++ b/zhtp/configs/test-node4.toml
@@ -37,7 +37,7 @@ pricing_tier = "hot"
 [network_config]
 mesh_port = 9004
 max_peers = 50
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = ["127.0.0.1:9001"]  # Connect to Node 1
 long_range_relays = false
 

--- a/zhtp/configs/testnet-edge-node.toml
+++ b/zhtp/configs/testnet-edge-node.toml
@@ -39,7 +39,7 @@ pricing_tier = "archive"  # Cheapest tier
 [network_config]
 mesh_port = 33445  # Testnet mesh port
 max_peers = 20    # Low peer count for edge devices
-protocols = ["bluetooth", "wifi_direct"]  # Mesh protocols only
+protocols = ["bluetooth", "wifi_direct", "quic"]  # Mesh protocols with required QUIC
 bootstrap_peers = [
     "testnet-seed1.sovereign.net:9334",
     "testnet-seed2.sovereign.net:9334"

--- a/zhtp/configs/testnet-full-node.toml
+++ b/zhtp/configs/testnet-full-node.toml
@@ -62,7 +62,7 @@ pricing_tier = "cold"       # Low-cost storage for testing
 [network_config]
 mesh_port = 33445           # Testnet mesh port (different from mainnet)
 max_peers = 100             # Moderate peer count for testing
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = [
     "testnet-seed1.sovereign.net:9334",
     "testnet-seed2.sovereign.net:9334",

--- a/zhtp/configs/testnet-storage-node.toml
+++ b/zhtp/configs/testnet-storage-node.toml
@@ -39,7 +39,7 @@ pricing_tier = "cold"  # Low-cost storage for testing
 [network_config]
 mesh_port = 33445  # Testnet mesh port
 max_peers = 80
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = [
     "testnet-seed1.sovereign.net:9334",
     "testnet-seed2.sovereign.net:9334"

--- a/zhtp/configs/testnet-validator-node.toml
+++ b/zhtp/configs/testnet-validator-node.toml
@@ -39,7 +39,7 @@ pricing_tier = "warm"
 [network_config]
 mesh_port = 33445  # Testnet mesh port
 max_peers = 100    # Moderate peer count for testnet
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = [
     "testnet-seed1.sovereign.net:9334",
     "testnet-seed2.sovereign.net:9334"

--- a/zhtp/configs/validator-node.toml
+++ b/zhtp/configs/validator-node.toml
@@ -39,7 +39,7 @@ pricing_tier = "hot"  # High performance storage
 [network_config]
 mesh_port = 33444
 max_peers = 200  # Higher peer count for validators
-protocols = ["tcp", "bluetooth", "wifi_direct"]
+protocols = ["tcp", "quic", "bluetooth", "wifi_direct"]
 bootstrap_peers = ["100.94.204.6:9333", "bootstrap.sovereign.net:9333", "validator.sovereign.net:9333"]
 long_range_relays = true  # Validators may need relay access
 

--- a/zhtp/src/config/aggregation.rs
+++ b/zhtp/src/config/aggregation.rs
@@ -396,6 +396,7 @@ impl Default for NodeConfig {
                     "bluetooth".to_string(),
                     "wifi_direct".to_string(),
                     "lorawan".to_string(),
+                    "quic".to_string(),
                     "tcp".to_string()
                 ],
                 bootstrap_peers: vec![


### PR DESCRIPTION
## Summary
Fixes the "mesh mode validation failed: QUIC is required for all mesh modules" error that prevents nodes from starting.

The recent QUIC-only architecture changes enforce QUIC as a mandatory protocol for all mesh modes (PureMesh and Hybrid). Configuration files were missing `"quic"` in their `protocols` lists, causing validation to fail.

## Changes
- Added `"quic"` to the `protocols` configuration in:
  - Default config in `aggregation.rs`
  - All node configuration files (17 TOML files):
    - Production nodes (mainnet variants)
    - Development and testing nodes
    - Generic node templates (full, storage, validator, edge)

## Root Cause
The validation chain at `zhtp/src/config/validation.rs:158` calls `MeshMode::validate_capabilities()` which checks if `"quic"` exists in the protocols list. If missing, it returns the error: "QUIC is required for all mesh modes".

## Testing
- [x] Code builds successfully with no errors
- [x] Validation logic confirmed to work with updated configs
- [x] All 18 files updated consistently

## Related Issues
- Fixes #562: "Node fails to start: mesh mode validation failed - QUIC is required for all mesh modules"
- Related to QUIC-only architecture refactor (PR #549) and NodeRuntime trait integration

## Files Changed
- 1 source file: `zhtp/src/config/aggregation.rs`
- 17 config files in `zhtp/configs/`