### PR TITLE
ORACLE-3/4/5: Exchange price feed, slashing, and staleness

### DIFF
--- a/AGENT_TASKS.md
+++ b/AGENT_TASKS.md
@@ -1,8 +1,59 @@
-# Agent Task List - TYPES Migration (Phase B Complete)
+# Agent Task List - ORACLE Protocol v1 Implementation
+
+**Last Updated:** 2026-03-01 by Kimi
+
+## ORACLE-3 (#1688): Sovereign Exchange Price Feed - COMPLETED ✅
+
+### Summary
+Implemented §5 of Oracle Spec v1: 3 independent on-chain exchange price sources for SOV/USDC.
+
+**Post-Review Fix:** Renamed misleading test `governance_path_is_enforced` → `committee_changes_require_governance_path` (PR #1702 follow-up). Added `compile_fail` doctest to `set_members_genesis_only` to actually verify API unreachability from external crates.
+
+### Changes Made
+
+**lib-blockchain (Exchange State):**
+- Created `lib-blockchain/src/exchange/mod.rs` - Exchange module
+- Created `lib-blockchain/src/exchange/state.rs` with:
+  - `ExchangeState` - On-chain order book state
+  - `TradingPair` - Trading pair identifier (SOV/USDC)
+  - `LastTradePrice` - Last trade price with timestamp
+  - `last_trade_price_sov_usdc()` - Most recent trade price
+  - `order_book_mid_sov_usdc()` - (best_bid + best_ask) / 2
+  - `vwap_sov_usdc(since_ts, until_ts)` - Volume-weighted average price
+- Integrated `exchange_state: ExchangeState` into `Blockchain` struct
+- Updated storage format V4 to persist exchange state
+- All prices use `ORACLE_PRICE_SCALE` (1e8) fixed-point
+
+**zhtp (Exchange Price Feed Service):**
+- Created `zhtp/src/runtime/components/oracle_exchange_feed.rs`:
+  - `ExchangePriceFeed` service for gathering prices
+  - `PriceSample` - Price with source and timestamp
+  - `PriceSource` enum (LastTrade, OrderBookMid, Vwap)
+  - `gather_prices()` - Queries blockchain for 3 price sources
+  - `median_price()` - Calculates median from samples
+  - `is_price_valid()` - Sanity check for price bounds
+- Updated `zhtp/src/runtime/components/oracle.rs`:
+  - `gather_prices()` now uses `ExchangePriceFeed` with on-chain state
+  - Falls back to 3 synthetic mock sources when `mock_sov_usd_price` is set
+
+**Tests:**
+- `lib-blockchain/src/exchange/state.rs` - 4 unit tests
+- `lib-blockchain/tests/oracle_exchange_feed_tests.rs` - 9 integration tests
+- `zhtp/src/runtime/components/oracle_exchange_feed.rs` - 3 unit tests
+- All oracle tests passing (committee tests: 9, epoch tests: 8)
+
+### Spec Compliance
+- ✅ §5: 3 independent on-chain sources (last_trade, order_book_mid, vwap)
+- ✅ §5: All prices in ORACLE_PRICE_SCALE (1e8) atomic units
+- ✅ §4.1: Epoch derived from block timestamp (not wall clock)
+
+---
+
+## Legacy: TYPES Migration (Phase B Complete)
 
 **Last Updated:** 2026-02-28 by Code
 
-## TYPES-EPIC #1642: Phase B Status
+### TYPES-EPIC #1642: Phase B Status
 
 ### Completed ✅
 

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -341,6 +341,19 @@ pub struct Blockchain {
     /// Oracle protocol v1 consensus state (committee/config/finalized prices).
     #[serde(default)]
     pub oracle_state: crate::oracle::OracleState,
+    /// On-chain exchange state for SOV/USDC and other trading pairs.
+    /// Provides price feeds to the oracle protocol.
+    #[serde(default)]
+    pub exchange_state: crate::exchange::ExchangeState,
+    /// Oracle slashing events log.
+    #[serde(default)]
+    pub oracle_slash_events: Vec<crate::oracle::OracleSlashEvent>,
+    /// Oracle slashing configuration.
+    #[serde(default)]
+    pub oracle_slashing_config: crate::oracle::OracleSlashingConfig,
+    /// Validators banned from oracle committee (key_id).
+    #[serde(default)]
+    pub oracle_banned_validators: std::collections::HashSet<[u8; 32]>,
 
     // ── DAO Phase Transitions (dao-3) ─────────────────────────────────────
     /// Most recently computed decentralization snapshot.
@@ -679,6 +692,10 @@ impl BlockchainV1 {
             treasury_epoch_execution_count: HashMap::new(),
             max_executions_per_epoch: default_max_executions(),
             oracle_state: crate::oracle::OracleState::default(),
+            exchange_state: crate::exchange::ExchangeState::new(),
+            oracle_slash_events: Vec::new(),
+            oracle_slashing_config: crate::oracle::OracleSlashingConfig::default(),
+            oracle_banned_validators: std::collections::HashSet::new(),
 
             // DAO Phase Transitions
             last_decentralization_snapshot: None,
@@ -1136,6 +1153,10 @@ impl BlockchainStorageV3 {
             treasury_epoch_execution_count: self.treasury_epoch_execution_count,
             max_executions_per_epoch: self.max_executions_per_epoch,
             oracle_state: crate::oracle::OracleState::default(),
+            exchange_state: crate::exchange::ExchangeState::new(),
+            oracle_slash_events: Vec::new(),
+            oracle_slashing_config: crate::oracle::OracleSlashingConfig::default(),
+            oracle_banned_validators: std::collections::HashSet::new(),
             // DAO Phase Transitions
             last_decentralization_snapshot: self.last_decentralization_snapshot,
             phase_transition_config: self.phase_transition_config,
@@ -1153,6 +1174,14 @@ struct BlockchainStorageV4 {
     pub v3: BlockchainStorageV3,
     #[serde(default)]
     pub oracle_state: crate::oracle::OracleState,
+    #[serde(default)]
+    pub exchange_state: crate::exchange::ExchangeState,
+    #[serde(default)]
+    pub oracle_slash_events: Vec<crate::oracle::OracleSlashEvent>,
+    #[serde(default)]
+    pub oracle_slashing_config: crate::oracle::OracleSlashingConfig,
+    #[serde(default)]
+    pub oracle_banned_validators: std::collections::HashSet<[u8; 32]>,
 }
 
 impl BlockchainStorageV4 {
@@ -1160,12 +1189,20 @@ impl BlockchainStorageV4 {
         Self {
             v3: BlockchainStorageV3::from_blockchain(bc),
             oracle_state: bc.oracle_state.clone(),
+            exchange_state: bc.exchange_state.clone(),
+            oracle_slash_events: bc.oracle_slash_events.clone(),
+            oracle_slashing_config: bc.oracle_slashing_config.clone(),
+            oracle_banned_validators: bc.oracle_banned_validators.clone(),
         }
     }
 
     fn to_blockchain(self) -> Blockchain {
         let mut blockchain = self.v3.to_blockchain();
         blockchain.oracle_state = self.oracle_state;
+        blockchain.exchange_state = self.exchange_state;
+        blockchain.oracle_slash_events = self.oracle_slash_events;
+        blockchain.oracle_slashing_config = self.oracle_slashing_config;
+        blockchain.oracle_banned_validators = self.oracle_banned_validators;
         blockchain
     }
 }
@@ -1270,6 +1307,10 @@ impl Blockchain {
             treasury_epoch_execution_count: HashMap::new(),
             max_executions_per_epoch: default_max_executions(),
             oracle_state: crate::oracle::OracleState::default(),
+            exchange_state: crate::exchange::ExchangeState::new(),
+            oracle_slash_events: Vec::new(),
+            oracle_slashing_config: crate::oracle::OracleSlashingConfig::default(),
+            oracle_banned_validators: std::collections::HashSet::new(),
 
             // DAO Phase Transitions
             last_decentralization_snapshot: None,
@@ -11150,6 +11191,79 @@ impl Blockchain {
 
         cosigns.push((signer_did, signature));
         Ok(())
+    }
+
+    /// Slash an oracle validator for misbehavior.
+    ///
+    /// Implements §9 of Oracle Spec v1:
+    /// - Reduces offender's stake by the slash fraction
+    /// - Removes offender from oracle committee
+    /// - Bans validator from future committee participation
+    ///
+    /// # Arguments
+    /// * `key_id` - The validator's oracle key_id (blake3 of consensus_key)
+    /// * `reason` - The slashing reason (double-sign or wrong-epoch)
+    /// * `epoch_id` - The epoch where the violation occurred
+    ///
+    /// # Returns
+    /// The amount of stake slashed (in SOV atomic units)
+    pub fn slash_oracle_validator(
+        &mut self,
+        key_id: [u8; 32],
+        reason: crate::oracle::OracleSlashReason,
+        epoch_id: u64,
+    ) -> u64 {
+        use crate::types::hash::blake3_hash;
+        use tracing::{info, warn};
+
+        // 1. Find validator by key_id match in validator_registry
+        let validator = self.validator_registry.values_mut().find(|v| {
+            let kid = blake3_hash(&v.consensus_key).as_array();
+            kid == key_id
+        });
+
+        let slash_amount = if let Some(v) = validator {
+            let config = &self.oracle_slashing_config;
+            let amount = config.calculate_slash(v.stake);
+            v.stake = v.stake.saturating_sub(amount);
+            amount
+        } else {
+            0
+        };
+
+        // 2. Ban from oracle committee (permanent until governance re-adds)
+        self.oracle_banned_validators.insert(key_id);
+
+        // 3. Remove from active committee immediately
+        self.oracle_state.committee.remove_member(key_id);
+
+        // 4. Record the slash event
+        self.oracle_slash_events.push(crate::oracle::OracleSlashEvent {
+            validator_key_id: key_id,
+            reason,
+            epoch_id,
+            slash_amount,
+            slashed_at_height: self.height,
+        });
+
+        if slash_amount > 0 {
+            warn!(
+                "⚔️ Oracle validator {} slashed {} SOV for {} at epoch {}",
+                hex::encode(&key_id[..8]),
+                slash_amount,
+                reason,
+                epoch_id
+            );
+        } else {
+            info!(
+                "⚔️ Oracle validator {} banned for {} at epoch {} (no stake to slash)",
+                hex::encode(&key_id[..8]),
+                reason,
+                epoch_id
+            );
+        }
+
+        slash_amount
     }
 }
 

--- a/lib-blockchain/src/exchange/mod.rs
+++ b/lib-blockchain/src/exchange/mod.rs
@@ -1,0 +1,12 @@
+//! Sovereign Network Exchange Module
+//!
+//! On-chain order book exchange for SOV/USDC and other trading pairs.
+//! This module provides the exchange state and price feeds for the oracle.
+
+pub mod state;
+
+pub use state::{
+    ExchangeState,
+    LastTradePrice,
+    TradingPair,
+};

--- a/lib-blockchain/src/exchange/state.rs
+++ b/lib-blockchain/src/exchange/state.rs
@@ -1,0 +1,256 @@
+//! Exchange State
+//!
+//! Manages on-chain order book state and provides price feeds for oracle.
+
+use serde::{Deserialize, Serialize};
+
+/// A trading pair identifier (e.g., "SOV/USDC").
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct TradingPair {
+    pub base: String,  // e.g., "SOV"
+    pub quote: String, // e.g., "USDC"
+}
+
+impl TradingPair {
+    /// Create a new trading pair.
+    pub fn new(base: impl Into<String>, quote: impl Into<String>) -> Self {
+        Self {
+            base: base.into(),
+            quote: quote.into(),
+        }
+    }
+
+    /// The canonical SOV/USDC pair.
+    pub fn sov_usdc() -> Self {
+        Self::new("SOV", "USDC")
+    }
+}
+
+/// Last trade price information.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LastTradePrice {
+    /// Price in atomic ORACLE_PRICE_SCALE (1e8) units.
+    pub price_atomic: u128,
+    /// Unix timestamp of the trade.
+    pub timestamp: u64,
+}
+
+/// Exchange state for on-chain order book.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExchangeState {
+    /// Last trade prices by trading pair.
+    last_trade_prices: std::collections::HashMap<TradingPair, LastTradePrice>,
+    /// Order book bids (price level -> total volume) by pair.
+    /// Prices are stored in atomic units.
+    order_book_bids: std::collections::HashMap<TradingPair, std::collections::BTreeMap<u128, u128>>,
+    /// Order book asks (price level -> total volume) by pair.
+    /// Prices are stored in atomic units.
+    order_book_asks: std::collections::HashMap<TradingPair, std::collections::BTreeMap<u128, u128>>,
+    /// Trade history for VWAP calculation: (timestamp, price, volume).
+    /// Limited to recent trades to prevent unbounded growth.
+    trade_history: std::collections::HashMap<TradingPair, Vec<(u64, u128, u128)>>,
+}
+
+impl ExchangeState {
+    /// Create a new empty exchange state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a trade and update last trade price and trade history.
+    pub fn record_trade(
+        &mut self,
+        pair: &TradingPair,
+        price_atomic: u128,
+        volume: u128,
+        timestamp: u64,
+    ) {
+        // Update last trade price
+        self.last_trade_prices.insert(
+            pair.clone(),
+            LastTradePrice {
+                price_atomic,
+                timestamp,
+            },
+        );
+
+        // Add to trade history
+        let history = self.trade_history.entry(pair.clone()).or_default();
+        history.push((timestamp, price_atomic, volume));
+
+        // Prune old trades (keep last 1000 per pair)
+        const MAX_TRADE_HISTORY: usize = 1000;
+        if history.len() > MAX_TRADE_HISTORY {
+            *history = history.split_off(history.len() - MAX_TRADE_HISTORY);
+        }
+    }
+
+    /// Update order book bid at a price level.
+    /// Set volume to 0 to remove the level.
+    pub fn update_bid(&mut self, pair: &TradingPair, price_atomic: u128, volume: u128) {
+        let bids = self.order_book_bids.entry(pair.clone()).or_default();
+        if volume == 0 {
+            bids.remove(&price_atomic);
+        } else {
+            bids.insert(price_atomic, volume);
+        }
+    }
+
+    /// Update order book ask at a price level.
+    /// Set volume to 0 to remove the level.
+    pub fn update_ask(&mut self, pair: &TradingPair, price_atomic: u128, volume: u128) {
+        let asks = self.order_book_asks.entry(pair.clone()).or_default();
+        if volume == 0 {
+            asks.remove(&price_atomic);
+        } else {
+            asks.insert(price_atomic, volume);
+        }
+    }
+
+    // =========================================================================
+    // Oracle Price Feed Methods
+    // =========================================================================
+
+    /// Price (in atomic ORACLE_PRICE_SCALE units) and timestamp of most recent
+    /// SOV/USDC trade.
+    ///
+    /// Returns `None` if no trades have occurred.
+    pub fn last_trade_price_sov_usdc(&self) -> Option<LastTradePrice> {
+        self.last_trade_prices.get(&TradingPair::sov_usdc()).copied()
+    }
+
+    /// (best_bid + best_ask) / 2 for SOV/USDC, in atomic units.
+    ///
+    /// Returns `None` if order book is empty or one side is missing.
+    pub fn order_book_mid_sov_usdc(&self) -> Option<u128> {
+        let pair = TradingPair::sov_usdc();
+
+        let bids = self.order_book_bids.get(&pair)?;
+        let asks = self.order_book_asks.get(&pair)?;
+
+        // Best bid is the highest price (max key)
+        let best_bid = bids.keys().next_back().copied()?;
+
+        // Best ask is the lowest price (min key)
+        let best_ask = asks.keys().next().copied()?;
+
+        // Calculate mid price with checked arithmetic
+        let sum = best_bid.checked_add(best_ask)?;
+        Some(sum / 2)
+    }
+
+    /// Volume-weighted average price for SOV/USDC trades in [since_ts, until_ts].
+    ///
+    /// Returns `None` if no trades in the window.
+    pub fn vwap_sov_usdc(&self, since_ts: u64, until_ts: u64) -> Option<u128> {
+        let pair = TradingPair::sov_usdc();
+        let history = self.trade_history.get(&pair)?;
+
+        let mut total_volume: u128 = 0;
+        let mut volume_x_price: u128 = 0;
+
+        for (timestamp, price, volume) in history {
+            if *timestamp >= since_ts && *timestamp <= until_ts {
+                total_volume = total_volume.checked_add(*volume)?;
+                volume_x_price = volume_x_price.checked_add(volume.checked_mul(*price)?)?;
+            }
+        }
+
+        if total_volume == 0 {
+            return None;
+        }
+
+        Some(volume_x_price / total_volume)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn last_trade_price_returns_most_recent() {
+        let mut state = ExchangeState::new();
+        let pair = TradingPair::sov_usdc();
+
+        // No trades yet
+        assert!(state.last_trade_price_sov_usdc().is_none());
+
+        // Record first trade
+        state.record_trade(&pair, 100_000_000, 1_000_000, 1000);
+        let price1 = state.last_trade_price_sov_usdc().unwrap();
+        assert_eq!(price1.price_atomic, 100_000_000);
+        assert_eq!(price1.timestamp, 1000);
+
+        // Record second trade (newer)
+        state.record_trade(&pair, 105_000_000, 2_000_000, 2000);
+        let price2 = state.last_trade_price_sov_usdc().unwrap();
+        assert_eq!(price2.price_atomic, 105_000_000);
+        assert_eq!(price2.timestamp, 2000);
+    }
+
+    #[test]
+    fn order_book_mid_calculates_correctly() {
+        let mut state = ExchangeState::new();
+        let pair = TradingPair::sov_usdc();
+
+        // Empty order book
+        assert!(state.order_book_mid_sov_usdc().is_none());
+
+        // Only bids
+        state.update_bid(&pair, 99_000_000, 1_000_000);
+        assert!(state.order_book_mid_sov_usdc().is_none());
+
+        // Only asks
+        state.update_ask(&pair, 101_000_000, 1_000_000);
+        state.order_book_bids.clear(); // Clear bids
+        assert!(state.order_book_mid_sov_usdc().is_none());
+
+        // Both sides
+        state.update_bid(&pair, 99_000_000, 1_000_000);
+        let mid = state.order_book_mid_sov_usdc().unwrap();
+        assert_eq!(mid, 100_000_000); // (99M + 101M) / 2
+    }
+
+    #[test]
+    fn vwap_calculates_correctly() {
+        let mut state = ExchangeState::new();
+        let pair = TradingPair::sov_usdc();
+
+        // No trades
+        assert!(state.vwap_sov_usdc(0, 10000).is_none());
+
+        // Record trades
+        // Trade 1: price=100, vol=10 at t=100
+        state.record_trade(&pair, 100_000_000, 10_000_000, 100);
+        // Trade 2: price=110, vol=20 at t=200
+        state.record_trade(&pair, 110_000_000, 20_000_000, 200);
+        // Trade 3: price=120, vol=30 at t=300
+        state.record_trade(&pair, 120_000_000, 30_000_000, 300);
+
+        // VWAP for all trades: (100*10 + 110*20 + 120*30) / (10+20+30) = 6800/60 = 113.33...
+        let vwap_all = state.vwap_sov_usdc(0, 10000).unwrap();
+        let expected = (100_000_000u128 * 10_000_000 + 110_000_000 * 20_000_000 + 120_000_000 * 30_000_000)
+            / (10_000_000 + 20_000_000 + 30_000_000);
+        assert_eq!(vwap_all, expected);
+
+        // VWAP for first two trades only
+        let vwap_first_two = state.vwap_sov_usdc(0, 200).unwrap();
+        let expected_first_two = (100_000_000u128 * 10_000_000 + 110_000_000 * 20_000_000)
+            / (10_000_000 + 20_000_000);
+        assert_eq!(vwap_first_two, expected_first_two);
+
+        // VWAP for no trades in window
+        assert!(state.vwap_sov_usdc(10000, 20000).is_none());
+    }
+
+    #[test]
+    fn trading_pair_equality() {
+        let pair1 = TradingPair::new("SOV", "USDC");
+        let pair2 = TradingPair::new("SOV", "USDC");
+        let pair3 = TradingPair::new("USDC", "SOV");
+
+        assert_eq!(pair1, pair2);
+        assert_ne!(pair1, pair3);
+    }
+}

--- a/lib-blockchain/src/lib.rs
+++ b/lib-blockchain/src/lib.rs
@@ -34,6 +34,7 @@ pub mod resources;
 pub mod snapshot;
 pub mod vm;
 pub mod oracle;
+pub mod exchange;
 
 // Smart contracts submodule (feature-gated)
 #[cfg(feature = "contracts")]
@@ -101,6 +102,13 @@ pub use oracle::{
     ORACLE_ATTESTATION_DOMAIN, OraclePriceAttestationPayload, OraclePriceAttestation,
     OracleAttestationValidationError, OracleAttestationAdmission, OracleAttestationAdmissionError,
     PendingConfigUpdate, FinalizedOraclePrice, OracleEpochState, OracleState,
+    // ORACLE-4: Slashing
+    OracleSlashEvent, OracleSlashReason, OracleSlashingConfig,
+};
+
+// Exchange module re-exports (ORACLE-3)
+pub use exchange::{
+    ExchangeState, TradingPair, LastTradePrice,
 };
 
 // Protocol module (Phase 3B)

--- a/lib-blockchain/src/oracle/mod.rs
+++ b/lib-blockchain/src/oracle/mod.rs
@@ -252,6 +252,20 @@ impl OracleCommitteeState {
     /// Direct calls to this method bypass governance consensus. Use only for:
     /// - Genesis block initialization (when no prior committee exists)
     /// - Unit tests with `#[cfg(test)]` guards
+    /// 
+    /// # Compile-Time Enforcement
+    /// 
+    /// The `pub(crate)` visibility ensures external crates cannot call this method.
+    /// The following code will fail to compile:
+    ///
+    /// ```compile_fail,E0599
+    /// // This code fails to compile because set_members_genesis_only is pub(crate)
+    /// use lib_blockchain::oracle::OracleCommitteeState;
+    /// 
+    /// let mut committee = OracleCommitteeState::default();
+    /// // ERROR: method `set_members_genesis_only` is private
+    /// committee.set_members_genesis_only(vec![[1u8; 32]]);
+    /// ```
     pub(crate) fn set_members_genesis_only(&mut self, members: Vec<[u8; 32]>) {
         self.members = normalize_members(members);
     }
@@ -269,6 +283,18 @@ impl OracleCommitteeState {
 
     pub fn set_pending_update(&mut self, pending_update: Option<PendingCommitteeUpdate>) {
         self.pending_update = normalize_pending_update(pending_update);
+    }
+
+    /// Remove a member from the committee immediately.
+    /// 
+    /// This is used for slashing — the slashed validator is removed from the
+    /// committee for the remainder of the epoch and all future epochs.
+    /// 
+    /// # Security
+    /// This is `pub(crate)` to restrict usage to slashing within lib-blockchain.
+    pub(crate) fn remove_member(&mut self, key_id: [u8; 32]) {
+        self.members.retain(|m| *m != key_id);
+        // Note: threshold is computed dynamically from member count
     }
 
     /// Threshold formula: floor(2N/3)+1.
@@ -416,6 +442,21 @@ impl OracleState {
     /// Returns the most recently finalized price with epoch_id <= `epoch`.
     pub fn latest_finalized_price_at_or_before(&self, epoch: u64) -> Option<&FinalizedOraclePrice> {
         self.finalized_prices.range(..=epoch).next_back().map(|(_, v)| v)
+    }
+
+    /// Returns the latest finalized price only if it is within `max_price_staleness_epochs`
+    /// of `current_epoch`. Returns None if no fresh price exists.
+    /// 
+    /// This enforces Oracle Spec v1 §11 — Staleness.
+    pub fn latest_fresh_price(&self, current_epoch: u64) -> Option<&FinalizedOraclePrice> {
+        let max_staleness = self.config.max_price_staleness_epochs;
+        let oldest_acceptable = current_epoch.saturating_sub(max_staleness);
+        
+        self.finalized_prices
+            .range(..=current_epoch)
+            .next_back()
+            .filter(|(epoch, _)| **epoch >= oldest_acceptable)
+            .map(|(_, v)| v)
     }
 
     pub fn finalized_prices_len(&self) -> usize {
@@ -1144,3 +1185,12 @@ mod tests {
         assert_eq!(restored.epoch_state, b.epoch_state);
     }
 }
+
+// ORACLE-4: Slashing module
+pub mod slashing;
+
+pub use slashing::{
+    OracleSlashEvent,
+    OracleSlashReason,
+    OracleSlashingConfig,
+};

--- a/lib-blockchain/src/oracle/slashing.rs
+++ b/lib-blockchain/src/oracle/slashing.rs
@@ -1,0 +1,122 @@
+//! Oracle Slashing Module
+//!
+//! Implements §9 of Oracle Spec v1: penalties for misbehavior.
+//! - Double-sign: Two different prices for same epoch
+//! - Wrong-epoch: Attestation for non-current epoch
+
+use serde::{Deserialize, Serialize};
+
+/// Reason for oracle slashing.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OracleSlashReason {
+    /// Two different prices attested for the same epoch.
+    ConflictingAttestation,
+    /// Attestation stamped for an epoch other than current.
+    WrongEpoch,
+}
+
+impl std::fmt::Display for OracleSlashReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OracleSlashReason::ConflictingAttestation => write!(f, "conflicting_attestation"),
+            OracleSlashReason::WrongEpoch => write!(f, "wrong_epoch"),
+        }
+    }
+}
+
+/// Record of an oracle slash event.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OracleSlashEvent {
+    /// Validator key_id that was slashed (blake3 of consensus_key).
+    pub validator_key_id: [u8; 32],
+    /// Reason for the slash.
+    pub reason: OracleSlashReason,
+    /// Epoch where the violation occurred.
+    pub epoch_id: u64,
+    /// SOV atomic units removed from stake.
+    pub slash_amount: u64,
+    /// Block height where slash was recorded.
+    pub slashed_at_height: u64,
+}
+
+/// Slashing configuration for oracle protocol.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OracleSlashingConfig {
+    /// Slash fraction in basis points (100 = 1% of stake).
+    pub slash_fraction_bps: u16,
+}
+
+impl Default for OracleSlashingConfig {
+    fn default() -> Self {
+        Self {
+            slash_fraction_bps: 100, // 1% default
+        }
+    }
+}
+
+impl OracleSlashingConfig {
+    /// Create with custom slash fraction.
+    pub fn with_slash_fraction(bps: u16) -> Self {
+        Self {
+            slash_fraction_bps: bps,
+        }
+    }
+
+    /// Calculate slash amount from stake.
+    pub fn calculate_slash(&self, stake: u64) -> u64 {
+        (stake as u128)
+            .saturating_mul(self.slash_fraction_bps as u128)
+            .saturating_div(10_000) as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slash_reason_display() {
+        assert_eq!(
+            OracleSlashReason::ConflictingAttestation.to_string(),
+            "conflicting_attestation"
+        );
+        assert_eq!(OracleSlashReason::WrongEpoch.to_string(), "wrong_epoch");
+    }
+
+    #[test]
+    fn slashing_config_default() {
+        let config = OracleSlashingConfig::default();
+        assert_eq!(config.slash_fraction_bps, 100);
+    }
+
+    #[test]
+    fn calculate_slash_amounts() {
+        let config = OracleSlashingConfig::default(); // 1%
+
+        // 1% of 10,000 = 100
+        assert_eq!(config.calculate_slash(10_000), 100);
+
+        // 1% of 1,000,000 = 10,000
+        assert_eq!(config.calculate_slash(1_000_000), 10_000);
+
+        // Custom 5% config
+        let config_5pct = OracleSlashingConfig::with_slash_fraction(500);
+        assert_eq!(config_5pct.calculate_slash(1_000_000), 50_000);
+    }
+
+    #[test]
+    fn slash_event_serialization() {
+        let event = OracleSlashEvent {
+            validator_key_id: [1u8; 32],
+            reason: OracleSlashReason::ConflictingAttestation,
+            epoch_id: 100,
+            slash_amount: 5000,
+            slashed_at_height: 1000,
+        };
+
+        let serialized = bincode::serialize(&event).unwrap();
+        let deserialized: OracleSlashEvent = bincode::deserialize(&serialized).unwrap();
+
+        assert_eq!(event, deserialized);
+    }
+}

--- a/lib-blockchain/tests/oracle_committee_tests.rs
+++ b/lib-blockchain/tests/oracle_committee_tests.rs
@@ -197,10 +197,15 @@ fn empty_committee_threshold_is_one() {
     assert!(committee.members().is_empty());
 }
 
-/// Test that direct set_members_genesis_only is not callable from external crates.
-/// This verifies the governance-only enforcement at the API level.
+/// Test that committee changes after genesis use the governance path.
+///
+/// This verifies runtime behavior: post-genesis, committee updates must go through
+/// `schedule_committee_update()` → `apply_pending_updates()`. 
+///
+/// For compile-time verification that `set_members_genesis_only` is unreachable from
+/// external crates, see the `compile_fail` doctest on `OracleCommitteeState::set_members_genesis_only`.
 #[test]
-fn governance_path_is_enforced() {
+fn committee_changes_require_governance_path() {
     let mut state = OracleState::default();
 
     // Pre-genesis/bootstrap: committee can be set via constructor
@@ -208,8 +213,7 @@ fn governance_path_is_enforced() {
     assert_eq!(state.committee.members().len(), 2);
 
     // Post-genesis: committee changes must go through schedule_committee_update
-    // This is enforced by having set_members_genesis_only be pub(crate)
-    // which means external crates cannot call it directly.
+    // (The pub(crate) visibility of set_members_genesis_only enforces this at compile time)
     
     // Verify the governance path works
     state

--- a/lib-blockchain/tests/oracle_exchange_feed_tests.rs
+++ b/lib-blockchain/tests/oracle_exchange_feed_tests.rs
@@ -1,0 +1,198 @@
+//! Oracle Exchange Feed Integration Tests
+//!
+//! Tests the integration between exchange state and oracle price feeds
+//! per Oracle Spec v1 §5.
+
+use lib_blockchain::{
+    exchange::{ExchangeState, LastTradePrice, TradingPair},
+    ORACLE_PRICE_SCALE,
+};
+
+/// ORACLE-3: Verify 3 independent on-chain price sources are available.
+#[test]
+fn exchange_provides_three_independent_price_sources() {
+    let mut exchange = ExchangeState::new();
+    let pair = TradingPair::sov_usdc();
+    let now = 10000u64;
+
+    // Setup: seed all 3 price sources
+    // 1. Last trade
+    exchange.record_trade(&pair, 105_000_000, 1_000_000, now - 60);
+
+    // 2. Order book
+    exchange.update_bid(&pair, 104_000_000, 5_000_000);
+    exchange.update_ask(&pair, 106_000_000, 5_000_000);
+
+    // 3. VWAP history (record trades over the last hour)
+    for i in 0..10 {
+        let price = 100_000_000 + i * 1_000_000; // $1.00 to $1.09
+        exchange.record_trade(&pair, price, 100_000, now - 3000 + i as u64 * 600);
+    }
+
+    // Verify all 3 sources are available
+    let last_trade = exchange.last_trade_price_sov_usdc();
+    assert!(last_trade.is_some(), "last_trade should be available");
+
+    let mid = exchange.order_book_mid_sov_usdc();
+    assert!(mid.is_some(), "order_book_mid should be available");
+
+    let vwap = exchange.vwap_sov_usdc(now - 3600, now);
+    assert!(vwap.is_some(), "vwap should be available");
+
+    // All 3 sources should be independent (different calculation methods)
+    let last_trade_price = last_trade.unwrap().price_atomic;
+    let mid_price = mid.unwrap();
+    let vwap_price = vwap.unwrap();
+
+    // They should generally be close but can differ slightly
+    // Verify they're all in reasonable ranges ($0.50 - $2.00 at 1e8 scale)
+    let min_price = 50_000_000u128;
+    let max_price = 200_000_000u128;
+
+    assert!(
+        last_trade_price >= min_price && last_trade_price <= max_price,
+        "last_trade price should be in reasonable range"
+    );
+    assert!(
+        mid_price >= min_price && mid_price <= max_price,
+        "order_book_mid price should be in reasonable range"
+    );
+    assert!(
+        vwap_price >= min_price && vwap_price <= max_price,
+        "vwap price should be in reasonable range"
+    );
+}
+
+/// ORACLE-3: Verify prices use ORACLE_PRICE_SCALE (1e8) fixed-point.
+#[test]
+fn exchange_prices_use_oracle_scale() {
+    let mut exchange = ExchangeState::new();
+    let pair = TradingPair::sov_usdc();
+
+    // Record a trade at exactly $1.50 = 150_000_000 at 1e8 scale
+    let price_150 = 150_000_000u128;
+    exchange.record_trade(&pair, price_150, 1_000_000, 1000);
+
+    let last_trade = exchange.last_trade_price_sov_usdc().unwrap();
+    assert_eq!(last_trade.price_atomic, price_150);
+    assert_eq!(last_trade.price_atomic, 150 * ORACLE_PRICE_SCALE / 100);
+}
+
+/// ORACLE-3: Verify order book mid price calculation.
+#[test]
+fn order_book_mid_is_average_of_best_bid_and_ask() {
+    let mut exchange = ExchangeState::new();
+    let pair = TradingPair::sov_usdc();
+
+    // Best bid: $0.99 (99_000_000), Best ask: $1.01 (101_000_000)
+    // Mid should be $1.00 (100_000_000)
+    exchange.update_bid(&pair, 99_000_000, 1_000_000);
+    exchange.update_ask(&pair, 101_000_000, 1_000_000);
+
+    let mid = exchange.order_book_mid_sov_usdc().unwrap();
+    assert_eq!(mid, 100_000_000); // ($0.99 + $1.01) / 2 = $1.00
+}
+
+/// ORACLE-3: Verify VWAP calculation over time window.
+#[test]
+fn vwap_is_volume_weighted_average() {
+    let mut exchange = ExchangeState::new();
+    let pair = TradingPair::sov_usdc();
+    let now = 10000u64;
+
+    // Trade 1: 10 SOV at $1.00
+    exchange.record_trade(&pair, 100_000_000, 10_000_000, now - 1800);
+    // Trade 2: 20 SOV at $1.10
+    exchange.record_trade(&pair, 110_000_000, 20_000_000, now - 1200);
+    // Trade 3: 30 SOV at $1.20
+    exchange.record_trade(&pair, 120_000_000, 30_000_000, now - 600);
+
+    // VWAP = (10*1.00 + 20*1.10 + 30*1.20) / (10+20+30) = 68/60 = $1.1333...
+    let vwap = exchange.vwap_sov_usdc(now - 3600, now).unwrap();
+
+    // Expected: 68,000,000 / 60 = 1,133,333.33... (at 1e8 scale)
+    let expected = (100_000_000u128 * 10_000_000
+        + 110_000_000 * 20_000_000
+        + 120_000_000 * 30_000_000)
+        / (10_000_000 + 20_000_000 + 30_000_000);
+
+    assert_eq!(vwap, expected);
+    // Should be approximately $1.133
+    assert!(vwap > 113_000_000 && vwap < 114_000_000);
+}
+
+/// ORACLE-3: Verify VWAP returns None when no trades in window.
+#[test]
+fn vwap_returns_none_for_empty_window() {
+    let mut exchange = ExchangeState::new();
+    let pair = TradingPair::sov_usdc();
+
+    // Record a trade at t=1000
+    exchange.record_trade(&pair, 100_000_000, 1_000_000, 1000);
+
+    // Query VWAP for a window that doesn't include the trade
+    let vwap = exchange.vwap_sov_usdc(2000, 3000);
+    assert!(vwap.is_none(), "vwap should be None when no trades in window");
+}
+
+/// ORACLE-3: Verify last trade returns most recent trade.
+#[test]
+fn last_trade_returns_most_recent() {
+    let mut exchange = ExchangeState::new();
+    let pair = TradingPair::sov_usdc();
+
+    // Record older trade
+    exchange.record_trade(&pair, 100_000_000, 1_000_000, 1000);
+
+    // Record newer trade at higher price
+    exchange.record_trade(&pair, 110_000_000, 2_000_000, 2000);
+
+    let last_trade = exchange.last_trade_price_sov_usdc().unwrap();
+    assert_eq!(last_trade.price_atomic, 110_000_000);
+    assert_eq!(last_trade.timestamp, 2000);
+}
+
+/// ORACLE-3: Verify order book returns None when one side is missing.
+#[test]
+fn order_book_mid_requires_both_sides() {
+    let mut exchange = ExchangeState::new();
+    let pair = TradingPair::sov_usdc();
+
+    // Only bids
+    exchange.update_bid(&pair, 99_000_000, 1_000_000);
+    assert!(exchange.order_book_mid_sov_usdc().is_none());
+
+    // Clear and add only asks
+    exchange = ExchangeState::new();
+    exchange.update_ask(&pair, 101_000_000, 1_000_000);
+    assert!(exchange.order_book_mid_sov_usdc().is_none());
+
+    // Now both sides
+    exchange.update_bid(&pair, 99_000_000, 1_000_000);
+    assert!(exchange.order_book_mid_sov_usdc().is_some());
+}
+
+/// ORACLE-3: Verify trading pair equality and SOV/USDC helper.
+#[test]
+fn trading_pair_helpers_work() {
+    let sov_usdc_1 = TradingPair::sov_usdc();
+    let sov_usdc_2 = TradingPair::new("SOV", "USDC");
+    let usdc_sov = TradingPair::new("USDC", "SOV");
+
+    assert_eq!(sov_usdc_1, sov_usdc_2);
+    assert_ne!(sov_usdc_1, usdc_sov);
+    assert_eq!(sov_usdc_1.base, "SOV");
+    assert_eq!(sov_usdc_1.quote, "USDC");
+}
+
+/// ORACLE-3: Verify LastTradePrice struct fields.
+#[test]
+fn last_trade_price_structure() {
+    let price = LastTradePrice {
+        price_atomic: 150_000_000,
+        timestamp: 1234567890,
+    };
+
+    assert_eq!(price.price_atomic, 150_000_000);
+    assert_eq!(price.timestamp, 1234567890);
+}

--- a/lib-blockchain/tests/oracle_slashing_tests.rs
+++ b/lib-blockchain/tests/oracle_slashing_tests.rs
@@ -1,0 +1,309 @@
+//! Oracle Slashing Tests (ORACLE-4)
+//!
+//! Tests for double-sign and wrong-epoch slashing penalties.
+
+use lib_blockchain::{
+    oracle::{
+        OracleCommitteeState, OracleSlashingConfig, OracleSlashReason,
+        OracleState,
+    },
+    types::hash::blake3_hash,
+    Blockchain, ValidatorInfo,
+};
+
+/// Create a mock validator info with given consensus_key and stake
+fn create_validator_info(consensus_key: Vec<u8>, stake: u64) -> (ValidatorInfo, [u8; 32]) {
+    let key_id = blake3_hash(&consensus_key).as_array();
+    let info = ValidatorInfo {
+        identity_id: hex::encode(key_id),
+        stake,
+        storage_provided: 0,
+        consensus_key,
+        networking_key: vec![],
+        rewards_key: vec![],
+        network_address: "127.0.0.1".to_string(),
+        commission_rate: 0,
+        status: "active".to_string(),
+        registered_at: 0,
+        last_activity: 0,
+        blocks_validated: 0,
+        slash_count: 0,
+        admission_source: "test".to_string(),
+        governance_proposal_id: None,
+        oracle_key_id: Some(key_id),
+    };
+    (info, key_id)
+}
+
+/// Test that slashing reduces stake correctly with default 1% config.
+#[test]
+fn slashing_reduces_stake_by_one_percent() {
+    let mut blockchain = Blockchain::default();
+    
+    let consensus_key = vec![1u8; 32];
+    let (validator, key_id) = create_validator_info(consensus_key, 1_000_000);
+    
+    blockchain.validator_registry.insert(
+        hex::encode(key_id),
+        validator,
+    );
+    
+    // Default config is 1%
+    assert_eq!(blockchain.oracle_slashing_config.slash_fraction_bps, 100);
+    
+    // Slash the validator
+    let slashed = blockchain.slash_oracle_validator(
+        key_id,
+        OracleSlashReason::ConflictingAttestation,
+        100,
+    );
+    
+    // 1% of 1M = 10K
+    assert_eq!(slashed, 10_000);
+    
+    // Verify stake reduced
+    let v = blockchain.validator_registry.get(&hex::encode(key_id)).unwrap();
+    assert_eq!(v.stake, 990_000); // 1M - 10K
+}
+
+/// Test slashing with custom slash fraction.
+#[test]
+fn custom_slash_fraction() {
+    let mut blockchain = Blockchain::default();
+    
+    let consensus_key = vec![2u8; 32];
+    let (validator, key_id) = create_validator_info(consensus_key, 1_000_000);
+    
+    blockchain.validator_registry.insert(
+        hex::encode(key_id),
+        validator,
+    );
+    
+    // Use 5% slash fraction
+    blockchain.oracle_slashing_config = OracleSlashingConfig::with_slash_fraction(500);
+    
+    let slashed = blockchain.slash_oracle_validator(
+        key_id,
+        OracleSlashReason::WrongEpoch,
+        50,
+    );
+    
+    // 5% of 1M = 50K
+    assert_eq!(slashed, 50_000);
+    
+    let v = blockchain.validator_registry.get(&hex::encode(key_id)).unwrap();
+    assert_eq!(v.stake, 950_000);
+}
+
+/// Test that slashing records the slash event.
+#[test]
+fn slashing_records_event() {
+    let mut blockchain = Blockchain::default();
+    
+    let consensus_key = vec![3u8; 32];
+    let (validator, key_id) = create_validator_info(consensus_key, 500_000);
+    
+    blockchain.validator_registry.insert(
+        hex::encode(key_id),
+        validator,
+    );
+    
+    blockchain.slash_oracle_validator(
+        key_id,
+        OracleSlashReason::ConflictingAttestation,
+        42,
+    );
+    
+    // Verify event recorded
+    assert_eq!(blockchain.oracle_slash_events.len(), 1);
+    
+    let event = &blockchain.oracle_slash_events[0];
+    assert_eq!(event.validator_key_id, key_id);
+    assert_eq!(event.reason, OracleSlashReason::ConflictingAttestation);
+    assert_eq!(event.epoch_id, 42);
+    assert_eq!(event.slash_amount, 5_000); // 1% of 500K
+    assert_eq!(event.slashed_at_height, 0); // Default height
+}
+
+/// Test that slashing bans the validator.
+#[test]
+fn slashing_bans_validator() {
+    let mut blockchain = Blockchain::default();
+    
+    let consensus_key = vec![4u8; 32];
+    let (validator, key_id) = create_validator_info(consensus_key, 100_000);
+    
+    blockchain.validator_registry.insert(
+        hex::encode(key_id),
+        validator,
+    );
+    
+    // Initially not banned
+    assert!(!blockchain.oracle_banned_validators.contains(&key_id));
+    
+    blockchain.slash_oracle_validator(
+        key_id,
+        OracleSlashReason::WrongEpoch,
+        100,
+    );
+    
+    // Now banned
+    assert!(blockchain.oracle_banned_validators.contains(&key_id));
+}
+
+/// Test that slashing removes validator from committee.
+#[test]
+fn slashing_removes_from_committee() {
+    let mut blockchain = Blockchain::default();
+    
+    let consensus_key = vec![5u8; 32];
+    let (validator, key_id) = create_validator_info(consensus_key, 100_000);
+    
+    blockchain.validator_registry.insert(
+        hex::encode(key_id),
+        validator,
+    );
+    
+    // Setup committee with validator
+    blockchain.oracle_state = OracleState::default();
+    blockchain.oracle_state.committee = OracleCommitteeState::new(vec![key_id], None);
+    
+    assert!(blockchain.oracle_state.committee.members().contains(&key_id));
+    
+    // Slash removes from committee
+    blockchain.slash_oracle_validator(
+        key_id,
+        OracleSlashReason::ConflictingAttestation,
+        100,
+    );
+    
+    // No longer in committee
+    assert!(!blockchain.oracle_state.committee.members().contains(&key_id));
+    assert!(blockchain.oracle_state.committee.members().is_empty());
+}
+
+/// Test that slashing events survive blockchain serialization.
+#[test]
+fn slashing_events_survive_restart() {
+    let mut blockchain = Blockchain::default();
+    
+    let consensus_key = vec![6u8; 32];
+    let (validator, key_id) = create_validator_info(consensus_key, 100_000);
+    
+    blockchain.validator_registry.insert(
+        hex::encode(key_id),
+        validator,
+    );
+    
+    blockchain.slash_oracle_validator(
+        key_id,
+        OracleSlashReason::ConflictingAttestation,
+        100,
+    );
+    
+    // Serialize/deserialize
+    let serialized = bincode::serialize(&blockchain).unwrap();
+    let restored: Blockchain = bincode::deserialize(&serialized).unwrap();
+    
+    // Verify slashing events preserved
+    assert_eq!(restored.oracle_slash_events.len(), 1);
+    assert_eq!(restored.oracle_banned_validators.len(), 1);
+    assert!(restored.oracle_banned_validators.contains(&key_id));
+    
+    // Verify event details preserved
+    let event = &restored.oracle_slash_events[0];
+    assert_eq!(event.validator_key_id, key_id);
+    assert_eq!(event.reason, OracleSlashReason::ConflictingAttestation);
+}
+
+/// Test slashing reason display format.
+#[test]
+fn slashing_reason_display() {
+    assert_eq!(
+        OracleSlashReason::ConflictingAttestation.to_string(),
+        "conflicting_attestation"
+    );
+    assert_eq!(
+        OracleSlashReason::WrongEpoch.to_string(),
+        "wrong_epoch"
+    );
+}
+
+/// Test slashing config default.
+#[test]
+fn slashing_config_default_one_percent() {
+    let config = OracleSlashingConfig::default();
+    assert_eq!(config.slash_fraction_bps, 100); // 1%
+    
+    // Test calculation
+    assert_eq!(config.calculate_slash(1_000_000), 10_000); // 1% of 1M
+    assert_eq!(config.calculate_slash(100_000), 1_000);    // 1% of 100K
+}
+
+/// Test slashing with zero stake (edge case).
+#[test]
+fn slashing_zero_stake() {
+    let mut blockchain = Blockchain::default();
+    
+    let consensus_key = vec![7u8; 32];
+    let (validator, key_id) = create_validator_info(consensus_key, 0);
+    
+    blockchain.validator_registry.insert(
+        hex::encode(key_id),
+        validator,
+    );
+    
+    let slashed = blockchain.slash_oracle_validator(
+        key_id,
+        OracleSlashReason::WrongEpoch,
+        100,
+    );
+    
+    // Nothing to slash
+    assert_eq!(slashed, 0);
+    
+    // But still banned and recorded
+    assert!(blockchain.oracle_banned_validators.contains(&key_id));
+    assert_eq!(blockchain.oracle_slash_events.len(), 1);
+    assert_eq!(blockchain.oracle_slash_events[0].slash_amount, 0);
+}
+
+/// Test multiple slash events accumulate.
+#[test]
+fn multiple_slashes_recorded() {
+    let mut blockchain = Blockchain::default();
+    
+    let consensus_key1 = vec![8u8; 32];
+    let consensus_key2 = vec![9u8; 32];
+    
+    let (validator1, key_id1) = create_validator_info(consensus_key1, 100_000);
+    let (validator2, key_id2) = create_validator_info(consensus_key2, 200_000);
+    
+    blockchain.validator_registry.insert(
+        hex::encode(key_id1),
+        validator1,
+    );
+    blockchain.validator_registry.insert(
+        hex::encode(key_id2),
+        validator2,
+    );
+    
+    // Slash both
+    blockchain.slash_oracle_validator(key_id1, OracleSlashReason::ConflictingAttestation, 100);
+    blockchain.slash_oracle_validator(key_id2, OracleSlashReason::WrongEpoch, 101);
+    
+    // Both events recorded
+    assert_eq!(blockchain.oracle_slash_events.len(), 2);
+    
+    // First event
+    assert_eq!(blockchain.oracle_slash_events[0].validator_key_id, key_id1);
+    assert_eq!(blockchain.oracle_slash_events[0].reason, OracleSlashReason::ConflictingAttestation);
+    
+    // Second event
+    assert_eq!(blockchain.oracle_slash_events[1].validator_key_id, key_id2);
+    assert_eq!(blockchain.oracle_slash_events[1].reason, OracleSlashReason::WrongEpoch);
+    
+    // Both banned
+    assert!(blockchain.oracle_banned_validators.contains(&key_id1));
+    assert!(blockchain.oracle_banned_validators.contains(&key_id2));
+}

--- a/lib-blockchain/tests/oracle_staleness_tests.rs
+++ b/lib-blockchain/tests/oracle_staleness_tests.rs
@@ -1,0 +1,181 @@
+//! Oracle Price Staleness Tests (ORACLE-5)
+//!
+//! Tests for price staleness gating per Oracle Spec v1 §11.
+
+use lib_blockchain::{
+    oracle::{FinalizedOraclePrice, OracleState},
+    Blockchain,
+};
+
+/// Test that latest_fresh_price returns None when price is stale.
+#[test]
+fn latest_fresh_price_returns_none_when_stale() {
+    let mut state = OracleState::default();
+    
+    // Set staleness window to 2 epochs
+    state.config.max_price_staleness_epochs = 2;
+    
+    // Finalize price at epoch 0
+    state.try_finalize_price(FinalizedOraclePrice {
+        epoch_id: 0,
+        sov_usd_price: 100_000_000,
+    });
+    
+    // At epoch 2, price is still fresh (age = 2)
+    assert!(state.latest_fresh_price(2).is_some());
+    
+    // At epoch 3, price is stale (age = 3 > 2)
+    assert!(state.latest_fresh_price(3).is_none());
+}
+
+/// Test that latest_fresh_price returns price when fresh.
+#[test]
+fn latest_fresh_price_returns_price_when_fresh() {
+    let mut state = OracleState::default();
+    state.config.max_price_staleness_epochs = 5;
+    
+    state.try_finalize_price(FinalizedOraclePrice {
+        epoch_id: 10,
+        sov_usd_price: 150_000_000,
+    });
+    
+    // At epoch 12, price is fresh (age = 2 <= 5)
+    let fresh = state.latest_fresh_price(12);
+    assert!(fresh.is_some());
+    assert_eq!(fresh.unwrap().sov_usd_price, 150_000_000);
+    
+    // At epoch 15, price is still fresh (age = 5 <= 5)
+    let fresh = state.latest_fresh_price(15);
+    assert!(fresh.is_some());
+}
+
+/// Test staleness with no finalized price.
+#[test]
+fn latest_fresh_price_none_when_no_finalized() {
+    let state = OracleState::default();
+    
+    assert!(state.latest_fresh_price(100).is_none());
+}
+
+/// Test CBE graduation blocked with stale price.
+#[test]
+fn cbe_graduation_blocked_with_stale_price() {
+    use lib_blockchain::contracts::bonding_curve::{BondingCurveToken, Phase, CurveType};
+    use lib_blockchain::contracts::tokens::CBE_SYMBOL;
+    use lib_crypto::PublicKey;
+    
+    let mut blockchain = Blockchain::default();
+    
+    // Create CBE token with $300K reserve
+    let token = BondingCurveToken {
+        token_id: [1u8; 32],
+        name: "Test CBE".to_string(),
+        symbol: CBE_SYMBOL.to_string(),
+        decimals: 8,
+        phase: Phase::Curve,
+        total_supply: 1_000_000_000,
+        reserve_balance: 300_000_000_000, // $300K micro-USD
+        curve_type: CurveType::Linear { base_price: 1, slope: 1 },
+        threshold: lib_blockchain::contracts::bonding_curve::Threshold::ReserveAmount(1_000_000),
+        sell_enabled: true,
+        amm_pool_id: None,
+        creator: PublicKey::new(vec![1u8; 32]),
+        deployed_at_block: 1,
+        deployed_at_timestamp: 1,
+    };
+    
+    blockchain.bonding_curve_registry.register(token).unwrap();
+    
+    // Set a finalized price at epoch 0
+    blockchain.oracle_state.try_finalize_price(FinalizedOraclePrice {
+        epoch_id: 0,
+        sov_usd_price: 100_000_000, // $1.00
+    });
+    
+    // Configure short staleness window
+    blockchain.oracle_state.config.max_price_staleness_epochs = 5;
+    blockchain.oracle_state.config.epoch_duration_secs = 300;
+    
+    // Try to graduate at epoch 10 (stale: age = 10 > 5)
+    let block_timestamp = 10 * 300;
+    let result = blockchain.validate_cbe_graduation_oracle_gate(
+        [1u8; 32],
+        block_timestamp,
+    );
+    
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("stale"), "Expected stale error, got: {}", err_msg);
+}
+
+/// Test CBE graduation proceeds with fresh price.
+#[test]
+fn cbe_graduation_proceeds_with_fresh_price() {
+    use lib_blockchain::contracts::bonding_curve::{BondingCurveToken, Phase, CurveType};
+    use lib_blockchain::contracts::tokens::CBE_SYMBOL;
+    use lib_crypto::PublicKey;
+    
+    let mut blockchain = Blockchain::default();
+    
+    let token = BondingCurveToken {
+        token_id: [1u8; 32],
+        name: "Test CBE".to_string(),
+        symbol: CBE_SYMBOL.to_string(),
+        decimals: 8,
+        phase: Phase::Curve,
+        total_supply: 1_000_000_000,
+        reserve_balance: 300_000_000_000, // $300K micro-USD
+        curve_type: CurveType::Linear { base_price: 1, slope: 1 },
+        threshold: lib_blockchain::contracts::bonding_curve::Threshold::ReserveAmount(1_000_000),
+        sell_enabled: true,
+        amm_pool_id: None,
+        creator: PublicKey::new(vec![1u8; 32]),
+        deployed_at_block: 1,
+        deployed_at_timestamp: 1,
+    };
+    
+    blockchain.bonding_curve_registry.register(token).unwrap();
+    
+    // Set finalized price at epoch 8
+    blockchain.oracle_state.try_finalize_price(FinalizedOraclePrice {
+        epoch_id: 8,
+        sov_usd_price: 100_000_000,
+    });
+    
+    blockchain.oracle_state.config.max_price_staleness_epochs = 5;
+    blockchain.oracle_state.config.epoch_duration_secs = 300;
+    
+    // Try to graduate at epoch 10 (fresh: age = 2 <= 5)
+    let block_timestamp = 10 * 300;
+    let result = blockchain.validate_cbe_graduation_oracle_gate(
+        [1u8; 32],
+        block_timestamp,
+    );
+    
+    assert!(result.is_ok(), "Expected Ok but got: {:?}", result);
+}
+
+/// Test staleness at exact boundary (inclusive).
+#[test]
+fn staleness_at_exact_boundary() {
+    let mut state = OracleState::default();
+    state.config.max_price_staleness_epochs = 3;
+    
+    state.try_finalize_price(FinalizedOraclePrice {
+        epoch_id: 10,
+        sov_usd_price: 100_000_000,
+    });
+    
+    // At epoch 13, age = 3, which equals max_staleness (inclusive boundary)
+    assert!(state.latest_fresh_price(13).is_some());
+    
+    // At epoch 14, age = 4, which exceeds max_staleness
+    assert!(state.latest_fresh_price(14).is_none());
+}
+
+/// Test that default staleness config is reasonable (2 epochs).
+#[test]
+fn default_staleness_config() {
+    let state = OracleState::default();
+    assert_eq!(state.config.max_price_staleness_epochs, 2);
+}

--- a/zhtp/src/api/handlers/oracle/mod.rs
+++ b/zhtp/src/api/handlers/oracle/mod.rs
@@ -88,6 +88,12 @@ impl OracleHandler {
         match latest {
             Some(finalized) => {
                 let price_usd = finalized.sov_usd_price as f64 / ORACLE_PRICE_SCALE as f64;
+                
+                // ORACLE-5: Include staleness metadata
+                let epochs_since = current_epoch.saturating_sub(finalized.epoch_id);
+                let max_staleness = bc.oracle_state.config.max_price_staleness_epochs;
+                let is_fresh = epochs_since <= max_staleness;
+                
                 // u128 fields are serialized as strings — serde_json cannot represent
                 // integers beyond u64::MAX and will return an error otherwise.
                 let body = json!({
@@ -95,6 +101,10 @@ impl OracleHandler {
                     "sov_usd_price_atomic": finalized.sov_usd_price.to_string(),
                     "sov_usd_price": price_usd,
                     "oracle_price_scale": ORACLE_PRICE_SCALE.to_string(),
+                    "current_epoch": current_epoch,
+                    "epochs_since_finalization": epochs_since,
+                    "is_fresh": is_fresh,
+                    "max_price_staleness_epochs": max_staleness,
                 });
                 let bytes = match serde_json::to_vec(&body) {
                     Ok(b) => b,
@@ -146,10 +156,14 @@ impl OracleHandler {
             .latest_finalized_price_at_or_before(current_epoch)
             .map(|p| {
                 let price_usd = p.sov_usd_price as f64 / ORACLE_PRICE_SCALE as f64;
+                let epochs_since = current_epoch.saturating_sub(p.epoch_id);
+                let max_staleness = bc.oracle_state.config.max_price_staleness_epochs;
                 json!({
                     "epoch_id": p.epoch_id,
                     "sov_usd_price_atomic": p.sov_usd_price.to_string(),
                     "sov_usd_price": price_usd,
+                    "epochs_since_finalization": epochs_since,
+                    "is_fresh": epochs_since <= max_staleness,
                 })
             });
 
@@ -162,6 +176,7 @@ impl OracleHandler {
             "finalized_prices_count": finalized_count,
             "latest_finalized_price": latest_price,
             "oracle_price_scale": ORACLE_PRICE_SCALE.to_string(),
+            "max_price_staleness_epochs": bc.oracle_state.config.max_price_staleness_epochs,
         });
 
         let bytes = match serde_json::to_vec(&body) {

--- a/zhtp/src/runtime/components/mod.rs
+++ b/zhtp/src/runtime/components/mod.rs
@@ -10,6 +10,7 @@ pub mod economics;
 pub mod protocols;
 pub mod api;
 pub mod oracle;
+pub mod oracle_exchange_feed;
 
 // Re-export component types
 pub use crypto::CryptoComponent;

--- a/zhtp/src/runtime/components/oracle.rs
+++ b/zhtp/src/runtime/components/oracle.rs
@@ -21,6 +21,7 @@ use lib_network::types::mesh_message::ZhtpMeshMessage;
 use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, info, warn};
 
+use crate::runtime::components::oracle_exchange_feed::ExchangePriceFeed;
 use crate::runtime::services::{OracleFetchedPrice, OracleProducerConfig, OracleProducerService};
 
 /// Oracle attestation consumer/producer runtime.
@@ -164,6 +165,8 @@ impl OracleComponent {
                 },
             );
 
+            use lib_blockchain::oracle::{OracleAttestationAdmissionError, OracleSlashReason};
+            
             match result {
                 Ok(admission) => {
                     info!(
@@ -171,6 +174,30 @@ impl OracleComponent {
                         attestation.epoch_id,
                         attestation.sov_usd_price as f64 / ORACLE_PRICE_SCALE as f64,
                         admission
+                    );
+                }
+                Err(OracleAttestationAdmissionError::ConflictingSigner { .. }) => {
+                    // ORACLE-4: Slash for double-signing (two different prices for same epoch)
+                    warn!(
+                        "🔮 Oracle: ConflictingSigner detected — slashing validator {} for double-sign",
+                        hex::encode(&attestation.validator_pubkey[..8])
+                    );
+                    bc.slash_oracle_validator(
+                        attestation.validator_pubkey,
+                        OracleSlashReason::ConflictingAttestation,
+                        attestation.epoch_id,
+                    );
+                }
+                Err(OracleAttestationAdmissionError::Validation(_)) => {
+                    // ORACLE-4: Slash for validation errors including wrong-epoch
+                    warn!(
+                        "🔮 Oracle: Validation error — slashing validator {} for protocol violation",
+                        hex::encode(&attestation.validator_pubkey[..8])
+                    );
+                    bc.slash_oracle_validator(
+                        attestation.validator_pubkey,
+                        OracleSlashReason::WrongEpoch,
+                        attestation.epoch_id,
                     );
                 }
                 Err(e) => {
@@ -223,9 +250,9 @@ impl OracleComponent {
                 (ts, bc.oracle_state.epoch_id(ts))
             };
 
-            // Fetch prices (may involve network I/O for real exchange feeds).
-            // Note: gather_prices uses wall clock for source freshness (intentional per §5)
-            let prices = Self::gather_prices(mock_sov_usd_price, unix_now()).await;
+            // Fetch prices from on-chain exchange state (Oracle Spec v1 §5).
+            // Uses 3 independent sources: last trade, order book mid, VWAP.
+            let prices = Self::gather_prices(blockchain.clone(), mock_sov_usd_price, unix_now()).await;
             if prices.is_empty() {
                 warn!("Oracle producer: no price sources available, skipping epoch {}", current_epoch);
                 tokio::time::sleep(tokio::time::Duration::from_secs(epoch_duration_secs)).await;
@@ -321,7 +348,14 @@ impl OracleComponent {
     ///
     /// When `mock_price` is set it is used as three identical synthetic sources so
     /// the median aggregation always passes the `min_sources_required = 3` check.
-    async fn gather_prices(mock_price: Option<u64>, now: u64) -> Vec<OracleFetchedPrice> {
+    ///
+    /// Otherwise, queries the on-chain exchange state for 3 independent price sources
+    /// (last trade, order book mid, VWAP) per Oracle Spec v1 §5.
+    async fn gather_prices(
+        blockchain: Arc<RwLock<Blockchain>>,
+        mock_price: Option<u64>,
+        now: u64,
+    ) -> Vec<OracleFetchedPrice> {
         if let Some(price) = mock_price {
             // Three synthetic sources (identical values, different source IDs) so the
             // producer's min_sources_required = 3 check passes.
@@ -332,17 +366,20 @@ impl OracleComponent {
             ];
         }
 
-        // Real exchange feeds (SOV not yet listed — these will return errors; kept as scaffolding).
-        let mut prices = Vec::new();
+        // Query on-chain exchange state for 3 independent price sources (Oracle Spec v1 §5)
+        let feed = ExchangePriceFeed::new();
+        let samples = feed.gather_prices(blockchain, now).await;
 
-        if let Some(p) = fetch_coingecko_sov_usd(now).await {
-            prices.push(p);
-        }
-        if let Some(p) = fetch_binance_sov_usdt(now).await {
-            prices.push(p);
-        }
-
-        prices
+        // Convert PriceSample to OracleFetchedPrice
+        samples
+            .into_iter()
+            .filter(|s| ExchangePriceFeed::is_price_valid(s.price_atomic))
+            .map(|s| OracleFetchedPrice {
+                source_id: s.source.as_str().to_string(),
+                sov_usd_price: s.price_atomic,
+                timestamp: s.timestamp,
+            })
+            .collect()
     }
 
     // ── Gossip ──────────────────────────────────────────────────────────────

--- a/zhtp/src/runtime/components/oracle_exchange_feed.rs
+++ b/zhtp/src/runtime/components/oracle_exchange_feed.rs
@@ -1,0 +1,236 @@
+//! Exchange Price Feed Service for Oracle Protocol
+//!
+//! Implements §5 of Oracle Spec v1: Sourcing price data from 3 independent
+//! on-chain exchange sources:
+//! 1. Last trade price
+//! 2. Order book mid price
+//! 3. VWAP (Volume-Weighted Average Price)
+//!
+//! All prices are returned in ORACLE_PRICE_SCALE (1e8) atomic units.
+
+use lib_blockchain::ORACLE_PRICE_SCALE;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+/// Price source identifier for logging and attestation metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PriceSource {
+    LastTrade,
+    OrderBookMid,
+    Vwap,
+}
+
+impl PriceSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PriceSource::LastTrade => "last_trade",
+            PriceSource::OrderBookMid => "order_book_mid",
+            PriceSource::Vwap => "vwap",
+        }
+    }
+}
+
+/// A price sample from an on-chain source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PriceSample {
+    /// Price in atomic ORACLE_PRICE_SCALE units.
+    pub price_atomic: u128,
+    /// Unix timestamp when the price was sampled.
+    pub timestamp: u64,
+    /// Source of the price.
+    pub source: PriceSource,
+}
+
+/// Exchange price feed service for oracle protocol.
+///
+/// This service queries the on-chain exchange state to gather price data
+/// from 3 independent sources as required by Oracle Spec v1 §5.
+pub struct ExchangePriceFeed;
+
+impl ExchangePriceFeed {
+    /// Creates a new exchange price feed service.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Gather prices from 3 independent on-chain sources.
+    ///
+    /// Returns up to 3 price samples:
+    /// - Last trade price (if available)
+    /// - Order book mid price (if available)
+    /// - VWAP over the last N seconds (if available)
+    ///
+    /// Prices are in atomic ORACLE_PRICE_SCALE (1e8) units.
+    pub async fn gather_prices(
+        &self,
+        blockchain: Arc<RwLock<lib_blockchain::blockchain::Blockchain>>,
+        current_timestamp: u64,
+    ) -> Vec<PriceSample> {
+        let mut samples = Vec::with_capacity(3);
+        let bc = blockchain.read().await;
+
+        // Source 1: Last trade price
+        if let Some(last_trade) = bc.exchange_state.last_trade_price_sov_usdc() {
+            debug!(
+                price = last_trade.price_atomic,
+                timestamp = last_trade.timestamp,
+                "ExchangePriceFeed: last_trade price"
+            );
+            samples.push(PriceSample {
+                price_atomic: last_trade.price_atomic,
+                timestamp: last_trade.timestamp,
+                source: PriceSource::LastTrade,
+            });
+        } else {
+            warn!("ExchangePriceFeed: last_trade price unavailable");
+        }
+
+        // Source 2: Order book mid price
+        if let Some(mid_price) = bc.exchange_state.order_book_mid_sov_usdc() {
+            debug!(
+                price = mid_price,
+                "ExchangePriceFeed: order_book_mid price"
+            );
+            samples.push(PriceSample {
+                price_atomic: mid_price,
+                timestamp: current_timestamp,
+                source: PriceSource::OrderBookMid,
+            });
+        } else {
+            warn!("ExchangePriceFeed: order_book_mid price unavailable");
+        }
+
+        // Source 3: VWAP over the last 1 hour (3600 seconds)
+        // This provides a smoothed price that is resistant to short-term manipulation
+        const VWAP_WINDOW_SECS: u64 = 3600;
+        let vwap_since = current_timestamp.saturating_sub(VWAP_WINDOW_SECS);
+
+        if let Some(vwap) = bc.exchange_state.vwap_sov_usdc(vwap_since, current_timestamp) {
+            debug!(
+                price = vwap,
+                window_secs = VWAP_WINDOW_SECS,
+                "ExchangePriceFeed: vwap price"
+            );
+            samples.push(PriceSample {
+                price_atomic: vwap,
+                timestamp: current_timestamp,
+                source: PriceSource::Vwap,
+            });
+        } else {
+            warn!("ExchangePriceFeed: vwap price unavailable (no trades in window)");
+        }
+
+        samples
+    }
+
+    /// Calculate the median price from multiple samples.
+    ///
+    /// Returns `None` if no samples are available.
+    pub fn median_price(samples: &[PriceSample]) -> Option<u128> {
+        if samples.is_empty() {
+            return None;
+        }
+
+        let mut prices: Vec<u128> = samples.iter().map(|s| s.price_atomic).collect();
+        prices.sort();
+
+        let mid = prices.len() / 2;
+        if prices.len() % 2 == 0 {
+            // Even number of samples: average the two middle values
+            let sum = prices[mid - 1].checked_add(prices[mid])?;
+            Some(sum / 2)
+        } else {
+            // Odd number of samples: take the middle value
+            Some(prices[mid])
+        }
+    }
+
+    /// Validate that a price is within reasonable bounds.
+    ///
+    /// This is a sanity check to prevent obviously invalid prices from
+    /// being included in attestations.
+    pub fn is_price_valid(price_atomic: u128) -> bool {
+        // Minimum price: $0.00000001 (1e-8 USD)
+        const MIN_PRICE_ATOMIC: u128 = 1;
+
+        // Maximum price: $1,000,000.00 (1e6 USD)
+        // At 1e8 scale, this is 1e14
+        const MAX_PRICE_ATOMIC: u128 = 100_0000_0000_0000u128; // $1M * 1e8
+
+        price_atomic >= MIN_PRICE_ATOMIC && price_atomic <= MAX_PRICE_ATOMIC
+    }
+}
+
+impl Default for ExchangePriceFeed {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn median_price_calculates_correctly() {
+        // Odd number of samples
+        let samples = vec![
+            PriceSample {
+                price_atomic: 100_000_000,
+                timestamp: 1000,
+                source: PriceSource::LastTrade,
+            },
+            PriceSample {
+                price_atomic: 110_000_000,
+                timestamp: 1001,
+                source: PriceSource::OrderBookMid,
+            },
+            PriceSample {
+                price_atomic: 120_000_000,
+                timestamp: 1002,
+                source: PriceSource::Vwap,
+            },
+        ];
+        assert_eq!(ExchangePriceFeed::median_price(&samples), Some(110_000_000));
+
+        // Even number of samples
+        let samples = vec![
+            PriceSample {
+                price_atomic: 100_000_000,
+                timestamp: 1000,
+                source: PriceSource::LastTrade,
+            },
+            PriceSample {
+                price_atomic: 120_000_000,
+                timestamp: 1001,
+                source: PriceSource::OrderBookMid,
+            },
+        ];
+        // Median of 100M and 120M = (100M + 120M) / 2 = 110M
+        assert_eq!(ExchangePriceFeed::median_price(&samples), Some(110_000_000));
+
+        // Empty samples
+        let empty: Vec<PriceSample> = vec![];
+        assert_eq!(ExchangePriceFeed::median_price(&empty), None);
+    }
+
+    #[test]
+    fn price_validation_sanity_checks() {
+        // Valid prices
+        assert!(ExchangePriceFeed::is_price_valid(1)); // Minimum valid
+        assert!(ExchangePriceFeed::is_price_valid(100_000_000)); // $1.00
+        assert!(ExchangePriceFeed::is_price_valid(100_0000_0000_0000u128)); // $1M maximum
+
+        // Invalid prices
+        assert!(!ExchangePriceFeed::is_price_valid(0)); // Too low
+        assert!(!ExchangePriceFeed::is_price_valid(100_0001_0000_0000u128)); // Too high (> $1M)
+    }
+
+    #[test]
+    fn price_source_as_str() {
+        assert_eq!(PriceSource::LastTrade.as_str(), "last_trade");
+        assert_eq!(PriceSource::OrderBookMid.as_str(), "order_book_mid");
+        assert_eq!(PriceSource::Vwap.as_str(), "vwap");
+    }
+}


### PR DESCRIPTION
## Summary

Implements three critical oracle protocol features:
- **ORACLE-3**: Sovereign exchange price feed (3 on-chain sources)
- **ORACLE-4**: Oracle slashing for double-sign and wrong-epoch violations
- **ORACLE-5**: Price staleness enforcement in CBE graduation

## Changes

### ORACLE-3: Exchange Price Feed
- `lib-blockchain/src/exchange/state.rs`: `ExchangeState` with:
  - `last_trade_price_sov_usdc()` - Most recent trade price
  - `order_book_mid_sov_usdc()` - (best_bid + best_ask) / 2
  - `vwap_sov_usdc()` - Volume-weighted average price
- `zhtp/src/runtime/components/oracle_exchange_feed.rs`: `ExchangePriceFeed` service
- Updated `gather_prices()` to query on-chain exchange state
- All prices use `ORACLE_PRICE_SCALE` (1e8) fixed-point

### ORACLE-4: Oracle Slashing
- `lib-blockchain/src/oracle/slashing.rs`: New types:
  - `OracleSlashEvent` - Record of slash with reason, amount, epoch
  - `OracleSlashReason` - `ConflictingAttestation` or `WrongEpoch`
  - `OracleSlashingConfig` - Configurable slash fraction (default 1%)
- `Blockchain::slash_oracle_validator()` - Reduces stake, bans validator, removes from committee
- Consumer task triggers slashing on `ConflictingSigner` and validation errors
- `oracle_banned_validators` HashSet prevents re-addition to committee

### ORACLE-5: Price Staleness
- `OracleState::latest_fresh_price()` - Returns price only if within `max_price_staleness_epochs`
- CBE graduation gate already had staleness check - verified working
- API endpoints updated with staleness metadata:
  - `is_fresh` - Boolean indicating if price is within staleness window
  - `epochs_since_finalization` - Age in epochs
  - `max_price_staleness_epochs` - Configured threshold

## Storage
- Added `oracle_slash_events: Vec<OracleSlashEvent>`
- Added `oracle_slashing_config: OracleSlashingConfig`
- Added `oracle_banned_validators: HashSet<[u8; 32]>`
- Updated `BlockchainStorageV4` for persistence

## Tests
- `oracle_exchange_feed_tests.rs` - 9 tests
- `oracle_slashing_tests.rs` - 10 tests  
- `oracle_staleness_tests.rs` - 7 tests
- Plus existing: `oracle_committee_tests.rs` (9), `oracle_epoch_tests.rs` (8)
- **Total: 43 oracle tests passing**

## Spec Compliance
- ✅ §5: 3 independent on-chain sources (last_trade, order_book_mid, vwap)
- ✅ §9: Double-sign and wrong-epoch slashing
- ✅ §11: Price staleness gating
- ✅ §4.1: Epoch derived from block timestamp (from ORACLE-2)
- ✅ §3.1: Governance-only committee updates (from ORACLE-1)

## Related Issues
- Closes #1688 (ORACLE-3)
- Closes #1687 (ORACLE-4)
- Closes #1689 (ORACLE-5)