### PR TITLE
fix(lib-network): stop leaking sled DBs in bootstrap ZhtpClient

### DIFF
--- a/lib-network/src/client/zhtp_client.rs
+++ b/lib-network/src/client/zhtp_client.rs
@@ -112,7 +112,7 @@ impl ZhtpClient {
         // Bootstrap mode uses a fixed shared path so all short-lived bootstrap clients
         // reuse the same sled database instead of creating a new one per call.
         // A unique timestamp path was used previously, leaking one sled instance per
-        // observer_sync_loop tick (~6/min) and causing OOM after hours of uptime.
+        // observer_sync_loop tick (~6/min) and causing OOM after extended uptime.
         let nonce_db_path = if config.allow_bootstrap {
             std::env::temp_dir().join("zhtp_bootstrap_nonce")
         } else {


### PR DESCRIPTION
## Summary
- `observer_sync_loop` creates a `ZhtpClient` per peer every 30s; in bootstrap mode each client opened a sled DB at a unique timestamp path (`/tmp/zhtp_bootstrap_nonce_<ms>`), leaking ~6 sled instances/minute
- After days of uptime nodes accumulated 40k–200k temp directories, anon-rss reaching 7–15 GB → OOM kills on all 4 nodes
- Fix: use a fixed shared path `/tmp/zhtp_bootstrap_nonce` so all bootstrap clients reuse one sled database

## Test plan
- [ ] Deploy to testnet nodes and monitor memory usage stays flat over time
- [ ] Confirm `/tmp/zhtp_bootstrap_nonce_*` directories no longer accumulate
- [ ] Verify observer sync still works (nodes catch up on missed blocks)