### PR TITLE
VALIDATORS: enforce namespace authorization before mesh dispatch (#1422)

### DIFF
--- a/zhtp/src/runtime/components/protocols.rs
+++ b/zhtp/src/runtime/components/protocols.rs
@@ -31,6 +31,7 @@ pub struct ProtocolsComponent {
     /// Note: multicast peer discovery uses fixed port 37775/UDP (see NETWORK_RULES.md).
     discovery_port: u16,
     is_edge_node: bool,
+    validator_enabled: bool,
     /// Enable ZDNS transport server (UDP/TCP DNS on port 53)
     enable_zdns_transport: bool,
     /// Gateway IP for ZDNS transport responses
@@ -79,6 +80,7 @@ impl ProtocolsComponent {
             quic_port,
             discovery_port,
             is_edge_node: false,
+            validator_enabled: false,
             enable_zdns_transport: false, // Disabled by default (requires root for port 53)
             zdns_gateway_ip: std::net::Ipv4Addr::new(127, 0, 0, 1),
             zdns_bind_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
@@ -89,7 +91,7 @@ impl ProtocolsComponent {
     }
 
     pub fn new_with_node_type(environment: crate::config::environment::Environment, api_port: u16, is_edge_node: bool) -> Self {
-        Self::new_with_node_type_and_ports(environment, api_port, 9334, 9333, is_edge_node)
+        Self::new_with_node_type_and_ports(environment, api_port, 9334, 9333, is_edge_node, false)
     }
 
     pub fn new_with_node_type_and_ports(
@@ -98,6 +100,7 @@ impl ProtocolsComponent {
         quic_port: u16,
         discovery_port: u16,
         is_edge_node: bool,
+        validator_enabled: bool,
     ) -> Self {
         Self {
             status: Arc::new(RwLock::new(ComponentStatus::Stopped)),
@@ -112,6 +115,7 @@ impl ProtocolsComponent {
             quic_port,
             discovery_port,
             is_edge_node,
+            validator_enabled,
             enable_zdns_transport: false, // Disabled by default
             zdns_gateway_ip: std::net::Ipv4Addr::new(127, 0, 0, 1),
             zdns_bind_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
@@ -141,6 +145,7 @@ impl ProtocolsComponent {
             quic_port: 9334,
             discovery_port: 9333,
             is_edge_node: false,
+            validator_enabled: false,
             enable_zdns_transport: true,
             zdns_gateway_ip: gateway_ip,
             // SECURITY: Default to localhost even when enabled
@@ -171,6 +176,7 @@ impl ProtocolsComponent {
             quic_port: 9334,
             discovery_port: 9333,
             is_edge_node: false,
+            validator_enabled: false,
             enable_zdns_transport: false,
             zdns_gateway_ip: std::net::Ipv4Addr::new(127, 0, 0, 1),
             zdns_bind_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
@@ -200,6 +206,7 @@ impl ProtocolsComponent {
             quic_port: 9334,
             discovery_port: 9333,
             is_edge_node: false,
+            validator_enabled: false,
             enable_zdns_transport: true,
             zdns_gateway_ip: gateway_ip,
             zdns_bind_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
@@ -340,6 +347,8 @@ impl Component for ProtocolsComponent {
             Some(self.quic_port),       // quic_port from config
             None,  // protocols_config - will use defaults (Bluetooth disabled by default)
             None,  // bootstrap_peers - will use defaults
+            self.is_edge_node,
+            self.validator_enabled,
         ).await
             .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
         

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -445,8 +445,14 @@ impl RuntimeOrchestrator {
             let quic_port = self.config.protocols_config.quic_port;
             let discovery_port = self.config.protocols_config.discovery_port;
             let is_edge_node = *self.is_edge_node.read().await;
+            let validator_enabled = self.config.consensus_config.validator_enabled;
             self.register_component(Arc::new(ProtocolsComponent::new_with_node_type_and_ports(
-                environment, api_port, quic_port, discovery_port, is_edge_node
+                environment,
+                api_port,
+                quic_port,
+                discovery_port,
+                is_edge_node,
+                validator_enabled,
             ))).await?;
         }
         

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -294,7 +294,20 @@ impl ZhtpUnifiedServer {
         economic_model: Arc<RwLock<EconomicModel>>,
         port: u16, // Port from configuration
     ) -> Result<Self> {
-        Self::new_with_peer_notification(blockchain, storage, identity_manager, economic_model, port, None, None, None, None, None).await
+        Self::new_with_peer_notification(
+            blockchain,
+            storage,
+            identity_manager,
+            economic_model,
+            port,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+        ).await
     }
     
     /// Create new unified server with peer discovery notification channel
@@ -309,6 +322,8 @@ impl ZhtpUnifiedServer {
         quic_port: Option<u16>,
         protocols_config: Option<crate::config::aggregation::ProtocolsConfig>,
         bootstrap_peers: Option<Vec<String>>,
+        is_edge_node: bool,
+        validator_enabled: bool,
     ) -> Result<Self> {
         let server_id = Uuid::new_v4();
         let monitoring_system = Some(MonitoringSystem::new().await?);
@@ -354,6 +369,9 @@ impl ZhtpUnifiedServer {
         let wifi_router = WiFiRouter::new_with_peer_notification(peer_discovery_tx);
         let bluetooth_router = BluetoothRouter::new();
         let bluetooth_classic_router = BluetoothClassicRouter::new();
+        mesh_router
+            .configure_authorization_context(is_edge_node, validator_enabled)
+            .await;
         
         // Set identity manager on mesh router for direct UDP access
         // This is used by send_with_routing() and broadcast_to_peers() to get sender identity


### PR DESCRIPTION
## Summary
- add mesh authorization context (runtime role + consensus role) to `MeshRouter`
- wire context from runtime startup (`is_edge_node`, `validator_enabled`) into unified server/mesh
- add pre-dispatch namespace authorization gate in `handle_udp_mesh` before any handler execution
- classify consensus read vs consensus mutation message namespaces and reject unauthorized namespaces
- add unit tests for validator/non-validator/service namespace authorization behavior

## Validation
- `cargo check -p zhtp`
- `cargo test -p zhtp server::mesh::core::tests -- --nocapture`

Closes #1422
