### PR TITLE
[codex] Disable unilateral consensus round skip

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/mod.rs
+++ b/lib-consensus/src/engines/consensus_engine/mod.rs
@@ -76,8 +76,7 @@
 //! 3. **Height**: vote.height == local.height (stale past-height votes are discarded;
 //!    future-height votes trigger catch-up sync and are discarded)
 //! 4. **Round**: vote.round >= local.round (stale rounds are rejected; higher rounds are
-//!    accepted to enable Tendermint round-skip — `on_prevote`/`on_precommit` advance to
-//!    the peer's round so all nodes converge without waiting for timer cycles)
+//!    admitted for accounting and quorum checks, but do not mutate local round state)
 //! 5. **Vote type**: Only PreVote, PreCommit, and Commit are valid in BFT; Against is
 //!    rejected unconditionally. All three accepted types are stored regardless of the
 //!    local step — quorum safety is enforced by `maybe_finalize()` and `vote_pool`

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -819,8 +819,7 @@ impl ConsensusEngine {
     #[allow(deprecated)]
     async fn process_committed_block(&mut self, proposal_id: &Hash, commit_round: u32) -> ConsensusResult<()> {
         // SAFETY: Verify commit quorum before processing (Issue #939)
-        // commit_round is the round in which the commit quorum was reached — it may differ
-        // from self.current_round.round if the local node advanced via a round-skip.
+        // commit_round is the round in which the commit quorum was reached.
         let commit_count = self.count_commits_for(
             self.current_round.height,
             commit_round,
@@ -1250,47 +1249,6 @@ impl ConsensusEngine {
     }
 
     pub(super) async fn on_proposal(&mut self, proposal: ConsensusProposal) -> ConsensusResult<()> {
-        // Proposal round-skip: if this proposal is for a higher round at our height,
-        // jump to that round BEFORE running any other checks.
-        //
-        // This MUST happen before the fork check so that `valid_proposal` (which is
-        // round-scoped) is cleared for the new round.  Otherwise a higher-round
-        // proposal from the correct proposer gets falsely rejected as a "fork" because
-        // the old round's `valid_proposal` is still set.
-        //
-        // **LIVENESS FIX**: Do NOT skip rounds from PreCommit or Commit step.
-        // Once a node has accumulated prevote quorum and entered precommit, it must
-        // stay in the current round long enough for commit votes to accumulate from
-        // 2/3 validators. Skipping from PreCommit/Commit clears locked_proposal and
-        // scatters validators across different rounds, making it impossible for any
-        // single proposal_id to reach supermajority. Only skip from Propose/PreVote
-        // where no vote commitment has been made yet.
-        if proposal.height == self.current_round.height && proposal.round > self.current_round.round
-            && self.current_round.step < ConsensusStep::PreCommit
-        {
-            tracing::info!(
-                "⏩ Round skip H={}: R={} → R={} (proposal from proposer {})",
-                proposal.height,
-                self.current_round.round,
-                proposal.round,
-                proposal.proposer,
-            );
-            self.current_round.round = proposal.round;
-            self.current_round.step = ConsensusStep::Propose;
-            self.current_round.proposals.clear();
-            self.current_round.votes.clear();
-            self.current_round.timed_out = false;
-            self.current_round.locked_proposal = None;
-            self.current_round.valid_proposal = None;
-            // Update proposer from the frozen snapshot (round changed, not height).
-            if let Some(proposer) = self
-                .compute_proposer_for_round(self.current_round.height, self.current_round.round)
-            {
-                self.current_round.proposer = Some(proposer);
-            }
-            self.snapshot_validator_set(self.current_round.height);
-        }
-
         // BFT SAFETY: Reject any proposal that would create a fork.
         //
         // In BFT consensus, forks are invalid by definition. Once a block is committed
@@ -1300,8 +1258,8 @@ impl ConsensusEngine {
         //
         // Same-round fork: if `valid_proposal` is already set for the current round
         // and a conflicting proposal arrives for the SAME round, it is a fork.
-        // Different-round proposals are handled above by the round-skip (which clears
-        // `valid_proposal`), so they never reach this check with a stale lock.
+        // Proposals for different rounds are handled independently and do not mutate
+        // local round state until timeout advances the round.
         //
         // This is a hard gate: fork proposals are never stored, never voted on,
         // and never forwarded to peers.
@@ -1409,31 +1367,6 @@ impl ConsensusEngine {
     }
 
     pub(super) async fn on_prevote(&mut self, vote: ConsensusVote) -> ConsensusResult<()> {
-        // Tendermint round-skip: if a valid vote arrives for a higher round at the
-        // same height, advance immediately to that round.  Without this, nodes whose
-        // local round timers drift apart never agree on the same round and can never
-        // form quorum — they keep proposing for different rounds indefinitely.
-        if vote.height == self.current_round.height && vote.round > self.current_round.round {
-            tracing::info!(
-                "⏩ Round skip H={}: R={} → R={} (prevote from {})",
-                vote.height,
-                self.current_round.round,
-                vote.round,
-                vote.voter
-            );
-            self.current_round.round = vote.round;
-            self.current_round.step = ConsensusStep::Propose;
-            self.current_round.proposals.clear();
-            self.current_round.votes.clear();
-            self.current_round.timed_out = false;
-            self.current_round.locked_proposal = None;
-            self.current_round.valid_proposal = None;
-            // If this node is the proposer for the new round, broadcast a proposal.
-            if let Err(e) = self.enter_propose_step().await {
-                tracing::warn!("Round skip: enter_propose_step failed: {}", e);
-            }
-        }
-
         // Harden: Validate remote vote against all BFT safety invariants
         if !self.validate_remote_vote(&vote).await? {
             return Ok(());
@@ -1532,27 +1465,6 @@ impl ConsensusEngine {
     }
 
     pub(super) async fn on_precommit(&mut self, vote: ConsensusVote) -> ConsensusResult<()> {
-        // Tendermint round-skip: same as on_prevote — advance to peer's round if higher.
-        if vote.height == self.current_round.height && vote.round > self.current_round.round {
-            tracing::info!(
-                "⏩ Round skip H={}: R={} → R={} (precommit from {})",
-                vote.height,
-                self.current_round.round,
-                vote.round,
-                vote.voter
-            );
-            self.current_round.round = vote.round;
-            self.current_round.step = ConsensusStep::Propose;
-            self.current_round.proposals.clear();
-            self.current_round.votes.clear();
-            self.current_round.timed_out = false;
-            self.current_round.locked_proposal = None;
-            self.current_round.valid_proposal = None;
-            if let Err(e) = self.enter_propose_step().await {
-                tracing::warn!("Round skip (precommit): enter_propose_step failed: {}", e);
-            }
-        }
-
         // Harden: Validate remote vote against all BFT safety invariants
         if !self.validate_remote_vote(&vote).await? {
             return Ok(());
@@ -2094,9 +2006,6 @@ impl ConsensusEngine {
             );
 
             // Finalize regardless of current step (CE-L1) and regardless of current round.
-            // The round check was a liveness bug: when validators advance rounds via round-skip
-            // before commit votes accumulate, `current_round.round != round` and the commit
-            // was silently dropped even though 2/3+ validators had committed for this proposal.
             // A commit quorum for the current HEIGHT is sufficient — the specific proposal_id
             // guarantees we're committing the right block, and process_committed_block is
             // idempotent if the block was already applied.
@@ -2112,19 +2021,10 @@ impl ConsensusEngine {
                     );
                 }
 
-                if self.current_round.round != round {
-                    tracing::info!(
-                        "Committing block at height {} from round {} (local round advanced to {} via round-skip — liveness fix)",
-                        height,
-                        round,
-                        self.current_round.round
-                    );
-                }
-
                 // Process the committed block (finalization) directly.
                 // Pass `round` (the round where commit quorum was reached) so that
-                // vote counting uses the correct round even if current_round.round
-                // has already advanced via a round-skip.
+                // vote counting uses the correct round even if the local state has
+                // already moved on due to timeout-driven round advancement.
                 self.process_committed_block(proposal_id, round).await?;
             } else {
                 tracing::debug!(

--- a/lib-consensus/src/engines/consensus_engine/tests.rs
+++ b/lib-consensus/src/engines/consensus_engine/tests.rs
@@ -2621,6 +2621,95 @@ async fn test_proposal_admission_valid_proposal_accepted() {
 }
 
 #[tokio::test]
+async fn test_future_round_proposal_does_not_advance_local_round() {
+    let (mut engine, validators) = setup_bft_engine(1, 0).await;
+    let expected = engine.compute_proposer_for_round(1, 2).unwrap();
+    let (proposer_id, proposer_kp) = validators
+        .iter()
+        .find(|(id, _)| *id == expected)
+        .expect("future-round proposer must exist");
+
+    let proposal = make_signed_proposal(
+        &engine,
+        proposer_id,
+        proposer_kp,
+        1,
+        2,
+        Hash([0u8; 32]),
+        b"future-round-block".to_vec(),
+    );
+
+    engine
+        .on_proposal(proposal.clone())
+        .await
+        .expect("future-round proposal should be processed");
+
+    assert_eq!(engine.current_round.round, 0, "proposal must not advance local round");
+    assert!(
+        engine.pending_proposals.iter().any(|p| p.id == proposal.id),
+        "future-round proposal should still be tracked"
+    );
+}
+
+#[tokio::test]
+async fn test_future_round_prevote_does_not_advance_local_round() {
+    let (mut engine, validators) = setup_bft_engine(5, 1).await;
+    engine.current_round.step = ConsensusStep::PreVote;
+
+    let proposal_id = Hash::from_bytes(&[7u8; 32]);
+    let vote = make_signed_vote(
+        &engine,
+        &validators[1].1,
+        validators[1].0.clone(),
+        proposal_id.clone(),
+        VoteType::PreVote,
+        5,
+        3,
+    );
+
+    engine
+        .on_prevote(vote)
+        .await
+        .expect("future-round prevote should be processed");
+
+    assert_eq!(engine.current_round.round, 1, "prevote must not advance local round");
+    assert_eq!(
+        engine.count_prevotes_for(5, 3, &proposal_id),
+        1,
+        "future-round prevote should still be stored"
+    );
+}
+
+#[tokio::test]
+async fn test_future_round_precommit_does_not_advance_local_round() {
+    let (mut engine, validators) = setup_bft_engine(5, 1).await;
+    engine.current_round.step = ConsensusStep::PreCommit;
+
+    let proposal_id = Hash::from_bytes(&[8u8; 32]);
+    let vote = make_signed_vote(
+        &engine,
+        &validators[1].1,
+        validators[1].0.clone(),
+        proposal_id.clone(),
+        VoteType::PreCommit,
+        5,
+        3,
+    );
+
+    engine
+        .on_precommit(vote)
+        .await
+        .expect("future-round precommit should be processed");
+
+    assert_eq!(engine.current_round.round, 1, "precommit must not advance local round");
+    assert_eq!(
+        engine.count_precommits_for(5, 3, &proposal_id),
+        1,
+        "future-round precommit should still be stored"
+    );
+}
+
+#[tokio::test]
 async fn test_proposal_admission_wrong_protocol_version_rejected() {
     let (engine, validators) = setup_bft_engine(1, 0).await;
     let expected = engine.compute_proposer_for_round(1, 0).unwrap();

--- a/lib-consensus/src/engines/consensus_engine/validation.rs
+++ b/lib-consensus/src/engines/consensus_engine/validation.rs
@@ -262,9 +262,9 @@ impl ConsensusEngine {
         // 5. Round check.
         //
         // Stale rounds (vote.round < current) are rejected outright.
-        // Higher rounds (vote.round > current) are allowed through so that
-        // on_prevote / on_precommit can perform a Tendermint round-skip and bring
-        // all nodes to the same round without waiting for an entire timer cycle.
+        // Higher rounds (vote.round > current) are allowed through so future-round
+        // votes can still be observed and stored, but they do not advance local round
+        // state. Round changes are driven by timeout, not by unilateral peer messages.
         if vote.round < self.current_round.round {
             tracing::debug!(
                 "Vote rejected: stale round {} < our round {}",
@@ -592,9 +592,9 @@ impl ConsensusEngine {
         //
         // This check is scoped to SAME-ROUND proposals only. A proposal for a different
         // round is not a fork — each round has its own designated proposer and legitimately
-        // produces a different block. When round-skips are blocked at PreCommit/Commit step
-        // (liveness fix), different-round proposals arrive while valid_proposal is still set
-        // from the local node's current round; treating those as forks causes deadlock.
+        // produces a different block. Different-round proposals may arrive while
+        // `valid_proposal` is still set from the local node's current round; treating those
+        // as same-round forks would deadlock timeout-driven round progression.
         if proposal_height == self.current_round.height
             && proposal_round == self.current_round.round
         {


### PR DESCRIPTION
## What changed
Removes the consensus engine's unilateral round-skip behavior for higher-round proposals, prevotes, and precommits.

This keeps local round advancement timeout-driven instead of letting a single future-round message reset round state. It also updates the related engine documentation/comments and adds regression tests covering future-round proposal, prevote, and precommit handling.

## Why it changed
The current implementation could abandon a round immediately after casting or receiving votes for it, which prevents prevote accumulation from ever reaching quorum.

In the observed 3-validator bootstrap flow, a node could prevote in round `R`, then jump to `R+1` on a single future-round proposal or vote. That strands the round-`R` prevote and can repeat indefinitely, stalling block production.

## Impact
This narrows liveness behavior to the simpler bootstrap mode implied by the current canonical spec direction:
- rounds advance by timeout
- future-round messages can still be observed/stored
- future-round messages do not mutate local round state

## Root cause
Consensus progression used message-driven round changes without quorum evidence. `RoundChange` messages already exist on the wire, but they are not used today as a counted round-change certificate, so unilateral skip was effectively acting as the round-change mechanism.

## Validation
- `cargo test -p lib-consensus --lib 'future_round_' -- --nocapture`
- `cargo test -p lib-consensus --lib consensus_engine -- --nocapture`

Notes:
- The focused future-round regression tests pass.
- The broader engine suite still has one pre-existing failing test: `test_hardening_commit_vote_accepts_past_round`, which fails because it triggers finalization without a proposal artifact in the test setup.