### PR TITLE
fix: Add missing NetworkEpoch argument to NonceCache::open_default in test

### DIFF
--- a/lib-network/tests/handshake_verification_test.rs
+++ b/lib-network/tests/handshake_verification_test.rs
@@ -8,7 +8,7 @@ use lib_identity::{ZhtpIdentity, IdentityType, NodeId};
 use lib_network::{
     ClientHello, HandshakeCapabilities,
 };
-use lib_network::handshake::{HandshakeContext, NonceCache};
+use lib_network::handshake::{HandshakeContext, NonceCache, NetworkEpoch};
 use tempfile::TempDir;
 
 /// Helper to create test identity
@@ -24,7 +24,8 @@ fn create_test_identity(device: &str, seed: Option<[u8; 64]>) -> Result<ZhtpIden
 
 fn create_test_context() -> Result<(HandshakeContext, TempDir)> {
     let temp_dir = TempDir::new()?;
-    let cache = NonceCache::open_default(temp_dir.path(), 300)?;
+    let network_epoch = NetworkEpoch::from_chain_id(0); // Test network
+    let cache = NonceCache::open_default(temp_dir.path(), 300, network_epoch)?;
     let ctx = HandshakeContext::new(cache).with_channel_binding(vec![0u8; 32]);
     Ok((ctx, temp_dir))
 }


### PR DESCRIPTION
## Summary
Fixes compilation error in `handshake_verification_test.rs` where `NonceCache::open_default()` was called with only 2 arguments instead of the required 3.

## Changes
- Added `NetworkEpoch` import to test file
- Pass `NetworkEpoch::from_chain_id(0)` as the third argument to `NonceCache::open_default()`

## Test Results
✅ All 13 tests in handshake_verification_test.rs passing
✅ No compilation errors

## Related
Follows up on PR #653 which added the `NetworkEpoch` parameter to `NonceCache::open_default()`