### PR TITLE
feat(lib-client): Android JNI export for SOV wallet transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,6 +2807,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hex",
  "hkdf",
+ "jni",
  "js-sys",
  "lib-blockchain",
  "lib-crypto",

--- a/lib-client/Cargo.toml
+++ b/lib-client/Cargo.toml
@@ -56,6 +56,10 @@ pqcrypto-kyber = "0.8"
 pqcrypto-traits = "0.3"
 crystals-dilithium = "1.0"  # For deterministic keypair generation from seed
 
+# Android JNI bindings
+[target.'cfg(target_os = "android")'.dependencies]
+jni = "0.21"
+
 # WASM: Pure Rust PQC implementations
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 crystals-dilithium = "1.0"


### PR DESCRIPTION
## Summary
- Add `nativeBuildSovWalletTransfer` JNI binding for Android (`com.sovereignnetworkmobile.Identity`)
- Wraps existing `zhtp_client_build_sov_wallet_transfer` C FFI for Java/Kotlin interop
- `jni` crate dependency gated behind `cfg(target_os = "android")`

## Test plan
- [ ] Verify desktop build unaffected (jni dep is android-only)
- [ ] Cross-compile for Android target and verify JNI symbol exported
- [ ] Call from Android app via `Identity.nativeBuildSovWalletTransfer()`