### PR TITLE
feat(pouw): Wire PoUW components into unified server

### DIFF
--- a/zhtp/src/api/handlers/pouw/mod.rs
+++ b/zhtp/src/api/handlers/pouw/mod.rs
@@ -51,6 +51,24 @@ impl PouwHandler {
         }
     }
 
+    /// Create with a pre-wrapped `Arc<RwLock<ReceiptValidator>>` so it can be shared
+    /// with Web4 handlers, QuicHandler, and MeshMessageRouter.
+    pub fn new_with_validator_arc(
+        challenge_generator: Arc<ChallengeGenerator>,
+        receipt_validator: Arc<RwLock<ReceiptValidator>>,
+        reward_calculator: RewardCalculator,
+        identity_manager: Arc<RwLock<IdentityManager>>,
+    ) -> Self {
+        Self {
+            challenge_generator,
+            receipt_validator,
+            reward_calculator: Arc::new(RwLock::new(reward_calculator)),
+            metrics: Arc::new(PouwMetrics::new()),
+            rate_limiter: Arc::new(PouwRateLimiter::with_defaults()),
+            identity_manager,
+        }
+    }
+
     fn parse_query_params(uri: &str) -> HashMap<String, String> {
         let mut params = HashMap::new();
         if let Some(query) = uri.split('?').nth(1) {

--- a/zhtp/src/pouw/validation.rs
+++ b/zhtp/src/pouw/validation.rs
@@ -685,7 +685,7 @@ impl ReceiptValidator {
 /// Call this in `unified_server.rs` after creating the `ReceiptValidator` and
 /// attaching a `pouw_routing_tx` to `MeshMessageRouter`.
 pub fn spawn_mesh_routing_listener(
-    validator: Arc<ReceiptValidator>,
+    validator: Arc<RwLock<ReceiptValidator>>,
     mut rx: tokio::sync::mpsc::Receiver<lib_network::MeshRoutingEvent>,
     node_did: String,
 ) {
@@ -714,7 +714,7 @@ pub fn spawn_mesh_routing_listener(
                 served_from_cache: None,
             };
 
-            validator.emit_direct(receipt).await;
+            validator.read().await.emit_direct(receipt).await;
         }
 
         tracing::info!("POUW mesh routing listener stopped (channel closed)");


### PR DESCRIPTION
## Summary

Connects all PoUW-BETA components end-to-end in `unified_server.rs`:

- **SharedSessionLog** created at startup and wired to both `QuicHandler` (writer on handshake) and `ReceiptValidator` (reader on Web4 receipt validation)
- **MeshRoutingEvent channel** created at startup; `pouw_routing_tx` wired into `MeshMessageRouter`, `spawn_mesh_routing_listener()` spawned to convert events → `Web4ManifestRoute` receipts
- **Web4Handler** receives `pouw_validator_arc` + `node_did` via `with_pouw_validator()` to emit `Web4ContentServed` receipts on content serves
- **ReceiptValidator** configured with session log and `MIN_IDENTITY_AGE_SECS` at construction
- **PouwHandler** updated with `new_with_validator_arc()` constructor so the validator Arc can be shared across all handlers
- `spawn_mesh_routing_listener()` signature updated to `Arc<RwLock<ReceiptValidator>>` for consistency with web4 handler API

## Test plan
- [ ] `cargo build -p zhtp` — no errors
- [ ] `cargo test --test pouw_web4_integration_tests` — 6 tests pass
- [ ] `cargo test -p zhtp --lib` — 228 tests pass (2 pre-existing failures unrelated)