### PR TITLE
feat(BFT-I-1009): define consensus signature schemes and aggregation …

### DIFF
--- a/lib-blockchain/src/integration/consensus_integration.rs
+++ b/lib-blockchain/src/integration/consensus_integration.rs
@@ -1539,6 +1539,20 @@ impl BlockchainConsensusCoordinator {
         
         // BFT-I: Only Dilithium2 (CONSENSUS_SIGNATURE_SCHEME) is permitted here.
         // Dilithium5 and other schemes are prohibited for consensus votes.
+        //
+        // Enforce this invariant by validating the key sizes against the expected
+        // Dilithium2 public/private key lengths before signing.
+        const DILITHIUM2_PUBLIC_KEY_LEN: usize = 1312;
+        const DILITHIUM2_PRIVATE_KEY_LEN: usize = 2528;
+
+        if keypair.public_key.dilithium_pk.len() != DILITHIUM2_PUBLIC_KEY_LEN
+            || keypair.private_key.dilithium_sk.len() != DILITHIUM2_PRIVATE_KEY_LEN
+        {
+            return Err(anyhow!(
+                "Invalid consensus keypair: expected Dilithium2 key sizes (CONSENSUS_SIGNATURE_SCHEME) for votes"
+            ));
+        }
+
         // Create signature using lib-crypto
         let signature = lib_crypto::sign_message(&keypair, &vote_data)?;
         

--- a/lib-crypto/src/keypair/mod.rs
+++ b/lib-crypto/src/keypair/mod.rs
@@ -7,3 +7,6 @@ pub mod operations;
 
 // Re-export main KeyPair type
 pub use generation::KeyPair;
+
+// Re-export consensus signature scheme validation
+pub use operations::{CONSENSUS_SIGNATURE_SCHEME, validate_consensus_signature_scheme};

--- a/lib-crypto/src/keypair/operations.rs
+++ b/lib-crypto/src/keypair/operations.rs
@@ -59,7 +59,7 @@ pub const CONSENSUS_SIGNATURE_SCHEME: &str = "Dilithium2";
 pub fn validate_consensus_signature_scheme(scheme: &str) -> anyhow::Result<()> {
     if scheme != CONSENSUS_SIGNATURE_SCHEME {
         return Err(anyhow::anyhow!(
-            "consensus signature scheme violation: only Dilithium2 is permitted \n             for consensus votes and commits; received {}",
+            "consensus signature scheme violation: only Dilithium2 is permitted for consensus votes and commits; received {}",
             scheme
         ));
     }

--- a/lib-crypto/src/lib.rs
+++ b/lib-crypto/src/lib.rs
@@ -26,7 +26,7 @@ pub use types::{
     keys::{PublicKey, PrivateKey},
     signatures::{Signature, SignatureAlgorithm, PostQuantumSignature}
 };
-pub use verification::verify_signature;
+pub use verification::{verify_signature, validate_consensus_vote_signature_scheme, verify_consensus_vote_signature};
 
 // Re-export security traits for zeroization enforcement
 pub use traits::{ZeroizingKey, SecureKey};
@@ -41,7 +41,11 @@ pub use random::{SecureRng, generate_nonce};
 pub use seed::generate_identity_seed;
 
 // Re-export keypair functionality
-pub use keypair::generation::KeyPair;
+pub use keypair::{
+    generation::KeyPair,
+    CONSENSUS_SIGNATURE_SCHEME,
+    validate_consensus_signature_scheme,
+};
 
 // Re-export symmetric encryption
 pub use symmetric::{

--- a/lib-crypto/src/verification/mod.rs
+++ b/lib-crypto/src/verification/mod.rs
@@ -6,4 +6,4 @@ pub mod signature_verify;
 pub mod dev_mode;
 
 // Re-export main functions
-pub use signature_verify::verify_signature;
+pub use signature_verify::{verify_signature, validate_consensus_vote_signature_scheme, verify_consensus_vote_signature};


### PR DESCRIPTION
…rules

- Add CONSENSUS_SIGNATURE_SCHEME = "Dilithium2" as the sole permitted scheme for votes/commits
- Add validate_consensus_signature_scheme() guard rejecting any other scheme
- Document aggregation rules: single scheme, no multi-sig in current protocol
- Include unit tests for acceptance and rejection