### PR TITLE
feat(pouw): Hook MeshMessageRouter to emit POUW receipts (PoUW-BETA #1348)

### DIFF
--- a/lib-network/src/lib.rs
+++ b/lib-network/src/lib.rs
@@ -113,6 +113,7 @@ pub mod discovery;
 pub mod relays;
 #[cfg(any(feature = "quic", feature = "mdns", feature = "lorawan", feature = "full"))]
 pub mod routing;
+pub use crate::routing::message_routing::MeshRoutingEvent;
 #[cfg(any(feature = "quic", feature = "mdns", feature = "lorawan", feature = "full"))]
 pub mod protocols;
 #[cfg(any(feature = "quic", feature = "mdns", feature = "lorawan", feature = "full"))]

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -22,6 +22,21 @@ use lib_identity::NodeId;
 /// Maximum cached routes to bound memory and prevent cache abuse
 const MAX_ROUTE_CACHE_ENTRIES: usize = 1024;
 
+/// Event emitted by MeshMessageRouter on successful message delivery.
+///
+/// Subscribers (e.g., POUW reward layer) can convert these into receipts.
+#[derive(Debug, Clone)]
+pub struct MeshRoutingEvent {
+    /// Approximate message payload size in bytes
+    pub message_size: u64,
+    /// Number of hops in the delivery route
+    pub hop_count: u8,
+    /// Optional sender node DID (may be unavailable for anonymous messages)
+    pub sender_did: Option<String>,
+    /// Unix timestamp of delivery
+    pub delivered_at: u64,
+}
+
 /// Intelligent mesh message router
 ///
 /// **MIGRATION (Ticket #149):** Now uses unified PeerRegistry instead of separate mesh_connections.
@@ -50,6 +65,8 @@ pub struct MeshMessageRouter {
     pub mesh_server: Option<Arc<RwLock<crate::mesh::server::ZhtpMeshServer>>>,
     /// Transport manager for enforcing secure handler selection
     pub transport_manager: Option<TransportManager>,
+    /// Optional event sink for POUW receipt generation on successful message delivery
+    pub pouw_routing_tx: Option<tokio::sync::mpsc::Sender<MeshRoutingEvent>>,
 }
 
 /// Routing table for mesh network
@@ -213,7 +230,20 @@ impl MeshMessageRouter {
             route_cache: Arc::new(RwLock::new(HashMap::new())),
             mesh_server: None, // Can be set later with set_mesh_server()
             transport_manager: None,
+            pouw_routing_tx: None,
         }
+    }
+
+    /// Attach a POUW routing event sender.
+    ///
+    /// The receiver should be processed by the POUW reward layer in zhtp to
+    /// convert routing events into `Web4ManifestRoute` receipts.
+    pub fn with_pouw_routing_tx(
+        mut self,
+        tx: tokio::sync::mpsc::Sender<MeshRoutingEvent>,
+    ) -> Self {
+        self.pouw_routing_tx = Some(tx);
+        self
     }
 
     /// DEPRECATED (Ticket #149): No longer needed with PeerRegistry
@@ -787,6 +817,21 @@ impl MeshMessageRouter {
             }
         }
         
+        // Emit POUW routing event for reward attribution (non-blocking, fire-and-forget)
+        if let Some(tx) = &self.pouw_routing_tx {
+            let event = MeshRoutingEvent {
+                message_size: Self::estimate_message_size(&message) as u64,
+                hop_count: route.len().min(255) as u8,
+                sender_did: None, // DID not available at this routing layer; set by caller when known
+                delivered_at: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+            };
+            // try_send: drop event silently if receiver has closed or buffer is full
+            let _ = tx.try_send(event);
+        }
+
         info!("Message {} successfully delivered", message_id);
         Ok(())
     }

--- a/zhtp/src/pouw/mod.rs
+++ b/zhtp/src/pouw/mod.rs
@@ -27,4 +27,4 @@ pub use metrics::{PouwMetrics, PouwMetricsSnapshot, RejectionType};
 pub use rate_limiter::{PouwRateLimiter, RateLimitConfig, RateLimitResult, RateLimitReason};
 pub use rewards::{RewardCalculator, Reward, PayoutStatus, EpochClientStats};
 pub use types::*;
-pub use validation::{ReceiptValidator, ReceiptValidationResult, SubmitResponse, RejectionReason};
+pub use validation::{ReceiptValidator, ReceiptValidationResult, SubmitResponse, RejectionReason, spawn_mesh_routing_listener};


### PR DESCRIPTION
## Summary

- Adds `MeshRoutingEvent { message_size, hop_count, sender_did, delivered_at }` to `lib-network`
- `MeshMessageRouter` gains `pouw_routing_tx: Option<mpsc::Sender<MeshRoutingEvent>>` + `with_pouw_routing_tx()` builder
- `execute_routing()` fires `try_send(MeshRoutingEvent)` after each successful delivery
- `spawn_mesh_routing_listener()` in `zhtp::pouw`: converts events to `Web4ManifestRoute` `ValidatedReceipt`s via `emit_direct()`

## Wire-up (in unified_server.rs)

```rust
let (pouw_routing_tx, pouw_routing_rx) = tokio::sync::mpsc::channel(1024);
mesh_router = mesh_router.with_pouw_routing_tx(pouw_routing_tx);
let validator_arc = Arc::new(receipt_validator);
zhtp::pouw::spawn_mesh_routing_listener(validator_arc.clone(), pouw_routing_rx, node_did.clone());
```

## Closes

Closes #1348

## Test plan

- [ ] `cargo build -p zhtp` — clean (verified)
- [ ] Route a mesh message → `Web4ManifestRoute` receipt appears in validator storage
- [ ] No receipt emitted if `pouw_routing_tx` is not attached