### PR TITLE
fix(#920): Resolve post-bootstrap sync issues — wallet balances, nonce cache, DHT persistence

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -4095,7 +4095,7 @@ impl Blockchain {
                 created_at: wallet_ref.created_at,
                 registration_fee: wallet_ref.registration_fee,
                 capabilities: 0, // Default - will need DHT for real capabilities
-                initial_balance: 0, // Default - will need DHT for real balance
+                initial_balance: wallet_ref.initial_balance,
             };
             (id.clone(), wallet_data)
         }).collect()
@@ -4322,6 +4322,7 @@ impl Blockchain {
                     owner_identity_id: wallet_data.owner_identity_id,
                     created_at: wallet_data.created_at,
                     registration_fee: wallet_data.registration_fee,
+                    initial_balance: wallet_data.initial_balance,
                 };
                 (id.clone(), wallet_ref)
             })

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -273,6 +273,8 @@ pub struct WalletReference {
     pub created_at: u64,
     /// Registration fee paid
     pub registration_fee: u64,
+    /// Initial balance (source of truth for wallet balances in UTXO/Pedersen system)
+    pub initial_balance: u64,
 }
 
 /// Sensitive wallet data stored in encrypted DHT

--- a/zhtp/src/integration/dht_integration.rs
+++ b/zhtp/src/integration/dht_integration.rs
@@ -132,11 +132,9 @@ fn create_persistent_storage(
         max_bytes: DHT_STORAGE_BYTES,
     });
 
-    Arc::new(Mutex::new(DhtStorage::new_with_persistence(
-        local_node_id,
-        DHT_STORAGE_BYTES,
-        dht_persist_path,
-    )))
+    // Initial in-memory placeholder; replaced by network-enabled storage in
+    // setup_mesh_dht_integration() once mesh transport is wired.
+    Arc::new(Mutex::new(DhtStorage::new(local_node_id, DHT_STORAGE_BYTES)))
 }
 
 fn derive_local_node_id(server_id: Uuid) -> lib_identity::NodeId {

--- a/zhtp/src/runtime/network_blockchain_event_receiver.rs
+++ b/zhtp/src/runtime/network_blockchain_event_receiver.rs
@@ -52,9 +52,12 @@ impl BlockchainEventReceiver for ZhtpBlockchainEventReceiver {
             return Ok(());
         }
 
+        let block_hash = hex::encode(&block.header.hash().as_bytes()[..8]);
         match bc.add_block_from_network_with_persistence(block).await {
             Ok(()) => {
-                info!("Imported block {} from mesh peer", height);
+                let new_height = bc.get_height();
+                info!("Imported block {} (hash {}) from mesh peer — local height {} → {}",
+                      height, block_hash, local_height, new_height);
                 Ok(())
             }
             Err(e) => {

--- a/zhtp/src/server/mesh/blockchain_sync.rs
+++ b/zhtp/src/server/mesh/blockchain_sync.rs
@@ -30,7 +30,13 @@ impl MeshRouter {
             while let Some(msg) = receiver.recv().await {
                 match msg {
                     lib_blockchain::BlockchainBroadcastMessage::NewBlock(block) => {
-                        info!("📡 Broadcasting new block {} to mesh network", block.height());
+                        let block_hash = hex::encode(&block.header.hash().as_bytes()[..8]);
+                        let peer_count = {
+                            let quic = self_arc.quic_protocol.read().await;
+                            quic.as_ref().map(|q| q.peer_count()).unwrap_or(0)
+                        };
+                        info!("📡 Broadcasting block {} (hash {}) to {} connected peers",
+                              block.height(), block_hash, peer_count);
 
                         // ✅ TICKET 2.6: Verify sender identity is available
                         let sender_pubkey = match self_arc.get_sender_public_key().await {


### PR DESCRIPTION
## Summary

- **Wallet balances zero after sync**: Added `initial_balance` field to `WalletReference` struct so wallet balances survive blockchain export/import. Previously hardcoded to `0` in `convert_wallet_references_to_full_data()`, dropping the source-of-truth balance.
- **Nonce cache blocking all auth**: Changed `verify_or_store_network_epoch()` from hard error to auto-recovery on epoch mismatch — clears stale nonces and updates the epoch. The previous behavior bricked the global `NonceCache` singleton (`OnceLock`), blocking every authenticated QUIC connection including mobile clients.
- **DHT deprecated persistence error**: Replaced `DhtStorage::new_with_persistence()` (deprecated, logs ERROR) with explicit `DhtStorage::new()` in-memory placeholder, since it gets replaced by `new_with_transport()` later anyway.
- **DHT bootstrap skipped**: Added retry loop (10 attempts, 500ms apart) for `get_global_storage()` in identity bootstrap, matching the pattern in `ProtocolsComponent`.
- **Block propagation diagnostics**: Enhanced logging with block hash, height delta, and peer count for easier production debugging.

## Files Changed

| File | Change |
|------|--------|
| `lib-blockchain/src/transaction/core.rs` | Add `initial_balance` to `WalletReference` |
| `lib-blockchain/src/blockchain.rs` | Wire `initial_balance` through export and import |
| `lib-network/src/handshake/nonce_cache.rs` | Epoch mismatch auto-recovery + enhanced error logging |
| `zhtp/src/integration/dht_integration.rs` | Replace deprecated persistence call |
| `zhtp/src/runtime/components/identity.rs` | Retry loop for storage availability |
| `zhtp/src/runtime/network_blockchain_event_receiver.rs` | Enhanced block import logging |
| `zhtp/src/server/mesh/blockchain_sync.rs` | Enhanced block broadcast logging |

## Test plan

- [x] `cargo build --release` — compiles clean
- [x] Deployed to zhtp-dev-2, zhtp-prod, zhtp-prod-1 — all nodes start with zero errors
- [x] Wallet balances synced correctly (25 wallets, 5000 ZHTP each)
- [x] Block mining and persistence verified (block 9 mined, persisted, survives restart)
- [x] Mobile client authentication working (nonce cache fix confirmed)
- [x] No deprecated DHT persistence errors in logs

Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)