### PR TITLE
fix(oracle): implement attestation transaction submission to mempool

### DIFF
--- a/zhtp/src/runtime/components/oracle.rs
+++ b/zhtp/src/runtime/components/oracle.rs
@@ -608,10 +608,13 @@ impl OracleComponent {
 
         // Derive chain_id from runtime configuration via the ZHTP_CHAIN_ID environment
         // variable, falling back to the legacy dev-chain id (0x03) if not set or invalid.
-        let chain_id = std::env::var("ZHTP_CHAIN_ID")
+        let chain_id: u8 = std::env::var("ZHTP_CHAIN_ID")
             .ok()
-            .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or(0x03);
+            .and_then(|s| s.parse::<u8>().ok())
+            .unwrap_or_else(|| {
+                debug!("ZHTP_CHAIN_ID not set or invalid; using fallback chain_id=0x03");
+                0x03
+            });
 
         let tx = Transaction {
             version: TX_VERSION_V8,
@@ -678,8 +681,170 @@ fn slash_reason_for_validation_error(
 
 #[cfg(test)]
 mod tests {
-    use super::slash_reason_for_validation_error;
-    use lib_blockchain::oracle::{OracleAttestationValidationError, OracleSlashReason};
+    use super::*;
+    use lib_blockchain::{
+        oracle::{OracleAttestationValidationError, OraclePriceAttestation, OracleSlashReason},
+        transaction::core::TransactionPayload,
+        types::transaction_type::TransactionType,
+        Blockchain, ValidatorInfo,
+    };
+    use lib_crypto::keypair::generation::KeyPair;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    /// Build a minimal ValidatorInfo for tests — fills only the fields that
+    /// `validate_oracle_attestation_transaction` inspects.
+    fn make_validator_info(identity: &str, consensus_key: Vec<u8>) -> ValidatorInfo {
+        let oracle_key_id = lib_crypto::hash_blake3(&consensus_key);
+        ValidatorInfo {
+            identity_id: identity.to_string(),
+            stake: 10_000,
+            storage_provided: 0,
+            networking_key: Vec::new(),
+            rewards_key: Vec::new(),
+            network_address: "127.0.0.1:0".to_string(),
+            commission_rate: 0,
+            status: "active".to_string(),
+            registered_at: 0,
+            last_activity: 0,
+            blocks_validated: 0,
+            slash_count: 0,
+            admission_source: "test".to_string(),
+            governance_proposal_id: None,
+            oracle_key_id: Some(oracle_key_id),
+            consensus_key,
+        }
+    }
+
+    /// Set up a blockchain with a single oracle committee member, return the keypair
+    /// and the `validator_pubkey` (= blake3 of the raw Dilithium public key).
+    ///
+    /// `Blockchain::default()` starts with an empty validator registry, a single
+    /// genesis block (height 0), and oracle config defaults (epoch_duration_secs = 600).
+    /// These are sufficient for the oracle attestation mempool submission path.
+    fn setup_blockchain_with_oracle_validator() -> (Blockchain, KeyPair, [u8; 32]) {
+        let kp = KeyPair::generate().expect("keypair generation must succeed");
+        // consensus_key = raw Dilithium pk bytes; validator_pubkey = blake3 of those bytes
+        let dilithium_pk = kp.public_key.dilithium_pk.clone();
+        let validator_pubkey = lib_crypto::hash_blake3(&dilithium_pk);
+
+        let mut blockchain = Blockchain::default();
+
+        // Register the validator in the registry so the stateful validator can look it up
+        let validator_info = make_validator_info("test-validator", dilithium_pk);
+        blockchain
+            .validator_registry
+            .insert("test-validator".to_string(), validator_info);
+
+        // Initialize oracle committee with only this validator's pubkey hash
+        blockchain
+            .init_oracle_committee(vec![validator_pubkey])
+            .expect("oracle committee init must succeed");
+
+        (blockchain, kp, validator_pubkey)
+    }
+
+    /// Build a signed OraclePriceAttestation for epoch 0 using the given keypair.
+    fn build_signed_attestation(
+        kp: &KeyPair,
+        validator_pubkey: [u8; 32],
+        epoch_id: u64,
+        timestamp: u64,
+    ) -> OraclePriceAttestation {
+        let mut attestation = OraclePriceAttestation {
+            epoch_id,
+            sov_usd_price: 100_000_000, // $1.00 at 8 decimal precision
+            cbe_usd_price: None,
+            timestamp,
+            validator_pubkey,
+            signature: Vec::new(),
+        };
+        let digest = attestation
+            .signing_digest()
+            .expect("signing digest must build");
+        let sig = kp.sign(&digest).expect("signing must succeed");
+        attestation.signature = sig.signature;
+        attestation
+    }
+
+    /// Verify that `submit_attestation_transaction` enqueues a single
+    /// `TransactionType::OracleAttestation` transaction whose payload fields
+    /// match the source attestation.
+    #[tokio::test]
+    async fn submit_attestation_enqueues_oracle_attestation_tx() {
+        let (blockchain, kp, validator_pubkey) = setup_blockchain_with_oracle_validator();
+
+        // Use a timestamp in the middle of epoch 0 so epoch_id(timestamp) == 0
+        let epoch_duration = blockchain.oracle_state.config().epoch_duration_secs;
+        let timestamp = epoch_duration / 2;
+        let epoch_id = blockchain.oracle_state.epoch_id(timestamp);
+        assert_eq!(epoch_id, 0, "timestamp should fall in epoch 0");
+
+        let attestation = build_signed_attestation(&kp, validator_pubkey, epoch_id, timestamp);
+
+        let blockchain_arc = Arc::new(RwLock::new(blockchain));
+
+        OracleComponent::submit_attestation_transaction(&attestation, &blockchain_arc).await;
+
+        // The transaction must have been enqueued
+        let bc = blockchain_arc.read().await;
+        let pending = bc.get_pending_transactions();
+        assert_eq!(pending.len(), 1, "exactly one pending transaction expected");
+
+        let tx = &pending[0];
+        assert_eq!(
+            tx.transaction_type,
+            TransactionType::OracleAttestation,
+            "transaction type must be OracleAttestation"
+        );
+
+        // Verify payload fields match the source attestation
+        match &tx.payload {
+            TransactionPayload::OracleAttestation(data) => {
+                assert_eq!(data.epoch_id, attestation.epoch_id);
+                assert_eq!(data.sov_usd_price, attestation.sov_usd_price);
+                assert_eq!(data.cbe_usd_price, attestation.cbe_usd_price);
+                assert_eq!(data.timestamp, attestation.timestamp);
+                assert_eq!(data.validator_pubkey, attestation.validator_pubkey);
+                assert_eq!(data.signature, attestation.signature);
+            }
+            other => panic!("unexpected payload variant: {:?}", other),
+        }
+    }
+
+    /// Verify that the fallback chain_id (0x03) is used when ZHTP_CHAIN_ID is absent.
+    ///
+    /// Saves and restores the previous value of ZHTP_CHAIN_ID to avoid polluting
+    /// the environment for concurrently-running tests.
+    #[tokio::test]
+    async fn submit_attestation_defaults_chain_id_when_env_unset() {
+        // Save previous value so we can restore it after the test
+        let previous = std::env::var("ZHTP_CHAIN_ID").ok();
+        std::env::remove_var("ZHTP_CHAIN_ID");
+
+        let (blockchain, kp, validator_pubkey) = setup_blockchain_with_oracle_validator();
+        let epoch_duration = blockchain.oracle_state.config().epoch_duration_secs;
+        let timestamp = epoch_duration / 2;
+        let epoch_id = blockchain.oracle_state.epoch_id(timestamp);
+        let attestation = build_signed_attestation(&kp, validator_pubkey, epoch_id, timestamp);
+
+        let blockchain_arc = Arc::new(RwLock::new(blockchain));
+        OracleComponent::submit_attestation_transaction(&attestation, &blockchain_arc).await;
+
+        let bc = blockchain_arc.read().await;
+        let pending = bc.get_pending_transactions();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(
+            pending[0].chain_id, 0x03,
+            "chain_id must fall back to 0x03 when ZHTP_CHAIN_ID is not set"
+        );
+
+        // Restore the previous env var value (if any) to avoid polluting other tests
+        match previous {
+            Some(val) => std::env::set_var("ZHTP_CHAIN_ID", val),
+            None => std::env::remove_var("ZHTP_CHAIN_ID"),
+        }
+    }
 
     #[test]
     fn slashes_on_wrong_epoch_and_deviation_band() {


### PR DESCRIPTION
<!--
⚠️ CRITICAL: All PRs must target `development` branch
🚫 DO NOT target `main` - release process handles main merges
-->

## Target Branch Check
- [ ] I have selected `development` as the target branch (NOT `main`)

## Branch Policy
| Branch | Purpose | Who Merges |
|--------|---------|------------|
| `development` | Active development, feature integration | Anyone with approval |
| `main` | Production releases only | Release manager only |

## Type of Change
- [x] Bug fix (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other: ___

## Related Issues

## Description

- **Root cause**: `submit_attestation_transaction` was a no-op stub — logged "TODO: implement" and returned, silently discarding attestations in strict spec mode
- **Fix**: build `OracleAttestation` transaction from attestation payload and submit to mempool via `add_pending_transaction()`; proposer includes the transaction in a future block, processed through `process_oracle_attestation_transactions()` canonical path
- **chain_id**: derived from the `ZHTP_CHAIN_ID` environment variable (falling back to `0x03`) rather than hard-coded, strengthening replay protection across networks. A `debug!` log is emitted when the fallback is used.
- **Type fix**: `Transaction.chain_id` is `u8`; corrected env-var parsing from `u32` to `u8`.

### Unit tests added (`zhtp/src/runtime/components/oracle.rs`)

- **`submit_attestation_enqueues_oracle_attestation_tx`** — creates a blockchain with a real oracle committee (Dilithium5 keypair + validator registry entry), builds a cryptographically valid signed attestation for epoch 0, calls `submit_attestation_transaction`, and asserts that `pending_transactions` contains exactly one `TransactionType::OracleAttestation` whose payload fields (`epoch_id`, `sov_usd_price`, `cbe_usd_price`, `timestamp`, `validator_pubkey`, `signature`) all match the source attestation.
- **`submit_attestation_defaults_chain_id_when_env_unset`** — verifies that `chain_id = 0x03` is used when `ZHTP_CHAIN_ID` is not set; saves and restores the previous env-var value to avoid cross-test pollution.

## Testing
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes
- [x] Manual testing completed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [x] No direct merges to `main`

## Type Architecture Check (for type-related changes)
- [ ] New data types are in `lib-types` (not domain crates)
- [ ] Behavior is in domain crates via extension traits (`<Type>Ext`)
- [ ] No duplicate type definitions across crates
- [ ] Domain crates re-export from `lib-types` for backward compatibility
- [ ] Serialization stability considered for consensus-relevant types
- [ ] See [lib-types/README.md](lib-types/README.md) for full architecture rule

## For Maintainers Only
> ⚠️ **DO NOT MERGE TO MAIN** - This PR must target `development`
>
> If this PR accidentally targets `main`, change it to `development` before merging.