### PR TITLE
fix(bluetooth): Remove duplicate BLE_MESH_SERVICE_UUID import

### DIFF
--- a/lib-network/src/protocols/bluetooth/discovery.rs
+++ b/lib-network/src/protocols/bluetooth/discovery.rs
@@ -12,7 +12,6 @@ use super::BluetoothMeshProtocol;
 use super::device;
 
 use sha2::{Digest, Sha256};
-use crate::constants::BLE_MESH_SERVICE_UUID;
 
 #[cfg(target_os = "macos")]
 use super::macos_core::CoreBluetoothManager;


### PR DESCRIPTION
## Summary
- Remove duplicate import of `BLE_MESH_SERVICE_UUID` that was causing E0252 compilation error
- Resolves the redefinition of the same constant in the imports section

## Test plan
- [x] Code compiles without E0252 error
- [x] No functional changes to the logic