### PR TITLE
FEES-8/9: Document multiplier rationale

### DIFF
--- a/lib-fees/src/model_v2.rs
+++ b/lib-fees/src/model_v2.rs
@@ -155,18 +155,19 @@ impl SigScheme {
     ///
     /// ## Cryptographic Specifications
     ///
-    /// | Scheme | Sig Size | Multiplier | Verification Cost |
-    /// |--------|----------|------------|-------------------|
-    /// | Ed25519 | 64 bytes | 1.0x | ~50μs (fast) |
-    /// | Dilithium5 | 4,627 bytes | 5.0x | ~200μs (4x slower) |
-    /// | Hybrid | 4,691 bytes | 5.5x | Combined cost |
+    /// | Scheme     | Sig Size   | Multiplier | Verification Cost (relative)        |
+    /// |------------|------------|------------|-------------------------------------|
+    /// | Ed25519    | 64 bytes   | 1.0x       | Baseline (fast on commodity CPUs)   |
+    /// | Dilithium5 | 4,627 bytes| 5.0x       | Higher than Ed25519                 |
+    /// | Hybrid     | 4,691 bytes| 5.5x       | Combined Ed25519 + Dilithium5 cost  |
     ///
     /// ## Detailed Reasoning
     ///
     /// ### Ed25519 (1.0x)
     /// Standard elliptic curve signatures. Serves as the baseline.
     /// - 64 bytes (compact)
-    /// - Fast verification (~50 microseconds)
+    /// - Fast verification on commodity hardware (exact timings are
+    ///   hardware- and implementation-dependent, not a protocol guarantee)
     /// - Well-established security
     ///
     /// ### Dilithium5 (5.0x)


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for fee multipliers in the ZHTP economic model.

## Documentation Added

### TxKind::base_multiplier_bps() (FEES-8)

| Transaction Kind | Multiplier | Rationale |
|------------------|------------|-----------|
| NativeTransfer | 1.0x | Baseline - minimal computation |
| TokenTransfer | 1.2x | Token state lookups + balance checks |
| ContractCall | 1.5x | VM execution + state transitions |
| DataUpload | 2.0x | Permanent storage commitment |
| Governance | 0.5x | Subsidized - encourages participation |

**Key points documented:**
- Why Governance is subsidized (0.5x)
- Why DataUpload is expensive (2.0x storage cost)
- Economic model behind each multiplier
- Examples showing fee differences

### SigScheme::size_multiplier_bps() (FEES-9)

| Scheme | Size | Multiplier | Verification |
|--------|------|------------|--------------|
| Ed25519 | 64 bytes | 1.0x | ~50μs |
| Dilithium5 | 4,627 bytes | 5.0x | ~200μs |
| Hybrid | 4,691 bytes | 5.5x | Combined |

**Key points documented:**
- Why Dilithium5 is 5x more expensive
- Verification cost vs size tradeoff
- Why Hybrid is 5.5x (not simply 6x) due to parallelization
- Reference to NIST FIPS 204 specification

## Examples Included

```rust
// Governance is 50% cheaper than native transfer
let gov = TxKind::Governance.base_multiplier_bps();      // 5000
let native = TxKind::NativeTransfer.base_multiplier_bps(); // 10000
assert_eq!(gov * 2, native);

// Dilithium5 is 5x more expensive than Ed25519
let dil = SigScheme::Dilithium5.size_multiplier_bps();  // 50000
let ed = SigScheme::Ed25519.size_multiplier_bps();      // 10000
assert_eq!(dil, ed * 5);
```

## Related

- Closes #1577 (FEES-8)
- Closes #1578 (FEES-9)
- Parent: #1569 (FEES-EPIC)