### PR TITLE
[ORACLE][R4] Normalize Epoch Tracking Semantics + Migration (#1774)

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -354,8 +354,11 @@ pub struct Blockchain {
     /// Validators banned from oracle committee (key_id).
     #[serde(default)]
     pub oracle_banned_validators: std::collections::HashSet<[u8; 32]>,
-    /// Last oracle epoch for which apply_pending_updates() was called.
+    /// Last oracle timestamp for which apply_pending_updates() was called.
     /// Prevents double-application within the same epoch.
+    /// 
+    /// ORACLE-R4: This field always stores a Unix timestamp (seconds), not an epoch ID.
+    /// Legacy data may have epoch IDs - migration happens on load.
     #[serde(default)]
     pub last_oracle_epoch_processed: u64,
 
@@ -2329,11 +2332,17 @@ impl Blockchain {
             warn!("Error processing governance proposals at height {}: {}", self.height, e);
         }
 
-        // ORACLE-7/13: Apply pending oracle updates at epoch boundaries (both BlockExecutor and legacy paths)
-        let current_epoch = self.oracle_state.epoch_id(block.header.timestamp);
-        if current_epoch > self.last_oracle_epoch_processed {
+        // ORACLE-R4: Apply pending oracle updates at epoch boundaries
+        // Uses timestamp-based comparison to handle epoch_duration changes correctly
+        if self
+            .oracle_state
+            .should_process_epoch(block.header.timestamp, self.last_oracle_epoch_processed)
+        {
+            // ORACLE-R4: Apply pending oracle updates at epoch boundaries
+            // Uses timestamp-based comparison to handle epoch_duration changes correctly
+            let current_epoch = self.oracle_state.epoch_id(block.header.timestamp);
             self.oracle_state.apply_pending_updates(current_epoch);
-            self.last_oracle_epoch_processed = current_epoch;
+            self.last_oracle_epoch_processed = block.header.timestamp;
             debug!("Oracle epoch processed: {} at block {}", current_epoch, self.height);
         }
 
@@ -2427,14 +2436,15 @@ impl Blockchain {
             warn!("Error processing governance proposals at height {}: {}", self.height, e);
         }
 
-        // Process oracle epoch advancement
+        // ORACLE-R4: Process oracle epoch advancement
         // Apply pending committee/config updates when epoch boundary is crossed
-        // This runs for both BlockExecutor and legacy paths
-        let block_epoch = self.oracle_state.epoch_id(block.header.timestamp);
-        let last_processed_epoch = self.oracle_state.epoch_id(self.last_oracle_epoch_processed);
-        if block_epoch > last_processed_epoch {
+        // Uses timestamp-based comparison for consistency across epoch_duration changes
+        if self
+            .oracle_state
+            .should_process_epoch(block.header.timestamp, self.last_oracle_epoch_processed)
+        {
+            let block_epoch = self.oracle_state.epoch_id(block.header.timestamp);
             self.oracle_state.apply_pending_updates(block_epoch);
-            // Store timestamp (not epoch_id) to remain correct if epoch_duration_secs changes
             self.last_oracle_epoch_processed = block.header.timestamp;
             info!("🔮 Oracle advanced to epoch {} (block height {})", block_epoch, self.height);
         }
@@ -10271,13 +10281,21 @@ impl Blockchain {
             warn!("Failed to apply governance parameter updates during load_from_file: {}", e);
         }
 
+        // ORACLE-R4: Migrate epoch tracking if needed (legacy format used epoch IDs)
+        if blockchain.oracle_state.needs_epoch_tracking_migration(blockchain.last_oracle_epoch_processed) {
+            blockchain.last_oracle_epoch_processed = blockchain.oracle_state.migrate_epoch_tracking(
+                blockchain.last_oracle_epoch_processed
+            );
+        }
+
         // Catch up oracle epoch advancement for any epochs missed while offline
-        // Use canonical committed timestamp to determine current epoch
-        let current_epoch = blockchain.oracle_state.epoch_id(blockchain.last_committed_timestamp());
-        let last_processed_epoch = blockchain.oracle_state.epoch_id(blockchain.last_oracle_epoch_processed);
-        if current_epoch > last_processed_epoch {
+        // ORACLE-R4: Uses timestamp-based comparison for consistency
+        if blockchain.oracle_state.should_process_epoch(
+            blockchain.last_committed_timestamp(),
+            blockchain.last_oracle_epoch_processed
+        ) {
+            let current_epoch = blockchain.oracle_state.epoch_id(blockchain.last_committed_timestamp());
             blockchain.oracle_state.apply_pending_updates(current_epoch);
-            // Store timestamp (not epoch_id) to remain correct if epoch_duration_secs changes
             blockchain.last_oracle_epoch_processed = blockchain.last_committed_timestamp();
             info!("🔮 Oracle caught up to epoch {} during load", current_epoch);
         }

--- a/lib-blockchain/src/oracle/mod.rs
+++ b/lib-blockchain/src/oracle/mod.rs
@@ -459,7 +459,7 @@ pub struct OracleEpochState {
 }
 
 /// Root oracle consensus state.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OracleState {
     #[serde(default)]
     pub config: OracleConfig,
@@ -484,6 +484,33 @@ pub struct OracleState {
     /// Controls which oracle behavior set is active.
     #[serde(default)]
     pub protocol_config: protocol::OracleProtocolConfig,
+    /// ORACLE-R4: Epoch tracking format version.
+    /// 
+    /// Version 0 (legacy): last_oracle_timestamp_processed stored epoch IDs
+    /// Version 1 (current): last_oracle_timestamp_processed stores timestamps
+    /// 
+    /// Used for migration to ensure consistent semantics after epoch_duration changes.
+    #[serde(default = "default_epoch_tracking_version")]
+    pub epoch_tracking_version: u8,
+}
+
+fn default_epoch_tracking_version() -> u8 {
+    0 // Default to 0 for backward compatibility; new state explicitly sets to 1
+}
+
+impl Default for OracleState {
+    fn default() -> Self {
+        Self {
+            config: OracleConfig::default(),
+            committee: OracleCommitteeState::default(),
+            pending_config_update: None,
+            finalized_prices: BTreeMap::new(),
+            epoch_state: BTreeMap::new(),
+            oracle_signing_pubkeys: std::collections::HashMap::new(),
+            protocol_config: protocol::OracleProtocolConfig::default(),
+            epoch_tracking_version: 1, // New state uses current version
+        }
+    }
 }
 
 impl OracleState {
@@ -1018,6 +1045,61 @@ impl OracleState {
     /// Get pending protocol activation details.
     pub fn pending_protocol_activation(&self) -> Option<&protocol::PendingProtocolActivation> {
         self.protocol_config.pending_activation()
+    }
+
+    // =========================================================================
+    // Epoch Tracking (ORACLE-R4)
+    // =========================================================================
+
+    /// Check if epoch tracking needs migration from legacy format.
+    ///
+    /// Returns true if the stored last_oracle_timestamp_processed contains
+    /// epoch IDs instead of timestamps (legacy format).
+    pub fn needs_epoch_tracking_migration(&self, last_timestamp_processed: u64) -> bool {
+        // Legacy detection: if epoch_tracking_version is 0, we may need migration
+        // Heuristic: if the value is very small (likely an epoch ID), it's legacy format
+        self.epoch_tracking_version == 0 && last_timestamp_processed < 1_000_000_000
+    }
+
+    /// Migrate epoch tracking from legacy format to current format.
+    ///
+    /// Converts a last_processed value from epoch ID to timestamp.
+    /// Should be called during blockchain load if migration is detected.
+    pub fn migrate_epoch_tracking(&mut self, last_timestamp_processed: u64) -> u64 {
+        if self.epoch_tracking_version >= 1 {
+            return last_timestamp_processed; // Already current format
+        }
+
+        // Legacy format: stored value was an epoch ID
+        // Convert to timestamp: epoch_id * epoch_duration_secs
+        let epoch_id = last_timestamp_processed;
+        let timestamp = epoch_id.saturating_mul(self.config.epoch_duration_secs);
+        
+        self.epoch_tracking_version = 1;
+        
+        tracing::info!(
+            "🔮 ORACLE-R4: Migrated epoch tracking from epoch {} to timestamp {} (version 0 -> 1)",
+            epoch_id,
+            timestamp
+        );
+        
+        timestamp
+    }
+
+    /// Determine if a new epoch should be processed based on timestamp.
+    ///
+    /// ORACLE-R4: Uses timestamp comparison to handle epoch_duration changes correctly.
+    /// Returns true if the current block timestamp indicates a new epoch.
+    pub fn should_process_epoch(&self, block_timestamp: u64, last_timestamp_processed: u64) -> bool {
+        let current_epoch = self.epoch_id(block_timestamp);
+        let last_processed_epoch = self.epoch_id(last_timestamp_processed);
+        
+        current_epoch > last_processed_epoch
+    }
+
+    /// Get the effective epoch tracking version.
+    pub fn epoch_tracking_version(&self) -> u8 {
+        self.epoch_tracking_version
     }
 }
 


### PR DESCRIPTION
Implements ORACLE-R4: Standardizes epoch tracking on timestamps for consistent behavior across epoch_duration config changes.