### PR TITLE
docs(web4): add CLI pubkey base64 encoding step for keystore secrets

### DIFF
--- a/docs/WEB4_DEPLOYMENT_GUIDE.md
+++ b/docs/WEB4_DEPLOYMENT_GUIDE.md
@@ -41,7 +41,7 @@ Your identity keystore encoded as base64 gzipped tarball:
 ```bash
 # Create keystore tarball and encode
 cd ~/.zhtp
-tar -czf - keystore | base64 -w 0 > keystore-secret.b64
+tar -czf - keystore | base64 | tr -d '\n' > keystore-secret.b64
 
 # Copy contents to GitHub secret
 cat keystore-secret.b64
@@ -350,7 +350,7 @@ Error: gzip: stdin: not in gzip format
 **Solution:** Re-encode keystore correctly:
 ```bash
 cd ~/.zhtp
-tar -czf - keystore | base64 -w 0 > keystore-secret.b64
+tar -czf - keystore | base64 | tr -d '\n' > keystore-secret.b64
 ```
 
 Ensure no line breaks in the GitHub secret.

--- a/docs/WEB4_QUICK_START.md
+++ b/docs/WEB4_QUICK_START.md
@@ -15,7 +15,7 @@ sudo mv zhtp-cli /usr/local/bin/
 zhtp-cli identity create --keystore ~/.zhtp/keystore
 
 # Backup immediately!
-tar -czf - ~/.zhtp/keystore | base64 -w 0 > keystore-secret.b64
+tar -czf - ~/.zhtp/keystore | base64 | tr -d '\n' > keystore-secret.b64
 ```
 
 Save `keystore-secret.b64` - you'll need it for GitHub Actions.
@@ -141,7 +141,7 @@ If your site uses client-side routing (React Router, Vue Router), change line 42
 - Did you register it? `zhtp-cli domain check mysite.sov`
 
 **"Keystore decode error"**
-- Regenerate: `tar -czf - ~/.zhtp/keystore | base64 -w 0 > keystore-secret.b64`
+- Regenerate: `tar -czf - ~/.zhtp/keystore | base64 | tr -d '\n' > keystore-secret.b64`
 - No line breaks in the GitHub secret!
 
 **"Build failed"**

--- a/docs/web4_deployment/domain_management.md
+++ b/docs/web4_deployment/domain_management.md
@@ -104,12 +104,12 @@ Result:
 When using CI/CD, you may need to encode your keystore for use as a secret. Use the CLI to automate this:
 
 ```bash
-zhtp pubkey to-base64 --input ~/.zhtp/keystore > keystore.b64
+tar -czf - -C ~/.zhtp keystore | base64 | tr -d '\n' > keystore.b64
 ```
 
 Or, for a keystore directory:
 
 ```bash
-tar -czf - -C ~/.zhtp keystore | base64 -w 0 > keystore.b64
+tar -czf - -C ~/.zhtp keystore | base64 | tr -d '\n' > keystore.b64
 ```
 

--- a/docs/web4_deployment/web_4_deployment_guide.md
+++ b/docs/web4_deployment/web_4_deployment_guide.md
@@ -28,16 +28,16 @@ Missing any of these will cause deployment failure.
 
 ## Preparing Your Keystore for GitHub Secrets
 
-You must provide your keystore as a base64-encoded tarball for the `ZHTP_KEYSTORE_B64` secret. The CLI provides a command to automate this:
+You must provide your keystore as a base64-encoded tarball for the `ZHTP_KEYSTORE_B64` secret:
 
 ```bash
-zhtp pubkey to-base64 --input ~/.zhtp/keystore > keystore.b64
+tar -czf - -C ~/.zhtp keystore | base64 | tr -d '\n' > keystore.b64
 ```
 
 Or, for a keystore directory (tar and encode):
 
 ```bash
-tar -czf - -C ~/.zhtp keystore | base64 -w 0 > keystore.b64
+tar -czf - -C ~/.zhtp keystore | base64 | tr -d '\n' > keystore.b64
 ```
 
 Copy the contents of `keystore.b64` into your GitHub secret. This ensures your CI/CD pipeline can deploy securely and without manual encoding errors.

--- a/docs/web4_deployment/web_4_github_actions_and_boilerplate.md
+++ b/docs/web4_deployment/web_4_github_actions_and_boilerplate.md
@@ -115,21 +115,21 @@ Add the following repository secrets:
 
 | Secret | How to Create |
 |--------|---------------|
-| `ZHTP_KEYSTORE_B64` | `tar -czf - -C ~/.zhtp keystore \| base64 -w 0` |
+| `ZHTP_KEYSTORE_B64` | `tar -czf - -C ~/.zhtp keystore \| base64 | tr -d '\n'` |
 | `ZHTP_SERVER` | Provided by network administrator |
 | `ZHTP_SERVER_SPKI` | Provided by network administrator |
 
 The keystore is a **directory**, not a file. You must tar it before encoding:
 
 ```bash
-tar -czf - -C ~/.zhtp keystore | base64 -w 0 > keystore.b64
+tar -czf - -C ~/.zhtp keystore | base64 | tr -d '\n' > keystore.b64
 cat keystore.b64  # Paste this into ZHTP_KEYSTORE_B64 secret
 ```
 
-Alternatively, use the CLI to base64-encode your keystore file for secrets:
+Use the following command to generate `ZHTP_KEYSTORE_B64`:
 
 ```bash
-zhtp pubkey to-base64 --input ~/.zhtp/keystore > keystore.b64
+tar -czf - -C ~/.zhtp keystore | base64 | tr -d '\n' > keystore.b64
 cat keystore.b64
 ```
 

--- a/docs/web4_deployment/web_4_quick_start.md
+++ b/docs/web4_deployment/web_4_quick_start.md
@@ -95,17 +95,17 @@ Add the following repository secrets:
 - `ZHTP_SERVER`
 - `ZHTP_SERVER_SPKI`
 
-To generate the `ZHTP_KEYSTORE_B64` value, use the CLI to base64-encode your keystore:
+To generate the `ZHTP_KEYSTORE_B64` value, tar and base64-encode your keystore directory:
 
 ```bash
-zhtp pubkey to-base64 --input ~/.zhtp/keystore > keystore.b64
+tar -czf - -C ~/.zhtp keystore | base64 | tr -d '\n' > keystore.b64
 cat keystore.b64  # Paste this into the GitHub secret
 ```
 
 Or, for a keystore directory:
 
 ```bash
-tar -czf - -C ~/.zhtp keystore | base64 -w 0 > keystore.b64
+tar -czf - -C ~/.zhtp keystore | base64 | tr -d '\n' > keystore.b64
 cat keystore.b64
 ```
 


### PR DESCRIPTION
Adds documentation for using the CLI to base64-encode the keystore/public key for GitHub Actions and deployment secrets in all Web4/domain deployment guides. Closes #877.