### PR TITLE
feat(BFT-J-1014): Expose consensus liveness/latency/fork-rate metrics

### DIFF
--- a/lib-consensus/src/lib.rs
+++ b/lib-consensus/src/lib.rs
@@ -33,7 +33,10 @@ pub use engines::enhanced_bft_engine::{ConsensusStatus, EnhancedBftEngine};
 pub use engines::ConsensusEngine;
 pub use mempool::{Mempool, MempoolTransaction, MempoolStats};
 pub use mining::{should_mine_block, IdentityData};
-pub use network::{BincodeConsensusCodec, CodecError, ConsensusMessageCodec};
+pub use network::{
+    check_consensus_health, BincodeConsensusCodec, CodecError, ConsensusMessageCodec,
+    ConsensusMetrics,
+};
 pub use proofs::*;
 pub use testing::NoOpBroadcaster;
 pub use types::*;

--- a/lib-consensus/src/network/mod.rs
+++ b/lib-consensus/src/network/mod.rs
@@ -14,7 +14,10 @@ pub mod heartbeat;
 pub mod liveness_monitor;
 
 pub use codec::{BincodeConsensusCodec, CodecError, ConsensusMessageCodec};
-pub use heartbeat::{HeartbeatProcessingResult, HeartbeatTracker, HeartbeatValidationError};
+pub use heartbeat::{
+    check_consensus_health, ConsensusMetrics, HeartbeatProcessingResult, HeartbeatTracker,
+    HeartbeatValidationError,
+};
 pub use liveness_monitor::{
     LivenessMonitor,
     MAX_MISSED_BLOCKS,


### PR DESCRIPTION
## Summary
- Introduces `ConsensusMetrics` struct: liveness, last_commit_latency_ms, fork_rate, rounds_to_commit
- Adds `check_consensus_health()` returning Err on non-zero fork_rate (safety violation) or liveness failure
- Documents: fork_rate MUST be 0.0 in correct BFT operation; non-zero = safety violation

## Fixes
Closes #1014

## Test plan
- [ ] Unit test: healthy metrics pass
- [ ] Unit test: non-zero fork_rate detected
- [ ] Unit test: liveness failure detected
- [ ] No regression in consensus correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)