### PR TITLE
fix(lib-network): use singleton nonce cache for bootstrap clients

### DIFF
--- a/lib-network/src/client/zhtp_client.rs
+++ b/lib-network/src/client/zhtp_client.rs
@@ -128,7 +128,13 @@ impl ZhtpClient {
                 if let Some(cached) = BOOTSTRAP_NONCE_CACHE.get() {
                     cached.clone()
                 } else {
-                    let nonce_db_path = std::env::temp_dir().join("zhtp_bootstrap_nonce");
+                    // Use per-process subdirectory to avoid cross-process contention
+                    // when running multiple nodes on the same host (common in local testing)
+                    let pid = std::process::id();
+                    let nonce_db_path = std::env::temp_dir()
+                        .join("zhtp_bootstrap_nonce")
+                        .join(pid.to_string())
+                        .join("db");
                     if let Some(parent) = nonce_db_path.parent() {
                         std::fs::create_dir_all(parent)?;
                     }


### PR DESCRIPTION
## Summary

- Bootstrap QUIC clients previously used a fixed shared sled path (from a previous OOM fix), but sled only allows one opener per DB at a time. Concurrent bootstrap clients (3 peers in the sync loop) raced to open the same sled, only the first succeeded, breaking initial sync on all non-leader nodes.
- Fix: `OnceLock` + `Mutex` singleton ensures the bootstrap nonce cache sled is opened exactly once per process. `NonceCache::clone()` is cheap (shares `Arc<sled::Db>`), so all bootstrap clients share the same instance.
- On epoch mismatch (stale sled from a previous run with different genesis epoch), automatically wipe and recreate the DB.

## Test plan

- [ ] Verify nodes can boot with empty state and sync from peers via QUIC bootstrap
- [ ] Verify no "Failed to open nonce cache" errors in logs during startup
- [ ] Verify no OOM from sled accumulation after extended uptime