### PR TITLE
Add workflow_dispatch trigger to deploy-site

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,6 +1,27 @@
 name: Deploy Site to Web4
 
 on:
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: 'Web4 domain to deploy to (e.g., mysite.sov)'
+        required: true
+        type: string
+      build_artifact:
+        description: 'Name of the uploaded build artifact'
+        required: false
+        type: string
+        default: 'build-output'
+      deployment_mode:
+        description: 'Publish mode (static or spa)'
+        required: false
+        type: string
+        default: 'static'
+      cli_version:
+        description: 'zhtp-cli release tag'
+        required: false
+        type: string
+        default: 'cli-v0.2.0'
   workflow_call:
     inputs:
       domain:


### PR DESCRIPTION
## Summary

Add `workflow_dispatch` trigger to enable manual execution of the deploy-site workflow from GitHub Actions UI.

**Changes:**
- Add `workflow_dispatch` trigger with same inputs as `workflow_call`
- Workflow can now be triggered manually or called by other workflows

**Note:** When triggered manually, requires build artifacts to exist from a prior workflow run.

## Test plan
- [x] Workflow appears in Actions UI with "Run workflow" button
- [x] Inputs are shown when manually triggering