### PR TITLE
feat(lib-client): Generic contract transaction builder

### DIFF
--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -61,7 +61,19 @@ pub use request::{
     ZhtpRequest, ZhtpResponse,
 };
 pub use session::Session;
-pub use token_tx::{build_burn_tx, build_create_token_tx, build_mint_tx, build_transfer_tx};
+pub use token_tx::{
+    // Generic contract transaction builder
+    build_contract_transaction,
+    // Token-specific (backward compatible)
+    build_burn_tx, build_create_token_tx, build_mint_tx, build_transfer_tx,
+    // Domain-specific
+    build_domain_register_tx, build_domain_update_tx, build_domain_transfer_tx,
+    // Param types for serialization
+    CreateTokenParams, MintParams, TransferParams, BurnParams,
+    DomainRegisterParams, DomainUpdateParams, DomainTransferParams,
+};
+// Re-export ContractType for FFI callers
+pub use lib_blockchain::types::ContractType;
 
 /// Library version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -1,7 +1,9 @@
-//! Token Transaction Builder
+//! Contract Transaction Builder
 //!
-//! Provides FFI-exportable functions for building signed token transactions.
+//! Provides FFI-exportable functions for building signed contract transactions.
 //! iOS/Android clients call these to get hex-encoded transactions ready for the API.
+//!
+//! Supports all contract types: Token, DomainRegistry, Identity, etc.
 
 use serde::{Deserialize, Serialize};
 use crate::identity::Identity;
@@ -31,7 +33,7 @@ pub fn create_public_key(dilithium_pk: Vec<u8>) -> PublicKey {
 }
 
 // ============================================================================
-// Token Operation Parameters
+// Token Operation Parameters (kept for backward compatibility)
 // ============================================================================
 
 /// Parameters for creating a new token
@@ -67,30 +69,73 @@ pub struct BurnParams {
 }
 
 // ============================================================================
-// Transaction Builder
+// Domain Operation Parameters
 // ============================================================================
 
-/// Build a signed token transaction
+/// Parameters for registering a domain
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DomainRegisterParams {
+    pub domain: String,
+    pub content_cid: Option<String>,
+}
+
+/// Parameters for updating a domain
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DomainUpdateParams {
+    pub domain: String,
+    pub content_cid: String,
+}
+
+/// Parameters for transferring a domain
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DomainTransferParams {
+    pub domain: String,
+    pub to: Vec<u8>,  // New owner PublicKey bytes
+}
+
+// ============================================================================
+// Generic Transaction Builder
+// ============================================================================
+
+/// Build a signed contract transaction for ANY contract type
 ///
 /// CRITICAL: Uses lib-blockchain's signing_hash() for deterministic, version-safe signing.
 /// This ensures compatibility between server, CLI, and mobile clients.
 ///
-/// Signing process:
-/// 1. Build tx with placeholder signature
-/// 2. Call tx.signing_hash() - uses deterministic field-by-field hashing
-/// 3. Sign the hash with Dilithium
-/// 4. Put real signature back into transaction
-/// 5. Serialize with bincode for transmission
-fn build_token_transaction(
+/// # Arguments
+/// * `identity` - The signer's identity (contains Dilithium keypair)
+/// * `contract_type` - Type of contract (Token, DomainRegistry, Identity, etc.)
+/// * `method` - Contract method name (e.g., "transfer", "register", "mint")
+/// * `params` - Serialized parameters (bincode bytes)
+/// * `chain_id` - Network chain ID
+///
+/// # Returns
+/// Hex-encoded signed transaction ready for API submission
+///
+/// # Example
+/// ```ignore
+/// // For token transfer:
+/// let params = bincode::serialize(&TransferParams { ... })?;
+/// let tx_hex = build_contract_transaction(&identity, ContractType::Token, "transfer", params, 1)?;
+///
+/// // For domain registration:
+/// let params = bincode::serialize(&DomainRegisterParams { ... })?;
+/// let tx_hex = build_contract_transaction(&identity, ContractType::DomainRegistry, "register", params, 1)?;
+/// ```
+pub fn build_contract_transaction(
     identity: &Identity,
+    contract_type: ContractType,
     method: &str,
     params: Vec<u8>,
     chain_id: u8,
 ) -> Result<String, String> {
+    eprintln!("[contract_tx] Contract: {:?}", &contract_type);
+    eprintln!("[contract_tx] Method: {}", method);
+
     // Build ContractCall with Public permissions
     // Authorization is via tx.signature.public_key, not the permissions field
     let call = ContractCall {
-        contract_type: ContractType::Token,
+        contract_type,
         method: method.to_string(),
         params,
         permissions: CallPermissions::Public,
@@ -155,28 +200,27 @@ fn build_token_transaction(
         dao_execution_data: None,
         ubi_claim_data: None,
         profit_declaration_data: None,
-        token_transfer_data: None,        // Added - was missing
-        governance_config_data: None,     // Added - was missing
+        token_transfer_data: None,
+        governance_config_data: None,
     };
 
-    eprintln!("[token_tx] Method: {}", method);
-    eprintln!("[token_tx] Chain ID: {}", chain_id);
-    eprintln!("[token_tx] Memo length: {} bytes", memo.len());
-    eprintln!("[token_tx] Public key size: {}", identity.public_key.len());
-    eprintln!("[token_tx] Estimated tx size: {} bytes", estimated_tx_size);
-    eprintln!("[token_tx] Calculated minimum fee: {} ZHTP", min_fee);
+    eprintln!("[contract_tx] Chain ID: {}", chain_id);
+    eprintln!("[contract_tx] Memo length: {} bytes", memo.len());
+    eprintln!("[contract_tx] Public key size: {}", identity.public_key.len());
+    eprintln!("[contract_tx] Estimated tx size: {} bytes", estimated_tx_size);
+    eprintln!("[contract_tx] Calculated minimum fee: {} ZHTP", min_fee);
 
     // Step 3: Use signing_hash() - deterministic field-by-field hashing
     // This is the SAFE method that won't break when Transaction struct changes
     let tx_hash = tx.signing_hash();
 
-    eprintln!("[token_tx] Signing hash: {}", hex::encode(tx_hash.as_bytes()));
+    eprintln!("[contract_tx] Signing hash: {}", hex::encode(tx_hash.as_bytes()));
 
     // Step 4: Sign the hash with Dilithium
     let signature_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
         .map_err(|e| format!("Failed to sign: {}", e))?;
 
-    eprintln!("[token_tx] Signature size: {} bytes", signature_bytes.len());
+    eprintln!("[contract_tx] Signature size: {} bytes", signature_bytes.len());
 
     // Step 5: Put real signature and public key back into transaction
     tx.signature = Signature {
@@ -193,8 +237,8 @@ fn build_token_transaction(
     let final_tx_bytes = bincode::serialize(&tx)
         .map_err(|e| format!("Failed to serialize final tx: {}", e))?;
 
-    eprintln!("[token_tx] Final tx size: {} bytes (estimated was {})", final_tx_bytes.len(), estimated_tx_size);
-    eprintln!("[token_tx] Fee verification: {} ZHTP for {} bytes = {:.3} ZHTP/byte",
+    eprintln!("[contract_tx] Final tx size: {} bytes (estimated was {})", final_tx_bytes.len(), estimated_tx_size);
+    eprintln!("[contract_tx] Fee verification: {} ZHTP for {} bytes = {:.3} ZHTP/byte",
         min_fee, final_tx_bytes.len(),
         min_fee as f64 / final_tx_bytes.len() as f64);
 
@@ -203,7 +247,7 @@ fn build_token_transaction(
 }
 
 // ============================================================================
-// Public API
+// Convenience: Token-specific API (backward compatible)
 // ============================================================================
 
 /// Build a signed token transfer transaction
@@ -222,7 +266,7 @@ pub fn build_transfer_tx(
     let params_bytes = bincode::serialize(&params)
         .map_err(|e| format!("Failed to serialize params: {}", e))?;
 
-    build_token_transaction(identity, "transfer", params_bytes, chain_id)
+    build_contract_transaction(identity, ContractType::Token, "transfer", params_bytes, chain_id)
 }
 
 /// Build a signed token mint transaction
@@ -241,7 +285,7 @@ pub fn build_mint_tx(
     let params_bytes = bincode::serialize(&params)
         .map_err(|e| format!("Failed to serialize params: {}", e))?;
 
-    build_token_transaction(identity, "mint", params_bytes, chain_id)
+    build_contract_transaction(identity, ContractType::Token, "mint", params_bytes, chain_id)
 }
 
 /// Build a signed token creation transaction
@@ -262,7 +306,7 @@ pub fn build_create_token_tx(
     let params_bytes = bincode::serialize(&params)
         .map_err(|e| format!("Failed to serialize params: {}", e))?;
 
-    build_token_transaction(identity, "create_custom_token", params_bytes, chain_id)
+    build_contract_transaction(identity, ContractType::Token, "create_custom_token", params_bytes, chain_id)
 }
 
 /// Build a signed token burn transaction
@@ -279,5 +323,60 @@ pub fn build_burn_tx(
     let params_bytes = bincode::serialize(&params)
         .map_err(|e| format!("Failed to serialize params: {}", e))?;
 
-    build_token_transaction(identity, "burn", params_bytes, chain_id)
+    build_contract_transaction(identity, ContractType::Token, "burn", params_bytes, chain_id)
+}
+
+// ============================================================================
+// Convenience: Domain-specific API
+// ============================================================================
+
+/// Build a signed domain registration transaction
+pub fn build_domain_register_tx(
+    identity: &Identity,
+    domain: &str,
+    content_cid: Option<&str>,
+    chain_id: u8,
+) -> Result<String, String> {
+    let params = DomainRegisterParams {
+        domain: domain.to_string(),
+        content_cid: content_cid.map(|s| s.to_string()),
+    };
+    let params_bytes = bincode::serialize(&params)
+        .map_err(|e| format!("Failed to serialize params: {}", e))?;
+
+    build_contract_transaction(identity, ContractType::Web4Website, "register", params_bytes, chain_id)
+}
+
+/// Build a signed domain update transaction
+pub fn build_domain_update_tx(
+    identity: &Identity,
+    domain: &str,
+    content_cid: &str,
+    chain_id: u8,
+) -> Result<String, String> {
+    let params = DomainUpdateParams {
+        domain: domain.to_string(),
+        content_cid: content_cid.to_string(),
+    };
+    let params_bytes = bincode::serialize(&params)
+        .map_err(|e| format!("Failed to serialize params: {}", e))?;
+
+    build_contract_transaction(identity, ContractType::Web4Website, "update", params_bytes, chain_id)
+}
+
+/// Build a signed domain transfer transaction
+pub fn build_domain_transfer_tx(
+    identity: &Identity,
+    domain: &str,
+    to_pubkey: &[u8],
+    chain_id: u8,
+) -> Result<String, String> {
+    let params = DomainTransferParams {
+        domain: domain.to_string(),
+        to: to_pubkey.to_vec(),
+    };
+    let params_bytes = bincode::serialize(&params)
+        .map_err(|e| format!("Failed to serialize params: {}", e))?;
+
+    build_contract_transaction(identity, ContractType::Web4Website, "transfer", params_bytes, chain_id)
 }


### PR DESCRIPTION
## Summary
- Refactors `build_token_transaction` to generic `build_contract_transaction`
- Takes `ContractType`, method name, and serialized params as arguments
- Adds domain convenience functions: `build_domain_register_tx`, `build_domain_update_tx`, `build_domain_transfer_tx`
- Exports `ContractType` and param structs for FFI callers
- Token functions remain backward compatible (call generic internally)

## Why
iOS/Android can now use **one generic function** for any contract type instead of needing separate FFI exports for each transaction type.

## Usage
```rust
// Generic - works for any contract
let tx = build_contract_transaction(&identity, ContractType::Web4Website, "register", params, 1)?;

// Or use convenience functions
let tx = build_domain_register_tx(&identity, "mydomain.sov", None, 1)?;
```

## Test plan
- [ ] Verify lib-client compiles
- [ ] Test token transactions still work
- [ ] Test domain registration from iOS