### PR TITLE
feat(BFT-I-1011): Define key rotation + validator identity binding

### DIFF
--- a/lib-crypto/src/keypair/generation.rs
+++ b/lib-crypto/src/keypair/generation.rs
@@ -26,12 +26,11 @@ pub const KEY_ROTATION_POLICY: &str = "no_rotation";
 ///
 /// Call this from any code path that would attempt to replace a validator's
 /// key without creating a new validator identity.
-pub fn validate_key_rotation_prohibited() -> Result<(), String> {
-    Err(
+pub fn validate_key_rotation_prohibited() -> Result<()> {
+    Err(anyhow::anyhow!(
         "key rotation is not supported (policy=no_rotation): \
          register a new validator identity for a new key"
-            .to_string(),
-    )
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Adds `KEY_ROTATION_POLICY = "no_rotation"`: rotation is not supported
- Adds `validate_key_rotation_prohibited()` returning Err on any rotation attempt
- Documents: validator identity permanently bound to the key at registration

## Fixes
Closes #1011

## Test plan
- [ ] Unit test: rotation is prohibited
- [ ] Unit test: policy constant is correct
- [ ] No regression in consensus correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)