### PR TITLE
fix(tokens): remove deprecated apply_token_transfer from public API

### DIFF
--- a/lib-tokens/src/contract.rs
+++ b/lib-tokens/src/contract.rs
@@ -50,10 +50,7 @@ impl AuthoritySet {
 
     /// Add an address to a role
     pub fn add(&mut self, role: Role, address: Address) {
-        self.authorities
-            .entry(role)
-            .or_default()
-            .insert(address);
+        self.authorities.entry(role).or_default().insert(address);
     }
 
     /// Remove an address from a role
@@ -191,9 +188,7 @@ impl FeeSchedule {
             return 0;
         }
 
-        let raw_fee = amount
-            .saturating_mul(self.transfer_fee_bps as Amount)
-            / MAX_BPS as Amount;
+        let raw_fee = amount.saturating_mul(self.transfer_fee_bps as Amount) / MAX_BPS as Amount;
 
         let clamped = raw_fee.max(self.min_fee);
         if self.fee_cap > 0 {
@@ -211,9 +206,7 @@ impl FeeSchedule {
             return 0;
         }
 
-        let raw_fee = amount
-            .saturating_mul(self.burn_fee_bps as Amount)
-            / MAX_BPS as Amount;
+        let raw_fee = amount.saturating_mul(self.burn_fee_bps as Amount) / MAX_BPS as Amount;
 
         if self.fee_cap > 0 {
             raw_fee.min(self.fee_cap)
@@ -371,9 +364,9 @@ impl TokenContract {
 
     /// Get remaining mintable supply (None = unlimited)
     pub fn mintable_supply(&self) -> Option<Amount> {
-        self.supply_policy.max_supply().map(|max| {
-            max.saturating_sub(self.total_supply)
-        })
+        self.supply_policy
+            .max_supply()
+            .map(|max| max.saturating_sub(self.total_supply))
     }
 }
 

--- a/lib-tokens/src/errors.rs
+++ b/lib-tokens/src/errors.rs
@@ -1,7 +1,7 @@
 //! Token Contract Errors
 
-use thiserror::Error;
 use lib_types::{Amount, TokenId};
+use thiserror::Error;
 
 /// Error during token operations
 #[derive(Error, Debug, Clone)]

--- a/lib-tokens/src/lib.rs
+++ b/lib-tokens/src/lib.rs
@@ -10,10 +10,6 @@
 //! - [`SupplyPolicy`]: Controls minting behavior
 //! - [`TransferPolicy`]: Controls transfer restrictions
 //! - [`FeeSchedule`]: Transfer and burn fee configuration
-//!
-//! # Execution
-//!
-//! Use [`apply_token_transfer`] to execute transfers with full validation.
 
 pub mod contract;
 pub mod errors;
@@ -21,4 +17,3 @@ pub mod transfer;
 
 pub use contract::*;
 pub use errors::*;
-pub use transfer::apply_token_transfer;


### PR DESCRIPTION
## Summary
Removes the deprecated  function from the public API of lib-tokens.

The function is non-canonical - consensus token execution is implemented in lib-blockchain. The function is still available internally for testing purposes.

Closes #1640