### PR TITLE
feat(pouw): Wire DID signature verification to identity registry (#1344)

### DIFF
--- a/zhtp/src/api/handlers/pouw/mod.rs
+++ b/zhtp/src/api/handlers/pouw/mod.rs
@@ -677,7 +677,7 @@ mod tests {
         priv_arr.copy_from_slice(&node_privkey[..32]);
         node_id.copy_from_slice(&node_pubkey[..32]);
         let generator = Arc::new(ChallengeGenerator::new(priv_arr, node_id));
-        let validator = ReceiptValidator::new(generator.clone());
+        let validator = ReceiptValidator::new(generator.clone(), Arc::new(tokio::sync::RwLock::new(lib_identity::IdentityManager::new())));
         let reward_calculator = RewardCalculator::new(1_700_000_000);
         let identity_manager = Arc::new(RwLock::new(lib_identity::IdentityManager::new()));
         PouwHandler::new(generator, validator, reward_calculator, identity_manager)
@@ -721,7 +721,7 @@ mod tests {
         priv_arr.copy_from_slice(&node_privkey[..32]);
         node_id.copy_from_slice(&node_pubkey[..32]);
         let generator = Arc::new(ChallengeGenerator::new(priv_arr, node_id));
-        let validator = ReceiptValidator::new(generator.clone());
+        let validator = ReceiptValidator::new(generator.clone(), Arc::new(tokio::sync::RwLock::new(lib_identity::IdentityManager::new())));
         let reward_calculator = RewardCalculator::new(1_700_000_000);
         let identity_manager = Arc::new(RwLock::new(lib_identity::IdentityManager::new()));
         register_known_identity(
@@ -759,7 +759,7 @@ mod tests {
         priv_arr.copy_from_slice(&node_privkey[..32]);
         node_id.copy_from_slice(&node_pubkey[..32]);
         let generator = Arc::new(ChallengeGenerator::new(priv_arr, node_id));
-        let validator = ReceiptValidator::new(generator.clone());
+        let validator = ReceiptValidator::new(generator.clone(), Arc::new(tokio::sync::RwLock::new(lib_identity::IdentityManager::new())));
         let reward_calculator = RewardCalculator::new(1_700_000_000);
         let identity_manager = Arc::new(RwLock::new(lib_identity::IdentityManager::new()));
         let client_did = "did:zhtp:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -810,7 +810,7 @@ mod tests {
         priv_arr.copy_from_slice(&node_privkey[..32]);
         node_id.copy_from_slice(&node_pubkey[..32]);
         let generator = Arc::new(ChallengeGenerator::new(priv_arr, node_id));
-        let validator = ReceiptValidator::new(generator.clone());
+        let validator = ReceiptValidator::new(generator.clone(), Arc::new(tokio::sync::RwLock::new(lib_identity::IdentityManager::new())));
         let reward_calculator = RewardCalculator::new(1_700_000_000);
         let identity_manager = Arc::new(RwLock::new(lib_identity::IdentityManager::new()));
         let client_did = "did:zhtp:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -874,7 +874,7 @@ impl ZhtpUnifiedServer {
             pouw_node_key,
             pouw_node_id,
         ));
-        let pouw_validator = crate::pouw::ReceiptValidator::new(pouw_generator_arc.clone());
+        let pouw_validator = crate::pouw::ReceiptValidator::new(pouw_generator_arc.clone(), identity_manager.clone());
         let pouw_calculator = crate::pouw::RewardCalculator::new(pouw_genesis_timestamp);
         let pouw_handler = crate::api::handlers::pouw::PouwHandler::new(
             pouw_generator_arc,


### PR DESCRIPTION
Closes #1344

Wires `get_client_pubkey()` and `get_client_pubkey_dilithium()` to `IdentityManager` so receipt signature verification actually runs against registered identities.

## Changes
- `ReceiptValidator` gains `identity_manager: Arc<RwLock<IdentityManager>>` field
- `get_client_pubkey()` resolves Ed25519 key via `key_id` bytes from registered identity
- `get_client_pubkey_dilithium()` resolves `dilithium_pk` bytes from registered identity
- All `ReceiptValidator::new()` call sites updated
- Receipt batches from unregistered DIDs → `ClientInvalid`
- Forged signatures → `BadSig`

Part of #1343