### PR TITLE
fix: Add missing error macro import to wifi.rs - fixes build failure

### DIFF
--- a/zhtp/src/server/protocols/wifi.rs
+++ b/zhtp/src/server/protocols/wifi.rs
@@ -18,7 +18,7 @@ use tokio::net::TcpStream;
 use tokio::sync::RwLock;
 use std::net::SocketAddr;
 use uuid::Uuid;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use lib_network::protocols::wifi_direct::WiFiDirectMeshProtocol;
 use lib_network::protocols::wifi_direct_handshake::handshake_as_responder;
 use lib_network::handshake::{HandshakeContext, NonceCache};


### PR DESCRIPTION
## Summary
Fixes critical compilation error preventing the entire build from succeeding.

## Issue
The `wifi.rs` file uses the `error!()` macro but doesn't import it from the `tracing` crate.

```rust
// Line 21 (BEFORE - missing error)
use tracing::{debug, info, warn};

// Line 75 (ERROR - macro not imported)
error!("CRITICAL: Network genesis not set in production...")
```

## Fix
Added `error` to the tracing imports:
```rust
use tracing::{debug, error, info, warn};
```

## Build Status
✅ Compiles successfully with this fix
✅ Ready for merge

## Impact
This fix is required for PR #692 to work correctly. Without this, the workspace build fails on CI.