### PR TITLE
TYPES-6: Remove duplicate BlockHeight from root_registry

### DIFF
--- a/lib-blockchain/src/contracts/root_registry/types.rs
+++ b/lib-blockchain/src/contracts/root_registry/types.rs
@@ -9,7 +9,7 @@
 //! - State lifecycle management
 //! - Governance pointers for dao.X resolution
 
-use lib_types::primitives::BlockHeight;
+pub use lib_types::primitives::BlockHeight;
 use serde::{Deserialize, Serialize};
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Removes duplicate `BlockHeight` type alias from `lib-blockchain/src/contracts/root_registry/types.rs` and imports from `lib-types`.

## Changes

### Before
```rust
// lib-blockchain/src/contracts/root_registry/types.rs
pub type BlockHeight = u64;  // DUPLICATE
```

### After
```rust
// lib-blockchain/src/contracts/root_registry/types.rs
use lib_types::primitives::BlockHeight;  // Canonical import
```

## Impact

- No breaking changes - `BlockHeight` was already `u64` in lib-types
- Single source of truth for the BlockHeight type

## Related

- Closes #1648 (TYPES-6)
- Parent: #1642 (TYPES-EPIC)