### PR TITLE
[BFT-A][#1862] Enforce BFT-only validator startup invariants (#1951-1955)

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2708,6 +2708,14 @@ impl Blockchain {
 
     /// Add a block received from the network. Skips mesh broadcast to prevent
     /// broadcast loops (block was already propagated by the sender).
+    ///
+    /// # Invariant BFT-A-1952
+    ///
+    /// This function is a **sync-only / observer path**. It MUST NOT be called from the
+    /// live validator block-reception path. In a running validator node, blocks arrive as
+    /// BFT proposals and are committed exclusively via `BlockCommitCallback::commit_finalized_block`
+    /// after 2f+1 quorum. Calling this function from a live validator message handler would
+    /// allow a Byzantine peer to inject canonical state without BFT agreement.
     pub async fn add_block_from_network(&mut self, block: Block) -> Result<()> {
         self.process_and_commit_block(block).await
     }
@@ -2716,6 +2724,12 @@ impl Blockchain {
     ///
     /// These blocks were already committed by a quorum of peers.  We must
     /// replay them exactly as-is regardless of the current fee schedule.
+    ///
+    /// # Invariant BFT-A-1952
+    ///
+    /// This function is a **catch-up sync path only**. It MUST NOT be called from the live
+    /// validator block-reception path. It is permissible only when a validator has fallen
+    /// significantly behind peers and needs to replay previously-committed blocks to re-sync.
     pub async fn apply_block_trusted_for_sync(&mut self, block: Block) -> Result<()> {
         if let Some(ref exec_arc) = self.executor {
             // Build a temporary fee-skipping executor sharing the same store.

--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -4,10 +4,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::{Duration, Instant};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
-use crate::config::aggregation::BootstrapValidator;
-use crate::runtime::dht_indexing::index_block_in_dht;
 use crate::runtime::node_runtime::NodeRole;
 use crate::runtime::services::{GenesisFundingService, GenesisValidator, TransactionBuilder};
 use crate::runtime::{Component, ComponentHealth, ComponentId, ComponentMessage, ComponentStatus};
@@ -25,7 +23,6 @@ pub struct BlockchainComponent {
     mining_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
     user_wallet: Arc<RwLock<Option<crate::runtime::did_startup::WalletStartupResult>>>,
     environment: crate::config::Environment,
-    _bootstrap_validators: Arc<RwLock<Vec<BootstrapValidator>>>,
     /// QUIC peer addresses (e.g. "77.42.37.161:9334") used by observer sync loop
     bootstrap_peers: Vec<String>,
     joined_existing_network: bool,
@@ -50,7 +47,6 @@ impl BlockchainComponent {
             mining_handle: Arc::new(RwLock::new(None)),
             user_wallet: Arc::new(RwLock::new(None)),
             environment: crate::config::Environment::Development,
-            _bootstrap_validators: Arc::new(RwLock::new(Vec::new())),
             bootstrap_peers: Vec::new(),
             joined_existing_network: false,
             validator_manager: Arc::new(RwLock::new(None)),
@@ -77,7 +73,6 @@ impl BlockchainComponent {
             mining_handle: Arc::new(RwLock::new(None)),
             user_wallet: Arc::new(RwLock::new(user_wallet)),
             environment: crate::config::Environment::Development,
-            _bootstrap_validators: Arc::new(RwLock::new(Vec::new())),
             bootstrap_peers: Vec::new(),
             joined_existing_network: false,
             validator_manager: Arc::new(RwLock::new(None)),
@@ -100,7 +95,6 @@ impl BlockchainComponent {
             mining_handle: Arc::new(RwLock::new(None)),
             user_wallet: Arc::new(RwLock::new(user_wallet)),
             environment,
-            _bootstrap_validators: Arc::new(RwLock::new(Vec::new())),
             bootstrap_peers: Vec::new(),
             joined_existing_network: false,
             validator_manager: Arc::new(RwLock::new(None)),
@@ -110,11 +104,14 @@ impl BlockchainComponent {
         }
     }
 
+    /// Invariant BFT-A-1954: Validator set is loaded exclusively from genesis/canonical state.
+    /// The `bootstrap_validators` config list is accepted here for API compatibility but is
+    /// NOT used for live validator-set resolution. Genesis block data is the sole source of truth.
     pub fn new_with_full_config(
         node_role: NodeRole,
         user_wallet: Option<crate::runtime::did_startup::WalletStartupResult>,
         environment: crate::config::Environment,
-        bootstrap_validators: Vec<BootstrapValidator>,
+        _bootstrap_validators: Vec<crate::config::aggregation::BootstrapValidator>,
         bootstrap_peers: Vec<String>,
         joined_existing_network: bool,
     ) -> Self {
@@ -126,7 +123,6 @@ impl BlockchainComponent {
             mining_handle: Arc::new(RwLock::new(None)),
             user_wallet: Arc::new(RwLock::new(user_wallet)),
             environment,
-            _bootstrap_validators: Arc::new(RwLock::new(bootstrap_validators)),
             bootstrap_peers,
             joined_existing_network,
             validator_manager: Arc::new(RwLock::new(None)),
@@ -139,42 +135,6 @@ impl BlockchainComponent {
     /// Get the current node role (immutable)
     pub fn get_node_role(&self) -> NodeRole {
         (*self.node_role).clone()
-    }
-
-    fn normalize_did(did: &str) -> &str {
-        did.strip_prefix("did:zhtp:").unwrap_or(did)
-    }
-
-    fn local_did_is_bootstrap_validator(
-        local_did: &str,
-        bootstrap_validators: &[BootstrapValidator],
-    ) -> bool {
-        let bootstrap_validator_dids: std::collections::HashSet<String> = bootstrap_validators
-            .iter()
-            .map(|validator| Self::normalize_did(&validator.identity_id).to_ascii_lowercase())
-            .collect();
-        bootstrap_validator_dids.contains(&Self::normalize_did(local_did).to_ascii_lowercase())
-    }
-
-    async fn is_bootstrap_mining_authority(&self) -> bool {
-        // No explicit bootstrap validator list: allow local mining behavior.
-        let bootstrap_validators_guard = self._bootstrap_validators.read().await;
-        if bootstrap_validators_guard.is_empty() {
-            return true;
-        }
-        let bootstrap_validators = bootstrap_validators_guard.clone();
-        drop(bootstrap_validators_guard);
-
-        let wallet_guard = self.user_wallet.read().await;
-        let Some(wallet) = wallet_guard.as_ref() else {
-            warn!("Bootstrap mining authority check failed: wallet identity not available");
-            return false;
-        };
-        Self::local_did_is_bootstrap_validator(&wallet.user_identity.did, &bootstrap_validators)
-            || Self::local_did_is_bootstrap_validator(
-                &wallet.node_identity.did,
-                &bootstrap_validators,
-            )
     }
 
     pub async fn set_validator_manager(&self, validator_manager: Arc<RwLock<ValidatorManager>>) {
@@ -288,192 +248,6 @@ impl BlockchainComponent {
         environment: &crate::config::Environment,
     ) -> Result<Transaction> {
         TransactionBuilder::create_reward_transaction(node_id, reward_amount, environment).await
-    }
-
-    /// Mine a block using actual blockchain methods
-    async fn mine_real_block(blockchain: &mut Blockchain) -> Result<()> {
-        let next_height = blockchain.height + 1;
-
-        // Phase 2 invariant: TokenTransfer and TokenMint must have fee == 0.
-        // The BlockExecutor enforces this at execution time; enforce the same rule here
-        // so that any bad transaction (admitted before the rule existed, or persisted
-        // across a restart) is evicted from the pool before it can block block production.
-        blockchain.evict_phase2_invalid_transactions("mine_real_block");
-
-        let mut ubi_txs: Vec<lib_blockchain::Transaction> = Vec::new();
-        for entry in blockchain.collect_ubi_mint_entries(next_height) {
-            let memo = format!(
-                "UBI_DISTRIBUTION_V1:{}:{}",
-                entry.identity_id, entry.wallet_id
-            )
-            .into_bytes();
-            match crate::runtime::token_utils::build_sov_mint_tx(
-                &entry.recipient_wallet_id,
-                entry.payout,
-                memo,
-            )
-            .await
-            {
-                Ok(tx) => ubi_txs.push(tx),
-                Err(e) => warn!("Failed to build UBI TokenMint tx: {}", e),
-            }
-        }
-
-        // Allow mining empty blocks so the chain never stalls waiting for transactions.
-
-        info!(
-            "Mining block with {} pending txs + {} UBI mints",
-            blockchain.pending_transactions.len(),
-            ubi_txs.len()
-        );
-
-        let mut transactions_for_block: Vec<lib_blockchain::Transaction> = Vec::new();
-        transactions_for_block.extend(ubi_txs);
-        let remaining = 10usize.saturating_sub(transactions_for_block.len());
-        if remaining > 0 {
-            transactions_for_block.extend(
-                blockchain
-                    .pending_transactions
-                    .iter()
-                    .take(remaining)
-                    .cloned(),
-            );
-        }
-
-        // Empty transaction list is allowed — heartbeat/empty blocks keep the chain advancing.
-
-        let has_system_transactions = transactions_for_block.iter().any(|tx| tx.inputs.is_empty());
-
-        let previous_hash = blockchain
-            .latest_block()
-            .map(|b| b.hash())
-            .unwrap_or_default();
-
-        // Get mining config from environment - this determines the difficulty to use
-        let mining_config = lib_blockchain::types::get_mining_config_from_env();
-        let block_difficulty = mining_config.difficulty.clone();
-
-        if has_system_transactions {
-            info!(
-                "Mining system transaction block with difficulty: {:#x}",
-                block_difficulty.bits()
-            );
-        } else {
-            info!(
-                "Mining normal transaction block with difficulty: {:#x}",
-                block_difficulty.bits()
-            );
-        }
-
-        let block = lib_blockchain::block::creation::create_block(
-            transactions_for_block,
-            previous_hash,
-            blockchain.height + 1,
-            block_difficulty,
-        )?;
-
-        info!(
-            "⛏️ Mining block with {} profile (difficulty: {:#x}, max_iter: {})...",
-            if mining_config.allow_instant_mining {
-                "Bootstrap"
-            } else {
-                "Standard"
-            },
-            block_difficulty.bits(),
-            mining_config.max_iterations
-        );
-        let new_block =
-            lib_blockchain::block::creation::mine_block_with_config(block, &mining_config)?;
-        info!("✓ Block mined with nonce: {}", new_block.header.nonce);
-
-        match blockchain.add_block_with_proof(new_block.clone()).await {
-            Ok(()) => {
-                info!("BLOCK MINED SUCCESSFULLY!");
-                info!("Block Hash: {:?}", new_block.hash());
-                info!("Block Height: {}", blockchain.height);
-                info!("Transactions in Block: {}", new_block.transactions.len());
-                info!("Total UTXOs: {}", blockchain.utxo_set.len());
-                info!(
-                    "Identity Registry: {} entries",
-                    blockchain.identity_registry.len()
-                );
-
-                if !blockchain.economics_transactions.is_empty() {
-                    info!(
-                        "Economics Transactions: {}",
-                        blockchain.economics_transactions.len()
-                    );
-                }
-                if let Err(e) = index_block_in_dht(&new_block).await {
-                    warn!("DHT indexing failed (mining): {}", e);
-                }
-            }
-            Err(e) => {
-                warn!("Failed to add block to blockchain: {}", e);
-                // Evict the block's transactions from the mempool so a permanently
-                // invalid transaction (e.g. bad nonce) cannot block all future blocks.
-                // Uses the shared helper to keep eviction semantics consistent.
-                // Note: if the block failure was caused by a store/consensus error
-                // unrelated to any specific tx, valid transactions may be evicted and
-                // clients must resubmit them.
-                let evicted = new_block.transactions.len();
-                blockchain.remove_pending_transactions(&new_block.transactions);
-                if evicted > 0 {
-                    warn!(
-                        "Evicted {} transaction(s) from mempool after block failure",
-                        evicted
-                    );
-                }
-                return Err(e);
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Minimum validators required for BFT consensus mode.
-    /// Keep at 4 so bootstrap mining is available while the validator set is forming.
-    /// Matches MIN_BFT_VALIDATORS in lib-types and lib-consensus.
-    const MIN_BFT_VALIDATORS: usize = 4;
-
-    /// Real mining loop with consensus coordination
-    ///
-    /// Operating Modes:
-    /// - Bootstrap Mode (< 4 validators): Direct mining allowed for network bootstrapping
-    /// - BFT Mode (>= 4 validators): Mining loop is disabled, BFT consensus drives blocks
-    ///
-    /// When BFT mode is active, the mining loop only checks for pending transactions
-    /// and logs status - actual block production is handled by the BFT consensus engine.
-    async fn real_mining_loop(
-        blockchain: Arc<RwLock<Option<Blockchain>>>,
-        validator_manager_arc: Arc<RwLock<Option<Arc<RwLock<ValidatorManager>>>>>,
-        node_identity_arc: Arc<RwLock<Option<IdentityId>>>,
-        env_for_persist: crate::config::Environment,
-        node_role: Arc<NodeRole>,
-        bootstrap_mining_authority: bool,
-    ) {
-        if !node_role.can_mine() {
-            error!(
-                "CRITICAL BUG: Non-mining node {:?} entered mining loop - config/component initialization bug",
-                *node_role
-            );
-            return;
-        }
-        let _ = (
-            blockchain,
-            validator_manager_arc,
-            node_identity_arc,
-            env_for_persist,
-            bootstrap_mining_authority,
-        );
-        info!(
-            "⛏️ Direct runtime mining disabled; validator block production must come from BFT finalization only"
-        );
-        let mut interval = tokio::time::interval(Duration::from_secs(120));
-        loop {
-            interval.tick().await;
-            debug!("⛏️ Mining loop heartbeat: direct mining remains disabled");
-        }
     }
 
     /// Periodic catch-up loop for Observer nodes.
@@ -801,47 +575,17 @@ impl Component for BlockchainComponent {
             return Ok(());
         }
 
+        // Invariant BFT-A-1955: Validator block production is driven exclusively by BFT
+        // finalization. There is no local mining loop — block proposals are created by
+        // the consensus engine (ConsensusComponent) and committed only after 2f+1 votes.
         info!(
-            "✓ Node role {:?} can mine - starting mining service",
+            "✓ Validator node {:?} started — block production via BFT only",
             *self.node_role
         );
-
-        let bootstrap_mining_authority = self.is_bootstrap_mining_authority().await;
-        if !bootstrap_mining_authority {
-            info!("⛏️ Bootstrap mining disabled for this validator (non-bootstrap authority node)");
-        }
-
-        // Start mining loop
-        // CRITICAL FIX: Pass None for local blockchain to force using global provider
-        // This ensures the mining loop always sees the latest state from Genesis/Sync
-        let validator_manager_arc = self.validator_manager.clone();
-        let node_identity_arc = self.node_identity.clone();
-        let env_for_persist = self.environment.clone();
-        let node_role_for_loop = self.node_role.clone();
-
-        // We pass a new empty Arc for the local fallback, effectively disabling it
-        // The mining loop prefers the global provider anyway
-        let dummy_local_blockchain = Arc::new(RwLock::new(None));
-
-        let mining_handle = tokio::spawn(async move {
-            info!("⛏️ Mining task spawned, starting mining loop...");
-            Self::real_mining_loop(
-                dummy_local_blockchain,
-                validator_manager_arc,
-                node_identity_arc,
-                env_for_persist,
-                node_role_for_loop,
-                bootstrap_mining_authority,
-            )
-            .await;
-        });
-
-        *self.mining_handle.write().await = Some(mining_handle);
 
         *self.start_time.write().await = Some(Instant::now());
         *self.status.write().await = ComponentStatus::Running;
 
-        info!("✓ Blockchain component started with mining enabled");
         Ok(())
     }
 
@@ -1111,7 +855,6 @@ pub use crate::runtime::components::consensus::BlockchainValidatorAdapter;
 #[cfg(test)]
 mod tests {
     use super::BlockchainComponent;
-    use crate::config::aggregation::BootstrapValidator;
 
     #[test]
     fn should_run_peer_sync_loop_for_joining_validator() {
@@ -1134,72 +877,4 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn normalize_did_supports_prefixed_and_raw_forms() {
-        let raw = "abc123";
-        let prefixed = "did:zhtp:abc123";
-        assert_eq!(BlockchainComponent::normalize_did(raw), "abc123");
-        assert_eq!(BlockchainComponent::normalize_did(prefixed), "abc123");
-    }
-
-    #[test]
-    fn bootstrap_authority_allows_any_listed_validator() {
-        let validators = vec![
-            BootstrapValidator {
-                identity_id: "did:zhtp:leader01".to_string(),
-                consensus_key: String::new(),
-                stake: 1000,
-                storage_provided: 0,
-                commission_rate: 0,
-                endpoints: Vec::new(),
-            },
-            BootstrapValidator {
-                identity_id: "did:zhtp:validator02".to_string(),
-                consensus_key: String::new(),
-                stake: 1000,
-                storage_provided: 0,
-                commission_rate: 0,
-                endpoints: Vec::new(),
-            },
-        ];
-
-        assert!(BlockchainComponent::local_did_is_bootstrap_validator(
-            "did:zhtp:validator02",
-            &validators
-        ));
-    }
-
-    #[test]
-    fn bootstrap_authority_check_is_case_insensitive() {
-        let validators = vec![BootstrapValidator {
-            identity_id: "did:zhtp:ABCDEF1234".to_string(),
-            consensus_key: String::new(),
-            stake: 1000,
-            storage_provided: 0,
-            commission_rate: 0,
-            endpoints: Vec::new(),
-        }];
-
-        assert!(BlockchainComponent::local_did_is_bootstrap_validator(
-            "did:zhtp:abcdef1234",
-            &validators
-        ));
-    }
-
-    #[test]
-    fn bootstrap_authority_rejects_unlisted_validator() {
-        let validators = vec![BootstrapValidator {
-            identity_id: "did:zhtp:leader01".to_string(),
-            consensus_key: String::new(),
-            stake: 1000,
-            storage_provided: 0,
-            commission_rate: 0,
-            endpoints: Vec::new(),
-        }];
-
-        assert!(!BlockchainComponent::local_did_is_bootstrap_validator(
-            "did:zhtp:outsider99",
-            &validators
-        ));
-    }
 }

--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -929,6 +929,32 @@ impl lib_consensus::types::BlockCommitCallback for ConsensusBlockCommitter {
             .into());
         }
 
+        // Invariant BFT-A-1951: Verify the committed block_data matches the proposal ID
+        // that 2f+1 validators actually signed. The proposal ID is blake3(height || prev_hash
+        // || block_data || proposer_id). This prevents a tampered artifact from being
+        // committed even if it passes the height/prev_hash checks above.
+        {
+            let expected_id = lib_crypto::hash_blake3(
+                &[
+                    proposal.height.to_le_bytes().as_slice(),
+                    proposal.previous_hash.0.as_slice(),
+                    proposal.block_data.as_slice(),
+                    proposal.proposer.as_bytes(),
+                ]
+                .concat(),
+            );
+            if expected_id != proposal.id.0 {
+                return Err(anyhow::anyhow!(
+                    "BFT commit rejected: block_data hash does not match proposal ID at height {}. \
+                     Expected {:?}, got {:?}. Possible tampered artifact.",
+                    proposal.height,
+                    &expected_id[..8],
+                    &proposal.id.0[..8],
+                )
+                .into());
+            }
+        }
+
         info!(
             "🔨 BFT consensus committing canonical block artifact at height {} with {} transactions",
             proposal.height,
@@ -1187,9 +1213,6 @@ pub struct ConsensusComponent {
     /// This is IMMUTABLE and set at construction time based on configuration
     /// The role cannot change after the component is created
     node_role: Arc<NodeRole>,
-    /// Bootstrap validators pre-seeded from config for initial proposer rotation.
-    /// These are replaced by on-chain ValidatorInfo once blocks are mined.
-    bootstrap_validators: Vec<crate::config::aggregation::BootstrapValidator>,
     /// Mock SOV/USD price for oracle attestations (testnet/bootstrap).
     /// `None` means attempt real exchange price feeds.
     oracle_mock_sov_usd_price: Option<u64>,
@@ -1210,15 +1233,6 @@ impl std::fmt::Debug for ConsensusComponent {
     }
 }
 
-/// Derive a deterministic 32-byte key from a validator identity ID and a domain tag.
-/// Used to pre-seed ValidatorManager before on-chain ValidatorRegistration txs are mined.
-fn derive_key_from_identity(identity_id: &str, domain: &[u8]) -> Vec<u8> {
-    let mut input = Vec::with_capacity(identity_id.len() + domain.len());
-    input.extend_from_slice(identity_id.as_bytes());
-    input.extend_from_slice(domain);
-    lib_crypto::hash_blake3(&input).to_vec()
-}
-
 /// Decode bootstrap consensus key from hex string (accepts 0x prefix or plain hex).
 pub fn decode_bootstrap_consensus_key(consensus_key_hex: &str) -> Option<Vec<u8>> {
     let trimmed = consensus_key_hex.trim();
@@ -1232,60 +1246,6 @@ pub fn decode_bootstrap_consensus_key(consensus_key_hex: &str) -> Option<Vec<u8>
         .unwrap_or(trimmed);
 
     hex::decode(normalized).ok().filter(|k| !k.is_empty())
-}
-
-/// Adapter that implements lib-consensus ValidatorInfo for bootstrap config entries.
-/// For the local validator, `actual_consensus_key` carries the real Dilithium2 public key
-/// loaded from the keystore so that `ConsensusEngine::set_validator_keypair()` can match it.
-/// For remote validators, `actual_consensus_key` carries the decoded `consensus_key` from
-/// bootstrap TOML when present; otherwise it falls back to deterministic derivation.
-struct BootstrapValidatorAdapter {
-    identity_id: String,
-    stake: u64,
-    storage_provided: u64,
-    commission_rate: u8,
-    /// Real consensus public key, either local keystore key or decoded bootstrap TOML key.
-    actual_consensus_key: Option<Vec<u8>>,
-}
-
-impl lib_consensus::validators::ValidatorInfo for BootstrapValidatorAdapter {
-    fn identity_id(&self) -> lib_crypto::Hash {
-        let identity_hex = self
-            .identity_id
-            .strip_prefix("did:zhtp:")
-            .unwrap_or(&self.identity_id);
-        if let Ok(bytes) = hex::decode(identity_hex) {
-            if bytes.len() >= 32 {
-                return lib_crypto::Hash::from_bytes(&bytes[..32]);
-            }
-        }
-        lib_crypto::Hash(lib_crypto::hash_blake3(self.identity_id.as_bytes()))
-    }
-
-    fn stake(&self) -> u64 {
-        self.stake
-    }
-    fn storage_provided(&self) -> u64 {
-        self.storage_provided
-    }
-
-    fn consensus_key(&self) -> Vec<u8> {
-        // Use the real Dilithium2 public key when available (local validator).
-        // For remote peers we fall back to the deterministic placeholder so the
-        // validator set stays populated until their signed announcements arrive.
-        self.actual_consensus_key
-            .clone()
-            .unwrap_or_else(|| derive_key_from_identity(&self.identity_id, b"consensus"))
-    }
-    fn networking_key(&self) -> Vec<u8> {
-        derive_key_from_identity(&self.identity_id, b"networking")
-    }
-    fn rewards_key(&self) -> Vec<u8> {
-        derive_key_from_identity(&self.identity_id, b"rewards")
-    }
-    fn commission_rate(&self) -> u8 {
-        self.commission_rate
-    }
 }
 
 impl ConsensusComponent {
@@ -1307,12 +1267,19 @@ impl ConsensusComponent {
         )
     }
 
-    /// Create a new ConsensusComponent with bootstrap validators pre-seeded.
+    /// Create a new ConsensusComponent with configurable timeouts.
+    ///
+    /// # Issue BFT-A-1954
+    ///
+    /// The `bootstrap_validators` config field is no longer pre-seeded into the ValidatorManager
+    /// here. Validators are loaded exclusively from canonical genesis state via
+    /// `sync_validators_from_blockchain()`. The bootstrap config entries are only used during
+    /// the genesis block construction path in `mod.rs`.
     pub fn new_with_bootstrap_validators(
         environment: crate::config::Environment,
         node_role: NodeRole,
         min_stake: u64,
-        bootstrap_validators: Vec<crate::config::aggregation::BootstrapValidator>,
+        _bootstrap_validators: Vec<crate::config::aggregation::BootstrapValidator>,
         propose_timeout_ms: u64,
         prevote_timeout_ms: u64,
         precommit_timeout_ms: u64,
@@ -1321,7 +1288,7 @@ impl ConsensusComponent {
             environment,
             node_role,
             min_stake,
-            bootstrap_validators,
+            _bootstrap_validators,
             None,
             propose_timeout_ms,
             prevote_timeout_ms,
@@ -1333,7 +1300,7 @@ impl ConsensusComponent {
         environment: crate::config::Environment,
         node_role: NodeRole,
         min_stake: u64,
-        bootstrap_validators: Vec<crate::config::aggregation::BootstrapValidator>,
+        _bootstrap_validators: Vec<crate::config::aggregation::BootstrapValidator>,
         oracle_mock_sov_usd_price: Option<u64>,
         propose_timeout_ms: u64,
         prevote_timeout_ms: u64,
@@ -1358,7 +1325,6 @@ impl ConsensusComponent {
             local_validator_identity: Arc::new(RwLock::new(None)),
             local_validator_keypair: Arc::new(RwLock::new(None)),
             node_role: Arc::new(node_role),
-            bootstrap_validators,
             oracle_mock_sov_usd_price,
         }
     }
@@ -1459,49 +1425,6 @@ impl ConsensusComponent {
         self.validator_manager.clone()
     }
 
-    /// Pre-seed the ValidatorManager from `bootstrap_validators` config entries.
-    ///
-    /// This runs before on-chain ValidatorRegistration transactions are mined, giving
-    /// each node knowledge of all expected validators so proposer rotation can begin
-    /// immediately (preventing forks from simultaneous mining).
-    ///
-    /// Keys are derived deterministically from identity_id — no keys stored in config.
-    /// When `sync_validators_from_blockchain()` runs after blocks are mined, real on-chain
-    /// keys will replace these bootstrap entries.
-    async fn seed_from_bootstrap_validators(&self) {
-        if self.bootstrap_validators.is_empty() {
-            return;
-        }
-
-        let adapters: Vec<BootstrapValidatorAdapter> = self
-            .bootstrap_validators
-            .iter()
-            .map(|bv| BootstrapValidatorAdapter {
-                identity_id: bv.identity_id.clone(),
-                stake: bv.stake.max(1), // ensure non-zero for admission
-                storage_provided: bv.storage_provided,
-                commission_rate: (bv.commission_rate.min(100)) as u8,
-                actual_consensus_key: decode_bootstrap_consensus_key(&bv.consensus_key),
-            })
-            .collect();
-
-        let count = adapters.len();
-        let mut vm = self.validator_manager.write().await;
-        match vm.sync_from_validator_list(adapters) {
-            Ok((added, skipped)) => {
-                info!(
-                    "🌱 Pre-seeded ValidatorManager with {} bootstrap validator(s) ({} added, {} already present)",
-                    count, added, skipped
-                );
-            }
-            Err(e) => {
-                warn!(
-                    "Failed to seed ValidatorManager from bootstrap config: {}",
-                    e
-                );
-            }
-        }
-    }
 }
 
 async fn load_local_validator_from_keystore() -> Result<(IdentityId, lib_crypto::KeyPair)> {
@@ -1741,13 +1664,15 @@ impl Component for ConsensusComponent {
         );
         // Storage is optional for validators in zhtp; do not block consensus on storage capacity.
         config.min_storage = 0;
-        // Allow non-mainnet to run with <4 validators while still enforcing real signatures.
-        config.development_mode = !matches!(self.environment, crate::config::Environment::Mainnet);
+        // Invariant BFT-A-1953: Only the Development environment relaxes the 4-validator BFT
+        // quorum. Testnet and Mainnet must have ≥ 4 active validators or startup fails.
+        let is_development = matches!(self.environment, crate::config::Environment::Development);
+        config.development_mode = is_development;
         if config.development_mode {
-            info!("🔧 Development mode enabled - single validator consensus allowed for testing");
-            info!("   Production deployment requires minimum 4 validators for BFT");
+            info!("🔧 Development mode enabled — single-validator consensus allowed for local testing");
+            info!("   Testnet and Mainnet require minimum 4 validators for BFT");
         } else {
-            info!("🛡️ Production mode: Full consensus validation required (minimum 4 validators for BFT)");
+            info!("🛡️ BFT-only mode: Full consensus validation required (minimum 4 validators)");
         }
 
         // Create broadcaster - use ConsensusMeshBroadcaster if mesh router is available,
@@ -1819,11 +1744,13 @@ impl Component for ConsensusComponent {
             validator_manager
                 .sync_from_validator_list(validator_adapters.clone())
                 .context("Failed to sync validator manager from blockchain state")?;
-            if matches!(self.environment, crate::config::Environment::Mainnet)
-                && !validator_manager.has_sufficient_validators()
-            {
+            // Invariant BFT-A-1953: Non-development environments must have ≥ 4 validators.
+            // A node that cannot form a BFT quorum must not start participating in consensus.
+            if !is_development && !validator_manager.has_sufficient_validators() {
                 return Err(anyhow::anyhow!(
-                    "Mainnet validator startup requires at least 4 active validators in canonical blockchain state"
+                    "BFT startup requires at least 4 active validators in canonical state \
+                     (environment: {}). Start with Development environment for single-node testing.",
+                    self.environment
                 ));
             }
         }


### PR DESCRIPTION
## Summary

Implements all 5 child issues of epic #1862 (BFT-only validator startup invariants):

- **#1951 — Block-data integrity**: `commit_finalized_block` now verifies `blake3(height_le || prev_hash || block_data || proposer_id)` matches `proposal.id` before committing. Tampered block artifacts are rejected with a descriptive error referencing the mismatched bytes.

- **#1952 — Relay path audit**: Added `/// # Invariant BFT-A-1952` doc-comments to `add_block_from_network` and `apply_block_trusted_for_sync` in `blockchain.rs` making explicit that these are **sync-only / observer paths** and must never be called from the live validator message handler.

- **#1953 — Validator count enforcement**: Fixed `development_mode` flag so only `Environment::Development` bypasses the ≥4 validator requirement. Testnet and all other non-development environments now fail startup with a descriptive error if canonical state has fewer than 4 active validators.

- **#1954 — Remove runtime config bootstrap seeding**: Deleted `seed_from_bootstrap_validators`, `BootstrapValidatorAdapter`, `derive_key_from_identity`, and the `bootstrap_validators` struct field from `ConsensusComponent`. Validator state is loaded exclusively from canonical genesis via `sync_validators_from_blockchain()`. `decode_bootstrap_consensus_key` is retained (pub) as it's used by the genesis construction path in `mod.rs`.

- **#1955 — Eliminate dead mining loop**: Removed `mine_real_block`, `real_mining_loop`, `is_bootstrap_mining_authority`, `local_did_is_bootstrap_validator`, `normalize_did`, and `MIN_BFT_VALIDATORS` from `BlockchainComponent`. The validator `start()` path now logs an invariant confirmation and sets `status=Running` — no background mining task is spawned.

## Net change

-457 lines / +73 lines (net -384 lines of dead code removed)

## Test plan

- [x] `cargo build` — clean (warnings only)
- [x] `cargo test --package lib-blockchain --test cbe_lifecycle_integration_tests` — 19/19 pass
- [ ] Full integration test suite on CI