### PR TITLE
fix(protocols): remove unused RESPONSE_BUFFER_SIZE constant

### DIFF
--- a/lib-protocols/src/zhtp/server.rs
+++ b/lib-protocols/src/zhtp/server.rs
@@ -28,10 +28,6 @@ const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(60);
 /// Request buffer size
 const REQUEST_BUFFER_SIZE: usize = 8192;
 
-/// Response buffer size
-#[allow(dead_code)]
-const RESPONSE_BUFFER_SIZE: usize = 8192;
-
 /// ZHTP Server state
 #[derive(Debug, Clone)]
 pub struct ServerState {


### PR DESCRIPTION
## Summary
- **PROTOCOLS-3**: Fixed - removed unused RESPONSE_BUFFER_SIZE constant
- **PROTOCOLS-1**: TODOs kept - represent future feature work, not cleanup
- **PROTOCOLS-2**: Storage stub is intentional feature-gating, not technical debt

Closes #1619 (PROTOCOLS-3)