### PR TITLE
feat(#167): Wire protocol handlers to storage - TransportManager integration

### DIFF
--- a/zhtp/src/server/mesh/core.rs
+++ b/zhtp/src/server/mesh/core.rs
@@ -62,6 +62,7 @@ use lib_network::protocols::zhtp_encryption::{ZhtpEncryptionManager, ZhtpEncrypt
 use lib_network::protocols::zhtp_auth::ZhtpAuthManager;
 use crate::web4_stub::ZhtpRelayProtocol;
 use lib_network::routing::message_routing::MeshMessageRouter;
+use lib_network::transport::TransportManager;
 use lib_blockchain::types::Hash;
 use lib_blockchain::BlockchainBroadcastMessage;
 use lib_identity::IdentityManager;
@@ -346,7 +347,15 @@ impl MeshRouter {
         *self.zhtp_router.write().await = Some(router);
         info!("🔀 ZHTP router registered for UDP endpoint routing");
     }
-    
+
+    /// Set transport manager on mesh message router for protocol handler selection (Issue #167)
+    pub async fn set_transport_manager(&self, manager: TransportManager) {
+        use tracing::info;
+        let mut router = self.mesh_message_router.write().await;
+        router.transport_manager = Some(manager);
+        info!("🚚 Transport manager registered for protocol handler selection (Issue #167)");
+    }
+
     /// List all peer reputations
     pub async fn list_peer_reputations(&self) -> Vec<PeerReputation> {
         self.peer_reputations.read().await.values().cloned().collect()

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -416,6 +416,14 @@ impl ZhtpUnifiedServer {
         mesh_router_arc.set_quic_protocol(quic_arc.clone()).await;
         info!(" [UNIFIED_SERVER] QUIC protocol set on mesh_router");
 
+        // Issue #167: Wire protocol handlers to message router (Transport Manager)
+        // Create TransportManager with QUIC handler and set on mesh message router
+        info!(" [UNIFIED_SERVER] Creating TransportManager with QUIC handler (Issue #167)");
+        let transport_manager = lib_network::transport::TransportManager::default()
+            .with_quic(quic_arc.clone());
+        mesh_router_arc.set_transport_manager(transport_manager).await;
+        info!(" [UNIFIED_SERVER] TransportManager set on mesh message router (Issue #167)");
+
         // Create DHT handler for pure UDP mesh protocol and register it on mesh_router
         // This MUST happen before register_api_handlers to ensure the actual mesh_router instance gets the handler
         let dht_handler: Arc<dyn ZhtpRequestHandler> = Arc::new(


### PR DESCRIPTION
## Summary

Implements Issue #167: Wire Protocol Handlers to Storage by integrating TransportManager with MeshMessageRouter. QUIC protocol handler is now properly wired and available for message routing.

## Problem

MeshMessageRouter had `transport_manager` field set to `None`, preventing message routing over protocol handlers. Despite QuicMeshProtocol being successfully instantiated, it was never registered with the router.

## Solution

- Created TransportManager with QUIC protocol handler during router initialization
- Set transport_manager on MeshMessageRouter via new `set_transport_manager()` method  
- Modified TransportManager to store QUIC handler as `Arc<QuicMeshProtocol>` directly (not RwLock-wrapped, per Issue #907)

## Files Changed

### zhtp/src/unified_server.rs
- Create TransportManager with QUIC handler after QuicMeshProtocol initialization
- Call `mesh_router.set_transport_manager(transport_manager).await`
- Added logging for transport manager registration

### zhtp/src/server/mesh/core.rs
- Import TransportManager
- Add `set_transport_manager()` async method to MeshRouter
- Sets transport_manager on internal mesh_message_router

### lib-network/src/transport/mod.rs
- Changed quic field from `Arc<RwLock<QuicMeshProtocol>>` to `Arc<QuicMeshProtocol>`
- Updated `with_quic()` signature accordingly
- Updated QUIC send case to call `send_to_peer()` directly (no `.read().await`)

## Architecture Notes

- QUIC protocol stored as global Arc (no Clone impl) per Issue #907
- Bluetooth, WiFi, LoRa protocols continue using `Arc<RwLock<Protocol>>`
- Handler availability validated in TransportManager.send()
- Transport downgrade prevention enforced

## Testing

✅ Code compiles successfully
✅ Transport module tests pass
✅ No existing functionality broken