### PR TITLE
docs(alpha): Add ALPHA_RELEASE_NOTES.md for v0.1.0-alpha.1

### DIFF
--- a/ALPHA_RELEASE_NOTES.md
+++ b/ALPHA_RELEASE_NOTES.md
@@ -16,7 +16,10 @@ This is the first alpha release of The Sovereign Network. This release establish
 
 - **Seed-Anchored Identity**: All identity components derive from a single seed via a deterministic root signing key
 - **Deterministic Root Key (ADR-0004)**: DID is anchored to the deterministic root signing public key derived from the seed
-- **NodeId Derivation**: `Blake3("ZHTP_NODE_V2:" + DID + ":" + device)` → 32 bytes
+- **NodeId Derivation**:
+  - **Legacy deterministic method** (`NodeId::from_did_device()`): Uses format `Blake3("ZHTP_NODE_V2:network={network}:version={version}:{DID}:{normalized_device}")` where device is normalized (trimmed, lowercase, validated). This method is kept for backward compatibility but is vulnerable to rainbow table attacks.
+  - **Recommended secure method** (`NodeId::from_identity_components()`): Uses domain separation prefix `"ZHTP_NODE_ID_V2"` with additional entropy sources including network genesis binding, cryptographic random nonce (256 bits), and timestamp binding. This non-deterministic approach prevents rainbow table attacks and cross-chain replay while enforcing minimum device ID entropy (8+ chars, 4+ unique characters).
+  - **Security tradeoff**: Legacy method provides deterministic reconstruction (same inputs = same NodeId) but is less secure. New method provides strong security guarantees but requires storing the generated NodeId and its metadata (nonce, network genesis) for verification.
 - **Unified Constructor**: `ZhtpIdentity::new_unified(type, age, jurisdiction, device, seed?)` derives the root key, DID, and per-device keys
 - **Multi-Device Support**: Same seed = same root signing key and DID; per-device NodeIds and operational keys are distinct and rotatable
 


### PR DESCRIPTION
## Summary
- Add ALPHA_RELEASE_NOTES.md documenting alpha v0.1.0-alpha.1 release
- Document seed-anchored identity architecture
- Document NodeId derivation from DID + device
- Document alpha goals, limitations, and roadmap
- Add migration guide for developers

## Changes
- New file: `ALPHA_RELEASE_NOTES.md`

## Related Issues
- Part of #32 (Alpha Step 5 - Documentation & Release)

## Status
This is the first step for issue #32. Additional documentation updates can follow in subsequent PRs.