### PR TITLE
feat(pouw): Per-DID epoch history tracking and anomaly detection (PoUW-BETA #1351)

### DIFF
--- a/zhtp/src/api/handlers/pouw/mod.rs
+++ b/zhtp/src/api/handlers/pouw/mod.rs
@@ -448,7 +448,13 @@ impl PouwHandler {
     }
 
     async fn handle_health_check(&self) -> ZhtpResult<ZhtpResponse> {
-        let body = serde_json::json!({"status": "ok"});
+        let calculator = self.reward_calculator.read().await;
+        let suspicious_dids = calculator.get_suspicious_dids().await;
+        let body = serde_json::json!({
+            "status": "ok",
+            "suspicious_dids": suspicious_dids,
+            "suspicious_did_count": suspicious_dids.len(),
+        });
         Ok(ZhtpResponse::json(&body, None).map_err(|e| anyhow::anyhow!(e))?)
     }
 
@@ -801,6 +807,10 @@ mod tests {
                 bytes_verified: 4096,
                 validated_at: 1_700_003_601,
                 challenge_nonce: vec![3u8; 16],
+                manifest_cid: None,
+                domain: None,
+                route_hops: None,
+                served_from_cache: None,
             }];
             let _ = calc.calculate_epoch_rewards(&validated, 1).await.unwrap();
         }
@@ -852,6 +862,10 @@ mod tests {
                 bytes_verified: 8192,
                 validated_at: 1_700_025_201,
                 challenge_nonce: vec![7u8; 16],
+                manifest_cid: None,
+                domain: None,
+                route_hops: None,
+                served_from_cache: None,
             }];
             let _ = calc.calculate_epoch_rewards(&validated, 7).await.unwrap();
         }

--- a/zhtp/src/pouw/load_test.rs
+++ b/zhtp/src/pouw/load_test.rs
@@ -10,6 +10,7 @@ use crate::pouw::types::{
 use crate::pouw::{ChallengeGenerator, ReceiptValidator};
 use rand::{Rng, thread_rng};
 use std::sync::Arc;
+use tokio::sync::RwLock;
 use std::time::{Duration, Instant};
 
 /// Configuration for load test generation
@@ -432,7 +433,7 @@ mod stress_tests {
         node_id.copy_from_slice(&node_pubkey[..32]);
 
         let generator = Arc::new(ChallengeGenerator::new(priv_arr, node_id));
-        ReceiptValidator::new(generator)
+        ReceiptValidator::new(generator, Arc::new(RwLock::new(lib_identity::IdentityManager::new())))
     }
 
     fn build_batch_with_client(config: &LoadTestConfig, client_did: &str) -> crate::pouw::types::ReceiptBatch {
@@ -669,7 +670,7 @@ mod stress_tests {
         node_id.copy_from_slice(&node_pubkey[..32]);
         
         let generator = Arc::new(ChallengeGenerator::new(priv_arr, node_id));
-        let validator = ReceiptValidator::new(generator);
+        let validator = ReceiptValidator::new(generator, Arc::new(RwLock::new(lib_identity::IdentityManager::new())));
         
         let mut latencies = vec![];
         

--- a/zhtp/src/pouw/validation.rs
+++ b/zhtp/src/pouw/validation.rs
@@ -571,7 +571,7 @@ mod tests {
     async fn test_format_validation() {
         let (priv_key, pub_key) = test_keys();
         let generator = Arc::new(ChallengeGenerator::new(priv_key, pub_key));
-        let validator = ReceiptValidator::new(generator);
+        let validator = ReceiptValidator::new(generator, Arc::new(RwLock::new(IdentityManager::new())));
 
         // Test invalid version
         let receipt = Receipt {
@@ -598,7 +598,7 @@ mod tests {
     async fn test_replay_detection() {
         let (priv_key, pub_key) = test_keys();
         let generator = Arc::new(ChallengeGenerator::new(priv_key, pub_key));
-        let validator = ReceiptValidator::new(generator);
+        let validator = ReceiptValidator::new(generator, Arc::new(RwLock::new(IdentityManager::new())));
 
         let nonce = vec![1u8; 32];
 
@@ -616,7 +616,7 @@ mod tests {
     async fn test_challenge_binding() {
         let (priv_key, pub_key) = test_keys();
         let generator = Arc::new(ChallengeGenerator::new(priv_key, pub_key));
-        let validator = ReceiptValidator::new(generator.clone());
+        let validator = ReceiptValidator::new(generator.clone(), Arc::new(RwLock::new(IdentityManager::new())));
 
         // Generate a challenge
         let challenge_response = generator.generate_challenge(Some("hash"), None, None, None).await.unwrap();
@@ -654,7 +654,7 @@ mod tests {
     async fn test_policy_enforcement() {
         let (priv_key, pub_key) = test_keys();
         let generator = Arc::new(ChallengeGenerator::new(priv_key, pub_key));
-        let validator = ReceiptValidator::new(generator);
+        let validator = ReceiptValidator::new(generator, Arc::new(RwLock::new(IdentityManager::new())));
 
         let policy = Policy {
             max_receipts: 20,


### PR DESCRIPTION
## Summary

- Adds `DIDEpochRecord` struct and per-DID `VecDeque` history (`did_history`) to `RewardCalculator`
- Adds `suspicious_dids: HashSet<String>` — populated on anomaly, exposed via health endpoint
- Three anomaly patterns detected and logged as `WARN`:
  1. **Sustained cap-hitting** — DID hits per-node epoch cap for ≥12 consecutive epochs
  2. **Volume spike** — weighted receipt count > 3× own 7-day average
  3. **Bytes uniformity** — all receipts claim exactly `MIN_BYTES_PER_RECEIPT` (≥3 receipts)
- Suspicious DIDs still receive rewards in beta (flag-only, no block)
- `GET /pouw/health` now returns `suspicious_dids` and `suspicious_did_count`
- Fixes test struct initializers for new `ValidatedReceipt` / `ProofTypeCounts` fields

## Closes

Closes #1351

## Test plan

- [ ] `cargo test -p zhtp pouw` — 56 passed, 0 failed (verified)
- [ ] Simulate sustained cap: create 12+ receipts hitting cap each epoch → WARN logged, DID in health
- [ ] Simulate spike: baseline of 5 receipts/epoch, then 20 in one epoch → spike detected