### PR TITLE
fix(lib-network): use anyhow::anyhow! consistently in wifi_direct.rs

### DIFF
--- a/lib-network/src/protocols/wifi_direct.rs
+++ b/lib-network/src/protocols/wifi_direct.rs
@@ -1018,7 +1018,7 @@ impl WiFiDirectMeshProtocol {
 
         #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
         {
-            Err(anyhow!(
+            Err(anyhow::anyhow!(
                 "Platform not supported for WiFi Direct MAC address retrieval"
             ))
         }


### PR DESCRIPTION
## Summary
- Line 1021 in `wifi_direct.rs` used the bare `anyhow!` macro, which requires an explicit `use anyhow::anyhow` import that was never added
- All ~20 other call sites in the file use the fully-qualified `anyhow::anyhow!(...)` form
- Changed the one inconsistent call site to match, resolving the compile error

## Test plan
- [ ] `cargo build -p lib-network` passes without errors
- [ ] No functional changes — error message and behaviour are identical