### PR TITLE
feat: Configurable fee model, DAO governance APIs, and client fee calculation

### DIFF
--- a/lib-blockchain/src/transaction/fee.rs
+++ b/lib-blockchain/src/transaction/fee.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+/// Governance-configurable fee parameters for the legacy size-based fee model.
+///
+/// Formula:
+/// fee = base_fee + ceil(effective_size / bytes_per_sov)
+/// effective_size = payload_bytes + min(witness_bytes, witness_cap)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxFeeConfig {
+    /// Fixed base fee (in atomic units)
+    pub base_fee: u64,
+    /// Bytes per 1 SOV unit (fee slope)
+    pub bytes_per_sov: u64,
+    /// Witness bytes cap applied to fee calculation
+    pub witness_cap: u32,
+}
+
+impl Default for TxFeeConfig {
+    fn default() -> Self {
+        Self {
+            base_fee: 100,
+            bytes_per_sov: 100,
+            witness_cap: 500,
+        }
+    }
+}

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -8,6 +8,7 @@ pub mod creation;
 pub mod validation;
 pub mod hashing;
 pub mod signing;
+pub mod fee;
 
 // Explicit re-exports from core module
 pub use core::{
@@ -40,6 +41,9 @@ pub use creation::{
     create_contract_transaction,
     create_token_transaction,
 };
+
+// Explicit re-exports from fee module
+pub use fee::TxFeeConfig;
 
 // Explicit re-exports from validation module
 pub use validation::{

--- a/lib-blockchain/src/utils.rs
+++ b/lib-blockchain/src/utils.rs
@@ -91,9 +91,7 @@ pub mod fees {
     
     /// Calculate minimum fee for transaction
     pub fn calculate_minimum_fee(transaction: &Transaction) -> u64 {
-        let base_fee = 1000u64; // Base fee
-        let size_fee = size::transaction_size(transaction) as u64; // 1 unit per byte
-        base_fee + size_fee
+        crate::transaction::creation::utils::calculate_minimum_fee(transaction.size())
     }
     
     /// Calculate fee rate (fee per byte)

--- a/lib-consensus/src/dao/dao_engine.rs
+++ b/lib-consensus/src/dao/dao_engine.rs
@@ -446,7 +446,10 @@ impl DaoEngine {
                 //      BlockchainConsensusCoordinator::apply_difficulty_governance_update()
                 GovernanceParameterValue::BlockchainInitialDifficulty(_)
                 | GovernanceParameterValue::BlockchainAdjustmentInterval(_)
-                | GovernanceParameterValue::BlockchainTargetTimespan(_) => {
+                | GovernanceParameterValue::BlockchainTargetTimespan(_)
+                | GovernanceParameterValue::TxFeeBase(_)
+                | GovernanceParameterValue::TxFeeBytesPerSov(_)
+                | GovernanceParameterValue::TxFeeWitnessCap(_) => {
                     // No-op here: these are applied via the DifficultyManager pathway
                     // described in the comment above, not via ConsensusConfig mutation
                 }
@@ -543,6 +546,21 @@ impl DaoEngine {
                 GovernanceParameterValue::BlockchainTargetTimespan(value) => {
                     if *value == 0 {
                         return Err(anyhow::anyhow!("Target timespan must be greater than zero"));
+                    }
+                }
+                GovernanceParameterValue::TxFeeBase(value) => {
+                    if *value == 0 {
+                        return Err(anyhow::anyhow!("Tx base fee must be greater than zero"));
+                    }
+                }
+                GovernanceParameterValue::TxFeeBytesPerSov(value) => {
+                    if *value == 0 {
+                        return Err(anyhow::anyhow!("Tx bytes_per_sov must be greater than zero"));
+                    }
+                }
+                GovernanceParameterValue::TxFeeWitnessCap(value) => {
+                    if *value == 0 {
+                        return Err(anyhow::anyhow!("Tx witness cap must be greater than zero"));
                     }
                 }
             }

--- a/lib-consensus/src/dao/dao_types.rs
+++ b/lib-consensus/src/dao/dao_types.rs
@@ -218,6 +218,12 @@ pub enum GovernanceParameterValue {
     BlockchainAdjustmentInterval(u64),
     /// Target time for difficulty adjustment interval (seconds)
     BlockchainTargetTimespan(u64),
+    /// Base fee for transaction fee calculation (atomic units)
+    TxFeeBase(u64),
+    /// Bytes per 1 SOV fee unit (slope)
+    TxFeeBytesPerSov(u64),
+    /// Witness cap in bytes for fee calculation
+    TxFeeWitnessCap(u32),
 }
 
 /// Types of DAO proposals


### PR DESCRIPTION
## Summary
- Add runtime-configurable fee parameters in lib-client (`set_fee_config()`) so governance can update fee constants without redeploying
- Match client-side fee calculation to the server's canonical formula (`creation.rs:417`) using `PQ_WITNESS_SIZE`, `WITNESS_CAP`, `BASE_FEE`, `BYTES_PER_SOV`
- Add `fee.rs` module in lib-blockchain for shared fee constants
- Extend DAO engine and types for governance integration
- Add blockchain info and fee parameter API endpoints
- Export fee config helpers in lib-client public API

## Test plan
- [ ] Verify client fee calculation matches server minimum for all tx types
- [ ] Verify `set_fee_config()` updates are reflected in subsequent tx builds
- [ ] Verify new API endpoints return correct blockchain/fee info