### PR TITLE
fix(#1078): Update workflow SHA and add security best practices documentation

### DIFF
--- a/.github/workflows/test-web4-deploy.yml
+++ b/.github/workflows/test-web4-deploy.yml
@@ -31,7 +31,7 @@ jobs:
   deploy:
     name: Deploy to Web4
     needs: build
-    uses: SOVEREIGN-NET/The-Sovereign-Network/.github/workflows/deploy-site.yml@b3aa0fc97457fa7aa0ba14e050e20ab1e0247274
+    uses: SOVEREIGN-NET/The-Sovereign-Network/.github/workflows/deploy-site.yml@4a53b4af5a6d3bc6f28c3125bae611958e15bdc8
     with:
       domain: remote.sov
       deployment_mode: static

--- a/docs/web4_deployment/web_4_github_actions_and_boilerplate.md
+++ b/docs/web4_deployment/web_4_github_actions_and_boilerplate.md
@@ -147,3 +147,37 @@ After pushing to `main`:
 - Deployment step succeeds
 - Domain serves the site
 
+---
+
+## Security Best Practices
+
+### Use Full Commit SHAs for External Workflows
+
+When referencing external or reusable workflows, **always use the full commit SHA** instead of branch names or tags. This prevents supply chain attacks where a malicious actor could push changes to a branch or move a tag.
+
+**WRONG - Branch reference (vulnerable):**
+```yaml
+uses: SOVEREIGN-NET/The-Sovereign-Network/.github/workflows/deploy-site.yml@main
+uses: SOVEREIGN-NET/The-Sovereign-Network/.github/workflows/deploy-site.yml@feat/some-branch
+```
+
+**WRONG - Tag reference (vulnerable to tag reassignment):**
+```yaml
+uses: SOVEREIGN-NET/The-Sovereign-Network/.github/workflows/deploy-site.yml@v1.0.0
+```
+
+**CORRECT - Full commit SHA (immutable):**
+```yaml
+uses: SOVEREIGN-NET/The-Sovereign-Network/.github/workflows/deploy-site.yml@4a53b4af5a6d3bc6f28c3125bae611958e15bdc8
+```
+
+To get the SHA for a branch:
+```bash
+git ls-remote origin refs/heads/development | cut -f1
+# or
+git rev-parse origin/development
+```
+
+This is enforced by SonarCloud security scanning (rule S7637).
+
+


### PR DESCRIPTION
## Changes
- Update deploy-site.yml reference to use development commit SHA (`4a53b4af5a6d3bc6f28c3125bae611958e15bdc8`)
- Add security best practices documentation for using full commit SHAs

## Why
The previous SHA (`b3aa0fc97457fa7aa0ba14e050e20ab1e0247274`) was from the feature branch which doesn't exist on development. Updated to the correct SHA.

## Security Documentation Added
Added a new section **Security Best Practices** to `docs/web4_deployment/web_4_github_actions_and_boilerplate.md`:
- Explains why full commit SHAs must be used instead of branch names or tags
- Shows examples of WRONG vs CORRECT references
- Provides commands to get the SHA
- References SonarCloud rule S7637

## Local Validation
- ✅ Build job validated with act (WSL Ubuntu-24.04)
- ✅ All workflow steps pass in dry run

## Relates to
- Fixes follow-up for #1078
- Addresses SonarCloud security hotspot S7637