### PR TITLE
TYPES-7: Move PeerId from lib-storage to lib-types

### DIFF
--- a/lib-storage/src/dht/transport.rs
+++ b/lib-storage/src/dht/transport.rs
@@ -8,76 +8,16 @@
 //! **Architecture Note:** The trait is defined here in lib-storage to avoid
 //! circular dependencies. Implementations live in lib-network which depends
 //! on lib-storage (not the other way around).
+//!
+//! **PeerId Note:** PeerId is now defined in lib-types and re-exported here
+//! for backward compatibility.
 
 use anyhow::Result;
 use async_trait::async_trait;
 use std::net::SocketAddr;
 
-/// Peer identifier for protocol-agnostic addressing
-///
-/// Each variant represents a different transport protocol with its
-/// native addressing scheme.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum PeerId {
-    /// UDP peer identified by socket address
-    Udp(SocketAddr),
-    /// Bluetooth peer identified by address (MAC or UUID)
-    Bluetooth(String),
-    /// WiFi Direct peer identified by IP address
-    WiFiDirect(SocketAddr),
-    /// LoRaWAN peer identified by device EUI
-    LoRaWAN(String),
-    /// QUIC peer identified by socket address (uses same addressing as UDP)
-    Quic(SocketAddr),
-    /// Mesh peer identified by public key (Ticket #154)
-    /// Routes DHT traffic through mesh network using public key addressing
-    Mesh(Vec<u8>), // Serialized PublicKey to avoid lib-crypto dependency
-}
-
-impl PeerId {
-    /// Convert to string representation for routing
-    pub fn to_address_string(&self) -> String {
-        match self {
-            PeerId::Udp(addr) => addr.to_string(),
-            PeerId::Bluetooth(addr) => format!("gatt://{}", addr),
-            PeerId::WiFiDirect(addr) => format!("wifid://{}", addr),
-            PeerId::LoRaWAN(eui) => format!("lora://{}", eui),
-            PeerId::Quic(addr) => format!("quic://{}", addr),
-            PeerId::Mesh(pubkey) => format!("mesh://{}", hex::encode(pubkey)),
-        }
-    }
-
-    /// Get protocol type
-    pub fn protocol(&self) -> &str {
-        match self {
-            PeerId::Udp(_) => "udp",
-            PeerId::Bluetooth(_) => "bluetooth",
-            PeerId::WiFiDirect(_) => "wifidirect",
-            PeerId::LoRaWAN(_) => "lorawan",
-            PeerId::Quic(_) => "quic",
-            PeerId::Mesh(_) => "mesh",
-        }
-    }
-
-    /// Create from socket address (defaults to UDP)
-    pub fn from_socket_addr(addr: SocketAddr) -> Self {
-        PeerId::Udp(addr)
-    }
-
-    /// Get socket address if this is a UDP, WiFiDirect, or QUIC peer
-    pub fn socket_addr(&self) -> Option<SocketAddr> {
-        match self {
-            PeerId::Udp(addr) | PeerId::WiFiDirect(addr) | PeerId::Quic(addr) => Some(*addr),
-            _ => None,
-        }
-    }
-}
-
-impl std::fmt::Display for PeerId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_address_string())
-    }
-}
+// Re-export PeerId from lib-types (canonical location)
+pub use lib_types::PeerId;
 
 /// Transport abstraction for DHT operations
 ///

--- a/lib-types/src/lib.rs
+++ b/lib-types/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod primitives;
 pub mod node_id;
+pub mod peer;
 pub mod dht;
 pub mod chunk;
 pub mod errors;
@@ -13,6 +14,7 @@ pub mod errors;
 pub use primitives::{Address, Amount, BlockHash, BlockHeight, Bps, TokenId, TxHash};
 
 pub use node_id::NodeId;
+pub use peer::PeerId;
 pub use dht::*;
 pub use chunk::*;
 pub use errors::*;

--- a/lib-types/src/peer.rs
+++ b/lib-types/src/peer.rs
@@ -1,0 +1,71 @@
+//! Peer Identifier Types
+//!
+//! Core networking identifiers for P2P communication.
+
+use std::net::SocketAddr;
+
+/// Peer identifier for protocol-agnostic addressing
+///
+/// Each variant represents a different transport protocol with its
+/// native addressing scheme.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum PeerId {
+    /// UDP peer identified by socket address
+    Udp(SocketAddr),
+    /// Bluetooth peer identified by address (MAC or UUID)
+    Bluetooth(String),
+    /// WiFi Direct peer identified by IP address
+    WiFiDirect(SocketAddr),
+    /// LoRaWAN peer identified by device EUI
+    LoRaWAN(String),
+    /// QUIC peer identified by socket address (uses same addressing as UDP)
+    Quic(SocketAddr),
+    /// Mesh peer identified by public key
+    /// Routes DHT traffic through mesh network using public key addressing
+    Mesh(Vec<u8>),
+}
+
+impl PeerId {
+    /// Convert to string representation for routing
+    pub fn to_address_string(&self) -> String {
+        match self {
+            PeerId::Udp(addr) => addr.to_string(),
+            PeerId::Bluetooth(addr) => format!("gatt://{}", addr),
+            PeerId::WiFiDirect(addr) => format!("wifid://{}", addr),
+            PeerId::LoRaWAN(eui) => format!("lora://{}", eui),
+            PeerId::Quic(addr) => format!("quic://{}", addr),
+            PeerId::Mesh(pubkey) => format!("mesh://{}", hex::encode(pubkey)),
+        }
+    }
+
+    /// Get protocol type
+    pub fn protocol(&self) -> &str {
+        match self {
+            PeerId::Udp(_) => "udp",
+            PeerId::Bluetooth(_) => "bluetooth",
+            PeerId::WiFiDirect(_) => "wifidirect",
+            PeerId::LoRaWAN(_) => "lorawan",
+            PeerId::Quic(_) => "quic",
+            PeerId::Mesh(_) => "mesh",
+        }
+    }
+
+    /// Create from socket address (defaults to UDP)
+    pub fn from_socket_addr(addr: SocketAddr) -> Self {
+        PeerId::Udp(addr)
+    }
+
+    /// Get socket address if this is a UDP, WiFiDirect, or QUIC peer
+    pub fn socket_addr(&self) -> Option<SocketAddr> {
+        match self {
+            PeerId::Udp(addr) | PeerId::WiFiDirect(addr) | PeerId::Quic(addr) => Some(*addr),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for PeerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_address_string())
+    }
+}


### PR DESCRIPTION
## Summary

Moves `PeerId` from `lib-storage` to `lib-types` for proper type centralization.

## Problem

PeerId was defined in `lib-storage/src/dht/transport.rs` but is a core networking type that should be in the canonical types crate.

## Solution

### Before
```rust
// lib-storage/src/dht/transport.rs
pub enum PeerId {
    Udp(SocketAddr),
    Bluetooth(String),
    // ...
}
```

### After
```rust
// lib-types/src/peer.rs (NEW)
pub enum PeerId {
    Udp(SocketAddr),
    Bluetooth(String),
    // ...
}

// lib-storage/src/dht/transport.rs
pub use lib_types::PeerId;  // Re-export
```

## Changes

| File | Change |
|------|--------|
| `lib-types/src/peer.rs` | NEW - PeerId definition |
| `lib-types/src/lib.rs` | Export peer module and PeerId |
| `lib-storage/src/dht/transport.rs` | Re-export from lib-types |

## Testing

- [x] `cargo build --workspace` passes
- [x] All PeerId functionality preserved
- [x] Backward compatibility maintained

## Backward Compatibility

✅ **Fully backward compatible**
- `lib_storage::dht::PeerId` still works (re-export)
- New canonical path: `lib_types::PeerId`

## Related

- Closes #1649 (TYPES-7)
- Parent: #1642 (TYPES-EPIC)