### PR TITLE
fix: resolve pre-existing lib-network test compilation errors

### DIFF
--- a/lib-network/src/bootstrap/handshake.rs
+++ b/lib-network/src/bootstrap/handshake.rs
@@ -676,6 +676,7 @@ mod tests {
     /// Test oversized message rejection
     #[tokio::test]
     async fn test_oversized_message_rejection() -> Result<()> {
+        use crate::handshake::MAX_HANDSHAKE_MESSAGE_SIZE;
         if net_tests_disabled() {
             eprintln!("network bootstrap tests disabled in this environment");
             return Ok(());

--- a/lib-network/src/handshake/core.rs
+++ b/lib-network/src/handshake/core.rs
@@ -778,11 +778,12 @@ mod tests {
     /// Test: Message size limit enforcement
     #[tokio::test]
     async fn test_oversized_message_rejection() {
+        use tokio::io::AsyncWriteExt;
         let (mut client, mut server) = duplex(16 * 1024 * 1024);
 
-        // Send a length that exceeds the limit
+        // Send a length prefix that exceeds the 1MB limit
         tokio::spawn(async move {
-            let _ = client.write_u32(2_000_000).await; // 2MB > 1MB limit
+            let _ = client.write_all(&2_000_000u32.to_be_bytes()).await;
             let _ = client.flush().await;
             let _ = graceful_shutdown(&mut client, 5).await;
         });


### PR DESCRIPTION
## Summary

- `bootstrap/handshake.rs`: add missing `MAX_HANDSHAKE_MESSAGE_SIZE` import in test
- `handshake/core.rs`: use `write_all` + `to_be_bytes` instead of nonexistent `write_u32`, add `AsyncWriteExt` import

These blocked `cargo test -p lib-network --lib` from compiling.

## Test plan

- [x] `cargo test -p lib-network --lib` compiles (619 pass, 10 ignored)