### PR TITLE
fix(#1078): Add ZHTP_SERVER and ZHTP_SERVER_SPKI secrets to deploy workflow

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -26,6 +26,12 @@ on:
       ZHTP_KEYSTORE_B64:
         description: 'Base64-encoded tarball of keystore directory'
         required: true
+      ZHTP_SERVER:
+        description: 'ZHTP server address'
+        required: true
+      ZHTP_SERVER_SPKI:
+        description: 'ZHTP server SPKI for certificate pinning'
+        required: true
 
 jobs:
   deploy:

--- a/.github/workflows/test-web4-deploy.yml
+++ b/.github/workflows/test-web4-deploy.yml
@@ -31,9 +31,12 @@ jobs:
   deploy:
     name: Deploy to Web4
     needs: build
-    uses: SOVEREIGN-NET/The-Sovereign-Network/.github/workflows/deploy-site.yml@4a53b4af5a6d3bc6f28c3125bae611958e15bdc8
+    # Using commit SHA for security (SonarCloud rule S7637)
+    uses: SOVEREIGN-NET/The-Sovereign-Network/.github/workflows/deploy-site.yml@b452e1754c84b9dc877bfeff5c9b1f8c9af5e8c5
     with:
       domain: remote.sov
       deployment_mode: static
     secrets:
       ZHTP_KEYSTORE_B64: ${{ secrets.ZHTP_KEYSTORE_B64 }}
+      ZHTP_SERVER: ${{ secrets.ZHTP_SERVER }}
+      ZHTP_SERVER_SPKI: ${{ secrets.ZHTP_SERVER_SPKI }}

--- a/docs/web4_deployment/web_4_github_actions_and_boilerplate.md
+++ b/docs/web4_deployment/web_4_github_actions_and_boilerplate.md
@@ -180,4 +180,35 @@ git rev-parse origin/development
 
 This is enforced by SonarCloud security scanning (rule S7637).
 
+### Pass Only Required Secrets to Reusable Workflows
+
+When calling reusable workflows, **explicitly pass only the secrets the workflow needs** instead of using `secrets: inherit`. This follows the principle of least privilege and prevents accidentally exposing unrelated secrets.
+
+**WRONG - Passes ALL repository secrets:**
+```yaml
+jobs:
+  deploy:
+    uses: SOVEREIGN-NET/The-Sovereign-Network/.github/workflows/deploy-site.yml@abc123...
+    with:
+      domain: my-site.sov
+    secrets: inherit  # Exposes ALL secrets to the called workflow
+```
+
+**CORRECT - Pass only required secrets:**
+```yaml
+jobs:
+  deploy:
+    uses: SOVEREIGN-NET/The-Sovereign-Network/.github/workflows/deploy-site.yml@abc123...
+    with:
+      domain: my-site.sov
+    secrets:
+      ZHTP_KEYSTORE_B64: ${{ secrets.ZHTP_KEYSTORE_B64 }}
+      ZHTP_SERVER: ${{ secrets.ZHTP_SERVER }}
+      ZHTP_SERVER_SPKI: ${{ secrets.ZHTP_SERVER_SPKI }}
+```
+
+The deployment workflow requires exactly three secrets:
+- `ZHTP_KEYSTORE_B64` - Base64-encoded keystore tarball
+- `ZHTP_SERVER` - Server address for deployment
+- `ZHTP_SERVER_SPKI` - Server public key for certificate pinning
 


### PR DESCRIPTION
## Problem
The deploy-site.yml reusable workflow references ZHTP_SERVER and ZHTP_SERVER_SPKI secrets but they were not declared in the workflow_call secrets section, causing deployment to fail with 'Invalid server address'.

## Solution
- Added ZHTP_SERVER and ZHTP_SERVER_SPKI to the secrets declaration in deploy-site.yml
- Updated test-web4-deploy.yml to pass these secrets
- Changed to use @development reference (will update SHA after merge)

## Error Fixed
```
ZHTP_SERVER: 
ZHTP_SERVER_SPKI:
Error: Configuration error: Failed to connect: Invalid server address
```

## Relates to
- Follow-up fix for #1078