### PR TITLE
fix(wallet): canonical user transaction history endpoint

### DIFF
--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -940,14 +940,6 @@ impl WalletHandler {
         }
 
         if tx
-            .inputs
-            .iter()
-            .any(|input| tracked_key_ids.contains(&input.previous_output.as_array()))
-        {
-            return true;
-        }
-
-        if tx
             .outputs
             .iter()
             .any(|output| tracked_key_ids.contains(&output.recipient.key_id))


### PR DESCRIPTION
Summary:\n- fixes GET /api/v1/wallet/transactions/{identity_id} to return canonical user-scoped transaction history\n- replaces fragile substring matching with deterministic matching using identity DID, signer key_id, owned wallet ids, and typed tx fields\n- includes both confirmed and pending transactions with dedupe by tx hash\n- improves amount/from/to extraction for token flows\n\nWhy:\nPrevious endpoint was partial and could miss many typed transactions, while global transaction listing is not user-scoped.\n\nFiles:\n- zhtp/src/api/handlers/wallet/mod.rs\n\nValidation:\n- cargo check -p zhtp --lib\n\nRisk:\n- low to medium: wallet history query path only; no consensus mutation path changes