### PR TITLE
fix: gate MeshRoutingEvent re-export with transport features

### DIFF
--- a/lib-network/src/lib.rs
+++ b/lib-network/src/lib.rs
@@ -113,6 +113,7 @@ pub mod discovery;
 pub mod relays;
 #[cfg(any(feature = "quic", feature = "mdns", feature = "lorawan", feature = "full"))]
 pub mod routing;
+#[cfg(any(feature = "quic", feature = "mdns", feature = "lorawan", feature = "full"))]
 pub use crate::routing::message_routing::MeshRoutingEvent;
 #[cfg(any(feature = "quic", feature = "mdns", feature = "lorawan", feature = "full"))]
 pub mod protocols;


### PR DESCRIPTION
The MeshRoutingEvent was being exported unconditionally, but the routing module only exists when transport features (quic/mdns/lorawan) are enabled. This fixes the iOS build failure when using handshake-only feature.