### PR TITLE
fix(config): remove tcp from default NetworkConfig protocols list

### DIFF
--- a/zhtp/src/config/aggregation.rs
+++ b/zhtp/src/config/aggregation.rs
@@ -653,7 +653,6 @@ impl Default for NodeConfig {
                     "wifi_direct".to_string(),
                     "lorawan".to_string(),
                     "quic".to_string(),
-                    "tcp".to_string()
                 ],
                 bootstrap_peers: vec![
                     "127.0.0.1:9333".to_string(),


### PR DESCRIPTION
## Summary
- New validator transport invariant gate (from #1435/#1439) rejects `tcp` in the mesh protocols list
- The default `NetworkConfig` initializer included `"tcp"` in the protocols vec, causing all nodes to crash on startup with: `Forbidden transport protocols configured: tcp`
- Removes `"tcp"` from the default list; QUIC is the mandatory mesh transport