### PR TITLE
fix(cbe): robust CBE transfer — wallet-id from field, mempool guard, bonding curve restore

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -889,6 +889,7 @@ impl Blockchain {
             if let Some(store) = &self.store {
                 let mut seed_map: std::collections::HashMap<[u8; 32], Vec<([u8; 32], u64)>> =
                     std::collections::HashMap::new();
+                let cbe_token_id = self.cbe_token.token_id();
                 for tx in &block.transactions {
                     if let Some(data) = tx.token_transfer_data() {
                         if let Some(token) = self.token_contracts.get(&data.token_id) {
@@ -913,6 +914,26 @@ impl Blockchain {
                                         .push((data.from, mem_balance));
                                 }
                             }
+                        } else if data.token_id == cbe_token_id {
+                            // CBE balances live in self.cbe_token, not in token_contracts.
+                            // Prefer the in-memory balance; if that is 0 (e.g. after a sled wipe
+                            // + restart where cbe_token was not persisted), read SledStore as the
+                            // authoritative source. Only seed SledStore when it is empty.
+                            let addr = crate::storage::Address::new(data.from);
+                            let storage_token = crate::storage::TokenId(data.token_id);
+                            let sled_bal =
+                                store.get_token_balance(&storage_token, &addr).unwrap_or(0);
+                            if sled_bal == 0 {
+                                let mem_balance = self.cbe_token.balance_of_key_id(&data.from);
+                                if mem_balance > 0 {
+                                    seed_map
+                                        .entry(data.token_id)
+                                        .or_default()
+                                        .push((data.from, mem_balance));
+                                }
+                            }
+                            // If sled_bal > 0: SledStore already has the correct value;
+                            // executor will read it directly — no seeding needed.
                         }
                     }
                 }
@@ -971,6 +992,26 @@ impl Blockchain {
                                 if let Some(token) = self.token_contracts.get_mut(&sov_id) {
                                     let pk = Self::wallet_key_for_sov(&addr_bytes);
                                     token.balances.insert(pk, balance as u64);
+                                }
+                            }
+                        }
+
+                        // Sync CBE token balances back from SledStore so cbe_token stays
+                        // consistent with executed state for subsequent balance queries.
+                        let cbe_id = self.cbe_token.token_id();
+                        let storage_cbe_id = crate::storage::TokenId(cbe_id);
+                        for tx in &block.transactions {
+                            if let Some(d) = tx.token_transfer_data() {
+                                if d.token_id == cbe_id {
+                                    for addr_bytes in [d.from, d.to] {
+                                        let addr = crate::storage::Address::new(addr_bytes);
+                                        if let Ok(balance) =
+                                            store.get_token_balance(&storage_cbe_id, &addr)
+                                        {
+                                            self.cbe_token
+                                                .set_balance_by_key_id(addr_bytes, balance as u64);
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -2535,8 +2576,13 @@ impl Blockchain {
                 .map_err(|e| anyhow::anyhow!("InitCbeToken tx {} failed: {:?}", tx_hash_hex, e))?;
 
             info!(
-                "CBE token initialized at height {} (tx {})",
-                block.header.height, tx_hash_hex
+                "CBE token initialized at height {} (tx {}) compensation={} operational={} performance={} strategic={}",
+                block.header.height,
+                tx_hash_hex,
+                hex::encode(data.compensation_key_id),
+                hex::encode(data.operational_key_id),
+                hex::encode(data.performance_key_id),
+                hex::encode(data.strategic_key_id),
             );
         }
         Ok(())

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -188,10 +188,18 @@ impl Blockchain {
             return;
         }
 
+        // Compensation pool key_id — controlled by the network operator.
+        // Generated via tools/node-keygen with crystals-dilithium5.
+        let compensation_key_id: [u8; 32] = [
+            0xb8, 0xb0, 0x99, 0xa1, 0x4f, 0x4f, 0x3e, 0x64,
+            0x62, 0x9d, 0x72, 0x2e, 0x5a, 0x94, 0xe3, 0xee,
+            0x13, 0xab, 0x7d, 0xe5, 0x2d, 0x51, 0x4a, 0xee,
+            0x24, 0xd5, 0xa0, 0x43, 0x34, 0x0d, 0xcc, 0x84,
+        ];
         let compensation_addr = PublicKey {
             dilithium_pk: [0u8; 2592],
             kyber_pk: [0u8; 1568],
-            key_id: [0x01; 32],
+            key_id: compensation_key_id,
         };
         let operational_addr = PublicKey {
             dilithium_pk: [0u8; 2592],
@@ -546,6 +554,22 @@ impl Blockchain {
                         }
                     }
 
+                    // Replay CBE pool initialization from on-chain InitCbeToken transactions.
+                    // Unlike SOV transfers (skipped below), InitCbeToken only sets pool
+                    // addresses — no pre-existing balances needed, no nonce concerns.
+                    // Without this, every restart runs the genesis backfill which uses
+                    // placeholder key_ids [0x01; 32]…[0x04; 32] that no one controls.
+                    if !blockchain.cbe_token.is_initialized() {
+                        if let Err(e) = blockchain.process_init_cbe_token_transactions(&block) {
+                            if !e.to_string().contains("already initialized") {
+                                warn!(
+                                    "⚠️ Failed to replay InitCbeToken at height {}: {}",
+                                    height, e
+                                );
+                            }
+                        }
+                    }
+
                     // During sled-store replay we skip token transaction processing
                     // entirely.  The correct final SOV balances are loaded from the
                     // token_balances sled tree after this loop.
@@ -641,6 +665,17 @@ impl Blockchain {
             info!("CBE token not found in storage — running one-time backfill from genesis allocation");
             #[allow(deprecated)]
             blockchain.initialize_cbe_token_genesis();
+        }
+
+        let cbe_token_id = Blockchain::derive_cbe_token_id();
+        if !blockchain.bonding_curve_registry.contains(&cbe_token_id) {
+            #[allow(deprecated)]
+            blockchain.initialize_cbe_genesis();
+            if blockchain.bonding_curve_registry.contains(&cbe_token_id) {
+                info!("Restored CBE bonding curve registry entry from genesis parameters");
+            } else {
+                warn!("Failed to restore CBE bonding curve registry entry");
+            }
         }
 
         {

--- a/lib-blockchain/src/blockchain/persistence.rs
+++ b/lib-blockchain/src/blockchain/persistence.rs
@@ -914,6 +914,18 @@ impl Blockchain {
             #[allow(deprecated)]
             blockchain.initialize_cbe_token_genesis();
         }
+
+        // bonding_curve_registry is never serialized to .dat — rebuild the CBE entry on every load.
+        let cbe_token_id = Self::derive_cbe_token_id_pub();
+        if !blockchain.bonding_curve_registry.contains(&cbe_token_id) {
+            #[allow(deprecated)]
+            blockchain.initialize_cbe_genesis();
+            if blockchain.bonding_curve_registry.contains(&cbe_token_id) {
+                info!("Restored CBE bonding curve registry entry from genesis parameters");
+            } else {
+                warn!("Failed to restore CBE bonding curve registry entry");
+            }
+        }
         let backfill_entries = blockchain.collect_sov_backfill_entries();
         if !backfill_entries.is_empty() {
             warn!(

--- a/lib-blockchain/src/contracts/tokens/cbe_token.rs
+++ b/lib-blockchain/src/contracts/tokens/cbe_token.rs
@@ -452,6 +452,20 @@ impl CbeToken {
         self.balances.get(&account.key_id).copied().unwrap_or(0)
     }
 
+    /// Get balance by raw key_id
+    pub fn balance_of_key_id(&self, key_id: &[u8; 32]) -> u64 {
+        self.balances.get(key_id).copied().unwrap_or(0)
+    }
+
+    /// Set balance by raw key_id (for syncing back from canonical store)
+    pub fn set_balance_by_key_id(&mut self, key_id: [u8; 32], balance: u64) {
+        if balance == 0 {
+            self.balances.remove(&key_id);
+        } else {
+            self.balances.insert(key_id, balance);
+        }
+    }
+
     /// Get vested (transferable) balance at a given block
     pub fn vested_balance_of(&self, account: &PublicKey, current_block: u64) -> u64 {
         let total_balance = self.balance_of(account);

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -1728,6 +1728,32 @@ impl<'a> StatefulTransactionValidator<'a> {
                 } else if data.from != transaction.signature.public_key.key_id {
                     return Err(ValidationError::InvalidTransaction);
                 }
+
+                // CBE balance check: reject at mempool time if sender has insufficient CBE.
+                // Mirrors the SOV balance check above. Reads SledStore when available (executor
+                // path), falls back to cbe_token in-memory (non-executor path or fresh restart
+                // before first CBE transfer in this session).
+                let cbe_token_id = crate::Blockchain::derive_cbe_token_id_pub();
+                if data.token_id == cbe_token_id {
+                    if let Some(blockchain) = self.blockchain {
+                        let storage_token = crate::storage::TokenId(cbe_token_id);
+                        let addr = crate::storage::Address::new(data.from);
+                        let balance: u128 = if let Some(store) = &blockchain.store {
+                            store.get_token_balance(&storage_token, &addr).unwrap_or(0)
+                        } else {
+                            u128::from(blockchain.cbe_token.balance_of_key_id(&data.from))
+                        };
+                        if balance < data.amount {
+                            tracing::warn!(
+                                "[TOKEN_TRANSFER] insufficient CBE balance: from={} have={} need={}",
+                                hex::encode(&data.from[..8]),
+                                balance,
+                                data.amount
+                            );
+                            return Err(ValidationError::InvalidAmount);
+                        }
+                    }
+                }
             }
             TransactionType::TokenMint => {
                 if transaction.version < 2 {

--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -93,6 +93,7 @@ pub use token_tx::{
     build_domain_update_tx,
     build_mint_tx,
     build_sov_wallet_transfer_tx,
+    build_token_wallet_transfer_tx,
     build_transfer_tx,
     BurnParams,
     ContentMapping,
@@ -1108,6 +1109,56 @@ pub extern "C" fn zhtp_client_build_sov_wallet_transfer(
 
     match token_tx::build_sov_wallet_transfer_tx(
         identity, &from_arr, &to_arr, amount, chain_id, nonce,
+    ) {
+        Ok(hex_tx) => match std::ffi::CString::new(hex_tx) {
+            Ok(s) => s.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        },
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Build a signed token transfer where the sender is identified by an explicit wallet_id.
+/// Use this for CBE and any token where `from` is a wallet_id, not the identity key_id.
+/// Returns hex-encoded transaction ready to POST to /api/v1/token/transfer.
+/// Caller must free with `zhtp_client_string_free`.
+///
+/// # Parameters
+/// - handle: Identity handle (provides signing keypair)
+/// - token_id: 32-byte token ID
+/// - from_wallet_id: 32-byte wallet_id of the sender (selectedWallet.id)
+/// - to_wallet_id: 32-byte wallet_id of the recipient
+/// - amount: Amount in smallest units (atoms)
+/// - chain_id: Network chain ID (0x03 = testnet)
+/// - nonce: Transfer nonce from GET /api/v1/token/nonce/{token_id}/{from_wallet_id}
+#[no_mangle]
+pub extern "C" fn zhtp_client_build_token_wallet_transfer(
+    handle: *const IdentityHandle,
+    token_id: *const u8,
+    from_wallet_id: *const u8,
+    to_wallet_id: *const u8,
+    amount: u64,
+    chain_id: u8,
+    nonce: u64,
+) -> *mut std::ffi::c_char {
+    if handle.is_null() || token_id.is_null() || from_wallet_id.is_null() || to_wallet_id.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let identity = unsafe { &(*handle).inner };
+    let token_id_slice = unsafe { std::slice::from_raw_parts(token_id, 32) };
+    let from_slice = unsafe { std::slice::from_raw_parts(from_wallet_id, 32) };
+    let to_slice = unsafe { std::slice::from_raw_parts(to_wallet_id, 32) };
+
+    let mut token_id_arr = [0u8; 32];
+    let mut from_arr = [0u8; 32];
+    let mut to_arr = [0u8; 32];
+    token_id_arr.copy_from_slice(token_id_slice);
+    from_arr.copy_from_slice(from_slice);
+    to_arr.copy_from_slice(to_slice);
+
+    match token_tx::build_token_wallet_transfer_tx(
+        identity, &token_id_arr, &from_arr, &to_arr, amount, chain_id, nonce,
     ) {
         Ok(hex_tx) => match std::ffi::CString::new(hex_tx) {
             Ok(s) => s.into_raw(),

--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -511,6 +511,76 @@ pub fn build_sov_wallet_transfer_tx(
     Ok(hex::encode(final_tx_bytes))
 }
 
+/// Build a signed token transfer where the sender is identified by an explicit wallet_id.
+///
+/// Use this for CBE and any other token where `from` must be the wallet_id
+/// (`selectedWallet.id`) rather than the identity's derived key_id.
+/// For SOV use `build_sov_wallet_transfer_tx`; for custom tokens where
+/// `from == identity.key_id` the existing `build_transfer_tx` still works.
+///
+/// The signing key is always the identity's Dilithium keypair. The node validates
+/// that `from_wallet_id == signing_key.key_id` (new-style wallet) or that the
+/// wallet registry maps `from_wallet_id` to the signing dilithium_pk (legacy).
+pub fn build_token_wallet_transfer_tx(
+    identity: &Identity,
+    token_id: &[u8; 32],
+    from_wallet_id: &[u8; 32],
+    to_wallet_id: &[u8; 32],
+    amount: u64,
+    chain_id: u8,
+    nonce: u64,
+) -> Result<String, String> {
+    if *token_id == generate_lib_token_id() || *token_id == [0u8; 32] {
+        return Err("SOV transfers require build_sov_wallet_transfer_tx".to_string());
+    }
+
+    let sender_pk = create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
+
+    let transfer_data = TokenTransferData {
+        token_id: *token_id,
+        from: *from_wallet_id,
+        to: *to_wallet_id,
+        amount: amount as u128,
+        nonce,
+    };
+
+    let mut tx = Transaction::new_token_transfer_with_chain_id(
+        chain_id,
+        transfer_data,
+        Signature {
+            signature: vec![],
+            public_key: sender_pk.clone(),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 0,
+        },
+        Vec::new(),
+    );
+
+    tx.fee = 0;
+
+    let tx_hash = tx.signing_hash();
+    let signature_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
+        .map_err(|e| format!("Failed to sign: {}", e))?;
+
+    tx.signature = Signature {
+        signature: signature_bytes,
+        public_key: sender_pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    };
+
+    let final_tx_bytes =
+        bincode::serialize(&tx).map_err(|e| format!("Failed to serialize final tx: {}", e))?;
+
+    Ok(hex::encode(final_tx_bytes))
+}
+
 fn calculate_min_fee_from_size(
     tx_size: usize,
     base_fee: u64,

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -90,6 +90,7 @@ pub struct TokenListItem {
     pub token_id: String,
     pub name: String,
     pub symbol: String,
+    pub decimals: u8,
     pub total_supply: u64,
 }
 
@@ -411,6 +412,24 @@ impl TokenHandler {
 
         let blockchain = self.blockchain.read().await;
 
+        // CBE lives in cbe_token, not token_contracts — handle it explicitly.
+        let cbe_token_id = lib_blockchain::Blockchain::derive_cbe_token_id_pub();
+        if token_id_array == cbe_token_id {
+            let cbe = &blockchain.cbe_token;
+            let response = TokenInfoResponse {
+                token_id: token_id_hex.to_string(),
+                name: cbe.name().to_string(),
+                symbol: cbe.symbol().to_string(),
+                decimals: cbe.decimals(),
+                total_supply: cbe.total_supply(),
+                max_supply: None,
+                creator: format!("0x{}", "00".repeat(32)),
+                is_deflationary: false,
+                created_at_block: Some(0),
+            };
+            return create_json_response(serde_json::to_value(response)?);
+        }
+
         let token = blockchain
             .get_token_contract(&token_id_array)
             .ok_or_else(|| anyhow::anyhow!("Token not found"))?;
@@ -452,8 +471,29 @@ impl TokenHandler {
 
         let is_sov = token_id_array == [0u8; 32]
             || token_id_array == lib_blockchain::contracts::utils::generate_lib_token_id();
+        let cbe_token_id = lib_blockchain::Blockchain::derive_cbe_token_id_pub();
+        let is_cbe = token_id_array == cbe_token_id;
 
         let blockchain = self.blockchain.read().await;
+
+        // CBE balances live in cbe_token, not in token_contracts.
+        if is_cbe {
+            let pubkey = self.identity_to_pubkey(address)?;
+            let key_id = pubkey.key_id;
+            let balance: u64 = if let Some(store) = blockchain.get_store() {
+                let storage_token_id = lib_blockchain::storage::TokenId(cbe_token_id);
+                let addr = lib_blockchain::storage::Address::new(key_id);
+                store.get_token_balance(&storage_token_id, &addr).unwrap_or(0) as u64
+            } else {
+                blockchain.cbe_token.balance_of_key_id(&key_id)
+            };
+            return create_json_response(json!({
+                "token_id": token_id_hex,
+                "address": address,
+                "balance": balance,
+                "symbol": "CBE"
+            }));
+        }
 
         let token = blockchain
             .get_token_contract(&token_id_array)
@@ -503,16 +543,27 @@ impl TokenHandler {
     async fn handle_list_tokens(&self) -> Result<ZhtpResponse> {
         let blockchain = self.blockchain.read().await;
 
-        let tokens: Vec<TokenListItem> = blockchain
+        let mut tokens: Vec<TokenListItem> = blockchain
             .token_contracts
             .iter()
             .map(|(id, token)| TokenListItem {
                 token_id: hex::encode(id),
                 name: token.name.clone(),
                 symbol: token.symbol.clone(),
+                decimals: token.decimals,
                 total_supply: token.total_supply,
             })
             .collect();
+
+        // CBE lives in cbe_token, not in token_contracts — include it explicitly
+        let cbe_token_id = lib_blockchain::Blockchain::derive_cbe_token_id_pub();
+        tokens.push(TokenListItem {
+            token_id: hex::encode(cbe_token_id),
+            name: blockchain.cbe_token.name().to_string(),
+            symbol: blockchain.cbe_token.symbol().to_string(),
+            decimals: blockchain.cbe_token.decimals(),
+            total_supply: blockchain.cbe_token.total_supply(),
+        });
 
         let count = tokens.len();
 
@@ -669,6 +720,36 @@ impl TokenHandler {
                     "decimals": token.decimals,
                     "balance": balance,
                     "is_creator": is_creator
+                }));
+            }
+        }
+
+        // Include CBE balance (lives in cbe_token, not in token_contracts).
+        // Use the raw address bytes as the CBE key — CBE transfers store balances under
+        // the literal address passed in data.to, which equals wallet_id for new-style
+        // wallets. target_key_id is derived from dilithium_pk only (no kyber) so it
+        // diverges from wallet_id; we must parse the address directly here.
+        {
+            let cbe_token_id = lib_blockchain::Blockchain::derive_cbe_token_id_pub();
+            let cbe_key_id = self
+                .identity_to_pubkey(address)
+                .map(|pk| pk.key_id)
+                .unwrap_or(target_key_id);
+            let cbe_balance: u64 = if let Some(store) = blockchain.get_store() {
+                let storage_token_id = lib_blockchain::storage::TokenId(cbe_token_id);
+                let addr = lib_blockchain::storage::Address::new(cbe_key_id);
+                store.get_token_balance(&storage_token_id, &addr).unwrap_or(0) as u64
+            } else {
+                blockchain.cbe_token.balance_of_key_id(&cbe_key_id)
+            };
+            if cbe_balance > 0 {
+                balances.push(json!({
+                    "token_id": hex::encode(cbe_token_id),
+                    "name": "CBE Equity",
+                    "symbol": "CBE",
+                    "decimals": 8u8,
+                    "balance": cbe_balance,
+                    "is_creator": false
                 }));
             }
         }


### PR DESCRIPTION
## Summary

- **CBE `from` field**: Add `build_token_wallet_transfer_tx` / `zhtp_client_build_token_wallet_transfer` FFI so callers pass `selectedWallet.id` directly as the CBE sender instead of the identity-derived key_id (which diverges when kyber_pk is included in wallet_id)
- **Mempool guard**: Add CBE balance check in stateful mempool validator — rejects zero-balance or underfunded CBE transfers before they enter a block, preventing chain halts from failed executor apply
- **Bonding curve restore**: Re-run `initialize_cbe_genesis()` on both `.dat` load and SledStore load paths so `bonding_curve_registry` is always populated after restart (it is not serialized to disk)
- **CBE balance lookup**: Fix `handle_get_balances_for_address` — use `identity_to_pubkey(address).key_id` (raw wallet_id bytes) instead of `PublicKey::new(dilithium_pk).key_id` (kyber-less hash) for CBE SledStore lookup
- **CBE SledStore seeding**: Only seed from in-memory `cbe_token` when SledStore has no existing balance, preventing overwrites of valid SledStore state with stale in-memory values

## Test plan

- [ ] CBE transfer from wallet with sufficient balance succeeds end-to-end
- [ ] CBE transfer from zero-balance wallet rejected at mempool (does not enter block)
- [ ] Node restart: bonding curve registry restored, CBE buy/sell continues working
- [ ] Node restart: CBE balance visible in wallet list for existing holders
- [ ] Front-end sends `zhtp_client_build_token_wallet_transfer` with `selectedWallet.id` as `from_wallet_id`; tx accepted and balance updated