### PR TITLE
feat(BFT-I-1010): Specify canonical hash functions for consensus-critical data

### DIFF
--- a/lib-crypto/src/hashing/mod.rs
+++ b/lib-crypto/src/hashing/mod.rs
@@ -53,9 +53,11 @@ mod canonical_hash_tests {
 }
 
 /// Blake3 hash function - primary hash function for ZHTP
+///
+/// This function wraps [`canonical_consensus_hash`] to maintain API compatibility
+/// while ensuring a single source of truth for BLAKE3 hashing.
 pub fn hash_blake3(data: &[u8]) -> [u8; 32] {
-    let hash = blake3::hash(data);
-    hash.into()
+    canonical_consensus_hash(data)
 }
 
 /// Hash multiple data segments


### PR DESCRIPTION
## Summary
- Adds `CONSENSUS_HASH_FUNCTION = "BLAKE3"` constant with full policy documentation
- Adds `canonical_consensus_hash()` enforcing BLAKE3 for block headers, state roots, vote IDs
- Prohibits SHA-3 for consensus commitments

## Fixes
Closes #1010

## Test plan
- [ ] Unit test: deterministic output
- [ ] Unit test: matches raw blake3::hash
- [ ] No regression in consensus correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)