### PR TITLE
fix: Correct is_system_transaction logging for token contracts

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -1667,9 +1667,8 @@ impl Blockchain {
         
         // Check if this is a system transaction (empty inputs indicates system transaction)
         // BUT token contract executions are NOT system transactions (they must pay fees)
-        let is_token_contract = transaction.transaction_type == TransactionType::ContractExecution
-            && transaction.memo.len() > 4
-            && &transaction.memo[0..4] == b"ZHTP";
+        // Use the full validation logic to ensure consistency with fee validation
+        let is_token_contract = crate::transaction::is_token_contract_execution(transaction);
         let is_system_transaction = transaction.inputs.is_empty() && !is_token_contract;
         
         tracing::info!("Verifying transaction with identity verification enabled");

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -46,6 +46,7 @@ pub use validation::{
     ValidationResult,
     TransactionValidator,
     StatefulTransactionValidator,
+    is_token_contract_execution,
 };
 
 // Explicit re-exports from hashing module

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -910,7 +910,14 @@ impl TransactionValidator {
     }
 }
 
-fn is_token_contract_execution(transaction: &Transaction) -> bool {
+/// Check if a transaction is a token contract execution
+///
+/// Returns true if the transaction:
+/// 1. Has type ContractExecution
+/// 2. Has memo starting with "ZHTP"
+/// 3. Contains a valid ContractCall with contract_type Token
+/// 4. Has a valid token method (create_custom_token, mint, transfer, burn)
+pub fn is_token_contract_execution(transaction: &Transaction) -> bool {
     if transaction.transaction_type != TransactionType::ContractExecution {
         tracing::debug!("is_token_contract_execution: not ContractExecution type");
         return false;


### PR DESCRIPTION
## Summary

Fix misleading logs where token contract executions showed `system=true` but failed fee validation because actual validation used `system=false`.

## Problem

```
validate_economics_with_system_check ENTER: system=false, fee=1000, size=10083
...
Transaction details: ... system=true
```

Two different definitions:
- **Logging** (blockchain.rs): `inputs.is_empty()` → true
- **Validation** (validation.rs): `inputs.is_empty() && !is_token` → false

## Fix

Align logging with validation logic. Token contract executions are NOT system transactions.

## Test plan

- [x] `cargo build -p lib-blockchain` passes