### PR TITLE
fix(web4): Populate content_mappings from deploy manifest and fix wallet_id handling

### DIFF
--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -984,6 +984,20 @@ pub enum DeployAction {
         #[command(flatten)]
         trust: TrustFlags,
     },
+
+    /// Fetch and print a Web4 manifest by CID (debug utility)
+    FetchManifest {
+        /// Manifest CID to fetch (bafk...)
+        #[arg(long)]
+        cid: String,
+
+        /// Path to identity keystore directory (used to establish a QUIC client session)
+        #[arg(short, long)]
+        keystore: Option<String>,
+
+        #[command(flatten)]
+        trust: TrustFlags,
+    },
 }
 
 /// Trust management commands

--- a/zhtp-cli/src/commands/trust.rs
+++ b/zhtp-cli/src/commands/trust.rs
@@ -9,7 +9,7 @@
 
 use anyhow::{anyhow, Result, Context};
 use std::path::PathBuf;
-use zhtp::web4_stub::{TrustDb, TrustConfig, TrustAuditEntry};
+use lib_network::web4::{TrustAuditEntry, TrustConfig, TrustDb};
 use crate::argument_parsing::{TrustArgs, TrustAction};
 
 // ============================================================================
@@ -59,14 +59,14 @@ pub fn action_to_operation(action: &TrustAction) -> TrustOperation {
 ///
 /// Pure function - path construction only
 pub fn get_trustdb_path() -> Result<String> {
-    TrustConfig::default_trustdb_path()
+    Ok(TrustConfig::default_trustdb_path()?.to_string_lossy().to_string())
 }
 
 /// Get default audit log path
 ///
 /// Pure function - path construction only
 pub fn get_audit_path() -> String {
-    TrustConfig::default_audit_path()
+    TrustConfig::default_audit_path().to_string_lossy().to_string()
 }
 
 /// Format audit entry for display
@@ -233,7 +233,6 @@ mod tests {
 
     #[test]
     fn test_format_audit_entry() {
-        use zhtp::web4_stub::TrustAuditEntry;
         let entry = TrustAuditEntry {
             timestamp: 1735689600u64,
             node_addr: "localhost:9002".to_string(),

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -274,21 +274,13 @@ impl Web4Handler {
 
             let owner_wallet_id = blockchain.wallet_registry.values()
                 .find(|wallet| wallet.owner_identity_id.as_ref() == Some(&owner_identity_hash) && wallet.wallet_type == "Primary")
-                .map(|wallet| wallet.wallet_id.clone())
+                .map(|wallet| wallet.wallet_id)
                 .ok_or_else(|| anyhow!("Primary wallet not found for identity"))?;
-
-            let owner_wallet_id_bytes = hex::decode(&owner_wallet_id)
-                .map_err(|_| anyhow!("Invalid primary wallet_id"))?;
-            if owner_wallet_id_bytes.len() != 32 {
-                return Err(anyhow!("Invalid primary wallet_id length"));
-            }
-            let mut owner_wallet_key_id = [0u8; 32];
-            owner_wallet_key_id.copy_from_slice(&owner_wallet_id_bytes);
 
             let owner_wallet_key = lib_blockchain::integration::crypto_integration::PublicKey {
                 dilithium_pk: vec![],
                 kyber_pk: vec![],
-                key_id: owner_wallet_key_id,
+                key_id: owner_wallet_id.into(),
             };
 
             // Check if SOV token contract exists
@@ -315,20 +307,13 @@ impl Web4Handler {
 
             let owner_wallet_id = blockchain.wallet_registry.values()
                 .find(|wallet| wallet.owner_identity_id.as_ref() == Some(&owner_identity_hash) && wallet.wallet_type == "Primary")
-                .map(|wallet| wallet.wallet_id.clone())
+                .map(|wallet| wallet.wallet_id)
                 .ok_or_else(|| anyhow!("Primary wallet not found for identity"))?;
-            let owner_wallet_id_bytes = hex::decode(&owner_wallet_id)
-                .map_err(|_| anyhow!("Invalid primary wallet_id"))?;
-            if owner_wallet_id_bytes.len() != 32 {
-                return Err(anyhow!("Invalid primary wallet_id length"));
-            }
-            let mut owner_wallet_key_id = [0u8; 32];
-            owner_wallet_key_id.copy_from_slice(&owner_wallet_id_bytes);
 
             let owner_wallet_key = lib_blockchain::integration::crypto_integration::PublicKey {
                 dilithium_pk: vec![],
                 kyber_pk: vec![],
-                key_id: owner_wallet_key_id,
+                key_id: owner_wallet_id.into(),
             };
 
             // Get height before mutable borrow of token_contracts


### PR DESCRIPTION
## Summary
- **Fix empty content_mappings**: Web4 gateway returned blank pages because `content_mappings` was never populated from CLI manifest-based deploys. Now copies manifest file entries into `content_mappings` with proper leading-slash keys during `register_domain()`.
- **Fix wallet_id hex::decode**: `hex::decode()` was called on raw `[u8; 32]` bytes (via `Hash.as_ref()`) instead of a hex string, causing "Invalid primary wallet_id" errors during domain registration. Now uses `Hash.into()` directly.
- **Fix owner_did truncation**: `get_domain_status()` was encoding only the first 16 bytes of the owner identity, producing a truncated DID. Now encodes the full 32 bytes.
- **Add `deploy delete` CLI command**: Allows deleting a deployed domain for cleanup/redeployment.

## Test plan
- [ ] Deploy a fresh site with `deploy site` and verify content_mappings is populated
- [ ] Browse the deployed site and confirm files are served (no white screen)
- [ ] Verify `deploy status` shows full owner DID
- [ ] Test `deploy delete` removes a domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)