### PR TITLE
fix: SOV balance check at mempool, deterministic genesis, consensus liveness

### DIFF
--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -1662,20 +1662,54 @@ impl<'a> StatefulTransactionValidator<'a> {
                     || data.token_id == crate::contracts::utils::generate_lib_token_id();
                 if is_sov {
                     let blockchain = self.blockchain.ok_or(ValidationError::InvalidTransaction)?;
-                    let wallet_id_hex = hex::encode(data.from);
-                    // Wallet must exist in the registry (new key_id or legacy HD-derived id).
-                    let wallet = blockchain
-                        .wallet_registry
-                        .get(&wallet_id_hex)
-                        .ok_or(ValidationError::InvalidTransaction)?;
-                    // Ownership check: for new wallets wallet_id == key_id; for legacy wallets
-                    // the wallet_id was HD-derived so they differ — fall back to dilithium_pk match.
+
+                    // For new-style wallets, wallet_id == key_id. The signature already proves
+                    // ownership — no registry lookup needed. Only legacy wallets (where wallet_id
+                    // was HD-derived and differs from key_id) require a registry check to resolve
+                    // the dilithium_pk.
                     if data.from != transaction.signature.public_key.key_id {
+                        let wallet_id_hex = hex::encode(data.from);
+                        let wallet = blockchain
+                            .wallet_registry
+                            .get(&wallet_id_hex)
+                            .ok_or_else(|| {
+                                tracing::warn!(
+                                    "[TOKEN_TRANSFER] legacy wallet not in registry: from={} key_id={}",
+                                    &wallet_id_hex[..16.min(wallet_id_hex.len())],
+                                    hex::encode(&transaction.signature.public_key.key_id[..8])
+                                );
+                                ValidationError::InvalidTransaction
+                            })?;
                         let sig_dilithium = transaction.signature.public_key.dilithium_pk.as_slice();
                         if wallet.public_key.len() != 2592
                             || wallet.public_key.as_slice() != sig_dilithium
                         {
+                            tracing::warn!(
+                                "[TOKEN_TRANSFER] legacy ownership check failed: from={} wallet_pk_len={}",
+                                &wallet_id_hex[..16.min(wallet_id_hex.len())],
+                                wallet.public_key.len()
+                            );
                             return Err(ValidationError::InvalidTransaction);
+                        }
+                    }
+
+                    // Balance check: reject at mempool time if sender has insufficient SOV.
+                    // This prevents accepted-but-unfunded transfers from being finalized by
+                    // consensus and then failing at block execution, which halts the network.
+                    let sov_token_id = crate::contracts::utils::generate_lib_token_id();
+                    let mut sender_id = [0u8; 32];
+                    sender_id.copy_from_slice(&data.from);
+                    let sender_key = crate::Blockchain::wallet_key_for_sov(&sender_id);
+                    if let Some(token) = blockchain.token_contracts.get(&sov_token_id) {
+                        let balance = token.balance_of(&sender_key);
+                        if u128::from(balance) < data.amount {
+                            tracing::warn!(
+                                "[TOKEN_TRANSFER] insufficient SOV balance: from={} have={} need={}",
+                                hex::encode(&data.from[..8]),
+                                balance,
+                                data.amount
+                            );
+                            return Err(ValidationError::InvalidAmount);
                         }
                     }
                 } else if data.from != transaction.signature.public_key.key_id {

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -897,8 +897,13 @@ impl ConsensusEngine {
         // (due to timing skew) but they all agree on the same proposal_id, which is what
         // matters for safety. Round-scoped filtering was the root cause of commit quorum
         // never being reached when validators entered the Commit step at different times.
+        //
+        // DETERMINISM: attestations must be sorted and deduplicated by validator_id so that
+        // all nodes compute the same quorum_root, which is embedded in the block header.
+        // A non-deterministic quorum_root causes each node to store a different block hash,
+        // breaking the previous_hash chain validation for the next height.
         let quorum_proof = {
-            let attestations: Vec<lib_types::consensus::CommitAttestation> = self
+            let mut attestations: Vec<lib_types::consensus::CommitAttestation> = self
                 .vote_pool
                 .iter()
                 .filter(|(k, (_, voted_id))| {
@@ -921,6 +926,14 @@ impl ConsensusEngine {
                     })
                 })
                 .collect();
+
+            // Sort by validator_id for deterministic ordering across all nodes.
+            attestations.sort_by_key(|a| a.validator_id);
+            // Deduplicate: keep only the first (lowest-round, since pool was round-sorted) entry
+            // per validator. A validator may have cast commit votes at multiple rounds if the
+            // local round advanced after the initial cast; only one attestation per validator
+            // should contribute to the quorum root so the hash is identical on all nodes.
+            attestations.dedup_by_key(|a| a.validator_id);
 
             lib_types::consensus::BftQuorumProof {
                 height: self.current_round.height,
@@ -1284,6 +1297,27 @@ impl ConsensusEngine {
             return Ok(());
         }
 
+        // Round synchronization: if the proposal is for a higher round, advance to it.
+        // This lets lagging nodes catch up when they missed timeout-driven round increments
+        // while other validators were already spinning ahead.  We only advance — never go back.
+        if proposal.round > self.current_round.round {
+            tracing::info!(
+                "Round-sync: advancing from round {} to {} on received proposal at H={}",
+                self.current_round.round,
+                proposal.round,
+                proposal.height,
+            );
+            self.current_round.round = proposal.round;
+            self.current_round.step = ConsensusStep::Propose;
+            self.current_round.proposer = None;
+            self.current_round.proposals.clear();
+            self.current_round.votes.clear();
+            self.current_round.timed_out = false;
+            self.current_round.locked_proposal = None;
+            self.current_round.valid_proposal = None;
+            self.snapshot_validator_set(self.current_round.height);
+        }
+
         if !self.current_round.proposals.is_empty() {
             return Ok(());
         }
@@ -1436,7 +1470,7 @@ impl ConsensusEngine {
         let total_validators = self.validator_manager.get_active_validators().len() as u64;
 
         if check_supermajority(prevote_count, total_validators)
-            && self.current_round.step == ConsensusStep::PreVote
+            && self.current_round.step <= ConsensusStep::PreCommit
         {
             // **CE-S1**: Only transition if this proposal can be the valid proposal
             // If valid_proposal is already set to a DIFFERENT proposal, we have conflicting quorums
@@ -1454,6 +1488,10 @@ impl ConsensusEngine {
                 // First proposal to reach quorum in this round
                 self.current_round.valid_proposal = Some(proposal_id.clone());
             }
+            // Allow late prevote quorum to still trigger precommit casting even if the
+            // prevote timeout already fired and step advanced to PreCommit. enter_precommit_step
+            // is idempotent for the step transition (guards against double-entry) but we bypass
+            // that guard here only if we haven't yet cast a precommit for this round.
             self.enter_precommit_step().await?;
         }
 
@@ -1532,7 +1570,7 @@ impl ConsensusEngine {
         let total_validators = self.validator_manager.get_active_validators().len() as u64;
 
         if check_supermajority(precommit_count, total_validators)
-            && self.current_round.step == ConsensusStep::PreCommit
+            && self.current_round.step <= ConsensusStep::Commit
         {
             // **CE-S1**: Only transition if this proposal can be locked
             // If locked_proposal is already set to a DIFFERENT proposal, we have conflicting quorums
@@ -1549,6 +1587,9 @@ impl ConsensusEngine {
                 // First proposal to reach precommit quorum in this round
                 self.current_round.locked_proposal = Some(proposal_id.clone());
             }
+            // Allow late precommit quorum to still trigger commit vote casting even if the
+            // precommit timeout already fired and step advanced to Commit. enter_commit_step
+            // is idempotent for the step transition but we bypass that guard to cast the vote.
             self.enter_commit_step().await?;
         }
 
@@ -1801,6 +1842,21 @@ impl ConsensusEngine {
                         {
                             tracing::debug!("Failed to broadcast proposal (CE-ENG-4): {}", e);
                         }
+
+                        // Proposer enters prevote immediately after broadcasting its proposal.
+                        // Without this, the proposer waits propose_timeout (3 s) before prevoting,
+                        // while non-proposers transition on proposal receipt (<100 ms).  By the
+                        // time the proposer finally prevotes, the other nodes have exhausted their
+                        // prevote+precommit+commit timeouts (3 × 1 s = 3 s) and advanced to the
+                        // next round — causing the proposer's prevote to be rejected as stale.
+                        if let Err(e) = self.enter_prevote_step().await {
+                            tracing::warn!(
+                                "Failed to enter prevote step after proposal broadcast at H={} R={}: {}",
+                                self.current_round.height,
+                                self.current_round.round,
+                                e
+                            );
+                        }
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -1856,19 +1912,63 @@ impl ConsensusEngine {
     }
 
     async fn enter_precommit_step(&mut self) -> ConsensusResult<()> {
-        if self.current_round.step >= ConsensusStep::PreCommit {
+        // Allow re-entry when already in PreCommit step so that late-arriving prevotes
+        // that complete the quorum can still cast a precommit. We guard against going
+        // backwards (Commit or later) but not against being already in PreCommit.
+        if self.current_round.step > ConsensusStep::PreCommit {
             return Ok(());
         }
 
-        self.current_round.step = ConsensusStep::PreCommit;
-        tracing::info!(
-            "Entering PreCommit step at height {} round {}",
-            self.current_round.height,
-            self.current_round.round
-        );
+        if self.current_round.step < ConsensusStep::PreCommit {
+            self.current_round.step = ConsensusStep::PreCommit;
+            tracing::info!(
+                "Entering PreCommit step at height {} round {}",
+                self.current_round.height,
+                self.current_round.round
+            );
+        }
 
-        if let Some(proposal_id) = self.current_round.proposals.first().cloned() {
-            let prevote_count = self.count_votes_for_proposal(&proposal_id, &VoteType::PreVote);
+        // Use valid_proposal (already set by on_prevote quorum path) or fall back to
+        // the first received proposal for this round.
+        let proposal_id_opt = self
+            .current_round
+            .valid_proposal
+            .clone()
+            .or_else(|| self.current_round.proposals.first().cloned());
+
+        if let Some(proposal_id) = proposal_id_opt {
+            // Skip if we already cast a precommit for this round.
+            let already_precommitted = self
+                .validator_identity
+                .as_ref()
+                .map(|id| {
+                    self.vote_pool.contains_key(&VotePoolKey {
+                        height: self.current_round.height,
+                        round: self.current_round.round,
+                        vote_type: VoteType::PreCommit,
+                        validator_id: id.clone(),
+                    })
+                })
+                .unwrap_or(false);
+            if already_precommitted {
+                return Ok(());
+            }
+
+            // Count prevotes for this proposal in the CURRENT round only.
+            // Cross-round prevote aggregation is unsafe: different rounds may have
+            // 2/3+ prevotes for different proposals (different proposers propose
+            // different blocks each round). Aggregating them can make two distinct
+            // proposals both appear to have supermajority, breaking BFT safety.
+            let prevote_count = self
+                .vote_pool
+                .iter()
+                .filter(|(k, (_, voted_id))| {
+                    k.height == self.current_round.height
+                        && k.round == self.current_round.round
+                        && k.vote_type == VoteType::PreVote
+                        && voted_id == &proposal_id
+                })
+                .count() as u64;
             let total_validators = self.validator_manager.get_active_validators().len() as u64;
 
             if check_supermajority(prevote_count, total_validators) {
@@ -1897,16 +1997,17 @@ impl ConsensusEngine {
     }
 
     async fn enter_commit_step(&mut self) -> ConsensusResult<()> {
-        if self.current_round.step >= ConsensusStep::Commit {
-            return Ok(());
+        // Allow re-entry when already in Commit step so that late-arriving precommits
+        // that complete the quorum can still cast a commit vote. We only prevent going
+        // backwards past Commit (which would be a new round / height).
+        if self.current_round.step < ConsensusStep::Commit {
+            self.current_round.step = ConsensusStep::Commit;
+            tracing::info!(
+                "Entering Commit step at height {} round {}",
+                self.current_round.height,
+                self.current_round.round
+            );
         }
-
-        self.current_round.step = ConsensusStep::Commit;
-        tracing::info!(
-            "Entering Commit step at height {} round {}",
-            self.current_round.height,
-            self.current_round.round
-        );
 
         // valid_proposal is set when prevote quorum is reached; locked_proposal is set
         // when precommit quorum is reached.  When the prevote timer fires before prevote
@@ -1921,7 +2022,37 @@ impl ConsensusEngine {
             .cloned();
 
         if let Some(proposal_id) = commit_target {
-            let precommit_count = self.count_votes_for_proposal(&proposal_id, &VoteType::PreCommit);
+            // Skip if we already cast a commit vote for this round.
+            let already_committed = self
+                .validator_identity
+                .as_ref()
+                .map(|id| {
+                    self.vote_pool.contains_key(&VotePoolKey {
+                        height: self.current_round.height,
+                        round: self.current_round.round,
+                        vote_type: VoteType::Commit,
+                        validator_id: id.clone(),
+                    })
+                })
+                .unwrap_or(false);
+            if already_committed {
+                return Ok(());
+            }
+
+            // Count precommits for this proposal across ALL rounds at this height.
+            // count_votes_for_proposal() filters by current round, which misses precommits
+            // from the round where quorum was actually reached when the round has since
+            // advanced via timeout.  Cross-round counting is safe because the proposal_id
+            // uniquely identifies the block; no two valid proposals share the same id.
+            let precommit_count = self
+                .vote_pool
+                .iter()
+                .filter(|(k, (_, voted_id))| {
+                    k.height == self.current_round.height
+                        && k.vote_type == VoteType::PreCommit
+                        && voted_id == &proposal_id
+                })
+                .count() as u64;
             let total_validators = self.validator_manager.get_active_validators().len() as u64;
 
             if check_supermajority(precommit_count, total_validators) {

--- a/lib-types/src/consensus.rs
+++ b/lib-types/src/consensus.rs
@@ -563,8 +563,15 @@ impl BftQuorumProof {
 /// proof itself off-chain for sync and audit. The block header commits only to
 /// the 32-byte root; peers exchange the full `BftQuorumProof` separately.
 pub fn compute_bft_quorum_root(proof: &BftQuorumProof) -> [u8; 32] {
+    // Sort attestations by validator_id for deterministic ordering.
+    // The quorum root is embedded in the block header; all nodes must compute
+    // the identical value or their block hashes diverge and the chain forks.
+    let mut sorted: Vec<&CommitAttestation> = proof.attestations.iter().collect();
+    sorted.sort_by_key(|a| a.validator_id);
+    sorted.dedup_by_key(|a| a.validator_id);
+
     let mut hasher = blake3::Hasher::new();
-    for att in &proof.attestations {
+    for att in sorted {
         hasher.update(&att.validator_id);
         hasher.update(&att.signature);
         hasher.update(&att.proposal_id);

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -65,6 +65,13 @@ impl GenesisFundingService {
             );
         }
 
+        // DETERMINISM: Sort genesis validators by identity_id so that every node
+        // produces the same genesis_tx output ordering regardless of the order
+        // validators appear in each node's config.toml. Different configs had
+        // validators in different orders, producing different genesis block hashes.
+        let mut genesis_validators = genesis_validators;
+        genesis_validators.sort_by_key(|v| v.identity_id.0);
+
         // Initialize outputs vector for genesis transaction
         let mut genesis_outputs = Vec::new();
         let mut total_validator_stake = 0u64;
@@ -175,23 +182,12 @@ impl GenesisFundingService {
                 identity_dilithium_pubkey.len()
             );
 
-            // Create wallet funding UTXO (still uses 32-byte identity hash for recipient)
-            let _identity_hash = user_identity_id.as_ref().unwrap().0.to_vec();
-            let wallet_output = TransactionOutput {
-                commitment: lib_blockchain::types::hash::blake3_hash(
-                    format!(
-                        "user_wallet_commitment_{}_{}",
-                        wallet_id_hex, SOV_WELCOME_BONUS
-                    )
-                    .as_bytes(),
-                ),
-                note: lib_blockchain::types::hash::blake3_hash(
-                    format!("user_wallet_note_{}", wallet_id_hex).as_bytes(),
-                ),
-                recipient: PublicKey::new([0u8; 2592]),
-            };
-
-            genesis_outputs.push(wallet_output);
+            // NOTE: The user wallet UTXO is intentionally NOT added to genesis_outputs.
+            // Each node has a different user wallet (different wallet_id), so including it
+            // in the genesis block transaction would produce a different genesis block hash
+            // on every node, making the genesis non-deterministic. The wallet is funded
+            // via the in-memory SOV mint below — the UTXO representation in the genesis
+            // block is not needed for SOV balance tracking.
 
             // Register wallet in blockchain's wallet_registry with initial balance
             // CRITICAL: Store the FULL Dilithium5 public key for signature verification


### PR DESCRIPTION
## Summary

- **SOV balance check**: Reject transfers at stateful validation time if sender balance < amount. Previously, unfunded transfers were accepted into the mempool, reached block execution, and panicked — halting all three nodes.
- **Deterministic genesis**: Sort genesis validators by `identity_id` and remove the per-node user wallet UTXO from `genesis_outputs`. Each node's config had validators in a different order and a node-specific wallet UTXO, producing a unique genesis hash per node on fresh sled starts — causing chain splits.
- **Deterministic quorum root**: Sort and deduplicate attestations by `validator_id` in both `compute_bft_quorum_root` and the quorum proof assembly path so all nodes embed the same 32-byte root in the block header.
- **Consensus liveness**: Proposer now enters prevote immediately after broadcasting (was waiting full `propose_timeout`); late prevote/precommit quorums can still cast votes; round-sync on received proposal lets lagging nodes catch up.

## Test plan

- [ ] Fresh sled wipe on all nodes produces identical genesis hashes
- [ ] SOV transfer with insufficient balance is rejected at mempool (`InvalidAmount`) and does not reach block execution
- [ ] Consensus commits blocks at round 0 on a healthy 3-node network
- [ ] A lagging node that rejoins after sled wipe syncs genesis from peers and participates in consensus