### PR TITLE
fix(mobile): domain registration chain_id mismatch + identity reload on restart

### DIFF
--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -795,9 +795,11 @@ impl Web4Handler {
                 "fee_payment_tx must use TransactionType::TokenTransfer"
             ));
         }
-        if fee_payment_tx.chain_id != 0x03 {
+        // Accept chain_id 0x02 (testnet/mobile) and 0x03 (mainnet).
+        // Mobile APK builds from config.ts always use CHAIN_ID=2 (testnet).
+        if fee_payment_tx.chain_id != 0x02 && fee_payment_tx.chain_id != 0x03 {
             return Err(anyhow!(
-                "fee_payment_tx must use chain_id 0x03, got {}",
+                "fee_payment_tx must use chain_id 0x02 or 0x03, got {}",
                 fee_payment_tx.chain_id
             ));
         }

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1938,6 +1938,72 @@ impl RuntimeOrchestrator {
             bc.ensure_council_bootstrap(&self.config.consensus_config.council);
         }
 
+        // Reload identities from blockchain.identity_registry into IdentityManager.
+        // On node restart the in-memory IdentityManager is empty; identities are
+        // persisted in blockchain.identity_registry (Sled-backed). Without this,
+        // register_domain_simple() returns "Owner identity not found" for all users.
+        {
+            let bc = blockchain_arc.read().await;
+            match crate::runtime::identity_manager_provider::get_global_identity_manager().await {
+                Ok(mgr_arc) => {
+                    let mut mgr = mgr_arc.write().await;
+                    let mut restored: usize = 0;
+                    for itd in bc.identity_registry.values() {
+                        let identity_id =
+                            match lib_identity::did::parse_did_to_identity_id(&itd.did) {
+                                Ok(id) => id,
+                                Err(e) => {
+                                    warn!(
+                                        "Skipping identity with unparseable DID {}: {}",
+                                        itd.did, e
+                                    );
+                                    continue;
+                                }
+                            };
+                        let public_key = lib_crypto::PublicKey::new(itd.public_key.clone());
+                        let identity_type = match itd.identity_type.as_str() {
+                            "Organization" => lib_identity::IdentityType::Organization,
+                            "Agent" => lib_identity::IdentityType::Agent,
+                            "Contract" => lib_identity::IdentityType::Contract,
+                            "Device" => lib_identity::IdentityType::Device,
+                            _ => lib_identity::IdentityType::Human,
+                        };
+                        let display_name = if itd.display_name.is_empty() {
+                            None
+                        } else {
+                            Some(itd.display_name.clone())
+                        };
+                        match mgr.register_external_identity(
+                            identity_id,
+                            itd.did.clone(),
+                            public_key,
+                            identity_type,
+                            "restored".to_string(),
+                            display_name,
+                            itd.created_at,
+                        ) {
+                            Ok(_) => restored += 1,
+                            Err(e) if e.to_string().contains("already registered") => {}
+                            Err(e) => warn!(
+                                "Failed to restore identity {} from blockchain: {}",
+                                itd.did, e
+                            ),
+                        }
+                    }
+                    info!(
+                        "Restored {} identities from blockchain.identity_registry into IdentityManager",
+                        restored
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "IdentityManager not yet initialized during identity restore: {}",
+                        e
+                    );
+                }
+            }
+        }
+
         if let Some(ref net_info) = network_info {
             info!(
                 "✓ Found existing network with {} peers at height {}",


### PR DESCRIPTION
## Summary

Fixes two of the four mobile-blocking bugs identified through APK reverse engineering (see 7. Mobile_Network/extra.agents.md and APK_ANALYSIS_DISCOVERIES.md for full context).

**These changes are staging only -- not for merge until a working system is demonstrated end-to-end.**

---

## FIX-1: Accept chain_id 0x02 in domain fee tx validation

**File:** \zhtp/src/api/handlers/web4/domains.rs\ line 798

**Problem:** Mobile APK bakes in CHAIN_ID=2 (testnet fallback in config.ts). Backend hard-rejected any domain fee tx where \chain_id != 0x03\, so every domain registration from mobile silently failed.

**Fix:** Accept both 0x02 (testnet/mobile) and 0x03 (mainnet) in validation.

---

## FIX-3: Reload IdentityManager from blockchain.identity_registry on startup

**File:** \zhtp/src/runtime/mod.rs\ (after council bootstrap block)

**Problem:** On node restart, the in-memory IdentityManager is created empty. Identities are persisted in the Sled-backed \lockchain.identity_registry\ but were never reloaded after startup. \egister_domain_simple()\ calls \identity_mgr.get_identity_by_did()\ and returned \Owner identity not found\ for every user registered before the last restart.

**Fix:** After blockchain loads and council bootstrap completes, iterate \lockchain.identity_registry\ and call \egister_external_identity()\ for each entry. Uses \lib_identity::did::parse_did_to_identity_id\ (same pattern as line 1041) to derive the IdentityId from the DID. Already-loaded identities (genesis) are skipped gracefully. Logs count of restored identities.

---

## Testing

- [ ] Node restart: domain registration must succeed for pre-restart users
- [ ] Mobile client (chain_id=2): domain registration must succeed end-to-end
- [ ] \GET /api/v1/dao/treasury/status\ must return non-null treasury_wallet_id after node restart (FIX-2 ops action, separate from this PR)

---

## Related Issues

- Closes: no existing issue tracked for chain_id mismatch (new issue needed)
- Closes: no existing issue tracked for identity reload (new issue needed)
- Partial: #1545 (DAO treasury -- requires separate node redeploy, not code fix)
- Partial: #869 (domain registration blockers)