### PR TITLE
fix(network): repair block propagation and observer sync

### DIFF
--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -1616,9 +1616,7 @@ impl ZhtpUnifiedServer {
 
     /// Set blockchain event receiver for receive-side block/tx forwarding (#916)
     pub async fn set_blockchain_event_receiver(&mut self, receiver: Arc<dyn lib_network::blockchain_sync::BlockchainEventReceiver>) {
-        let _ = receiver;
-        // TODO(#916): wire MeshRouter to forward blockchain events via lib-network message handler.
-        warn!("set_blockchain_event_receiver is a temporary no-op until MeshRouter event forwarding (#916) is wired");
+        self.mesh_router.set_blockchain_event_receiver(receiver).await;
     }
     
     /// Configure sync manager for edge node mode (headers + ZK proofs only)


### PR DESCRIPTION
## Summary

- **Block broadcast**: Validator was querying an unwired PeerRegistry instead of the live QUIC connection store, so broadcasts went nowhere. Fixed to use `quic.connected_peer_ids()`.
- **Block receive wiring**: `set_blockchain_event_receiver` was a no-op stub. Wired the real `ZhtpBlockchainEventReceiver` so received blocks are applied via `add_block_from_network_with_persistence`.
- **ValidatorRegistration in network blocks**: Executor returned `LegacySystem` for these txs, silently dropping them in the network-block path. Now processed inline to keep `validator_registry` consistent.
- **Observer startup fork prevention**: `run_post_bootstrap_sov_backfill` unconditionally called `mine_block`, causing observer nodes to produce a local fork. Added `can_mine: bool` to `IdentityComponent` (from `NodeRole`) and gated both mine calls.
- **Observer gap-fill sync loop**: Observers receiving a non-consecutive block had no way to catch up. Added `observer_sync_loop` to `BlockchainComponent`: fires every 30 s, connects to a bootstrap peer via QUIC, compares chain tips, and fetches+applies missing blocks in batches of 100.

## Test plan

- [x] Built release, deployed to 4-node testnet (g1–g4)
- [x] g1 sole validator mines blocks; g2/g3/g4 configured as observers (`validator_enabled=false`)
- [x] Observer sync loop filled the startup gap (fetched blocks 144–183 from g1)
- [x] All 4 nodes confirmed at identical height (212+) with consecutive block application across the network
- [x] No startup forks observed on any observer node