### PR TITLE
ci: Skip macOS build on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
   macos:
     name: Build/Test (macOS)
     runs-on: macos-14
+    if: github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Optimize CI by skipping macOS builds on PR events. The macOS job now only runs on pushes to development/main branches, providing faster feedback on PRs while ensuring macOS compatibility is tested before merging.