### PR TITLE
[codex] Update validator set governance limits

### DIFF
--- a/lib-blockchain/src/blockchain/tests/cbe_genesis_allocation_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/cbe_genesis_allocation_tests.rs
@@ -26,8 +26,8 @@ fn test_cbe_compensation_pool_allocation() {
     let blockchain = Blockchain::new().expect("Failed to create blockchain");
 
     let compensation_addr = PublicKey {
-        dilithium_pk: vec![],
-        kyber_pk: vec![],
+        dilithium_pk: [0u8; 2592],
+        kyber_pk: [0u8; 1568],
         key_id: [0x01; 32],
     };
 
@@ -42,8 +42,8 @@ fn test_cbe_operational_treasury_allocation() {
     let blockchain = Blockchain::new().expect("Failed to create blockchain");
 
     let operational_addr = PublicKey {
-        dilithium_pk: vec![],
-        kyber_pk: vec![],
+        dilithium_pk: [0u8; 2592],
+        kyber_pk: [0u8; 1568],
         key_id: [0x02; 32],
     };
 
@@ -58,8 +58,8 @@ fn test_cbe_performance_incentives_allocation() {
     let blockchain = Blockchain::new().expect("Failed to create blockchain");
 
     let performance_addr = PublicKey {
-        dilithium_pk: vec![],
-        kyber_pk: vec![],
+        dilithium_pk: [0u8; 2592],
+        kyber_pk: [0u8; 1568],
         key_id: [0x03; 32],
     };
 
@@ -74,8 +74,8 @@ fn test_cbe_strategic_reserves_allocation() {
     let blockchain = Blockchain::new().expect("Failed to create blockchain");
 
     let strategic_addr = PublicKey {
-        dilithium_pk: vec![],
-        kyber_pk: vec![],
+        dilithium_pk: [0u8; 2592],
+        kyber_pk: [0u8; 1568],
         key_id: [0x04; 32],
     };
 

--- a/lib-blockchain/src/blockchain/tests/store_backed_blockchain_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/store_backed_blockchain_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::block::{Block, BlockHeader};
 use crate::storage::SledStore;
-use crate::types::{Difficulty, Hash};
+use crate::types::Hash;
 
 fn make_header(height: u64, prev_hash: Hash) -> BlockHeader {
     let mut hash_bytes = [0u8; 32];

--- a/lib-blockchain/src/contracts/treasury_kernel/mod.rs
+++ b/lib-blockchain/src/contracts/treasury_kernel/mod.rs
@@ -286,16 +286,16 @@ mod tests {
 
     fn test_governance() -> PublicKey {
         PublicKey {
-            dilithium_pk: vec![99u8],
-            kyber_pk: vec![99u8],
+            dilithium_pk: [99u8; 2592],
+            kyber_pk: [99u8; 1568],
             key_id: [99u8; 32],
         }
     }
 
     fn test_kernel_address() -> PublicKey {
         PublicKey {
-            dilithium_pk: vec![88u8],
-            kyber_pk: vec![88u8],
+            dilithium_pk: [88u8; 2592],
+            kyber_pk: [88u8; 1568],
             key_id: [88u8; 32],
         }
     }

--- a/lib-blockchain/src/contracts/treasury_kernel/vesting.rs
+++ b/lib-blockchain/src/contracts/treasury_kernel/vesting.rs
@@ -498,24 +498,24 @@ mod tests {
 
     fn test_kernel_address() -> PublicKey {
         PublicKey {
-            dilithium_pk: vec![88u8],
-            kyber_pk: vec![88u8],
+            dilithium_pk: [88u8; 2592],
+            kyber_pk: [88u8; 1568],
             key_id: [88u8; 32],
         }
     }
 
     fn test_beneficiary() -> PublicKey {
         PublicKey {
-            dilithium_pk: vec![1u8],
-            kyber_pk: vec![1u8],
+            dilithium_pk: [1u8; 2592],
+            kyber_pk: [1u8; 1568],
             key_id: [1u8; 32],
         }
     }
 
     fn test_other_account() -> PublicKey {
         PublicKey {
-            dilithium_pk: vec![2u8],
-            kyber_pk: vec![2u8],
+            dilithium_pk: [2u8; 2592],
+            kyber_pk: [2u8; 1568],
             key_id: [2u8; 32],
         }
     }

--- a/lib-blockchain/src/contracts/types/permissions.rs
+++ b/lib-blockchain/src/contracts/types/permissions.rs
@@ -118,7 +118,7 @@ mod tests {
     use crate::integration::crypto_integration::PublicKey;
 
     fn create_test_public_key(id: u8) -> PublicKey {
-        PublicKey::new(vec![id; 32])
+        PublicKey::new([id; 2592])
     }
 
     #[test]

--- a/lib-blockchain/src/contracts/ubi_distribution/core.rs
+++ b/lib-blockchain/src/contracts/ubi_distribution/core.rs
@@ -702,8 +702,8 @@ impl UbiDistributor {
     pub fn test_new_with_zero_authority() -> Self {
         Self::new(
             PublicKey {
-                dilithium_pk: vec![],
-                kyber_pk: vec![],
+                dilithium_pk: [0u8; 2592],
+                kyber_pk: [0u8; 1568],
                 key_id: [0u8; 32],
             },
             1000,
@@ -723,8 +723,8 @@ mod tests {
 
     fn test_public_key(id: u8) -> PublicKey {
         PublicKey {
-            dilithium_pk: vec![id],
-            kyber_pk: vec![id],
+            dilithium_pk: [id; 2592],
+            kyber_pk: [id; 1568],
             key_id: [id; 32],
         }
     }

--- a/lib-blockchain/src/integration/consensus_integration.rs
+++ b/lib-blockchain/src/integration/consensus_integration.rs
@@ -1940,7 +1940,7 @@ pub async fn initialize_consensus_integration(
         consensus_type,
         min_stake: 1000 * 1_000_000,           // 1000 SOV minimum stake
         min_storage: 100 * 1024 * 1024 * 1024, // 100 GB minimum storage
-        max_validators: 100,
+        max_validators: 21,
         block_time: 10, // 10 second blocks
         epoch_length_blocks: 100,
         propose_timeout: 3000,
@@ -1976,7 +1976,7 @@ pub async fn initialize_consensus_integration_with_difficulty_config(
         consensus_type,
         min_stake: 1000 * 1_000_000,           // 1000 SOV minimum stake
         min_storage: 100 * 1024 * 1024 * 1024, // 100 GB minimum storage
-        max_validators: 100,
+        max_validators: 21,
         block_time: 10, // 10 second blocks
         epoch_length_blocks: 100,
         propose_timeout: 3000,

--- a/lib-consensus/src/dao/dao_engine.rs
+++ b/lib-consensus/src/dao/dao_engine.rs
@@ -514,10 +514,11 @@ impl DaoEngine {
                     // Governance may adjust max_validators only within the range
                     // [MIN_VALIDATORS, MAX_VALIDATORS_HARD_CAP].
                     //
-                    // - The lower bound (MIN_VALIDATORS = 4) protects BFT safety:
+                    // - The lower bound (MIN_VALIDATORS = 3) protects the
+                    //   genesis/bootstrap validator floor:
                     //   setting max below the minimum required by the protocol is
                     //   nonsensical and would prevent the network from operating.
-                    // - The upper bound (MAX_VALIDATORS_HARD_CAP = 256) prevents
+                    // - The upper bound (MAX_VALIDATORS_HARD_CAP = 21) prevents
                     //   governance from enabling O(n²) consensus message floods.
                     if (*value as usize) < MIN_VALIDATORS {
                         return Err(anyhow::anyhow!(

--- a/lib-consensus/src/engines/consensus_engine/mod.rs
+++ b/lib-consensus/src/engines/consensus_engine/mod.rs
@@ -279,11 +279,11 @@ pub const VIEW_CHANGE_CONDITIONS: &str =
 /// Minimum number of validators required for BFT consensus mode.
 ///
 /// Below this threshold, the system operates in bootstrap/single-node mode.
-/// This is a compile-time constant enforcing the BFT minimum: n >= 4 ensures
-/// that f = floor((n-1)/3) >= 1, i.e. at least one Byzantine fault can be tolerated.
+/// Sprint 3 sets this to `3` so genesis can operate with an initial three-validator
+/// committee while still requiring a strict supermajority for finalization.
 ///
 /// Invariant: Must equal `crate::types::MIN_BFT_VALIDATORS`.
-pub const BFT_MIN_VALIDATORS: usize = 4;
+pub const BFT_MIN_VALIDATORS: usize = 3;
 
 // Compile-time assertion: BFT_MIN_VALIDATORS must equal crate::types::MIN_BFT_VALIDATORS.
 // If this fails, the constant above is out of sync with the types module.
@@ -771,14 +771,14 @@ impl ConsensusEngine {
         }
     }
 
-    /// Check if BFT consensus mode is active (>= 4 validators)
+    /// Check if BFT consensus mode is active (>= 3 validators)
     ///
     /// Returns true if there are enough validators for BFT consensus.
-    /// In bootstrap mode (< 4 validators), the mining loop handles block production directly.
+    /// In bootstrap mode (< 3 validators), the mining loop handles block production directly.
     ///
     /// # Invariant
     ///
-    /// BFT mode requires at least `BFT_MIN_VALIDATORS` (= 4) validators. This matches
+    /// BFT mode requires at least `BFT_MIN_VALIDATORS` (= 3) validators. This matches
     /// `crate::types::MIN_BFT_VALIDATORS`. The compile-time assertion in the module
     /// ensures these two constants stay in sync.
     pub fn is_bft_mode_active(&self) -> bool {

--- a/lib-consensus/src/engines/consensus_engine/network.rs
+++ b/lib-consensus/src/engines/consensus_engine/network.rs
@@ -17,8 +17,8 @@ impl ConsensusEngine {
     /// - Receiver closure causes graceful shutdown
     ///
     /// Mode Awareness:
-    /// - BFT Mode (>= 4 validators): Full consensus participation
-    /// - Bootstrap Mode (< 4 validators): Passive monitoring, no proposals
+    /// - BFT Mode (>= 3 validators): Full consensus participation
+    /// - Bootstrap Mode (< 3 validators): Passive monitoring, no proposals
     pub async fn run_consensus_loop(&mut self) -> ConsensusResult<()> {
         let mut message_rx = self.message_rx.take().ok_or_else(|| {
             ConsensusError::ValidatorError("Message receiver not set".to_string())
@@ -53,7 +53,7 @@ impl ConsensusEngine {
         ));
 
         // Track the last time our blockchain height advanced, so we can trigger
-        // a catch-up sync even in bootstrap mode (< 4 validators) where the
+        // a catch-up sync even in bootstrap mode (< 3 validators) where the
         // HeartbeatTracker has no entries and the stall detector never fires.
         let mut last_height_seen: u64 = self.current_round.height;
         let mut last_height_advance_secs: u64 = std::time::SystemTime::now()
@@ -111,7 +111,7 @@ impl ConsensusEngine {
         loop {
             // Publish the height BFT is actively working on so catch-up sync
             // doesn't race with block commits at the same height.
-            // Only publish in BFT mode (>= 4 validators). In bootstrap mode,
+            // Only publish in BFT mode (>= 3 validators). In bootstrap mode,
             // catch-up sync must be unrestricted to fill the gap.
             if let Some(ref bft_height) = self.bft_active_height {
                 if self.is_bft_mode_active() {

--- a/lib-consensus/src/types/mod.rs
+++ b/lib-consensus/src/types/mod.rs
@@ -561,7 +561,7 @@ pub trait BlockCommitCallback: Send + Sync {
     ///
     /// Returns the count of validators currently registered and active.
     /// Used by the mining loop to determine whether to use BFT consensus
-    /// (4+ validators) or bootstrap mode (< 4 validators).
+    /// (3+ validators) or bootstrap mode (< 3 validators).
     async fn get_active_validator_count(
         &self,
     ) -> Result<usize, Box<dyn std::error::Error + Send + Sync>>;

--- a/lib-consensus/src/validators/validator_manager.rs
+++ b/lib-consensus/src/validators/validator_manager.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 /// Minimum validator count required for BFT safety.
 pub const MIN_VALIDATORS: usize = crate::types::MIN_BFT_VALIDATORS;
 /// Default governance target for maximum active validators.
-pub const MAX_VALIDATORS: u32 = 100;
+pub const MAX_VALIDATORS: u32 = 21;
 /// Hard protocol cap for maximum active validators.
-pub const MAX_VALIDATORS_HARD_CAP: u32 = 256;
+pub const MAX_VALIDATORS_HARD_CAP: u32 = 21;
 
 /// Trait for validator info structures that can be synced from blockchain.
 ///

--- a/lib-consensus/tests/consensus_engine_tests.rs
+++ b/lib-consensus/tests/consensus_engine_tests.rs
@@ -375,16 +375,16 @@ async fn test_consensus_round_initialization() -> Result<()> {
 #[tokio::test]
 async fn test_maximum_validator_limit() -> Result<()> {
     let mut config = create_test_config();
-    // MIN_VALIDATORS = 4 is the lowest value max_validators can be set to
+    // MIN_VALIDATORS = 3 is the lowest value max_validators can be set to
     // (the ValidatorManager constructor clamps max_validators to at least MIN_VALIDATORS).
     // Set exactly at the minimum to test the upper-bound enforcement with the
     // smallest possible active set.
-    config.max_validators = 4;
+    config.max_validators = 3;
 
     let mut consensus_engine = ConsensusEngine::new(config, Arc::new(NoOpBroadcaster))?;
 
-    // Register up to the limit (4 validators = MIN_VALIDATORS)
-    for i in 1..=4 {
+    // Register up to the limit (3 validators = MIN_VALIDATORS)
+    for i in 1..=3 {
         let identity = create_test_identity(&format!("validator_{}", i));
         let (consensus_key, networking_key, rewards_key) = validator_keys(i as u8);
         let result = consensus_engine

--- a/lib-types/src/consensus.rs
+++ b/lib-types/src/consensus.rs
@@ -146,8 +146,8 @@ pub enum SlashType {
 /// `max_validators` is the governance-adjustable upper bound on the active
 /// validator set. Its valid range at runtime is:
 ///
-/// - **Minimum**: `MIN_VALIDATORS` (= 4) — the BFT safety floor
-/// - **Maximum**: `MAX_VALIDATORS_HARD_CAP` (= 256) — the protocol ceiling
+/// - **Minimum**: `MIN_VALIDATORS` (= 3) — the BFT bootstrap floor
+/// - **Maximum**: `MAX_VALIDATORS_HARD_CAP` (= 21) — the protocol ceiling
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConsensusConfig {
     /// Type of consensus mechanism
@@ -190,7 +190,7 @@ impl Default for ConsensusConfig {
             consensus_type: ConsensusType::ByzantineFaultTolerance,
             min_stake: 1000 * 1_000_000,           // 1000 SOV tokens
             min_storage: 100 * 1024 * 1024 * 1024, // 100 GB
-            max_validators: 100,
+            max_validators: 21,
             block_time: 10, // 10 seconds
             epoch_length_blocks: 100,
             propose_timeout: 3000,   // 3 seconds
@@ -247,7 +247,7 @@ impl FeeDistributionResult {
 ///
 /// With fewer validators, the network operates in bootstrap mode where
 /// a single validator can mine blocks directly.
-pub const MIN_BFT_VALIDATORS: usize = 4;
+pub const MIN_BFT_VALIDATORS: usize = 3;
 
 // =============================================================================
 // TESTS
@@ -291,7 +291,7 @@ mod tests {
     #[test]
     fn test_consensus_config_default() {
         let config = ConsensusConfig::default();
-        assert_eq!(config.max_validators, 100);
+        assert_eq!(config.max_validators, 21);
         assert_eq!(config.block_time, 10);
         assert_eq!(config.min_stake, 1000 * 1_000_000);
         assert!(matches!(
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_min_bft_validators_constant() {
-        assert_eq!(MIN_BFT_VALIDATORS, 4);
+        assert_eq!(MIN_BFT_VALIDATORS, 3);
     }
 
     #[test]


### PR DESCRIPTION
## What changed
This PR implements Sprint 3 validator-set governance limits.

It reduces the default and hard validator-set ceiling to 21, lowers the BFT bootstrap floor to 3 validators, and updates the governance clamp/validation logic and related runtime comments/tests to match.

## Why
Sprint 3 requires governance and consensus to enforce a tighter validator committee size and to allow genesis operation at n = 3 while keeping the compile-time invariant between the consensus engine and shared types module.

## Impact
- MAX_VALIDATORS is now 21
- MAX_VALIDATORS_HARD_CAP is now 21
- MIN_BFT_VALIDATORS is now 3
- BFT_MIN_VALIDATORS is now 3
- Governance MaxValidators updates are bounded to 3..=21
- The compile-time assertion enforcing BFT_MIN_VALIDATORS == MIN_BFT_VALIDATORS remains in place and passes

## Validation
- cargo check -p lib-consensus
- cargo check -p lib-blockchain

## Notes
cargo test -p lib-consensus ... --no-run still hits unrelated pre-existing test-fixture failures from the fixed-array key migration in multiple test files. Those failures are separate from the Sprint 3 validator-governance changes.