### PR TITLE
fix: Remove hardcoded bootstrap peers and fix configuration

### DIFF
--- a/zhtp-cli/tests/handler_tests.rs
+++ b/zhtp-cli/tests/handler_tests.rs
@@ -4,8 +4,6 @@
 
 #[cfg(test)]
 mod tests {
-    use zhtp_cli::argument_parsing::{ZhtpCli, ZhtpCommand};
-
     // Test handler enumeration
     #[test]
     fn test_all_handlers_exist() {

--- a/zhtp-cli/tests/integration_tests.rs
+++ b/zhtp-cli/tests/integration_tests.rs
@@ -5,8 +5,6 @@
 
 #[cfg(test)]
 mod tests {
-    use zhtp_cli::argument_parsing::ZhtpCli;
-
     #[test]
     fn test_zhtp_cli_parse_help() {
         // Test that --help is recognized

--- a/zhtp/src/config/aggregation.rs
+++ b/zhtp/src/config/aggregation.rs
@@ -480,7 +480,7 @@ impl Default for NodeConfig {
                 ],
                 bootstrap_peers: vec![
                     "127.0.0.1:9333".to_string(),
-                    "192.168.1.245:9333".to_string(),
+                    "127.0.0.1:9334".to_string(),
                 ],
                 long_range_relays: false,
                 bootstrap_validators: Vec::new(), // Gap 5: Empty by default

--- a/zhtp/src/config/environment.rs
+++ b/zhtp/src/config/environment.rs
@@ -226,8 +226,7 @@ impl Environment {
                     network_id: "lib-dev".to_string(),
                     bootstrap_peers: vec![
                         "127.0.0.1:9333".to_string(),
-                        "localhost:9334".to_string(),
-                        "192.168.1.245:9333".to_string(),
+                        "127.0.0.1:9334".to_string(),
                     ],
                     max_peers: 10,
                     connection_timeout_ms: 5000,
@@ -356,8 +355,9 @@ impl Environment {
                 network_settings: NetworkSettings {
                     network_id: "lib-mainnet".to_string(),
                     bootstrap_peers: vec![
-                        "127.0.0.1:9333".to_string(),
-                        "192.168.1.245:9333".to_string(),
+                        // TODO: Configure with actual mainnet bootstrap nodes
+                        // "mainnet-node-1.example.com:9333".to_string(),
+                        // "mainnet-node-2.example.com:9333".to_string(),
                     ],
                     max_peers: 100,
                     connection_timeout_ms: 30000,


### PR DESCRIPTION
## Summary
Removes hardcoded bootstrap peer addresses that were causing connection timeouts and replaces them with proper localhost configuration.

## Changes
- **environment.rs**: Removed hardcoded 192.168.1.245:9333 from dev network bootstrap peers, standardized to 127.0.0.1:9333/9334
- **aggregation.rs**: Updated default network config to use 127.0.0.1:9334 instead of hardcoded external IP
- **Mainnet**: Cleared hardcoded bootstrap peers with TODO for proper configuration
- **Test files**: Removed unused imports (ZhtpCli, ZhtpCommand) from zhtp-cli tests

## Why This Matters
Previously, nodes were trying to bootstrap from a hardcoded external IP (192.168.1.245:9333) that didn't exist in the current network, causing connection timeouts. This change allows nodes to properly bootstrap from configured localhost peers in development.

## Testing
- Nodes will now bootstrap from 127.0.0.1:9333 and 127.0.0.1:9334
- Multiple local nodes can connect and form a mesh network
- No more "unable to reach bootstrap peer" errors on startup

## Related Issues
- Fixes nodes using hardcoded bootstrap peers despite --dev flag
- Allows proper local network testing without external dependencies