### PR TITLE
feat(pouw): Add identity registry validation (POUW-Phase-5)

### DIFF
--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -893,6 +893,7 @@ impl ZhtpUnifiedServer {
             pouw_generator_arc,
             pouw_validator,
             pouw_calculator,
+            identity_manager.clone(),
         );
         zhtp_router.register_handler("/pouw".to_string(), Arc::new(pouw_handler));
 


### PR DESCRIPTION
## Summary
Added identity registry validation to PoUW handler to address POUW-Phase-5 (#867) - Client Validation task.

## Changes
- Added `IdentityManager` to `PouwHandler` for client validation
- Validate client DID format (must start with `did:sov:` or `did:zhtp:`)
- Check client exists in identity registry before accepting receipts
- Reject unknown clients with 401 Unauthorized
- Added unit tests for identity validation

## Testing
- All 53 PoUW tests pass
- New identity validation test covers:
  - Invalid DID format rejection
  - Non-existent identity rejection
  - Valid DID format acceptance (did:sov: and did:zhtp:)

## Related Issues
- POUW-Phase-5 (#867): Node Hardening & Reward Calculation