### PR TITLE
fix(validation): allow legacy wallet ownership via dilithium_pk for SOV transfers

### DIFF
--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -1690,16 +1690,20 @@ impl<'a> StatefulTransactionValidator<'a> {
                 if is_sov {
                     let blockchain = self.blockchain.ok_or(ValidationError::InvalidTransaction)?;
                     let wallet_id_hex = hex::encode(data.from);
-                    // Wallet must exist in the registry
-                    let _wallet = blockchain
+                    // Wallet must exist in the registry (new key_id or legacy HD-derived id).
+                    let wallet = blockchain
                         .wallet_registry
                         .get(&wallet_id_hex)
                         .ok_or(ValidationError::InvalidTransaction)?;
-                    // The wallet_id IS the owner's key_id: signer must be the wallet owner.
-                    // This replaces the broken PublicKey::new() comparison which only covers
-                    // dilithium and fails for HD-derived wallets or full keypair identities.
+                    // Ownership check: for new wallets wallet_id == key_id; for legacy wallets
+                    // the wallet_id was HD-derived so they differ — fall back to dilithium_pk match.
                     if data.from != transaction.signature.public_key.key_id {
-                        return Err(ValidationError::InvalidTransaction);
+                        let sig_dilithium = transaction.signature.public_key.dilithium_pk.as_slice();
+                        if wallet.public_key.len() != 2592
+                            || wallet.public_key.as_slice() != sig_dilithium
+                        {
+                            return Err(ValidationError::InvalidTransaction);
+                        }
                     }
                 } else if data.from != transaction.signature.public_key.key_id {
                     return Err(ValidationError::InvalidTransaction);


### PR DESCRIPTION
## Summary

- The stateful validator checks `data.from == signer.key_id` to authorize SOV transfers. This fails for wallets registered before the key_id fix, where the wallet_id was HD-derived and does not equal `blake3(dilithium_pk || kyber_pk)`.
- Fix: when wallet is found in the registry but `wallet_id != key_id`, fall back to verifying ownership via dilithium_pk byte comparison. This matches the ownership check already used at block commit time in `contracts.rs`.
- The wallet key migration (re-keying the registry entry) still happens lazily at block commit time.

## Test plan

- [ ] SOV transfer from a legacy wallet (wallet_id != key_id) accepted into mempool
- [ ] SOV transfer from a new wallet (wallet_id == key_id) still works
- [ ] Transfer signed by wrong key still rejected