### PR TITLE
fix: Extract DomainRecord from DomainLookupResponse in name resolver

### DIFF
--- a/lib-network/src/web4/name_resolver.rs
+++ b/lib-network/src/web4/name_resolver.rs
@@ -20,8 +20,9 @@ impl NameResolver {
     ///
     /// NOTE: Until chain-backed queries are wired, this uses the local registry cache.
     pub async fn resolve(&self, domain: &str) -> Result<ResolvedNameRecord> {
-        let record = self.registry.lookup_domain(domain).await?;
-        Ok(record.into())
+        let response = self.registry.lookup_domain(domain).await?;
+        let domain_record = response.record.ok_or_else(|| anyhow::anyhow!("Domain not found: {}", domain))?;
+        Ok(domain_record.into())
     }
 
     pub fn registry(&self) -> &Arc<DomainRegistry> {


### PR DESCRIPTION
## Summary
- Fixed compilation error in `lib-network/src/web4/name_resolver.rs`
- The `resolve()` method was trying to convert `DomainLookupResponse` directly to `ResolvedNameRecord`
- Only `From<DomainRecord>` is implemented, so we now extract the record from the response first

## Test plan
- [x] Verified build compiles successfully with `cargo build --release -p zhtp`
- [x] Deployed and tested on zhtp-dev and zhtp-dev-2 nodes