### PR TITLE
fix: Set fee to 0 for wallet registration system transactions

### DIFF
--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -469,7 +469,7 @@ impl Transaction {
             transaction_type: TransactionType::WalletRegistration,
             inputs: Vec::new(), // Wallet registration doesn't need inputs
             outputs,
-            fee: wallet_data.registration_fee,
+            fee: 0, // System transactions must have zero fee (registration_fee stored in wallet_data for records)
             signature,
             memo,
             identity_data: None,


### PR DESCRIPTION
## Summary
- Fix mining stuck at block #6 due to `InvalidFee` validation error on wallet registration transactions
- Wallet registration transactions have no inputs (system transactions) but were incorrectly setting `fee: wallet_data.registration_fee` (e.g., 50)
- System transactions must have `fee == 0` per `validate_economics_with_system_check` validation rule

## Root Cause
In `lib-blockchain/src/transaction/core.rs`, `new_wallet_registration` was setting:
```rust
fee: wallet_data.registration_fee,  // Was 50
```

But the validation at `validation.rs:619` requires:
```rust
if is_system_transaction {
    if transaction.fee != 0 {
        return Err(ValidationError::InvalidFee);
    }
}
```

## Fix
Changed to match other system transactions (like validator registration):
```rust
fee: 0,  // System transactions must have zero fee
```

## Test plan
- [ ] Build and deploy to zhtp-dev-2
- [ ] Verify mining proceeds past block #6
- [ ] Run gold tests against dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)