### PR TITLE
feat(pouw): Hook Web4 handlers to emit POUW receipts (PoUW-BETA #1347)

### DIFF
--- a/zhtp/src/pouw/validation.rs
+++ b/zhtp/src/pouw/validation.rs
@@ -521,6 +521,14 @@ impl ReceiptValidator {
         self.dispute_log.write().await.push(entry);
     }
 
+    /// Directly emit a pre-validated receipt (for server-side hooks, bypasses challenge-response)
+    ///
+    /// Used by Web4ContentService and MeshMessageRouter to credit server-observed work
+    /// without requiring the full client challenge-response flow.
+    pub async fn emit_direct(&self, receipt: ValidatedReceipt) {
+        self.validated_receipts.write().await.push(receipt);
+    }
+
     /// Get all validated receipts (for reward calculation)
     pub async fn get_validated_receipts(&self) -> Vec<ValidatedReceipt> {
         self.validated_receipts.read().await.clone()


### PR DESCRIPTION
## Summary

- Adds `emit_direct()` to `ReceiptValidator` — server-side receipt injection bypassing challenge-response
- `Web4Handler` gains `pouw_validator` + `node_did` fields, set via `with_pouw_validator()` builder
- `Web4GatewayHandler` gains the same with a matching builder
- **Hooks**:
  - `serve_content()` → emits `Web4ContentServed` receipt on HTTP 200
  - `resolve_web4_domain()` → emits `Web4ManifestRoute` receipt on successful resolve
  - `handle_gateway_request()` → emits `Web4ContentServed` on gateway serve success
- No receipt emitted on failed or 404 requests

## Wire-up required

In `unified_server.rs`, add `.with_pouw_validator(pouw_validator.clone(), node_did)` when constructing `Web4Handler` and `Web4GatewayHandler`.

## Closes

Closes #1347

## Test plan

- [ ] `cargo build -p zhtp` — clean (verified)
- [ ] GET /api/v1/web4/content/{domain}/file.html → `Web4ContentServed` receipt in validator storage
- [ ] GET /api/v1/web4/resolve/{domain} → `Web4ManifestRoute` receipt in validator storage