### PR TITLE
fix: rename _request to request in check_https function

### DIFF
--- a/zhtp/src/api/handlers/identity/login_handlers.rs
+++ b/zhtp/src/api/handlers/identity/login_handlers.rs
@@ -204,7 +204,7 @@ fn extract_user_agent(request: &lib_protocols::types::ZhtpRequest) -> String {
 }
 
 /// Check HTTPS enforcement for production (P0-5)
-fn check_https(_request: &lib_protocols::types::ZhtpRequest) -> Result<(), ZhtpResponse> {
+fn check_https(request: &lib_protocols::types::ZhtpRequest) -> Result<(), ZhtpResponse> {
     // Only enforce HTTPS in production (non-debug builds)
     #[cfg(not(debug_assertions))]
     {


### PR DESCRIPTION
## Summary
- Fixed compilation error in `check_https` function where parameter was named `_request` but used as `request` inside the conditional block

## Test plan
- [x] `cargo check -p zhtp` passes