### PR TITLE
fix(docs): add missing imports in dao_prefix_router doctests

### DIFF
--- a/lib-blockchain/src/contracts/root_registry/dao_prefix_router.rs
+++ b/lib-blockchain/src/contracts/root_registry/dao_prefix_router.rs
@@ -82,6 +82,7 @@ impl DaoPrefixRouter {
     ///
     /// # Examples
     /// ```
+    /// use lib_blockchain::contracts::root_registry::DaoPrefixRouter;
     /// assert!(DaoPrefixRouter::is_dao_prefixed("dao.shoes.sov"));
     /// assert!(!DaoPrefixRouter::is_dao_prefixed("shoes.sov"));
     /// assert!(!DaoPrefixRouter::is_dao_prefixed("mydao.sov"));
@@ -96,7 +97,8 @@ impl DaoPrefixRouter {
     ///
     /// # Examples
     /// ```
-    /// assert_eq!(DaoPrefixRouter::extract_parent("dao.shoes.sov"), Some("shoes.sov"));
+    /// use lib_blockchain::contracts::root_registry::DaoPrefixRouter;
+    /// assert_eq!(DaoPrefixRouter::extract_parent("dao.shoes.sov"), Some("shoes.sov".to_string()));
     /// assert_eq!(DaoPrefixRouter::extract_parent("shoes.sov"), None);
     /// ```
     pub fn extract_parent(name: &str) -> Option<String> {


### PR DESCRIPTION
## Summary

- Pre-existing doctest failures in `dao_prefix_router.rs` caused by missing `use` imports
- `is_dao_prefixed` and `extract_parent` doctests were using `DaoPrefixRouter` without importing it
- `extract_parent` assertion also compared `&str` to the returned `String` — fixed to `.to_string()`

## Test plan

- [x] `cargo test -p lib-blockchain --doc` — all 6 doctests pass, 0 failed