### PR TITLE
fix: fallback to --trust-node when SPKI not provided

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -69,15 +69,15 @@ jobs:
 
       - name: Deploy site
         run: |
-          PIN_SPKI_ARG=""
+          TRUST_ARG="--trust-node"
           if [ -n "$ZHTP_SERVER_SPKI" ]; then
-            PIN_SPKI_ARG="--pin-spki $ZHTP_SERVER_SPKI"
+            TRUST_ARG="--pin-spki $ZHTP_SERVER_SPKI"
           fi
           /tmp/zhtp-cli deploy site \
             --domain "${{ inputs.domain }}" \
             --keystore ~/.zhtp/keystore \
             --mode "${{ inputs.deployment_mode }}" \
-            $PIN_SPKI_ARG \
+            $TRUST_ARG \
             out/
         env:
           ZHTP_SERVER: ${{ secrets.ZHTP_SERVER }}


### PR DESCRIPTION
## Summary
- Without either --pin-spki or --trust-node, the CLI cannot verify the server
- QUIC connection fails with no trust mechanism specified
- Falls back to --trust-node when ZHTP_SERVER_SPKI secret is not provided

## Test plan
- [x] Re-run Ballot-Voting-Dapp deploy workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)