### PR TITLE
feat(pouw): per-user reward transaction ledger and transactions endpoint

### DIFF
--- a/zhtp/src/pouw/mod.rs
+++ b/zhtp/src/pouw/mod.rs
@@ -27,7 +27,7 @@ pub use health::{PouwHealthChecker, HealthCheckResponse, HealthStatus, HealthChe
 pub use load_test::{SyntheticReceiptGenerator, LoadTestConfig, LoadTestResults, run_load_test};
 pub use metrics::{PouwMetrics, PouwMetricsSnapshot, RejectionType};
 pub use rate_limiter::{PouwRateLimiter, RateLimitConfig, RateLimitResult, RateLimitReason};
-pub use rewards::{RewardCalculator, Reward, PayoutStatus, EpochClientStats};
+pub use rewards::{RewardCalculator, Reward, RewardTransaction, PayoutStatus, EpochClientStats};
 pub use types::*;
 pub use validation::{ReceiptValidator, ReceiptValidationResult, SubmitResponse, RejectionReason, spawn_mesh_routing_listener};
 


### PR DESCRIPTION
## Summary
- Adds `RewardTransaction` struct as a user-facing view of a paid reward (reward_id, epoch, amount, paid_at, tx_hash)
- Adds `get_reward_transactions_for_did()` to `RewardCalculator` — filters paid rewards and maps to `RewardTransaction`
- Adds `handle_get_reward_transactions()` handler for `GET /pouw/rewards/{did}/transactions`
- Routes `/transactions` suffix BEFORE the existing `/pouw/rewards/{did}` handler to prevent prefix collision
- Access control: same auth rules as reward lookup (must be authenticated, requester DID must match target DID)

## Test plan
- [ ] `cargo build -p zhtp` passes (verified locally)
- [ ] `cargo test -p zhtp pouw` passes — 58 tests ok (verified locally)
- [ ] After a paid reward cycle: `GET /pouw/rewards/{did}/transactions` returns entries with correct epoch/amount/paid_at
- [ ] Unauthenticated request returns 401
- [ ] Cross-DID request returns 403

Closes #1384