### PR TITLE
fix(build.rs): Support cross-compilation for Android targets

### DIFF
--- a/lib-network/build.rs
+++ b/lib-network/build.rs
@@ -1,13 +1,11 @@
 // Build script to link macOS Core Bluetooth framework
 
-#[cfg(target_os = "macos")]
 fn main() {
-    // Link Core Bluetooth framework on macOS
-    println!("cargo:rustc-link-lib=framework=CoreBluetooth");
-    println!("cargo:rustc-link-lib=framework=Foundation");
-}
+    let target = std::env::var("TARGET").unwrap_or_default();
 
-#[cfg(not(target_os = "macos"))]
-fn main() {
-    // No framework linking needed on non-macOS platforms
+    // Only link frameworks when targeting macOS
+    if target.contains("darwin") || target.contains("macos") {
+        println!("cargo:rustc-link-lib=framework=CoreBluetooth");
+        println!("cargo:rustc-link-lib=framework=Foundation");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes framework linking error when cross-compiling to Android from macOS. The issue occurred because `#[cfg(target_os)]` attributes check the **host** platform, not the **target** platform.

## Root Cause

When building for Android on macOS, Rust's `#[cfg(target_os = \"macos\")]` still evaluates to true because the build is happening on a macOS host. This caused the build script to attempt linking macOS frameworks (`CoreBluetooth`, `Foundation`) even though the target is Android.

## Solution

Replace compile-time platform checks (`#[cfg]` attributes) with runtime checks using `std::env::var("TARGET")` in the build script:

```rust
fn main() {
    let target = std::env::var("TARGET").unwrap_or_default();
    
    // Only link frameworks when targeting macOS
    if target.contains("darwin") || target.contains("macos") {
        println!("cargo:rustc-link-lib=framework=CoreBluetooth");
        println!("cargo:rustc-link-lib=framework=Foundation");
    }
}
```

## Benefits

- ✅ Supports cross-compilation to Android from macOS
- ✅ Still links frameworks correctly when building native macOS binaries
- ✅ Works on all host platforms (Linux, Windows, macOS building to any target)

## Testing

- ✅ `cargo check -p lib-network` passes on macOS without errors
- ✅ Should now work with Android build scripts (e.g., `build-android.sh`)