### PR TITLE
fix(token-creation): correct fee calculation and skip identity check

### DIFF
--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -1595,6 +1595,7 @@ impl<'a> StatefulTransactionValidator<'a> {
             && transaction.transaction_type != TransactionType::IdentityRegistration
             && transaction.transaction_type != TransactionType::TokenTransfer
             && transaction.transaction_type != TransactionType::TokenMint
+            && transaction.transaction_type != TransactionType::TokenCreation
             && !is_token_contract_execution(transaction)
         {
             tracing::debug!("[BREADCRUMB] validate_sender_identity_exists CALL");

--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -645,6 +645,22 @@ pub fn build_create_token_tx(
         memo,
     );
 
+    // Estimate fee from serialized size. Serialize with empty signature (sig bytes = vec![]),
+    // then pad for the Dilithium5 signature bytes (4595) that will be appended after signing.
+    // The pubkey is already present in the Signature struct so its size is already accounted for.
+    tx.fee = 0;
+    let unsigned_bytes = bincode::serialize(&tx)
+        .map_err(|e| format!("Failed to serialize tx for fee estimation: {}", e))?;
+    const D5_SIG_BYTES: usize = 4595;
+    let estimated_size = unsigned_bytes.len() + D5_SIG_BYTES;
+    tx.fee = calculate_min_fee_from_size(
+        estimated_size,
+        TX_FEE_BASE_FEE.load(Ordering::SeqCst),
+        TX_FEE_BYTES_PER_SOV.load(Ordering::SeqCst),
+        TX_FEE_WITNESS_CAP.load(Ordering::SeqCst),
+    );
+
+
     let tx_hash = tx.signing_hash();
     let signature_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
         .map_err(|e| format!("Failed to sign: {}", e))?;


### PR DESCRIPTION
## Problem

`POST /api/v1/token/create` was failing with `Transaction verification failed` because:

1. The client was sending `fee=0` (broken by the previous commit on this branch which removed the fee calculation)
2. Server-side validation was running `validate_sender_identity_exists` for `TokenCreation` even though token ops are authorized by signature alone

## Changes

**`lib-client/src/token_tx.rs`**
Restore proper fee calculation in `build_create_token_tx`: serialize the unsigned tx (empty sig bytes), pad +4595 bytes for the Dilithium5 signature, compute the size-based fee, set it on the tx, then sign once with the correct fee committed to the signing hash.

**`lib-blockchain/src/transaction/validation.rs`**
Add `TokenCreation` to the `validate_sender_identity_exists` exclusion list, consistent with `TokenTransfer` and `TokenMint` which are already excluded for the same reason (token operations use public key auth, not identity registry lookup).

## Test plan

- [ ] `POST /api/v1/token/create` succeeds and tx lands in mempool
- [ ] Token appears on-chain after block commit
- [ ] Fee is deducted from creator SOV balance