### PR TITLE
fix(pouw): remove broken Ed25519 sig path, system is pure PQC (Dilithium5 only)

### DIFF
--- a/zhtp/src/pouw/load_test.rs
+++ b/zhtp/src/pouw/load_test.rs
@@ -184,8 +184,8 @@ impl SyntheticReceiptGenerator {
 
         SignedReceipt {
             receipt,
-            sig_scheme: "ed25519".to_string(),
-            signature: generate_random_vec(64), // Would be real signature in production
+            sig_scheme: "dilithium5".to_string(),
+            signature: generate_random_vec(4595), // Dilithium5 signature size
         }
     }
 


### PR DESCRIPTION
## Summary
- `PublicKey` has no Ed25519 field (`// ed25519_pk removed - pure PQC only`)
- The `"ed25519"` branch in `verify_signature()` was extracting `key_id` (a blake3 hash) as the Ed25519 public key — semantically wrong, would always fail for real identities
- Removed the broken branch and the dead `get_client_pubkey()` helper
- Unknown sig schemes now fall through to the existing `BadSig` rejection with a descriptive warning log
- Updated `load_test.rs` synthetic receipt `sig_scheme` from `"ed25519"` to `"dilithium5"` for consistency

## Test plan
- [ ] `cargo build -p zhtp` passes
- [ ] `cargo test -p zhtp pouw` — 58 tests pass (verified locally)
- [ ] Receipt with `sig_scheme: "ed25519"` is now rejected with `BAD_SIG`
- [ ] Receipt with `sig_scheme: "dilithium5"` and valid Dilithium5 signature is accepted

Closes #867