### PR TITLE
fix(pouw): use JSON for receipt signature verification instead of bincode

### DIFF
--- a/zhtp/src/pouw/validation.rs
+++ b/zhtp/src/pouw/validation.rs
@@ -541,9 +541,12 @@ impl ReceiptValidator {
         Ok(())
     }
 
-    /// Serialize receipt for signature verification
+    /// Serialize receipt for signature verification.
+    ///
+    /// Uses compact JSON so clients on any platform can reproduce the exact bytes to sign:
+    /// serialize the Receipt struct to compact JSON in struct-definition field order.
     fn serialize_receipt(&self, receipt: &Receipt) -> Result<Vec<u8>> {
-        bincode::serialize(receipt).context("Failed to serialize receipt")
+        serde_json::to_vec(receipt).context("Failed to serialize receipt")
     }
 
     /// Get client's Dilithium5 public key from DID


### PR DESCRIPTION
## Problem

All POUW receipt submissions were rejected with `BadSig: Signature verification failed`.

Root cause: `serialize_receipt()` used `bincode::serialize(receipt)`. Because the `Receipt` struct has `#[serde(with = "hex_bytes")]` on its `Vec<u8>` fields, bincode encodes them as hex strings inside a binary envelope (~480 bytes). Mobile clients sign the compact JSON representation of the receipt (~297 bytes). The format mismatch meant the server could never verify a valid client signature.

## Fix

Switch `serialize_receipt` from `bincode::serialize` to `serde_json::to_vec`. The canonical signing format is now compact JSON in struct-definition field order — unambiguous, platform-independent, and reproducible on any client that serializes the `Receipt` struct to compact JSON.

## Client contract

To sign a receipt, clients must:
1. Serialize the `Receipt` object to compact JSON (no extra whitespace, fields in struct-definition order)
2. Sign those bytes with Dilithium5
3. Hex-encode the signature and set `sig_scheme = "dilithium5"` in the `SignedReceipt`