### PR TITLE
Fix deploy-site: remove unsupported CLI args, keep secrets optional

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -26,6 +26,12 @@ on:
       ZHTP_KEYSTORE_B64:
         description: 'Base64-encoded tarball of keystore directory'
         required: true
+      ZHTP_SERVER:
+        description: 'QUIC server endpoint (reserved for future use)'
+        required: false
+      ZHTP_SERVER_SPKI:
+        description: 'Server SPKI pin (reserved for future use)'
+        required: false
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

This PR fixes the deploy-site workflow:

**Changes:**
- Remove `--server` and `--pin-spki` CLI arguments (the CLI doesn't support them)
- Keep ZHTP_SERVER and ZHTP_SERVER_SPKI secrets but mark as optional
- These secrets are no longer used at deploy time since the CLI doesn't accept them

**Why the secrets are kept (as optional):**
- Existing caller workflows (Sov-Swap-Dapp, Breakroom-Employee-Dapp) pass these secrets
- Removing them from the definition breaks GitHub workflow validation
- Marked as "reserved for future use" if CLI adds support later

**Behavior change:**
- Previously: Workflow attempted to pass server/SPKI to CLI (which failed with "unexpected argument")
- Now: Workflow does not pass these to CLI, secrets are accepted but unused

## Test plan
- [x] CLI deploy command uses only supported arguments
- [x] Caller workflows validate without errors