### PR TITLE
fix: Wire PoUW handler into QUIC and fix build errors

### DIFF
--- a/zhtp/src/api/handlers/pouw/mod.rs
+++ b/zhtp/src/api/handlers/pouw/mod.rs
@@ -19,6 +19,9 @@ use crate::pouw::{
 pub struct PouwHandler {
     challenge_generator: Arc<ChallengeGenerator>,
     receipt_validator: Arc<RwLock<ReceiptValidator>>,
+    /// TODO: Wire up reward_calculator to calculate and distribute rewards for validated receipts.
+    /// This will be used in Phase 3 to aggregate receipts by epoch, apply proof type multipliers,
+    /// and trigger on-chain payouts. See zhtp/src/pouw/rewards.rs for implementation details.
     reward_calculator: Arc<RwLock<RewardCalculator>>,
     metrics: Arc<PouwMetrics>,
     rate_limiter: Arc<PouwRateLimiter>,


### PR DESCRIPTION
## Summary
- Wire PouwHandler into ZhtpRouter for QUIC endpoints
- Fix multiple build errors in zhtp crate

## Changes

### PouwHandler
- Created handler with endpoints: GET /pouw/challenge, POST /pouw/submit, GET /pouw/health
- Wired into unified_server.rs

### Build Fixes
- Fix MeshHandshake import path (bluetooth_le.rs)
- Fix our_public_key moved value (bluetooth_le.rs)
- Fix mesh_router Arc handling (unified_server.rs)
- Fix bluetooth_router.initialize argument count
- Fix RoutingError type (blockchain_sync.rs)

## Testing
- cargo check --package zhtp ✅ passes

## Related Issues
- Closes #878 (NODE-Phase-1)
- Closes #879 (NODE-Phase-2)

## Notes
- Using placeholder node keys - real keys from identity to be integrated later
- Rewards calculation stubbed (returns empty array)