### PR TITLE
feat(pouw): Proof-of-presence via QUIC session ID cross-referencing (PoUW-BETA #1352)

### DIFF
--- a/zhtp/src/pouw/mod.rs
+++ b/zhtp/src/pouw/mod.rs
@@ -16,9 +16,11 @@ pub mod load_test;
 pub mod metrics;
 pub mod rate_limiter;
 pub mod rewards;
+pub mod session_log;
 pub mod types;
 pub mod validation;
 
+pub use session_log::{SessionLog, SessionLogEntry, SharedSessionLog, new_shared_session_log};
 pub use challenge::ChallengeGenerator;
 pub use disputes::{DisputeService, Dispute, DisputeType, DisputeStatus, DisputeError};
 pub use health::{PouwHealthChecker, HealthCheckResponse, HealthStatus, HealthCheck};

--- a/zhtp/src/pouw/session_log.rs
+++ b/zhtp/src/pouw/session_log.rs
@@ -1,0 +1,162 @@
+//! QUIC Session Log for Proof-of-Presence Verification
+//!
+//! Maintains a short-lived ring buffer of authenticated QUIC sessions.
+//! The POUW validator cross-references this log when validating Web4 receipts
+//! to confirm that the submitting DID had an authenticated QUIC session.
+//!
+//! Reference: PoUW-BETA #1352
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::RwLock;
+use tracing::debug;
+
+/// TTL for session log entries (10 minutes)
+pub const SESSION_LOG_TTL_SECS: u64 = 600;
+
+/// Maximum number of entries in the session log ring buffer
+pub const SESSION_LOG_MAX_ENTRIES: usize = 10_000;
+
+/// A single authenticated QUIC session record
+#[derive(Debug, Clone)]
+pub struct SessionLogEntry {
+    /// First 8 bytes of the 32-byte UHP v2 session_id
+    pub session_id: [u8; 8],
+    /// DID of the authenticated peer
+    pub peer_did: String,
+    /// Unix timestamp when the session was established
+    pub established_at: u64,
+    /// URI path prefix for this session (e.g. "/api/v1/pouw")
+    pub path_prefix: String,
+}
+
+/// In-memory ring buffer of recently authenticated QUIC sessions.
+///
+/// Shared via `Arc<RwLock<SessionLog>>` between `QuicHandler` (writer)
+/// and `ReceiptValidator` (reader).
+pub struct SessionLog {
+    entries: VecDeque<SessionLogEntry>,
+    max_entries: usize,
+    ttl_secs: u64,
+}
+
+impl SessionLog {
+    pub fn new() -> Self {
+        Self {
+            entries: VecDeque::new(),
+            max_entries: SESSION_LOG_MAX_ENTRIES,
+            ttl_secs: SESSION_LOG_TTL_SECS,
+        }
+    }
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    /// Record a new authenticated session
+    pub fn record(
+        &mut self,
+        session_id: [u8; 8],
+        peer_did: String,
+        path_prefix: String,
+    ) {
+        let now = Self::now();
+
+        // Evict expired entries from the front
+        while let Some(front) = self.entries.front() {
+            if now.saturating_sub(front.established_at) > self.ttl_secs {
+                self.entries.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        // Evict oldest if at capacity
+        if self.entries.len() >= self.max_entries {
+            self.entries.pop_front();
+        }
+
+        debug!(
+            session_id = ?hex::encode(session_id),
+            peer_did = %peer_did,
+            "Session log: recording authenticated QUIC session"
+        );
+
+        self.entries.push_back(SessionLogEntry {
+            session_id,
+            peer_did,
+            established_at: now,
+            path_prefix,
+        });
+    }
+
+    /// Verify that a session ID was established by the given DID within the TTL window
+    pub fn verify(&self, session_id: [u8; 8], peer_did: &str) -> bool {
+        let now = Self::now();
+        self.entries.iter().any(|e| {
+            e.session_id == session_id
+                && e.peer_did == peer_did
+                && now.saturating_sub(e.established_at) <= self.ttl_secs
+        })
+    }
+
+    /// Number of active (non-expired) entries
+    pub fn active_count(&self) -> usize {
+        let now = Self::now();
+        self.entries
+            .iter()
+            .filter(|e| now.saturating_sub(e.established_at) <= self.ttl_secs)
+            .count()
+    }
+}
+
+impl Default for SessionLog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Shared session log type alias for convenience
+pub type SharedSessionLog = Arc<RwLock<SessionLog>>;
+
+/// Create a new shared session log
+pub fn new_shared_session_log() -> SharedSessionLog {
+    Arc::new(RwLock::new(SessionLog::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_record_and_verify() {
+        let mut log = SessionLog::new();
+        let session_id = [1u8; 8];
+        let did = "did:zhtp:alice";
+
+        log.record(session_id, did.to_string(), "/api/v1/pouw".to_string());
+
+        assert!(log.verify(session_id, did));
+        assert!(!log.verify(session_id, "did:zhtp:bob")); // wrong DID
+        assert!(!log.verify([2u8; 8], did)); // wrong session_id
+    }
+
+    #[test]
+    fn test_max_entries_eviction() {
+        let mut log = SessionLog { entries: VecDeque::new(), max_entries: 3, ttl_secs: 600 };
+
+        for i in 0..5u8 {
+            log.record([i; 8], format!("did:zhtp:{}", i), "/".to_string());
+        }
+
+        // Should have evicted oldest, keeping 3
+        assert_eq!(log.entries.len(), 3);
+        // Should have kept the last 3 (2, 3, 4)
+        assert!(log.verify([4u8; 8], "did:zhtp:4"));
+        assert!(!log.verify([0u8; 8], "did:zhtp:0"));
+    }
+}


### PR DESCRIPTION
## Summary

- New `SessionLog` (ring buffer, max 10k entries, 600s TTL) in `zhtp/src/pouw/session_log.rs`
- `QuicHandler` records `(session_id[..8], peer_did)` after each successful UHP v2 handshake
- `ReceiptValidator.with_session_log()` builder for wiring the shared log
- New **Step 2.5** in `validate_receipt()`: for Web4 proof types, verifies `quic_session_id` from `aux` JSON is in the session log for the claiming DID
  - Missing `quic_session_id` → `BadProof`
  - Session ID not found / expired → `BadProof` 
  - Wrong DID for session ID → `BadProof`
- If no session log configured: check skipped (dev/test mode)

## Wire-up (in unified_server.rs)

```rust
let session_log = crate::pouw::new_shared_session_log();
let quic_handler = QuicHandler::new(...).with_pouw_session_log(session_log.clone());
let receipt_validator = ReceiptValidator::new(generator, identity_manager)
    .with_session_log(session_log);
```

## Closes

Closes #1352

## Test plan

- [ ] 58 pouw tests pass (verified)
- [ ] Web4 receipt with valid quic_session_id → accepted
- [ ] Web4 receipt with missing quic_session_id → `BAD_PROOF`
- [ ] Web4 receipt after session TTL expires → `BAD_PROOF`