### PR TITLE
fix(ci): Deploy zhtp node binary instead of zhtp-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,16 +66,16 @@ jobs:
       - name: Build
         run: cargo build --workspace --locked
 
-      - name: Build Release Binary (zhtp-cli only)
+      - name: Build Release Binary (zhtp node)
         if: (github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/development')
-        run: cargo build --release -p zhtp-cli --locked
+        run: cargo build --release -p zhtp --locked
 
-      - name: Upload Release Artifact (zhtp-cli)
+      - name: Upload Release Artifact (zhtp node)
         if: (github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/development')
         uses: actions/upload-artifact@v4
         with:
-          name: zhtp-cli-binary
-          path: target/release/zhtp-cli
+          name: zhtp-node-binary
+          path: target/release/zhtp
           retention-days: 1
 
       - name: Run zhtp-cli Integration Tests
@@ -142,56 +142,61 @@ jobs:
         run: cargo test -p zhtp-cli --test handler_tests --locked
 
   # Deploy to production server (main branch)
-  # NOTE: Disabled until zhtp library is converted to a binary crate
-  # deploy-production:
-  #   name: Deploy to Production Server
-  #   needs: smoke
-  #   runs-on: ubuntu-latest
-  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-  #   steps:
-  #     - name: Checkout (for service file)
-  #       uses: actions/checkout@v4
-  #       with:
-  #         sparse-checkout: deploy
-  #
-  #     - name: Download Release Artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: zhtp-binary
-  #
-  #     - name: Setup SSH
-  #       env:
-  #         SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-  #         DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-  #       run: |
-  #         mkdir -p ~/.ssh
-  #         echo "$SSH_KEY" > ~/.ssh/deploy_key
-  #         chmod 600 ~/.ssh/deploy_key
-  #         for i in 1 2 3; do
-  #           ssh-keyscan -T 10 -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts && break
-  #           echo "ssh-keyscan attempt $i failed, retrying..."
-  #           sleep 2
-  #         done
-  #
-  #     - name: Deploy Binary and Service
-  #       env:
-  #         DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-  #         DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
-  #       run: |
-  #         scp -i ~/.ssh/deploy_key ./zhtp "${DEPLOY_USER}@${DEPLOY_HOST}:/opt/zhtp/zhtp.new"
-  #         scp -i ~/.ssh/deploy_key ./deploy/zhtp.service "${DEPLOY_USER}@${DEPLOY_HOST}:/tmp/zhtp.service"
-  #         ssh -i ~/.ssh/deploy_key "${DEPLOY_USER}@${DEPLOY_HOST}" '
-  #           cd /opt/zhtp &&
-  #           systemctl stop zhtp 2>/dev/null || true &&
-  #           if [ -f zhtp ]; then mv zhtp zhtp.old; fi &&
-  #           mv zhtp.new zhtp &&
-  #           chmod +x zhtp &&
-  #           mv /tmp/zhtp.service /etc/systemd/system/zhtp.service &&
-  #           systemctl daemon-reload &&
-  #           systemctl enable zhtp &&
-  #           systemctl start zhtp &&
-  #           echo "Deployed to PRODUCTION at $(date)"
-  #         '
+  deploy-production:
+    name: Deploy to Production Server
+    needs: smoke
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout (for service file)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: deploy
+
+      - name: Download Release Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: zhtp-node-binary
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          for i in 1 2 3; do
+            ssh-keyscan -T 10 -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts && break
+            echo "ssh-keyscan attempt $i failed, retrying..."
+            sleep 2
+          done
+
+      - name: Deploy Binary and Service
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          scp -i ~/.ssh/deploy_key ./zhtp "${DEPLOY_USER}@${DEPLOY_HOST}:/opt/zhtp/zhtp.new"
+          scp -i ~/.ssh/deploy_key ./deploy/zhtp.service "${DEPLOY_USER}@${DEPLOY_HOST}:/tmp/zhtp.service"
+          ssh -i ~/.ssh/deploy_key "${DEPLOY_USER}@${DEPLOY_HOST}" '
+            cd /opt/zhtp &&
+            systemctl stop zhtp 2>/dev/null || true &&
+            sleep 2 &&
+            # Clear nonce caches to prevent sled DB corruption on restart
+            rm -rf /opt/zhtp/data/tls/quic_nonce_cache/* 2>/dev/null || true &&
+            rm -rf /opt/zhtp/nonce_cache_wifi/* 2>/dev/null || true &&
+            rm -rf /root/.zhtp/client_nonce_cache/* 2>/dev/null || true &&
+            if [ -f zhtp ]; then mv zhtp zhtp.old; fi &&
+            mv zhtp.new zhtp &&
+            chmod +x zhtp &&
+            mv /tmp/zhtp.service /etc/systemd/system/zhtp.service &&
+            systemctl daemon-reload &&
+            systemctl enable zhtp &&
+            systemctl start zhtp &&
+            sleep 5 &&
+            systemctl is-active zhtp && echo "Deployed to PRODUCTION at $(date)" || echo "WARNING: Service not active!"
+          '
 
   # Deploy to dev server (development branch) - uses separate secrets
   # Runs on: push to development OR manual trigger on development
@@ -209,7 +214,7 @@ jobs:
       - name: Download Release Artifact
         uses: actions/download-artifact@v4
         with:
-          name: zhtp-cli-binary
+          name: zhtp-node-binary
 
       - name: Setup SSH
         env:
@@ -234,7 +239,7 @@ jobs:
           DEV_HOST: ${{ secrets.DEV_DEPLOY_HOST }}
           DEV_USER: ${{ secrets.DEV_DEPLOY_USER }}
         run: |
-          scp -i ~/.ssh/deploy_key ./zhtp-cli "${DEV_USER}@${DEV_HOST}:/opt/zhtp/zhtp.new"
+          scp -i ~/.ssh/deploy_key ./zhtp "${DEV_USER}@${DEV_HOST}:/opt/zhtp/zhtp.new"
           scp -i ~/.ssh/deploy_key ./deploy/zhtp-dev.service "${DEV_USER}@${DEV_HOST}:/tmp/zhtp.service"
           ssh -i ~/.ssh/deploy_key "${DEV_USER}@${DEV_HOST}" '
             cd /opt/zhtp &&
@@ -260,7 +265,7 @@ jobs:
           DEV_HOST: ${{ secrets.DEV_DEPLOY_HOST_2 }}
           DEV_USER: ${{ secrets.DEV_DEPLOY_USER }}
         run: |
-          scp -i ~/.ssh/deploy_key ./zhtp-cli "${DEV_USER}@${DEV_HOST}:/opt/zhtp/zhtp.new"
+          scp -i ~/.ssh/deploy_key ./zhtp "${DEV_USER}@${DEV_HOST}:/opt/zhtp/zhtp.new"
           scp -i ~/.ssh/deploy_key ./deploy/zhtp-dev.service "${DEV_USER}@${DEV_HOST}:/tmp/zhtp.service"
           ssh -i ~/.ssh/deploy_key "${DEV_USER}@${DEV_HOST}" '
             cd /opt/zhtp &&

--- a/deploy/zhtp-dev.service
+++ b/deploy/zhtp-dev.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/opt/zhtp/zhtp node start --network dev --dev --config /opt/zhtp/config.toml
+ExecStart=/opt/zhtp/zhtp --testnet --config /opt/zhtp/config.toml
 WorkingDirectory=/opt/zhtp
 Restart=always
 RestartSec=5

--- a/deploy/zhtp.service
+++ b/deploy/zhtp.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/opt/zhtp/zhtp node start --network testnet --config /opt/zhtp/config.toml
+ExecStart=/opt/zhtp/zhtp --testnet --config /opt/zhtp/config.toml
 WorkingDirectory=/opt/zhtp
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Summary
- CI was deploying `zhtp-cli` (the command-line interface) instead of `zhtp` (the node binary)
- The CLI uses `node start` subcommand syntax, the standalone node uses `--testnet --config` flags
- Service files updated to use correct arguments for the node binary
- Production deployment job enabled for main branch

## Changes
- Build `cargo build --release -p zhtp` instead of `-p zhtp-cli`
- Deploy `./zhtp` instead of `./zhtp-cli`
- Service files: `ExecStart=/opt/zhtp/zhtp --testnet --config /opt/zhtp/config.toml`

## Test plan
- [ ] CI builds zhtp node binary successfully
- [ ] Dev deployment works after merge to development
- [ ] Golden rule test passes on dev servers