### PR TITLE
fix(ci): Clear nonce caches before restart to prevent sled DB corruption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,11 @@ jobs:
           ssh -i ~/.ssh/deploy_key "${DEV_USER}@${DEV_HOST}" '
             cd /opt/zhtp &&
             systemctl stop zhtp 2>/dev/null || true &&
+            sleep 2 &&
+            # Clear nonce caches to prevent sled DB corruption on restart
+            rm -rf /opt/zhtp/data/tls/quic_nonce_cache/* 2>/dev/null || true &&
+            rm -rf /opt/zhtp/nonce_cache_wifi/* 2>/dev/null || true &&
+            rm -rf /root/.zhtp/client_nonce_cache/* 2>/dev/null || true &&
             if [ -f zhtp ]; then mv zhtp zhtp.old; fi &&
             mv zhtp.new zhtp &&
             chmod +x zhtp &&
@@ -246,7 +251,8 @@ jobs:
             systemctl daemon-reload &&
             systemctl enable zhtp &&
             systemctl start zhtp &&
-            echo "Deployed to DEV SERVER 1 at $(date)"
+            sleep 5 &&
+            systemctl is-active zhtp && echo "Deployed to DEV SERVER 1 at $(date)" || echo "WARNING: Service not active!"
           '
 
       - name: Deploy to Dev Server 2 (zhtp-dev-2)
@@ -259,6 +265,11 @@ jobs:
           ssh -i ~/.ssh/deploy_key "${DEV_USER}@${DEV_HOST}" '
             cd /opt/zhtp &&
             systemctl stop zhtp 2>/dev/null || true &&
+            sleep 2 &&
+            # Clear nonce caches to prevent sled DB corruption on restart
+            rm -rf /opt/zhtp/data/tls/quic_nonce_cache/* 2>/dev/null || true &&
+            rm -rf /opt/zhtp/nonce_cache_wifi/* 2>/dev/null || true &&
+            rm -rf /root/.zhtp/client_nonce_cache/* 2>/dev/null || true &&
             if [ -f zhtp ]; then mv zhtp zhtp.old; fi &&
             mv zhtp.new zhtp &&
             chmod +x zhtp &&
@@ -266,5 +277,6 @@ jobs:
             systemctl daemon-reload &&
             systemctl enable zhtp &&
             systemctl start zhtp &&
-            echo "Deployed to DEV SERVER 2 at $(date)"
+            sleep 5 &&
+            systemctl is-active zhtp && echo "Deployed to DEV SERVER 2 at $(date)" || echo "WARNING: Service not active!"
           '


### PR DESCRIPTION
## Summary
- Clear sled-based nonce cache databases before restarting the service during deploys
- Add service health check after start

## Problem
The sled-based nonce cache databases get corrupted on unclean shutdown, causing "Failed to start component protocols" errors after every deploy. This has been a recurring issue requiring manual intervention.

## Solution
Added to both dev server deploy steps:
```bash
sleep 2 &&
# Clear nonce caches to prevent sled DB corruption on restart
rm -rf /opt/zhtp/data/tls/quic_nonce_cache/* 2>/dev/null || true &&
rm -rf /opt/zhtp/nonce_cache_wifi/* 2>/dev/null || true &&
rm -rf /root/.zhtp/client_nonce_cache/* 2>/dev/null || true &&
```

Also added `systemctl is-active` check after start to verify deployment success.

## Test plan
- [x] Verified fix works on zhtp-dev-2 manually
- [ ] CI deploy should now succeed without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)