### PR TITLE
fix(lib-network): add missing anyhow macro import in wifi_direct.rs

### DIFF
--- a/lib-network/src/protocols/wifi_direct.rs
+++ b/lib-network/src/protocols/wifi_direct.rs
@@ -3,7 +3,7 @@
 //! Handles WiFi Direct mesh networking for medium-range peer connections
 
 use crate::network_utils::get_local_ip;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use lib_crypto::symmetric::chacha20::encrypt_data;
 use mdns_sd::{ServiceDaemon, ServiceInfo};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary
- `anyhow!` macro used at line 1021 but only `anyhow::Result` was imported
- Causes compilation failure when building lib-network
- One-line fix: `use anyhow::Result` → `use anyhow::{anyhow, Result}`