### PR TITLE
feat(storage): Enable persistent DHT storage with SledBackend

### DIFF
--- a/zhtp/src/api/handlers/dht/mod.rs
+++ b/zhtp/src/api/handlers/dht/mod.rs
@@ -188,7 +188,7 @@ pub struct DhtHandler {
     /// Handler statistics
     stats: Arc<RwLock<DhtHandlerStats>>,
     /// Storage system (where Web4 content is actually stored)
-    storage_system: Arc<RwLock<Option<Arc<RwLock<lib_storage::UnifiedStorageSystem>>>>>,
+    storage_system: Arc<RwLock<Option<Arc<RwLock<lib_storage::PersistentStorageSystem>>>>>,
 }
 
 /// DHT handler internal statistics
@@ -222,7 +222,7 @@ impl DhtHandler {
     }
     
     /// Create a new DHT handler with storage system access (for fetching Web4 content)
-    pub fn new_with_storage(_mesh_router: Arc<MeshRouter>, storage: Arc<RwLock<lib_storage::UnifiedStorageSystem>>) -> Self {
+    pub fn new_with_storage(_mesh_router: Arc<MeshRouter>, storage: Arc<RwLock<lib_storage::PersistentStorageSystem>>) -> Self {
         Self {
             dht_client: Arc::new(RwLock::new(None)),
             stats: Arc::new(RwLock::new(DhtHandlerStats::default())),

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -45,7 +45,7 @@ pub struct IdentityHandler {
     account_lockout: Arc<login_handlers::AccountLockout>,
     csrf_protection: Arc<crate::api::middleware::CsrfProtection>,
     recovery_phrase_manager: Arc<RwLock<RecoveryPhraseManager>>,
-    storage_system: Arc<RwLock<lib_storage::UnifiedStorageSystem>>,
+    storage_system: Arc<RwLock<lib_storage::PersistentStorageSystem>>,
 }
 
 impl IdentityHandler {
@@ -57,7 +57,7 @@ impl IdentityHandler {
         account_lockout: Arc<login_handlers::AccountLockout>,
         csrf_protection: Arc<crate::api::middleware::CsrfProtection>,
         recovery_phrase_manager: Arc<RwLock<RecoveryPhraseManager>>,
-        storage_system: Arc<RwLock<lib_storage::UnifiedStorageSystem>>,
+        storage_system: Arc<RwLock<lib_storage::PersistentStorageSystem>>,
     ) -> Self {
         Self {
             identity_manager,

--- a/zhtp/src/api/handlers/storage/mod.rs
+++ b/zhtp/src/api/handlers/storage/mod.rs
@@ -13,20 +13,20 @@ use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
 use lib_protocols::types::{ZhtpRequest, ZhtpResponse, ZhtpStatus, ZhtpMethod};
 use lib_identity::types::IdentityId;
 
-// Storage imports - using UnifiedStorageSystem and types
-use lib_storage::{UnifiedStorageSystem, StorageRequirements, QualityRequirements, BudgetConstraints};
+// Storage imports - using PersistentStorageSystem and types
+use lib_storage::{PersistentStorageSystem, StorageRequirements, QualityRequirements, BudgetConstraints};
 use lib_storage::types::economic_types::PaymentSchedule;
 use lib_identity::ZhtpIdentity;
 use lib_identity::types::identity_types::IdentityType;
 
 /// Clean storage handler implementation
 pub struct StorageHandler {
-    storage: Arc<RwLock<UnifiedStorageSystem>>,
+    storage: Arc<RwLock<PersistentStorageSystem>>,
     wallet_content_manager: Option<Arc<RwLock<lib_storage::WalletContentManager>>>,
 }
 
 impl StorageHandler {
-    pub fn new(storage: Arc<RwLock<UnifiedStorageSystem>>) -> Self {
+    pub fn new(storage: Arc<RwLock<PersistentStorageSystem>>) -> Self {
         Self { 
             storage,
             wallet_content_manager: None,

--- a/zhtp/src/api/server.rs
+++ b/zhtp/src/api/server.rs
@@ -30,7 +30,7 @@ pub struct ZhtpServer {
     middleware: MiddlewareStack,
     identity_manager: Arc<RwLock<IdentityManager>>,
     blockchain: Arc<RwLock<Blockchain>>,
-    storage: Arc<RwLock<lib_storage::UnifiedStorageSystem>>,
+    storage: Arc<RwLock<lib_storage::PersistentStorageSystem>>,
     economic_model: Arc<RwLock<EconomicModel>>,
 }
 
@@ -65,30 +65,37 @@ impl ZhtpServer {
             Blockchain::new()?
         ));
         
-        // For storage, we'll use a placeholder - in implementation this would be proper storage
-        let dht_persist_path = dirs::home_dir()
+        // For storage, we'll use persistent storage
+        let db_path = dirs::home_dir()
             .unwrap_or_else(|| std::path::PathBuf::from("."))
             .join(".zhtp")
             .join("storage")
-            .join("dht_storage.bin");
+            .join("dht_db");
+
+        // Ensure the storage directory exists
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+
+        let storage_config = lib_storage::UnifiedStorageConfig {
+            node_id: lib_identity::NodeId::from_bytes([1u8; 32]),
+            addresses: vec!["127.0.0.1:8000".to_string()],
+            economic_config: lib_storage::EconomicManagerConfig::default(),
+            storage_config: lib_storage::StorageConfig {
+                max_storage_size: 1024 * 1024 * 1024, // 1GB
+                default_tier: lib_storage::StorageTier::Hot,
+                enable_compression: true,
+                enable_encryption: true,
+                dht_persist_path: Some(db_path.clone()),
+            },
+            erasure_config: lib_storage::ErasureConfig {
+                data_shards: 4,
+                parity_shards: 2,
+            },
+        };
 
         let storage = Arc::new(RwLock::new(
-            lib_storage::UnifiedStorageSystem::new(lib_storage::UnifiedStorageConfig {
-                node_id: lib_identity::NodeId::from_bytes([1u8; 32]),
-                addresses: vec!["127.0.0.1:8000".to_string()],
-                economic_config: lib_storage::EconomicManagerConfig::default(),
-                storage_config: lib_storage::StorageConfig {
-                    max_storage_size: 1024 * 1024 * 1024, // 1GB
-                    default_tier: lib_storage::StorageTier::Hot,
-                    enable_compression: true,
-                    enable_encryption: true,
-                    dht_persist_path: Some(dht_persist_path),
-                },
-                erasure_config: lib_storage::ErasureConfig {
-                    data_shards: 4,
-                    parity_shards: 2,
-                },
-            }).await?
+            lib_storage::UnifiedStorageSystem::new_persistent(storage_config, &db_path).await?
         ));
         
         let economic_model = Arc::new(RwLock::new(

--- a/zhtp/src/runtime/components/storage.rs
+++ b/zhtp/src/runtime/components/storage.rs
@@ -12,7 +12,7 @@ use crate::runtime::{Component, ComponentId, ComponentStatus, ComponentHealth, C
 pub struct StorageComponent {
     status: Arc<RwLock<ComponentStatus>>,
     start_time: Arc<RwLock<Option<Instant>>>,
-    storage_system: Arc<RwLock<Option<lib_storage::UnifiedStorageSystem>>>,
+    storage_system: Arc<RwLock<Option<lib_storage::PersistentStorageSystem>>>,
 }
 
 impl StorageComponent {
@@ -37,23 +37,40 @@ impl Component for StorageComponent {
 
     async fn start(&self) -> Result<()> {
         info!("Starting storage component with lib-storage implementation...");
-        
+
         *self.status.write().await = ComponentStatus::Starting;
-        
+
         match crate::runtime::components::identity::create_default_storage_config() {
             Ok(config) => {
-                match lib_storage::UnifiedStorageSystem::new(config).await {
+                // Get the persistence path from config
+                let db_path = config.storage_config.dht_persist_path.clone()
+                    .unwrap_or_else(|| {
+                        dirs::home_dir()
+                            .unwrap_or_else(|| std::path::PathBuf::from("."))
+                            .join(".zhtp")
+                            .join("storage")
+                            .join("dht_db")
+                    });
+
+                // Ensure the storage directory exists
+                if let Some(parent) = db_path.parent() {
+                    if let Err(e) = std::fs::create_dir_all(parent) {
+                        warn!("Failed to create storage directory {:?}: {}", parent, e);
+                    }
+                }
+
+                match lib_storage::UnifiedStorageSystem::new_persistent(config, &db_path).await {
                     Ok(storage) => {
-                        info!("unified storage system initialized successfully");
-                        info!("-style content addressing ready");
+                        info!("Persistent unified storage system initialized at {:?}", db_path);
+                        info!("DHT data will persist across restarts");
                         info!("DHT network integration active");
                         info!("Economic incentives for storage providers enabled");
-                        
+
                         *self.storage_system.write().await = Some(storage);
                         info!("Storage system stored in component state");
                     }
                     Err(e) => {
-                        warn!("Failed to initialize storage system: {}", e);
+                        warn!("Failed to initialize persistent storage system: {}", e);
                         info!("Continuing with basic storage component");
                     }
                 }

--- a/zhtp/src/runtime/services/bootstrap_service.rs
+++ b/zhtp/src/runtime/services/bootstrap_service.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, Context, anyhow};
 use lib_blockchain::Blockchain;
-use lib_storage::UnifiedStorageSystem;
+use lib_storage::PersistentStorageSystem;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::{timeout, Duration};
@@ -13,7 +13,7 @@ impl BootstrapService {
     /// Try to bootstrap blockchain from network discovery
     pub async fn try_bootstrap_blockchain(
         _blockchain: &Arc<RwLock<Blockchain>>,
-        _storage: &Arc<RwLock<UnifiedStorageSystem>>,
+        _storage: &Arc<RwLock<PersistentStorageSystem>>,
         _api_port: u16,
         environment: &crate::config::environment::Environment,
     ) -> Result<Blockchain> {
@@ -25,7 +25,7 @@ impl BootstrapService {
     /// Try to sync blockchain from a specific peer address using incremental protocol
     pub async fn try_bootstrap_blockchain_from_peer(
         blockchain: &Arc<RwLock<Blockchain>>,
-        _storage: &Arc<RwLock<UnifiedStorageSystem>>,
+        _storage: &Arc<RwLock<PersistentStorageSystem>>,
         peer_addr: &str,
     ) -> Result<Blockchain> {
         use serde::Deserialize;

--- a/zhtp/src/storage_network_integration.rs
+++ b/zhtp/src/storage_network_integration.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use lib_crypto::PublicKey;
 use lib_network::{NetworkOutput, global_output_queue};
-use lib_storage::UnifiedStorageSystem;
+use lib_storage::PersistentStorageSystem;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc;
@@ -178,9 +178,9 @@ pub fn spawn_network_output_processor(
     });
 }
 
-/// Wrapper type for Arc<RwLock<UnifiedStorageSystem>> to implement the UnifiedStorage trait.
+/// Wrapper type for Arc<RwLock<PersistentStorageSystem>> to implement the UnifiedStorage trait.
 /// Kept here to avoid lib-storage depending on lib-network.
-pub struct UnifiedStorageWrapper(pub Arc<RwLock<UnifiedStorageSystem>>);
+pub struct UnifiedStorageWrapper(pub Arc<RwLock<PersistentStorageSystem>>);
 
 #[async_trait]
 impl lib_network::storage_stub::UnifiedStorage for UnifiedStorageWrapper {

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -38,7 +38,7 @@ use lib_network::protocols::quic_mesh::QuicMeshProtocol;
 // Import new QUIC handler for native ZHTP-over-QUIC
 use crate::server::QuicHandler;
 use lib_blockchain::Blockchain;
-use lib_storage::UnifiedStorageSystem;
+use lib_storage::PersistentStorageSystem;
 use lib_identity::IdentityManager;
 use lib_economy::EconomicModel;
 use lib_crypto::PublicKey;
@@ -101,7 +101,7 @@ pub struct ZhtpUnifiedServer {
     
     // Shared backend state (from ZHTP orchestrator)
     blockchain: Arc<RwLock<Blockchain>>,
-    storage: Arc<RwLock<UnifiedStorageSystem>>,
+    storage: Arc<RwLock<PersistentStorageSystem>>,
     identity_manager: Arc<RwLock<IdentityManager>>,
     economic_model: Arc<RwLock<EconomicModel>>,
     
@@ -286,7 +286,7 @@ impl ZhtpUnifiedServer {
     /// Create new unified server with comprehensive backend integration
     pub async fn new(
         blockchain: Arc<RwLock<Blockchain>>,
-        storage: Arc<RwLock<UnifiedStorageSystem>>,
+        storage: Arc<RwLock<PersistentStorageSystem>>,
         identity_manager: Arc<RwLock<IdentityManager>>,
         economic_model: Arc<RwLock<EconomicModel>>,
         port: u16, // Port from configuration
@@ -297,7 +297,7 @@ impl ZhtpUnifiedServer {
     /// Create new unified server with peer discovery notification channel
     pub async fn new_with_peer_notification(
         blockchain: Arc<RwLock<Blockchain>>,
-        storage: Arc<RwLock<UnifiedStorageSystem>>,
+        storage: Arc<RwLock<PersistentStorageSystem>>,
         identity_manager: Arc<RwLock<IdentityManager>>,
         economic_model: Arc<RwLock<EconomicModel>>,
         port: u16,
@@ -564,7 +564,7 @@ impl ZhtpUnifiedServer {
     async fn register_api_handlers(
         zhtp_router: &mut crate::server::zhtp::ZhtpRouter,
         blockchain: Arc<RwLock<Blockchain>>,
-        storage: Arc<RwLock<UnifiedStorageSystem>>,
+        storage: Arc<RwLock<PersistentStorageSystem>>,
         identity_manager: Arc<RwLock<IdentityManager>>,
         _economic_model: Arc<RwLock<EconomicModel>>,
         _session_manager: Arc<SessionManager>,

--- a/zhtp/src/web4_stub.rs
+++ b/zhtp/src/web4_stub.rs
@@ -294,7 +294,7 @@ pub struct StubDomainRegistry {
 
 impl StubDomainRegistry {
     pub async fn new_with_storage(
-        _storage: Arc<RwLock<lib_storage::UnifiedStorageSystem>>,
+        _storage: Arc<RwLock<lib_storage::PersistentStorageSystem>>,
     ) -> Result<Self> {
         Ok(Self {
             domain_records: Arc::new(RwLock::new(HashMap::new())),
@@ -624,14 +624,14 @@ pub struct Web4Manager {
 impl Web4Manager {
     pub async fn new_with_registry(
         registry: Arc<StubDomainRegistry>,
-        _storage: Arc<RwLock<lib_storage::UnifiedStorageSystem>>,
+        _storage: Arc<RwLock<lib_storage::PersistentStorageSystem>>,
     ) -> Result<Self> {
         Ok(Self { registry })
     }
 }
 
 pub async fn initialize_web4_system_with_storage(
-    storage: Arc<RwLock<lib_storage::UnifiedStorageSystem>>,
+    storage: Arc<RwLock<lib_storage::PersistentStorageSystem>>,
 ) -> Result<Web4Manager> {
     let registry = Arc::new(StubDomainRegistry::new_with_storage(storage.clone()).await?);
     Web4Manager::new_with_registry(registry, storage).await


### PR DESCRIPTION
## Summary
- Add `PersistentStorageSystem` type alias for SledBackend storage
- Move domain/identity record methods to generic impl (works with all backends)
- Update `protocols.rs` and `storage.rs` to use `new_persistent()`
- Update type references across zhtp crate (11 files)

## Problem
DHT data was not persisting across node restarts despite having a persistence path configured. The warning message was:
```
DHT persistence path "/root/.zhtp/storage/dht_storage.bin" is configured but 
UnifiedStorageSystem::new() uses in-memory storage.
```

## Solution
- Created `PersistentStorageSystem` type alias pointing to `UnifiedStorageSystem<SledBackend>`
- Updated storage initialization to use `new_persistent()` with the configured path
- Made shared methods (domain records, identity records, statistics) generic over all backends

## Test plan
- [x] Build compiles successfully
- [ ] Deploy to zhtp-dev and zhtp-dev-2 nodes
- [ ] Verify DHT data persists after node restart
- [ ] Check logs for successful persistent storage initialization