### PR TITLE
fix(#846): Block Sync - Wire broadcast to QuicMeshProtocol

### DIFF
--- a/lib-network/src/protocols/quic_mesh.rs
+++ b/lib-network/src/protocols/quic_mesh.rs
@@ -804,7 +804,10 @@ impl QuicMeshProtocol {
     }
 
     /// Encrypt and send a message to a single QUIC connection via UNI stream.
-    async fn send_encrypted_to(conn: &Connection, session_key: &[u8; 32], message: &[u8]) -> Result<()> {
+    /// 
+    /// Made public for Issue #846 - allows direct sending to specific peers
+    /// from external code that has access to a Connection and session key.
+    pub async fn send_encrypted_to(conn: &Connection, session_key: &[u8; 32], message: &[u8]) -> Result<()> {
         let encrypted = encrypt_data(message, session_key)?;
         let mut stream = conn.open_uni().await
             .context("Failed to open UNI stream")?;


### PR DESCRIPTION
## Summary
Fixes the block sync issue where QUIC mesh peers were not being broadcast to.

## Problem (Issue #846)
The `broadcast_to_peers_except()` method in `udp_handler.rs` was using the deprecated `MeshRouter.connections` PeerRegistry which was never populated for QUIC peers. The method contained dead code paths (`if false` blocks).

## Root Cause
After UHP v2 handshake, peers are registered in `QuicMeshProtocol.connections` (DashMap), but the broadcast method was reading from the empty `MeshRouter.connections` (PeerRegistry).

## Solution
- Rewire `broadcast_to_peers_except()` to use `QuicMeshProtocol` as the canonical connection store
- Make `send_encrypted_to()` public for direct peer sending
- Filter out sender by comparing node_id to exclude pubkey

## Related
- Closes #846
- Complements existing fix in `blockchain_sync.rs` where `broadcast_to_peers()` already uses `QuicMeshProtocol` directly

## Testing
- Compilation verified
- Block broadcasts should now reach all connected QUIC peers