### PR TITLE
feat(lib-client): Add C FFI exports for iOS

### DIFF
--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -71,3 +71,183 @@ pub const ZHTP_WIRE_VERSION: u8 = 1;
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
+
+// =============================================================================
+// C FFI Exports for iOS (manual FFI without uniffi-bindgen)
+// =============================================================================
+
+/// Opaque handle to an Identity
+pub struct IdentityHandle {
+    inner: Identity,
+}
+
+/// Generate a new identity. Returns a pointer to IdentityHandle.
+/// Caller must free with `zhtp_client_identity_free`.
+#[no_mangle]
+pub extern "C" fn zhtp_client_generate_identity(
+    device_id: *const std::ffi::c_char,
+) -> *mut IdentityHandle {
+    let device_id = unsafe {
+        if device_id.is_null() {
+            return std::ptr::null_mut();
+        }
+        match std::ffi::CStr::from_ptr(device_id).to_str() {
+            Ok(s) => s.to_string(),
+            Err(_) => return std::ptr::null_mut(),
+        }
+    };
+
+    match generate_identity(device_id) {
+        Ok(identity) => Box::into_raw(Box::new(IdentityHandle { inner: identity })),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free an identity handle
+#[no_mangle]
+pub extern "C" fn zhtp_client_identity_free(handle: *mut IdentityHandle) {
+    if !handle.is_null() {
+        unsafe { drop(Box::from_raw(handle)) };
+    }
+}
+
+/// Get the DID string from an identity. Caller must free with `zhtp_client_string_free`.
+#[no_mangle]
+pub extern "C" fn zhtp_client_identity_get_did(handle: *const IdentityHandle) -> *mut std::ffi::c_char {
+    if handle.is_null() {
+        return std::ptr::null_mut();
+    }
+    let identity = unsafe { &(*handle).inner };
+    match std::ffi::CString::new(identity.did.clone()) {
+        Ok(s) => s.into_raw(),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Get the device ID from an identity. Caller must free with `zhtp_client_string_free`.
+#[no_mangle]
+pub extern "C" fn zhtp_client_identity_get_device_id(handle: *const IdentityHandle) -> *mut std::ffi::c_char {
+    if handle.is_null() {
+        return std::ptr::null_mut();
+    }
+    let identity = unsafe { &(*handle).inner };
+    match std::ffi::CString::new(identity.device_id.clone()) {
+        Ok(s) => s.into_raw(),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a string returned by the library
+#[no_mangle]
+pub extern "C" fn zhtp_client_string_free(s: *mut std::ffi::c_char) {
+    if !s.is_null() {
+        unsafe { drop(std::ffi::CString::from_raw(s)) };
+    }
+}
+
+/// Buffer for returning byte arrays
+#[repr(C)]
+pub struct ByteBuffer {
+    pub data: *mut u8,
+    pub len: usize,
+}
+
+/// Free a ByteBuffer
+#[no_mangle]
+pub extern "C" fn zhtp_client_buffer_free(buf: ByteBuffer) {
+    if !buf.data.is_null() && buf.len > 0 {
+        unsafe {
+            drop(Vec::from_raw_parts(buf.data, buf.len, buf.len));
+        }
+    }
+}
+
+/// Get public key from identity
+#[no_mangle]
+pub extern "C" fn zhtp_client_identity_get_public_key(handle: *const IdentityHandle) -> ByteBuffer {
+    if handle.is_null() {
+        return ByteBuffer { data: std::ptr::null_mut(), len: 0 };
+    }
+    let identity = unsafe { &(*handle).inner };
+    let mut bytes = identity.public_key.clone();
+    let buf = ByteBuffer {
+        data: bytes.as_mut_ptr(),
+        len: bytes.len(),
+    };
+    std::mem::forget(bytes);
+    buf
+}
+
+/// Get node ID from identity
+#[no_mangle]
+pub extern "C" fn zhtp_client_identity_get_node_id(handle: *const IdentityHandle) -> ByteBuffer {
+    if handle.is_null() {
+        return ByteBuffer { data: std::ptr::null_mut(), len: 0 };
+    }
+    let identity = unsafe { &(*handle).inner };
+    let mut bytes = identity.node_id.clone();
+    let buf = ByteBuffer {
+        data: bytes.as_mut_ptr(),
+        len: bytes.len(),
+    };
+    std::mem::forget(bytes);
+    buf
+}
+
+/// Sign registration proof. Returns signature bytes.
+#[no_mangle]
+pub extern "C" fn zhtp_client_sign_registration_proof(
+    handle: *const IdentityHandle,
+    timestamp: u64,
+) -> ByteBuffer {
+    if handle.is_null() {
+        return ByteBuffer { data: std::ptr::null_mut(), len: 0 };
+    }
+    let identity = unsafe { &(*handle).inner };
+    match sign_registration_proof(identity, timestamp) {
+        Ok(mut sig) => {
+            let buf = ByteBuffer {
+                data: sig.as_mut_ptr(),
+                len: sig.len(),
+            };
+            std::mem::forget(sig);
+            buf
+        }
+        Err(_) => ByteBuffer { data: std::ptr::null_mut(), len: 0 },
+    }
+}
+
+/// Serialize identity to JSON. Caller must free with `zhtp_client_string_free`.
+#[no_mangle]
+pub extern "C" fn zhtp_client_identity_serialize(handle: *const IdentityHandle) -> *mut std::ffi::c_char {
+    if handle.is_null() {
+        return std::ptr::null_mut();
+    }
+    let identity = unsafe { &(*handle).inner };
+    match identity::serialize_identity(identity) {
+        Ok(json) => match std::ffi::CString::new(json) {
+            Ok(s) => s.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        },
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Deserialize identity from JSON. Returns handle or null on error.
+#[no_mangle]
+pub extern "C" fn zhtp_client_identity_deserialize(json: *const std::ffi::c_char) -> *mut IdentityHandle {
+    let json = unsafe {
+        if json.is_null() {
+            return std::ptr::null_mut();
+        }
+        match std::ffi::CStr::from_ptr(json).to_str() {
+            Ok(s) => s,
+            Err(_) => return std::ptr::null_mut(),
+        }
+    };
+
+    match identity::deserialize_identity(json) {
+        Ok(identity) => Box::into_raw(Box::new(IdentityHandle { inner: identity })),
+        Err(_) => std::ptr::null_mut(),
+    }
+}


### PR DESCRIPTION
## Summary
Add manual C FFI exports so iOS can use lib-client without uniffi-bindgen tooling.

## Exports
- `zhtp_client_generate_identity(device_id)` → `*IdentityHandle`
- `zhtp_client_identity_free(handle)`
- `zhtp_client_identity_get_did(handle)` → `*char`
- `zhtp_client_identity_get_device_id(handle)` → `*char`
- `zhtp_client_identity_get_public_key(handle)` → `ByteBuffer`
- `zhtp_client_identity_get_node_id(handle)` → `ByteBuffer`
- `zhtp_client_sign_registration_proof(handle, timestamp)` → `ByteBuffer`
- `zhtp_client_identity_serialize(handle)` → `*char` (JSON)
- `zhtp_client_identity_deserialize(json)` → `*IdentityHandle`
- `zhtp_client_string_free(s)`
- `zhtp_client_buffer_free(buf)`

## iOS Usage
```swift
// In bridging header
void* zhtp_client_generate_identity(const char* device_id);
void zhtp_client_identity_free(void* handle);
// ... etc

// In Swift
let handle = zhtp_client_generate_identity(deviceId)
defer { zhtp_client_identity_free(handle) }
let proof = zhtp_client_sign_registration_proof(handle, timestamp)
```

## Test plan
- [ ] Build for iOS: `cargo build -p lib-client --release --target aarch64-apple-ios`
- [ ] Verify symbols: `nm -g libzhtp_client.a | grep zhtp_client`
- [ ] Integrate in iOS app