### PR TITLE
fix(cli): remove stale Migrate test references and fix Site keystore type

### DIFF
--- a/zhtp-cli/src/commands/deploy.rs
+++ b/zhtp-cli/src/commands/deploy.rs
@@ -1221,7 +1221,7 @@ mod tests {
             build_dir: "./dist".to_string(),
             domain: "myapp.zhtp".to_string(),
             mode: Some("spa".to_string()),
-            keystore: Some("~/.zhtp/keystore".to_string()),
+            keystore: "~/.zhtp/keystore".to_string(),
             fee: None,
             dry_run: false,
             trust: crate::argument_parsing::TrustFlags {

--- a/zhtp-cli/src/commands/identity.rs
+++ b/zhtp-cli/src/commands/identity.rs
@@ -621,24 +621,6 @@ mod tests {
     }
 
     #[test]
-    fn test_action_to_operation_migrate() {
-        let action = IdentityAction::Migrate {
-            display_name: "alice".to_string(),
-            device_id: "device-1".to_string(),
-            phrase: None,
-            phrase_file: None,
-            keystore: None,
-            trust: crate::argument_parsing::TrustFlags {
-                pin_spki: None,
-                node_did: None,
-                tofu: false,
-                trust_node: true,
-            },
-        };
-        assert_eq!(action_to_operation(&action), IdentityOperation::Migrate);
-    }
-
-    #[test]
     fn test_operation_description() {
         assert_eq!(
             IdentityOperation::Create.description(),
@@ -657,8 +639,8 @@ mod tests {
             "List blockchain identities"
         );
         assert_eq!(
-            IdentityOperation::Migrate.description(),
-            "Migrate identity (seed-only)"
+            IdentityOperation::Unsupported.description(),
+            "Run identity operation"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Removes `test_action_to_operation_migrate` test and the `Migrate` assertion in `test_operation_description` which referenced `IdentityAction::Migrate` and `IdentityOperation::Migrate` — both were dropped in a prior CI-compatibility commit but the tests were not updated
- Fixes `DeployAction::Site` test that passed `keystore` as `Option<String>` instead of the required `String`

## Test plan

- [ ] `cargo test -p zhtp-cli -- test_action_to_operation test_operation_description` passes with no errors