### PR TITLE
Fix deploy-site workflow CLI arguments

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -26,12 +26,6 @@ on:
       ZHTP_KEYSTORE_B64:
         description: 'Base64-encoded tarball of keystore directory'
         required: true
-      ZHTP_SERVER:
-        description: 'QUIC server endpoint (ip:port)'
-        required: true
-      ZHTP_SERVER_SPKI:
-        description: 'Server SPKI pin for TLS verification'
-        required: true
 
 jobs:
   deploy:
@@ -76,6 +70,4 @@ jobs:
             --domain "${{ inputs.domain }}" \
             --keystore ~/.zhtp/keystore \
             --mode "${{ inputs.deployment_mode }}" \
-            --server "${{ secrets.ZHTP_SERVER }}" \
-            --pin-spki "${{ secrets.ZHTP_SERVER_SPKI }}" \
             out/


### PR DESCRIPTION
## Summary
- Remove `--server` and `--pin-spki` options from zhtp-cli deploy command
- These options don't exist in the CLI
- Remove corresponding secrets from workflow inputs

CLI usage: `zhtp-cli deploy site --domain <DOMAIN> --keystore <KEYSTORE> --mode <MODE> <BUILD_DIR>`

## Test plan
- [x] Workflow will no longer fail with "unexpected argument" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)