### PR TITLE
fix: Comment out RuntimeOrchestrator creation in UnifiedServer

### DIFF
--- a/zhtp/src/server/quic_handler.rs
+++ b/zhtp/src/server/quic_handler.rs
@@ -229,6 +229,11 @@ impl QuicHandler {
         }
     }
 
+    /// Get the ZHTP router for registering additional handlers
+    pub fn get_zhtp_router(&self) -> Arc<RwLock<ZhtpRouter>> {
+        self.zhtp_router.clone()
+    }
+
     /// Check and update handshake rate limit for an IP address
     async fn check_handshake_rate_limit(&self, peer_addr: &SocketAddr) -> Result<()> {
         let mut limits = self.handshake_rate_limits.write().await;


### PR DESCRIPTION
## Problem

The unified server was creating a `RuntimeOrchestrator` with `NodeConfig::default()`, which has `node_type=None`. This causes a panic in `RuntimeOrchestrator::new()` because it expects `node_type` to be set by the `start_*` methods.

**Crash message:**
```
NodeType must be set before RuntimeOrchestrator::new. This should have been validated by the start_* method.
```

**Root cause:** `UnifiedServer` is initialized before the main `RuntimeOrchestrator`, but it was trying to create its own orchestrator for `NetworkHandler` and `MeshHandler`.

## Temporary Fix

Comment out the `RuntimeOrchestrator` creation and the handlers that depend on it (`NetworkHandler`, `MeshHandler`). 

**Core node functionality remains operational:**
- ✅ Blockchain API
- ✅ Identity API
- ✅ Wallet API
- ✅ Token API
- ✅ DAO API
- ✅ Storage API
- ✅ Crypto API
- ✅ ZKP API
- ✅ Web4 API
- ✅ Validator API
- ✅ PoUW API

**Disabled (non-critical):**
- ❌ Network management API (`/api/v1/network`)
- ❌ Mesh blockchain API (`/api/v1/mesh`)

## Proper Fix (Future Work)

Architectural refactoring needed to either:
1. Pass the properly configured `RuntimeOrchestrator` to `UnifiedServer::new()`, or
2. Remove the `RuntimeOrchestrator` dependency from these handlers

## Test Plan

- [x] Compile check passes
- [ ] Fresh node starts without crash
- [ ] Core APIs remain functional
- [ ] Deploy to dev without crash
- [ ] Deploy to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)