### PR TITLE
fix(lib-client): Update domain functions to use JSON request format

### DIFF
--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -71,11 +71,13 @@ pub use token_tx::{
     build_contract_transaction,
     // Token-specific (backward compatible)
     build_burn_tx, build_create_token_tx, build_mint_tx, build_transfer_tx,
-    // Domain-specific
+    // Domain-specific (new JSON-based API)
+    build_domain_register_request, build_domain_update_request, build_domain_transfer_request,
+    // Domain-specific (deprecated, use *_request functions instead)
     build_domain_register_tx, build_domain_update_tx, build_domain_transfer_tx,
     // Param types for serialization
     CreateTokenParams, MintParams, TransferParams, BurnParams,
-    DomainRegisterParams, DomainUpdateParams, DomainTransferParams,
+    DomainRegisterParams, DomainUpdateParams, DomainTransferParams, ContentMapping,
 };
 // Re-export ContractType for FFI callers
 pub use lib_blockchain::types::ContractType;


### PR DESCRIPTION
## Summary
- Fix domain registration/update/transfer functions to use JSON format expected by server
- Server expects `SimpleDomainRegistrationRequest`, `DomainUpdateRequest`, `ApiDomainTransferRequest`
- lib-client was sending contract transactions with bincode (wrong format)

## Changes
- Add `build_domain_register_request()` - builds JSON with proper signature
- Add `build_domain_update_request()` - builds JSON with compare-and-swap
- Add `build_domain_transfer_request()` - builds JSON with transfer proof
- Update param structs to match server expectations
- Deprecate old `*_tx` functions, wrap to new `*_request` functions

## Signature formats
| Operation | Signed Message |
|-----------|----------------|
| Register | `domain\|timestamp\|fee_amount` |
| Update | `domain\|expected_previous_manifest_cid\|new_manifest_cid\|timestamp` |
| Transfer | `domain\|from_owner\|to_owner\|timestamp` |

## Test plan
- [ ] Run lib-client tests
- [ ] Test domain registration from mobile against zhtp-dev-2