### PR TITLE
[ORACLE][R3] Canonicalize Attestation Execution Path (Shadow -> Cutover) (#1772)

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2439,6 +2439,11 @@ impl Blockchain {
             info!("🔮 Oracle advanced to epoch {} (block height {})", block_epoch, self.height);
         }
 
+        // ORACLE-R3: Process oracle attestation transactions through canonical path
+        // In V0 (legacy) mode: Also process gossip attestations (backward compatibility)
+        // In V1 (strict spec) mode: Only transaction attestations are processed
+        self.process_oracle_attestation_transactions(&block, block.header.timestamp);
+
         // Process economic features
         if let Err(e) = self.process_ubi_claim_transactions(&block) {
             warn!("Error processing UBI claims at height {}: {}", self.height, e);
@@ -11704,6 +11709,127 @@ impl Blockchain {
         
         self.oracle_state.committee.set_members_genesis_only(members);
         Ok(())
+    }
+
+    /// Process OracleAttestation transactions from a block.
+    ///
+    /// ORACLE-R3: This is the canonical execution path for attestations in blocks.
+    /// Called by finish_block_processing() for both BlockExecutor and legacy paths.
+    fn process_oracle_attestation_transactions(&mut self, block: &Block, block_timestamp: u64) {
+        for tx in &block.transactions {
+            if tx.transaction_type == TransactionType::OracleAttestation {
+                if let Some(data) = &tx.oracle_attestation_data {
+                    // Build the attestation from transaction data
+                    let attestation = crate::oracle::OraclePriceAttestation {
+                        epoch_id: data.epoch_id,
+                        sov_usd_price: data.sov_usd_price,
+                        timestamp: data.timestamp,
+                        validator_pubkey: data.validator_pubkey,
+                        signature: data.signature.clone(),
+                    };
+
+                    // Apply through canonical path
+                    match self.apply_oracle_attestation(&attestation, block_timestamp) {
+                        Ok(outcome) => {
+                            if outcome.finalized {
+                                info!(
+                                    "🔮 Oracle epoch {} finalized at price {} via transaction",
+                                    outcome.epoch_id, outcome.sov_usd_price
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "🔮 Oracle attestation transaction failed: {} (tx hash: {})",
+                                e,
+                                hex::encode(tx.hash().as_bytes())
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Apply an oracle attestation transaction through the canonical block execution path.
+    ///
+    /// ORACLE-R3: This is the canonical execution path for oracle attestations.
+    /// In strict-spec mode (V1), this is the ONLY allowed path for attestation processing.
+    ///
+    /// This method is called by:
+    /// - BlockExecutor when processing OracleAttestation transactions
+    /// - Runtime when in legacy mode (V0) for backward compatibility
+    ///
+    /// # Arguments
+    /// * `attestation` - The price attestation from a validator
+    /// * `block_timestamp` - The block timestamp for epoch derivation
+    ///
+    /// # Returns
+    /// * `Ok(OracleAttestationOutcome)` - Attestation was processed successfully
+    /// * `Err(...)` - Attestation was rejected (validation failure, double-sign, etc.)
+    pub fn apply_oracle_attestation(
+        &mut self,
+        attestation: &crate::oracle::OraclePriceAttestation,
+        block_timestamp: u64,
+    ) -> Result<crate::execution::tx_apply::OracleAttestationOutcome, String> {
+        let current_epoch = self.oracle_state.epoch_id(block_timestamp);
+
+        // Build key lookup for signature verification
+        let oracle_pubkeys = self.oracle_state.oracle_signing_pubkeys.clone();
+        let key_map: Vec<([u8; 32], Vec<u8>)> = self
+            .validator_registry
+            .values()
+            .filter(|v| !v.consensus_key.is_empty())
+            .map(|v| {
+                let kid = crate::types::hash::blake3_hash(&v.consensus_key).as_array();
+                (kid, v.consensus_key.clone())
+            })
+            .collect();
+
+        // Process the attestation through oracle state
+        let result = self.oracle_state.process_attestation(
+            attestation,
+            current_epoch,
+            |key_id: [u8; 32]| {
+                // Check bootstrapped oracle signing pubkeys first
+                if let Some(pk) = oracle_pubkeys.get(&key_id) {
+                    if !pk.is_empty() {
+                        return Some(pk.clone());
+                    }
+                }
+                // Fall back to validator_registry consensus keys
+                key_map
+                    .iter()
+                    .find(|(kid, _)| *kid == key_id)
+                    .map(|(_, pk)| pk.clone())
+            },
+        );
+
+        match result {
+            Ok(admission) => {
+                let finalized = matches!(
+                    admission,
+                    crate::oracle::OracleAttestationAdmission::Finalized(_)
+                );
+
+                Ok(crate::execution::tx_apply::OracleAttestationOutcome {
+                    epoch_id: attestation.epoch_id,
+                    validator_pubkey: attestation.validator_pubkey,
+                    sov_usd_price: attestation.sov_usd_price,
+                    finalized,
+                })
+            }
+            Err(crate::oracle::OracleAttestationAdmissionError::ConflictingSigner { .. }) => {
+                // Double-sign detected - slash the validator
+                self.slash_oracle_validator(
+                    attestation.validator_pubkey,
+                    crate::oracle::OracleSlashReason::ConflictingAttestation,
+                    attestation.epoch_id,
+                );
+                Err("Conflicting attestation detected - validator double-signed".to_string())
+            }
+            Err(e) => Err(format!("Attestation rejected: {:?}", e)),
+        }
     }
 }
 

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -677,6 +677,12 @@ impl BlockExecutor {
                 TxOutcome::BondingCurveGraduate(_) => {
                     summary.account_updates += 1; // phase transition to AMM
                 }
+                TxOutcome::OracleAttestation(_) => {
+                    // ORACLE-R3: Oracle attestations are processed by Blockchain after
+                    // block execution (not by BlockExecutor). They don't touch storage
+                    // directly - they update in-memory oracle_state.
+                    summary.account_updates += 1;
+                }
                 TxOutcome::Coinbase(_) => {
                     // Should not happen - coinbase filtered out
                     unreachable!("Coinbase should not be in non-coinbase pass");
@@ -2026,6 +2032,12 @@ impl BlockExecutor {
                 Ok(TxOutcome::DaoExecution(outcome))
             }
 
+            // ORACLE-R3: Oracle attestation is handled as LegacySystem in executor.
+            // The actual oracle_state mutation happens in Blockchain.finish_block_processing()
+            // which iterates through transactions and calls apply_oracle_attestation().
+            // This separation is necessary because oracle_state is in-memory (not in storage).
+            TransactionType::OracleAttestation => Ok(TxOutcome::LegacySystem),
+
             // Coinbase is routed through apply_coinbase_with_fees, never here.
             TransactionType::Coinbase => Err(TxApplyError::InvalidType(
                 "Coinbase must not be routed through apply_transaction".to_string(),
@@ -2107,6 +2119,8 @@ enum TxOutcome {
     BondingCurveBuy(BondingCurveBuyOutcome),
     BondingCurveSell(BondingCurveSellOutcome),
     BondingCurveGraduate(BondingCurveGraduateOutcome),
+    /// Oracle attestation outcome (ORACLE-R3: Canonical Path)
+    OracleAttestation(OracleAttestationOutcome),
     Coinbase(CoinbaseOutcome),
     /// Legacy system transaction types (IdentityRegistration, WalletRegistration, etc.)
     /// accepted as no-ops by the Phase-2 executor for backwards compatibility.
@@ -2204,6 +2218,15 @@ pub struct BondingCurveSellOutcome {
 pub struct BondingCurveGraduateOutcome {
     pub token_id: [u8; 32],
     pub pool_id: [u8; 32],
+}
+
+/// Outcome of an oracle attestation transaction (ORACLE-R3: Canonical Path)
+#[derive(Debug, Clone)]
+pub struct OracleAttestationOutcome {
+    pub epoch_id: u64,
+    pub validator_pubkey: [u8; 32],
+    pub sov_usd_price: u128,
+    pub finalized: bool,
 }
 
 // =============================================================================

--- a/lib-blockchain/src/execution/mod.rs
+++ b/lib-blockchain/src/execution/mod.rs
@@ -44,5 +44,5 @@ pub mod executor;
 // Re-exports
 pub use errors::{BlockApplyError, BlockApplyResult, TxApplyError, TxApplyResult};
 pub use state_view::{StateView, StateViewExt};
-pub use tx_apply::{StateMutator, TransferOutcome, CoinbaseOutcome};
+pub use tx_apply::{StateMutator, TransferOutcome, CoinbaseOutcome, OracleAttestationOutcome};
 pub use executor::{BlockExecutor, ExecutorConfig, ApplyOutcome, StateChangesSummary, TokenTransferOutcome, TokenMintOutcome};

--- a/lib-blockchain/src/execution/tx_apply.rs
+++ b/lib-blockchain/src/execution/tx_apply.rs
@@ -898,6 +898,94 @@ pub fn apply_coinbase(
 }
 
 // =============================================================================
+// Oracle Attestation Application (ORACLE-R3: Canonical Path)
+// =============================================================================
+
+/// Outcome of applying an oracle attestation transaction.
+#[derive(Debug, Clone)]
+pub struct OracleAttestationOutcome {
+    pub epoch_id: u64,
+    pub validator_pubkey: [u8; 32],
+    pub sov_usd_price: u128,
+    pub finalized: bool,
+}
+
+/// Apply an oracle attestation transaction.
+///
+/// This is the CANONICAL execution path for oracle attestations (ORACLE-R3).
+/// In strict-spec mode (V1), this is the ONLY allowed path for attestation processing.
+///
+/// # Arguments
+/// * `mutator` - State mutator for consensus state writes
+/// * `tx` - The attestation transaction
+/// * `block_timestamp` - The block's timestamp for epoch derivation
+/// * `oracle_state` - Mutable reference to oracle state (will be modified)
+/// * `resolve_signing_pubkey` - Function to resolve validator signing keys
+///
+/// # Returns
+/// The attestation outcome, including whether the epoch was finalized by this attestation.
+pub fn apply_oracle_attestation<F>(
+    _mutator: &StateMutator<'_>,
+    tx: &Transaction,
+    block_timestamp: u64,
+    oracle_state: &mut crate::oracle::OracleState,
+    resolve_signing_pubkey: F,
+) -> TxApplyResult<OracleAttestationOutcome>
+where
+    F: Fn([u8; 32]) -> Option<Vec<u8>>,
+{
+    let data = tx.oracle_attestation_data.as_ref().ok_or_else(|| {
+        TxApplyError::InvalidType("OracleAttestation requires oracle_attestation_data".to_string())
+    })?;
+
+    // Derive current epoch from block timestamp
+    let current_epoch = oracle_state.epoch_id(block_timestamp);
+
+    // Build the attestation
+    let attestation = crate::oracle::OraclePriceAttestation {
+        epoch_id: data.epoch_id,
+        sov_usd_price: data.sov_usd_price,
+        timestamp: data.timestamp,
+        validator_pubkey: data.validator_pubkey,
+        signature: data.signature.clone(),
+    };
+
+    // Process the attestation through oracle state
+    // This handles: validation, aggregation, threshold detection, finalization
+    let result = oracle_state.process_attestation(
+        &attestation,
+        current_epoch,
+        resolve_signing_pubkey,
+    );
+
+    match result {
+        Ok(admission) => {
+            let finalized = matches!(
+                admission,
+                crate::oracle::OracleAttestationAdmission::Finalized(_)
+            );
+
+            Ok(OracleAttestationOutcome {
+                epoch_id: data.epoch_id,
+                validator_pubkey: data.validator_pubkey,
+                sov_usd_price: data.sov_usd_price,
+                finalized,
+            })
+        }
+        Err(crate::oracle::OracleAttestationAdmissionError::ConflictingSigner { .. }) => {
+            // Double-sign detected - this should trigger slashing
+            Err(TxApplyError::InvalidType(
+                "Conflicting attestation detected - validator double-signed".to_string()
+            ))
+        }
+        Err(e) => Err(TxApplyError::InvalidType(format!(
+            "Attestation rejected: {:?}",
+            e
+        ))),
+    }
+}
+
+// =============================================================================
 // Outcome Types
 // =============================================================================
 

--- a/zhtp/src/runtime/components/oracle.rs
+++ b/zhtp/src/runtime/components/oracle.rs
@@ -128,6 +128,22 @@ impl OracleComponent {
                 }
             };
 
+            // ORACLE-R3: Check protocol version - in strict spec mode, attestations must go through
+            // transactions only, not direct gossip processing
+            {
+                let bc = blockchain.read().await;
+                if bc.oracle_state.is_strict_spec_active() {
+                    // In strict spec mode, reject direct gossip attestations
+                    // Validators must submit attestations via transactions
+                    debug!(
+                        "🔮 Oracle: rejecting gossip attestation in strict spec mode (epoch={}). \
+                         Validators must use transaction-based attestations.",
+                        attestation.epoch_id
+                    );
+                    continue;
+                }
+            }
+
             // Use block timestamp for epoch derivation (Oracle Spec v1 §4.1)
             // Wall clock MUST NOT be used to determine epoch_id.
             let mut bc = blockchain.write().await;
@@ -302,47 +318,51 @@ impl OracleComponent {
                         attestation.sov_usd_price as f64 / ORACLE_PRICE_SCALE as f64
                     );
 
-                    // Gossip to peers.
-                    Self::gossip_attestation(&attestation).await;
-
-                    // Process locally (our own vote counts).
-                    let _payload = match bincode::serialize(&attestation) {
-                        Ok(b) => b,
-                        Err(e) => {
-                            warn!("Oracle: failed to serialize own attestation: {}", e);
-                            tokio::time::sleep(tokio::time::Duration::from_secs(epoch_duration_secs)).await;
-                            continue;
-                        }
+                    // Check protocol version for local processing
+                    let is_strict_spec = {
+                        let bc = blockchain.read().await;
+                        bc.oracle_state.is_strict_spec_active()
                     };
 
-                    // Use block timestamp for epoch derivation (Oracle Spec v1 §4.1)
-                    let mut bc = blockchain.write().await;
-                    let epoch2 = bc.oracle_state.epoch_id(bc.last_committed_timestamp());
-                    let oracle_pubkeys2 = bc.oracle_state.oracle_signing_pubkeys.clone();
-                    let key_map: Vec<([u8; 32], Vec<u8>)> = bc
-                        .validator_registry
-                        .values()
-                        .filter(|v| !v.consensus_key.is_empty())
-                        .map(|v| {
-                            let kid = lib_blockchain::blake3_hash(&v.consensus_key).as_array();
-                            (kid, v.consensus_key.clone())
-                        })
-                        .collect();
+                    if is_strict_spec {
+                        // ORACLE-R3: In strict spec mode, create and submit a transaction
+                        // instead of processing directly. The transaction will be included
+                        // in a block and processed through the canonical path.
+                        debug!("🔮 Oracle: strict spec mode - submitting attestation as transaction");
+                        Self::submit_attestation_transaction(&attestation).await;
+                    } else {
+                        // Legacy mode: Gossip and process directly
+                        Self::gossip_attestation(&attestation).await;
 
-                    match bc.oracle_state.process_attestation(
-                        &attestation,
-                        epoch2,
-                        |key_id: [u8; 32]| {
-                            if let Some(pk) = oracle_pubkeys2.get(&key_id) {
-                                if !pk.is_empty() {
-                                    return Some(pk.clone());
+                        // Process locally (our own vote counts).
+                        let mut bc = blockchain.write().await;
+                        let epoch2 = bc.oracle_state.epoch_id(bc.last_committed_timestamp());
+                        let oracle_pubkeys2 = bc.oracle_state.oracle_signing_pubkeys.clone();
+                        let key_map: Vec<([u8; 32], Vec<u8>)> = bc
+                            .validator_registry
+                            .values()
+                            .filter(|v| !v.consensus_key.is_empty())
+                            .map(|v| {
+                                let kid = lib_blockchain::blake3_hash(&v.consensus_key).as_array();
+                                (kid, v.consensus_key.clone())
+                            })
+                            .collect();
+
+                        match bc.oracle_state.process_attestation(
+                            &attestation,
+                            epoch2,
+                            |key_id: [u8; 32]| {
+                                if let Some(pk) = oracle_pubkeys2.get(&key_id) {
+                                    if !pk.is_empty() {
+                                        return Some(pk.clone());
+                                    }
                                 }
-                            }
-                            key_map.iter().find(|(kid, _)| *kid == key_id).map(|(_, pk)| pk.clone())
-                        },
-                    ) {
-                        Ok(r) => info!("🔮 Oracle: self-attestation local result: {:?}", r),
-                        Err(e) => warn!("🔮 Oracle: self-attestation local rejected: {:?}", e),
+                                key_map.iter().find(|(kid, _)| *kid == key_id).map(|(_, pk)| pk.clone())
+                            },
+                        ) {
+                            Ok(r) => info!("🔮 Oracle: self-attestation local result: {:?}", r),
+                            Err(e) => warn!("🔮 Oracle: self-attestation local rejected: {:?}", e),
+                        }
                     }
                 }
                 Ok(None) => {
@@ -425,6 +445,23 @@ impl OracleComponent {
             }
         }
     }
+
+    /// Submit an attestation as a transaction in strict spec mode.
+    ///
+    /// ORACLE-R3: In strict spec mode, attestations must go through the canonical
+    /// transaction/block path rather than direct gossip processing.
+    ///
+    /// TODO: Implement transaction creation and mempool submission
+    async fn submit_attestation_transaction(_attestation: &OraclePriceAttestation) {
+        // This is a placeholder for the full implementation.
+        // In the full implementation, this would:
+        // 1. Create an OracleAttestation transaction
+        // 2. Sign it with the validator's key
+        // 3. Submit it to the mempool
+        // 4. The transaction will be included in a block and processed through
+        //    the canonical path in Blockchain.process_oracle_attestation_transactions()
+        info!("🔮 Oracle: submitting attestation as transaction (TODO: implement)");
+    }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -436,7 +473,6 @@ fn unix_now() -> u64 {
         .as_secs()
 }
 
-/// Build a shared `reqwest::Client` with a 10-second overall timeout.
 #[allow(dead_code)]
 fn exchange_http_client() -> Option<reqwest::Client> {
     reqwest::Client::builder()


### PR DESCRIPTION
## Summary

This PR implements **ORACLE-R3: Canonicalize Attestation Execution Path**, establishing a transaction-based canonical path for oracle attestations while maintaining backward compatibility with the existing direct gossip path.

## Problem

The current oracle implementation processes attestations directly in the runtime gossip consumer, bypassing the canonical block execution path. This creates:
- Dual mutation paths (gossip direct + transaction)
- Risk of replay mismatches
- Non-deterministic state across nodes
- No clear upgrade path to strict spec compliance

## Solution

### Architecture

**V0 (Legacy) Mode - Before Activation:**
```
Gossip Attestation → Runtime Consumer → Direct oracle_state mutation
```

**V1 (Strict Spec) Mode - After Activation:**
```
Attestation → Transaction → Block → Blockchain.apply_oracle_attestation() → oracle_state mutation
```

### Key Changes

| Component | Change |
|-----------|--------|
| `tx_apply.rs` | Added `apply_oracle_attestation()` function |
| `executor.rs` | Added `OracleAttestation` outcome type, handler |
| `blockchain.rs` | Added `process_oracle_attestation_transactions()` |
| `oracle.rs` (runtime) | Added strict spec mode checks |

### Safety Features

- **Protocol Version Gate**: Behavior controlled by `OracleProtocolVersion`
- **Backward Compatible**: V0 mode maintains existing behavior
- **Clear Separation**: Runtime vs blockchain responsibilities defined
- **Deterministic**: Same attestations → same state, regardless of path

## Implementation Details

### 1. Canonical Path (lib-blockchain)

```rust
// Block execution processes attestations from transactions
fn process_oracle_attestation_transactions(&mut self, block: &Block, timestamp: u64) {
    for tx in block.transactions {
        if tx.transaction_type == OracleAttestation {
            let attestation = build_attestation_from_tx(tx);
            self.apply_oracle_attestation(&attestation, timestamp)?;
        }
    }
}
```

### 2. Runtime Behavior (zhtp)

**V0 Mode (Legacy):**
- Consumer processes gossip attestations directly
- Producer processes self-attestations directly
- Both paths mutate `oracle_state` immediately

**V1 Mode (Strict Spec):**
- Consumer **rejects** gossip attestations (logs warning)
- Producer **creates transactions** instead of direct processing
- All attestations go through block execution

## Testing

### Manual Testing

1. **V0 Mode Test:**
   ```bash
   # Verify attestations work as before
   cargo test -p lib-blockchain oracle
   ```

2. **V1 Mode Test:**
   ```bash
   # After protocol upgrade, verify transaction path
   # TODO: Add integration test for V1 mode
   ```

### Checklist

- [x] Canonical attestation path implemented
- [x] Block execution handles `OracleAttestation` transactions
- [x] Runtime respects strict spec mode
- [x] Backward compatibility maintained
- [ ] Shadow mode parity metrics (future PR)
- [ ] Transaction submission implementation (future PR)

## Migration Path

1. **Current (V0)**: Direct gossip processing
2. **Upgrade**: Governance activates V1 protocol version
3. **Transition**: Runtime stops direct processing, uses transactions
4. **Future**: Remove legacy path entirely

## Related

- Epic: #1769
- Depends on: #1771 (Protocol Version Gate)
- Next: #1773 (CBE Graduation Formula)

## Notes

The `submit_attestation_transaction()` method is a stub for future implementation. In the full implementation, validators will:
1. Create signed `OracleAttestation` transactions
2. Submit to mempool
3. Transactions included in blocks by proposers
4. Processed through canonical path

This PR establishes the foundation; transaction creation/submission will be implemented in a follow-up.