### PR TITLE
Add DAORegistry contract (SOV-P0-2.3)

### DIFF
--- a/lib-blockchain/src/contracts/dao_registry/core.rs
+++ b/lib-blockchain/src/contracts/dao_registry/core.rs
@@ -1,0 +1,127 @@
+use crate::contracts::utils::id_generation;
+use crate::contracts::integration::ContractEvent;
+use crate::contracts::dao_registry::types::*;
+use crate::integration::crypto_integration::PublicKey;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// DAO Registry contract
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DAORegistry {
+    /// Map from dao_id -> DAOEntry
+    pub registry: HashMap<[u8; 32], DAOEntry>,
+    /// Index from token_addr -> dao_id for fast lookup
+    pub token_index: HashMap<[u8; 32], [u8; 32]>,
+}
+
+impl DAORegistry {
+    /// Create empty registry
+    pub fn new() -> Self {
+        Self {
+            registry: HashMap::new(),
+            token_index: HashMap::new(),
+        }
+    }
+
+    /// Register a new DAO
+    /// Returns (dao_id, ContractEvent::DaoRegistered)
+    pub fn register_dao(
+        &mut self,
+        token_addr: [u8; 32],
+        class: String,
+        metadata_hash: Option<[u8; 32]>,
+        treasury: PublicKey,
+        owner: PublicKey,
+    ) -> Result<([u8; 32], ContractEvent), String> {
+        if self.token_index.contains_key(&token_addr) {
+            return Err("DAO for token already registered".to_string());
+        }
+
+        // Generate unique DAO id using token_addr + owner + timestamp
+        let timestamp = crate::utils::time::current_timestamp();
+        let dao_id = id_generation::generate_contract_id(&[
+            &token_addr,
+            &owner.as_bytes(),
+            &timestamp.to_le_bytes(),
+        ]);
+
+        let entry = DAOEntry {
+            dao_id,
+            token_addr,
+            class: class.clone(),
+            metadata_hash,
+            treasury: treasury.clone(),
+            owner: owner.clone(),
+            created_at: timestamp,
+        };
+
+        self.registry.insert(dao_id, entry);
+        self.token_index.insert(token_addr, dao_id);
+
+        let event = ContractEvent::DaoRegistered {
+            dao_id,
+            token_addr,
+            owner: owner.clone(),
+            treasury,
+            class,
+            metadata_hash,
+        };
+
+        Ok((dao_id, event))
+    }
+
+    /// Lookup a DAO by token address
+    pub fn get_dao(&self, token_addr: [u8; 32]) -> Result<DAOMetadata, String> {
+        match self.token_index.get(&token_addr) {
+            Some(dao_id) => match self.registry.get(dao_id) {
+                Some(entry) => Ok(DAOMetadata {
+                    dao_id: entry.dao_id,
+                    token_addr: entry.token_addr,
+                    class: entry.class.clone(),
+                    metadata_hash: entry.metadata_hash,
+                    treasury: entry.treasury.clone(),
+                    owner: entry.owner.clone(),
+                    created_at: entry.created_at,
+                }),
+                None => Err("DAO entry not found for id".to_string()),
+            },
+            None => Err("DAO not found for token address".to_string()),
+        }
+    }
+
+    /// List all DAOs sorted by creation date ascending
+    /// Note: Pagination not implemented yet; consider adding (cursor, limit) later
+    pub fn list_daos(&self) -> Vec<DAOEntry> {
+        let mut all: Vec<DAOEntry> = self.registry.values().cloned().collect();
+        all.sort_by_key(|e| e.created_at);
+        all
+    }
+
+    /// Update metadata hash for a DAO. Only owner can update metadata.
+    /// Returns ContractEvent::DaoUpdated on success
+    pub fn update_metadata(
+        &mut self,
+        dao_id: [u8; 32],
+        updater: PublicKey,
+        metadata_hash: Option<[u8; 32]>,
+    ) -> Result<ContractEvent, String> {
+        let entry = self
+            .registry
+            .get_mut(&dao_id)
+            .ok_or_else(|| "DAO not found".to_string())?;
+
+        if entry.owner != updater {
+            return Err("Only DAO owner can update metadata".to_string());
+        }
+
+        entry.metadata_hash = metadata_hash;
+
+        let event = ContractEvent::DaoUpdated {
+            dao_id,
+            updater,
+            metadata_hash,
+        };
+
+        Ok(event)
+    }
+}

--- a/lib-blockchain/src/contracts/dao_registry/mod.rs
+++ b/lib-blockchain/src/contracts/dao_registry/mod.rs
@@ -1,0 +1,5 @@
+pub mod core;
+pub mod types;
+
+pub use core::DAORegistry;
+pub use types::{DAOEntry, DAOMetadata};

--- a/lib-blockchain/src/contracts/dao_registry/tests.rs
+++ b/lib-blockchain/src/contracts/dao_registry/tests.rs
@@ -1,0 +1,65 @@
+use super::*;
+use crate::integration::crypto_integration::PublicKey;
+use crate::contracts::dao_registry::DAORegistry;
+
+fn test_public_key(id: u8) -> PublicKey {
+    PublicKey::new(vec![id; 32])
+}
+
+#[test]
+fn test_register_and_get_dao() {
+    let mut reg = DAORegistry::new();
+    let token = [1u8; 32];
+    let owner = test_public_key(1);
+    let treasury = test_public_key(2);
+
+    let (dao_id, event) = reg
+        .register_dao(token, "NP".to_string(), None, treasury.clone(), owner.clone())
+        .expect("should register");
+
+    assert_eq!(event.event_type(), "DaoRegistered");
+
+    let meta = reg.get_dao(token).expect("should find dao");
+    assert_eq!(meta.dao_id, dao_id);
+    assert_eq!(meta.owner, owner);
+}
+
+#[test]
+fn test_list_daos_sorted() {
+    let mut reg = DAORegistry::new();
+    let t1 = [1u8; 32];
+    let t2 = [2u8; 32];
+    let owner = test_public_key(1);
+    let treasury = test_public_key(2);
+
+    let _ = reg.register_dao(t2, "NP".to_string(), None, treasury.clone(), owner.clone());
+    std::thread::sleep(std::time::Duration::from_millis(5));
+    let _ = reg.register_dao(t1, "NP".to_string(), None, treasury.clone(), owner.clone());
+
+    let list = reg.list_daos();
+    assert!(list.len() >= 2);
+    assert!(list[0].created_at <= list[1].created_at);
+}
+
+#[test]
+fn test_update_metadata_access_control() {
+    let mut reg = DAORegistry::new();
+    let token = [3u8; 32];
+    let owner = test_public_key(1);
+    let other = test_public_key(9);
+    let treasury = test_public_key(2);
+
+    let (dao_id, _) = reg
+        .register_dao(token, "NP".to_string(), None, treasury.clone(), owner.clone())
+        .expect("register");
+
+    // Unauthorized update
+    let res = reg.update_metadata(dao_id, other.clone(), Some([9u8; 32]));
+    assert!(res.is_err());
+
+    // Authorized update
+    let res = reg.update_metadata(dao_id, owner.clone(), Some([7u8; 32]));
+    assert!(res.is_ok());
+    let event = res.unwrap();
+    assert_eq!(event.event_type(), "DaoUpdated");
+}

--- a/lib-blockchain/src/contracts/dao_registry/types.rs
+++ b/lib-blockchain/src/contracts/dao_registry/types.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+use crate::integration::crypto_integration::PublicKey;
+
+/// DAO entry stored in the registry
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DAOEntry {
+    pub dao_id: [u8; 32],
+    pub token_addr: [u8; 32],
+    pub class: String,
+    pub metadata_hash: Option<[u8; 32]>,
+    pub treasury: PublicKey,
+    pub owner: PublicKey,
+    pub created_at: u64,
+}
+
+/// Metadata view returned by queries
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DAOMetadata {
+    pub dao_id: [u8; 32],
+    pub token_addr: [u8; 32],
+    pub class: String,
+    pub metadata_hash: Option<[u8; 32]>,
+    pub treasury: PublicKey,
+    pub owner: PublicKey,
+    pub created_at: u64,
+}

--- a/lib-blockchain/src/contracts/mod.rs
+++ b/lib-blockchain/src/contracts/mod.rs
@@ -29,6 +29,8 @@ pub mod emergency_reserve;
 #[cfg(feature = "contracts")]
 pub mod sov_swap;
 #[cfg(feature = "contracts")]
+pub mod dao_registry;
+#[cfg(feature = "contracts")]
 pub mod utils;
 #[cfg(feature = "contracts")]
 pub mod web4;
@@ -68,6 +70,8 @@ pub use treasuries::SovDaoTreasury;
 pub use emergency_reserve::EmergencyReserve;
 #[cfg(feature = "contracts")]
 pub use sov_swap::{SovSwapPool, SwapDirection, SwapResult, PoolState, SwapError};
+#[cfg(feature = "contracts")]
+pub use dao_registry::{DAOEntry, DAORegistry, DAOMetadata};
 #[cfg(feature = "contracts")]
 pub use utils::*;
 #[cfg(feature = "contracts")]


### PR DESCRIPTION
Add a new DAORegistry contract (Phase-0 SOV-P0-2.3).

Changes:
- Add  module with  and  types
- Implement  with , , ,  (owner-only)
- Add  and   variants and serialization tests
- Add unit tests for registry and event behavior and wire up re-exports

Notes:
-  returns all DAOs sorted by ; pagination is a TODO.
- The contract returns  values for runtime emission; runtime wiring can publish events.

Please review and merge to .