### PR TITLE
feat(pouw): implement on-chain SOV payout background task

### DIFF
--- a/zhtp/src/pouw/mod.rs
+++ b/zhtp/src/pouw/mod.rs
@@ -30,3 +30,116 @@ pub use rate_limiter::{PouwRateLimiter, RateLimitConfig, RateLimitResult, RateLi
 pub use rewards::{RewardCalculator, Reward, PayoutStatus, EpochClientStats};
 pub use types::*;
 pub use validation::{ReceiptValidator, ReceiptValidationResult, SubmitResponse, RejectionReason, spawn_mesh_routing_listener};
+
+
+/// Spawn the POUW reward payout background task.
+///
+/// Runs every interval_secs seconds (one full epoch by default = 3600s).
+/// Processes all Pending rewards: mints SOV on-chain via blockchain, persists,
+/// and marks rewards Paid or Failed.
+pub fn spawn_pouw_payout_task(
+    calculator: std::sync::Arc<crate::pouw::rewards::RewardCalculator>,
+    blockchain: std::sync::Arc<tokio::sync::RwLock<lib_blockchain::Blockchain>>,
+    blockchain_dat_path: std::path::PathBuf,
+    interval_secs: u64,
+) {
+    tokio::spawn(async move {
+        // Skip the immediate first tick -- let the node fully start before processing
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+        interval.tick().await;
+        tracing::info!(interval_secs = interval_secs, "POUW payout task started");
+
+        loop {
+            interval.tick().await;
+
+            // Reset any previously-failed rewards so they get retried this cycle
+            let reset_count = calculator.reset_failed_rewards().await;
+            if reset_count > 0 {
+                tracing::info!(count = reset_count, "Reset failed POUW rewards to Pending for retry");
+            }
+
+            let pending = calculator.get_pending_rewards().await;
+            if pending.is_empty() {
+                tracing::debug!("POUW payout: no pending rewards this cycle");
+                continue;
+            }
+
+            tracing::info!(count = pending.len(), "Processing POUW reward payouts");
+
+            for reward in pending {
+                let reward_id = reward.reward_id.clone();
+
+                // Attempt to lock reward as processing (prevents concurrent double-pay)
+                if !calculator.mark_processing(&reward_id).await {
+                    tracing::debug!("Reward already processing or no longer pending, skipping");
+                    continue;
+                }
+
+                // Derive recipient key_id from DID
+                // Expected format: did:zhtp:<hex-encoded-32-byte-key-id>
+                let key_id_result: anyhow::Result<[u8; 32]> = (|| {
+                    let hex_part = reward.client_did
+                        .strip_prefix("did:zhtp:")
+                        .ok_or_else(|| anyhow::anyhow!("DID missing did:zhtp: prefix"))?;
+                    let bytes = hex::decode(hex_part)
+                        .map_err(|e| anyhow::anyhow!("Invalid DID hex: {}", e))?;
+                    if bytes.len() != 32 {
+                        return Err(anyhow::anyhow!(
+                            "DID key_id must be 32 bytes, got {}", bytes.len()
+                        ));
+                    }
+                    let mut arr = [0u8; 32];
+                    arr.copy_from_slice(&bytes);
+                    Ok(arr)
+                })();
+
+                let key_id = match key_id_result {
+                    Ok(k) => k,
+                    Err(e) => {
+                        tracing::warn!(
+                            did = %reward.client_did,
+                            error = %e,
+                            "Cannot derive key_id from DID -- marking reward failed"
+                        );
+                        calculator.mark_failed(&reward_id).await;
+                        continue;
+                    }
+                };
+
+                // Mint SOV on the blockchain and persist immediately
+                let mint_result = {
+                    let mut bc = blockchain.write().await;
+                    bc.mint_sov_for_pouw(key_id, reward.final_amount).and_then(|_| {
+                        bc.save_to_file(&blockchain_dat_path)
+                            .map_err(|e| anyhow::anyhow!("save_to_file after POUW mint: {}", e))
+                    })
+                };
+
+                match mint_result {
+                    Ok(()) => {
+                        // Mark paid with None tx_hash (direct kernel mint, no mempool tx)
+                        calculator.mark_paid(&reward_id, None).await;
+                        tracing::info!(
+                            did = %reward.client_did,
+                            amount = reward.final_amount,
+                            epoch = reward.epoch,
+                            "POUW reward paid -- SOV minted successfully"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            did = %reward.client_did,
+                            amount = reward.final_amount,
+                            epoch = reward.epoch,
+                            error = %e,
+                            "POUW payout failed -- will retry next epoch"
+                        );
+                        calculator.mark_failed(&reward_id).await;
+                    }
+                }
+            }
+
+            tracing::info!("POUW payout cycle complete");
+        }
+    });
+}

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -1447,6 +1447,16 @@ impl ZhtpUnifiedServer {
                 }
             });
         }
+
+        // Spawn POUW reward payout task -- processes Pending rewards once per epoch
+        crate::pouw::spawn_pouw_payout_task(
+            self.pouw_calculator_arc.clone(),
+            self.blockchain.clone(),
+            std::path::PathBuf::from(crate::config::environment::Environment::default().blockchain_data_path()),
+            crate::pouw::rewards::DEFAULT_EPOCH_DURATION_SECS,
+        );
+        info!("POUW reward payout task spawned (epoch interval: {}s)",
+              crate::pouw::rewards::DEFAULT_EPOCH_DURATION_SECS);
         
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Adds `mint_sov_for_pouw()` to `Blockchain` for direct kernel-level SOV minting (mirrors UBI engine pattern)
- Adds `spawn_pouw_payout_task()` in `pouw/mod.rs` that runs once per epoch, processing all `Pending` rewards
- Wires payout task into `ZhtpUnifiedServer::start()` using the existing `pouw_calculator_arc`
- Rewards transition: `Pending` → `Processing` → `Paid` (or `Failed` with retry next epoch)
- DID format `did:zhtp:<hex-32-bytes>` decoded to `[u8; 32]` key_id for recipient lookup

## Test plan
- [ ] `cargo build -p zhtp` passes (verified locally)
- [ ] Deploy to dev-2, submit a POUW receipt, wait 1 epoch (or reduce interval for testing), confirm SOV balance increases
- [ ] Confirm `Failed` rewards are reset and retried on next epoch

Closes #1380