### PR TITLE
feat: Enforce centralized Web4 deployment configuration

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -26,12 +26,6 @@ on:
       ZHTP_KEYSTORE_B64:
         description: 'Base64-encoded tarball of keystore directory'
         required: true
-      ZHTP_SERVER:
-        description: 'QUIC server endpoint (ip:port)'
-        required: false
-      ZHTP_SERVER_SPKI:
-        description: 'Server SPKI pin for TLS verification'
-        required: false
 
 jobs:
   deploy:
@@ -69,15 +63,11 @@ jobs:
 
       - name: Deploy site
         run: |
-          TRUST_ARG="--trust-node"
-          if [ -n "$ZHTP_SERVER_SPKI" ]; then
-            TRUST_ARG="--pin-spki $ZHTP_SERVER_SPKI"
-          fi
           /tmp/zhtp-cli deploy site \
             --domain "${{ inputs.domain }}" \
             --keystore ~/.zhtp/keystore \
             --mode "${{ inputs.deployment_mode }}" \
-            $TRUST_ARG \
+            --pin-spki "$ZHTP_SERVER_SPKI" \
             out/
         env:
           ZHTP_SERVER: ${{ secrets.ZHTP_SERVER }}


### PR DESCRIPTION
## Summary
Enforce centralized Web4 deployment configuration by removing server overrides from the workflow interface. All sites now inherit ZHTP_SERVER and ZHTP_SERVER_SPKI from the main repo, ensuring consistent network endpoints and security across deployments.

Site repos only need to provide:
- Domain (e.g., breakroom.sov)
- ZHTP_KEYSTORE_B64 (their unique identity)

## Changes
- Remove ZHTP_SERVER and ZHTP_SERVER_SPKI from workflow_call secrets
- Simplify deploy logic (always use --pin-spki)
- Main repo secrets are used directly

## Test plan
- Verify site repos can deploy with only ZHTP_KEYSTORE_B64
- Confirm main repo secrets are properly passed through
- Test SPKI pinning works correctly