### PR TITLE
feat(pouw): add stats, epochs, receipts, and disputes API endpoints

### DIFF
--- a/zhtp/src/pouw/validation.rs
+++ b/zhtp/src/pouw/validation.rs
@@ -678,6 +678,28 @@ impl ReceiptValidator {
     pub async fn get_disputes(&self) -> Vec<DisputeLogEntry> {
         self.dispute_log.read().await.clone()
     }
+
+    /// Get all validated receipts for a specific client DID.
+    pub async fn get_receipts_for_did(&self, client_did: &str) -> Vec<ValidatedReceipt> {
+        self.validated_receipts
+            .read()
+            .await
+            .iter()
+            .filter(|r| r.client_did == client_did)
+            .cloned()
+            .collect()
+    }
+
+    /// Get dispute/rejection log entries for a specific client DID.
+    pub async fn get_disputes_for_did(&self, client_did: &str) -> Vec<DisputeLogEntry> {
+        self.dispute_log
+            .read()
+            .await
+            .iter()
+            .filter(|d| d.client_did == client_did)
+            .cloned()
+            .collect()
+    }
 }
 
 /// Spawn a background task that converts `MeshRoutingEvent`s into `Web4ManifestRoute` receipts.


### PR DESCRIPTION
## Summary

- `GET /pouw/stats` — global statistics: total rewards, earned, paid, pending, current epoch
- `GET /pouw/epochs` — paginated list of epochs that have rewards, with start/end timestamps
- `GET /pouw/receipts/{did}` — validated receipt history for a DID (proof_type, bytes_verified, domain)
- `GET /pouw/disputes/{did}` — rejection log for a DID (reason, timestamp, nonce)

All endpoints support `?limit=` and `?offset=` pagination.

## Test plan

- [ ] `cargo build -p zhtp` passes
- [ ] `cargo test -p zhtp -- pouw` passes
- [ ] `GET /pouw/stats` returns correct epoch and totals
- [ ] `GET /pouw/epochs` returns list with start/end timestamps

Closes #1383