### PR TITLE
Add CI type duplication check (TYPES-14)

### DIFF
--- a/.github/scripts/check-type-duplication.sh
+++ b/.github/scripts/check-type-duplication.sh
@@ -11,14 +11,15 @@ NC='\033[0m'
 echo "Checking for cross-crate duplicate types..."
 
 TEMP_DIR=$(mktemp -d)
-trap "rm -rf $TEMP_DIR" EXIT
+trap 'rm -rf "$TEMP_DIR"' EXIT
 
 # Collect all types - output as "type_name crate_name field1 field2 ..."
 for crate in lib-*/src; do
     [[ "$crate" == "lib-types/src" ]] && continue
     crate_name=$(echo "$crate" | sed 's|/src||')
     
-    for file in "$crate"/*.rs; do
+    # Recursively find all .rs files in the crate (fix for comment #4)
+    find "$crate" -name "*.rs" -print0 | while IFS= read -r -d '' file; do
         [[ -f "$file" ]] || continue
         
         grep -n "^pub struct" "$file" | while read -r line; do
@@ -26,7 +27,28 @@ for crate in lib-*/src; do
             struct_name=$(echo "$line" | sed 's/.*pub struct \([A-Za-z0-9_]*\).*/\1/')
             [[ -z "$struct_name" ]] && continue
             
-            fields=$(sed -n "${linenum},/^}/p" "$file" | \
+            # Extract struct body using balanced brace matching (fix for comment #1)
+            fields=$(awk -v start="$linenum" '
+                NR >= start {
+                    # Count opening and closing braces
+                    for (i = 1; i <= NF; i++) {
+                        # Remove non-brace characters, then count
+                        val = $i
+                        gsub(/[^{}]/, "", val)
+                        for (j = 1; j <= length(val); j++) {
+                            c = substr(val, j, 1)
+                            if (c == "{") depth++
+                            if (c == "}") depth--
+                        }
+                    }
+                    # Collect lines within the struct
+                    if (NR == start || in_struct) {
+                        in_struct = 1
+                        print
+                        if (depth == 0 && NR > start) exit
+                    }
+                }
+            ' "$file" | \
                 grep -E "^\s+pub" | \
                 sed 's/.*pub \([a-zA-Z0-9_]*\):.*/\1/' | \
                 tr '\n' ' ' | \
@@ -38,6 +60,7 @@ for crate in lib-*/src; do
 done > "$TEMP_DIR/types.txt"
 
 # Find duplicates: group by type_name and check if in multiple crates
+# Using exact string comparison instead of regex (fix for comment #2)
 awk '
 {
     type = $1
@@ -51,8 +74,19 @@ awk '
     
     if (!(key in crate_list)) {
         crate_list[key] = crate
-    } else if (crate_list[key] !~ crate) {
-        crate_list[key] = crate_list[key] "," crate
+    } else {
+        # Deduplicate using exact string comparison on comma-separated crate names
+        found = 0
+        n = split(crate_list[key], crates_arr, ",")
+        for (i = 1; i <= n; i++) {
+            if (crates_arr[i] == crate) {
+                found = 1
+                break
+            }
+        }
+        if (!found) {
+            crate_list[key] = crate_list[key] "," crate
+        }
     }
 }
 END {
@@ -69,13 +103,14 @@ END {
 
 if [[ -s "$TEMP_DIR/dups.txt" ]]; then
     echo ""
-    echo -e "${RED}ERROR: Found cross-crate duplicate types:${NC}"
+    echo -e "${YELLOW}WARNING: Found cross-crate duplicate types (informational only):${NC}"
     while IFS=: read -r name crates; do
         echo -e "${YELLOW}Type: $name${NC}"
         echo "$crates" | tr ',' '\n' | sed 's/^/  - /'
         echo ""
     done < "$TEMP_DIR/dups.txt"
-    exit 1
+    # Informational check - always exit 0 (fix for comment #5)
+    exit 0
 fi
 
 echo -e "${GREEN}No cross-crate duplicate types found.${NC}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Using bash prefix (fixes comment #3) and continue-on-error (fixes comment #5)
       - name: Check for duplicate types
-        run: .github/scripts/check-type-duplication.sh
+        run: bash .github/scripts/check-type-duplication.sh
+        continue-on-error: true
 
   # Deploy to production server (main branch)
   deploy-production:


### PR DESCRIPTION
## Summary
Implements TYPES-14: Add CI check to prevent type duplication across crates.

## Changes
- Add `.github/scripts/check-type-duplication.sh` - Script that detects TRUE duplicate types (same name + identical fields) across crates
- Add `type-check` job to CI workflow

## How it works
1. Scans all `lib-*/src` for `pub struct` definitions
2. Extracts field names for each struct
3. Groups by (type_name, fields) and checks if same definition exists in multiple crates
4. Reports duplicates if found

## Notes
- Skips lib-types (canonical source)
- Only reports TRUE duplicates (same name + identical fields), not just same names with different fields
- Informational check - won't block merges