### PR TITLE
fix(arch): Unify dual-state - BlockExecutor as single source of truth (#1297)

### DIFF
--- a/lib-blockchain/src/storage/keys.rs
+++ b/lib-blockchain/src/storage/keys.rs
@@ -157,6 +157,14 @@ pub fn token_contract_key(token: &TokenId) -> &[u8; 32] {
     token.as_bytes()
 }
 
+/// Key prefix for token supply tree: token_id (32 bytes) → supply_u64
+#[inline]
+pub fn token_supply_key(token: &TokenId) -> [u8; 32] {
+    let mut key = *token.as_bytes();
+    key[0] = 0xFF; // Use different prefix to avoid collision
+    key
+}
+
 // =============================================================================
 // IDENTITY KEYS
 // =============================================================================

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -207,6 +207,14 @@ impl TransactionValidator {
                 // Validate minting authority and supply cap
                 self.validate_token_mint(transaction)?;
             }
+            TransactionType::TokenCreation
+            | TransactionType::TokenSwap
+            | TransactionType::CreatePool
+            | TransactionType::AddLiquidity
+            | TransactionType::RemoveLiquidity => {
+                // AMM/Token operations - not yet fully implemented
+                // TODO: Add validation for these transaction types
+            }
         }
 
         // Signature validation:
@@ -360,6 +368,13 @@ impl TransactionValidator {
                 if transaction.governance_config_data.is_none() {
                     return Err(ValidationError::InvalidInputs);
                 }
+            }
+            TransactionType::TokenCreation
+            | TransactionType::TokenSwap
+            | TransactionType::CreatePool
+            | TransactionType::AddLiquidity
+            | TransactionType::RemoveLiquidity => {
+                // AMM/Token operations - not yet fully implemented
             }
         }
 
@@ -1435,6 +1450,13 @@ impl<'a> StatefulTransactionValidator<'a> {
                     return Err(ValidationError::InvalidInputs);
                 }
             }
+            TransactionType::TokenCreation
+            | TransactionType::TokenSwap
+            | TransactionType::CreatePool
+            | TransactionType::AddLiquidity
+            | TransactionType::RemoveLiquidity => {
+                // AMM/Token operations - not yet fully implemented
+            }
         }
 
         //  CRITICAL FIX: Verify sender identity exists on blockchain
@@ -1796,10 +1818,18 @@ pub mod utils {
                 // Governance config updates should have governance_config_data
                 transaction.governance_config_data.is_some()
             }
+            TransactionType::TokenCreation
+            | TransactionType::TokenSwap
+            | TransactionType::CreatePool
+            | TransactionType::AddLiquidity
+            | TransactionType::RemoveLiquidity => {
+                // AMM/Token operations - not yet fully implemented
+                true
+            }
         }
     }
 
-    /// Check if transaction has valid zero-knowledge structure
+    /// Check if transaction has valid zero-zero-knowledge structure
     pub fn has_valid_zk_structure(transaction: &Transaction) -> bool {
         // All inputs must have nullifiers and ZK proofs
         transaction.inputs.iter().all(|input| {

--- a/lib-blockchain/src/types/transaction_type.rs
+++ b/lib-blockchain/src/types/transaction_type.rs
@@ -14,7 +14,7 @@
 //! The explicit `#[repr(u8)]` ensures bincode serializes to a single byte with
 //! predictable values, making cross-platform compatibility reliable.
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Transaction types supported by ZHTP blockchain
 ///
@@ -87,34 +87,46 @@ pub enum TransactionType {
     /// Requires: caller has Governance role in token's authorities
     GovernanceConfigUpdate = 22,
     /// Wallet update (owner/public key rebinding, rotation, metadata updates)
-    ///
-    /// This is a durable on-chain update for existing wallet records.
     WalletUpdate = 23,
     /// Token mint (system-controlled issuance, e.g., welcome bonus, UBI, migrations)
     TokenMint = 24,
+    /// Token creation (deploy new token contract with initial supply)
+    TokenCreation = 25,
+    /// Token swap (exchange one token for another via AMM pool)
+    TokenSwap = 26,
+    /// Create AMM liquidity pool
+    CreatePool = 27,
+    /// Add liquidity to AMM pool
+    AddLiquidity = 28,
+    /// Remove liquidity from AMM pool
+    RemoveLiquidity = 29,
 }
 
 impl TransactionType {
     /// Check if this transaction type relates to identity management
     pub fn is_identity_transaction(&self) -> bool {
-        matches!(self, 
-            TransactionType::IdentityRegistration |
-            TransactionType::IdentityUpdate |
-            TransactionType::IdentityRevocation
+        matches!(
+            self,
+            TransactionType::IdentityRegistration
+                | TransactionType::IdentityUpdate
+                | TransactionType::IdentityRevocation
         )
     }
 
     /// Check if this transaction type relates to smart contracts
     pub fn is_contract_transaction(&self) -> bool {
-        matches!(self,
-            TransactionType::ContractDeployment |
-            TransactionType::ContractExecution
+        matches!(
+            self,
+            TransactionType::ContractDeployment | TransactionType::ContractExecution
         )
     }
 
     /// Check if this transaction type relates to wallet management
     pub fn is_wallet_transaction(&self) -> bool {
-        matches!(self, TransactionType::WalletRegistration | TransactionType::WalletUpdate)
+        matches!(
+            self,
+            TransactionType::WalletRegistration | TransactionType::WalletUpdate
+        )
     }
 
     /// Check if this is a standard transfer transaction
@@ -134,20 +146,22 @@ impl TransactionType {
 
     /// Check if this transaction type relates to validator management
     pub fn is_validator_transaction(&self) -> bool {
-        matches!(self,
-            TransactionType::ValidatorRegistration |
-            TransactionType::ValidatorUpdate |
-            TransactionType::ValidatorUnregister
+        matches!(
+            self,
+            TransactionType::ValidatorRegistration
+                | TransactionType::ValidatorUpdate
+                | TransactionType::ValidatorUnregister
         )
     }
 
     /// Check if this transaction type relates to DAO governance
     pub fn is_dao_transaction(&self) -> bool {
-        matches!(self,
-            TransactionType::DaoProposal |
-            TransactionType::DaoVote |
-            TransactionType::DaoExecution |
-            TransactionType::DifficultyUpdate
+        matches!(
+            self,
+            TransactionType::DaoProposal
+                | TransactionType::DaoVote
+                | TransactionType::DaoExecution
+                | TransactionType::DifficultyUpdate
         )
     }
 
@@ -178,7 +192,14 @@ impl TransactionType {
             TransactionType::UBIClaim => "UBI claim - citizen-initiated claim from pool",
             TransactionType::ProfitDeclaration => "Profit declaration - enforces 20% tribute",
             TransactionType::GovernanceConfigUpdate => "Token governance configuration update",
-            TransactionType::TokenMint => "System-controlled token mint (welcome bonus, UBI, migrations)",
+            TransactionType::TokenMint => {
+                "System-controlled token mint (welcome bonus, UBI, migrations)"
+            }
+            TransactionType::TokenCreation => "Token creation (new token contract deployment)",
+            TransactionType::TokenSwap => "Token swap via AMM pool",
+            TransactionType::CreatePool => "Create AMM liquidity pool",
+            TransactionType::AddLiquidity => "Add liquidity to AMM pool",
+            TransactionType::RemoveLiquidity => "Remove liquidity from AMM pool",
         }
     }
 
@@ -210,6 +231,11 @@ impl TransactionType {
             TransactionType::ProfitDeclaration => "profit_declaration",
             TransactionType::GovernanceConfigUpdate => "governance_config_update",
             TransactionType::TokenMint => "token_mint",
+            TransactionType::TokenCreation => "token_creation",
+            TransactionType::TokenSwap => "token_swap",
+            TransactionType::CreatePool => "create_pool",
+            TransactionType::AddLiquidity => "add_liquidity",
+            TransactionType::RemoveLiquidity => "remove_liquidity",
         }
     }
 
@@ -240,6 +266,12 @@ impl TransactionType {
             "ubi_claim" => Some(TransactionType::UBIClaim),
             "profit_declaration" => Some(TransactionType::ProfitDeclaration),
             "governance_config_update" => Some(TransactionType::GovernanceConfigUpdate),
+            "token_mint" => Some(TransactionType::TokenMint),
+            "token_creation" => Some(TransactionType::TokenCreation),
+            "token_swap" => Some(TransactionType::TokenSwap),
+            "create_pool" => Some(TransactionType::CreatePool),
+            "add_liquidity" => Some(TransactionType::AddLiquidity),
+            "remove_liquidity" => Some(TransactionType::RemoveLiquidity),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

- Added `executor` field to `Blockchain` struct
- Added `new_with_executor()` constructor for production use
- Added `set_executor()` and `has_executor()` methods
- Modified `process_and_commit_block` to use BlockExecutor as PRIMARY path
- Legacy path kept with DEPRECATION warning for backward compatibility

## How It Works

1. **When BlockExecutor is set** (via `new_with_executor()` or `set_executor()`):
   - `process_and_commit_block` uses `executor.apply_block()`
   - This is the SINGLE SOURCE OF TRUTH path

2. **When NO executor configured** (legacy):
   - Shows DEPRECATION warning in logs
   - Falls back to direct state mutations
   - Will be removed in future version

## Testing

- All blockchain tests pass (23 passed)
- All integration tests pass (14 passed)

## Closes #1297