### PR TITLE
fix(deploy): Add --config flag to systemd service templates

### DIFF
--- a/deploy/ansible/templates/zhtp.service.j2
+++ b/deploy/ansible/templates/zhtp.service.j2
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart={{ zhtp_dir }}/zhtp node start --network {{ zhtp_network }}
+ExecStart={{ zhtp_dir }}/zhtp node start --network {{ zhtp_network }} --config {{ zhtp_dir }}/config.toml
 WorkingDirectory={{ zhtp_dir }}
 Restart=always
 RestartSec=5

--- a/deploy/zhtp-dev.service
+++ b/deploy/zhtp-dev.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/opt/zhtp/zhtp node start --network dev --dev
+ExecStart=/opt/zhtp/zhtp node start --network dev --dev --config /opt/zhtp/config.toml
 WorkingDirectory=/opt/zhtp
 Restart=always
 RestartSec=5

--- a/deploy/zhtp.service
+++ b/deploy/zhtp.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/opt/zhtp/zhtp node start --network testnet
+ExecStart=/opt/zhtp/zhtp node start --network testnet --config /opt/zhtp/config.toml
 WorkingDirectory=/opt/zhtp
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Summary
- Service templates were missing the `--config` flag, causing `config.toml` to be ignored after each CI deploy
- This resulted in bootstrap peers and other config settings being lost on every deployment
- Fixed `deploy/zhtp.service` and `deploy/zhtp-dev.service`

## Test plan
- [ ] Deploy to dev nodes and verify config.toml is loaded
- [ ] Check logs for "Loaded X bootstrap peer(s) from config file"

🤖 Generated with [Claude Code](https://claude.com/claude-code)