### PR TITLE
Observer startup admission state and observer enrollment spec

### DIFF
--- a/docs/specs/observer-admission-v1.md
+++ b/docs/specs/observer-admission-v1.md
@@ -1,0 +1,453 @@
+# Observer Admission V1
+
+Status: Draft
+
+Scope: Observer node admission, sponsorship, rate limiting, anti-abuse controls, and bootstrap enforcement.
+
+## Purpose
+
+Define a production-safe admission model for observer nodes so that:
+
+- anonymous nodes cannot join as observers
+- every observer node is accountable to a sponsoring user DID
+- validator and bootstrap nodes can authenticate and authorize observers deterministically
+- abuse can be rate-limited, suspended, and revoked without treating observers as validators
+
+This spec is intentionally incremental. It is designed to fit protocol upgrades and additive state changes rather than large refactors.
+
+## Design Goals
+
+- Require explicit observer admission.
+- Separate node authentication from observer authorization.
+- Bind every observer node DID to a sponsoring user DID.
+- Enforce minimum proof requirements on the sponsoring user DID.
+- Support automatic registration through an API-driven enrollment flow.
+- Support per-observer and per-sponsor rate limits.
+- Support suspension and revocation.
+- Avoid validator stake semantics for ordinary observer access.
+
+## Non-Goals
+
+- Replacing validator registration.
+- Making observer admission anonymous.
+- Defining a token bond or slashing model in V1.
+- Reworking consensus or validator economics.
+
+## Core Model
+
+An observer is a node identity sponsored by a user identity.
+
+Two identities participate:
+
+- `observer_node_did`
+  - the machine/node identity used for QUIC peer authentication
+- `sponsoring_user_did`
+  - the user or operator identity that authorizes and is accountable for the observer
+
+Observer access is granted only when:
+
+1. the node proves ownership of `observer_node_did`
+2. the sponsor proves ownership of `sponsoring_user_did`
+3. the sponsor has sufficient proof level for observer operation
+4. the observer admission record is `active`
+
+## Invariants
+
+1. Anonymous users cannot operate observers.
+2. Authentication does not imply authorization.
+3. An observer may connect only if its node DID is bound to an active sponsoring user DID.
+4. Sponsoring user proof level determines whether observer access is allowed.
+5. Rate limits apply both per observer and per sponsoring user.
+6. Revoking a sponsor may revoke all sponsored observers.
+7. Observer access is independent from validator consensus rights.
+
+## Roles
+
+- `validator`
+  - consensus role
+  - stake-backed
+  - separate registration path
+- `observer`
+  - read/sync role
+  - admission-backed
+  - no proposing or voting rights
+
+## Admission Record
+
+Minimum persisted fields:
+
+- `observer_node_did`
+- `observer_public_key`
+- `sponsoring_user_did`
+- `sponsor_signature`
+- `role = observer`
+- `status = pending | active | suspended | revoked`
+- `proof_level`
+- `rate_limit_tier`
+- `allowed_network`
+- `trusted_sync_scope`
+- `created_at`
+- `updated_at`
+- `expires_at` optional
+
+Recommended optional fields:
+
+- `display_name`
+- `endpoints`
+- `invite_id`
+- `last_seen_at`
+- `suspension_reason`
+- `revocation_reason`
+
+## Proof-Level Policy
+
+Observer access is gated by sponsoring user proof level.
+
+Example policy:
+
+- `proof_level_0`
+  - cannot sponsor observers
+- `proof_level_1`
+  - may sponsor 1 observer
+- `proof_level_2`
+  - may sponsor up to 3 observers
+- `proof_level_3`
+  - may sponsor higher limits or organizational observers
+
+The exact tiers are governance-configurable, but the protocol rule is:
+
+`proof_level < minimum_observer_proof_level => observer admission denied`
+
+## Enrollment Flow
+
+### 1. Node identity creation
+
+The observer node generates or loads:
+
+- node keypair
+- `observer_node_did`
+
+### 2. Sponsor authorization
+
+The user wallet signs an enrollment statement authorizing the node:
+
+`I, sponsoring_user_did, authorize observer_node_did to operate as observer on network X`
+
+The signed statement must bind:
+
+- sponsor DID
+- observer node DID
+- requested role
+- network identifier
+- issuance time
+- expiry time or nonce
+
+### 3. Admission API submission
+
+The observer submits:
+
+- `observer_node_did`
+- `observer_public_key`
+- `sponsoring_user_did`
+- sponsor-signed enrollment statement
+- optional endpoint metadata
+- optional invite token
+
+### 4. Server validation
+
+The admission service verifies:
+
+- observer DID/public key consistency
+- sponsor DID validity
+- sponsor signature over the enrollment statement
+- sponsor proof level
+- sponsor quota availability
+- network match
+- invite token or approval requirements if configured
+
+### 5. Record creation
+
+If valid, the system creates or updates the admission record as:
+
+- `pending`, if approval is required
+- `active`, if auto-approval is allowed
+
+### 6. Bootstrap enforcement
+
+Bootstrap and validator nodes accept observer sync only when the record is `active`.
+
+## API
+
+### `POST /api/v1/node-admission/challenge`
+
+Purpose:
+- establish freshness and anti-replay challenge
+
+Request:
+
+```json
+{
+  "observer_node_did": "did:zhtp:...",
+  "observer_public_key": "base64..."
+}
+```
+
+Response:
+
+```json
+{
+  "challenge_id": "uuid-or-hash",
+  "challenge_nonce": "base64...",
+  "expires_at": 1760000000
+}
+```
+
+### `POST /api/v1/node-admission/register`
+
+Purpose:
+- request observer admission
+
+Request:
+
+```json
+{
+  "observer_node_did": "did:zhtp:...",
+  "observer_public_key": "base64...",
+  "sponsoring_user_did": "did:zhtp:...",
+  "requested_role": "observer",
+  "challenge_id": "uuid-or-hash",
+  "node_signature": "base64...",
+  "sponsor_signature": "base64...",
+  "endpoints": [
+    "203.0.113.10:9334"
+  ],
+  "invite_token": "optional"
+}
+```
+
+Response:
+
+```json
+{
+  "status": "active",
+  "observer_node_did": "did:zhtp:...",
+  "sponsoring_user_did": "did:zhtp:...",
+  "rate_limit_tier": "observer_basic",
+  "trusted_sync_sources": [
+    "77.42.37.161:9334",
+    "77.42.74.80:9334"
+  ]
+}
+```
+
+### `GET /api/v1/node-admission/status/{observer_node_did}`
+
+Purpose:
+- allow observer and operators to inspect admission state
+
+Response:
+
+```json
+{
+  "status": "active",
+  "role": "observer",
+  "sponsoring_user_did": "did:zhtp:...",
+  "proof_level": 2,
+  "rate_limit_tier": "observer_basic",
+  "expires_at": null
+}
+```
+
+### `POST /api/v1/node-admission/revoke`
+
+Purpose:
+- sponsor or governance revokes observer access
+
+Request:
+
+```json
+{
+  "observer_node_did": "did:zhtp:...",
+  "requested_by": "did:zhtp:...",
+  "signature": "base64..."
+}
+```
+
+## Authentication Rules
+
+Two signatures are required during enrollment:
+
+- `node_signature`
+  - proves the node controls `observer_node_did`
+- `sponsor_signature`
+  - proves the user DID authorizes that node
+
+This prevents:
+
+- registering someone else’s node DID
+- registering an observer without sponsor consent
+- binding a valid sponsor DID to an unrelated machine
+
+## Authorization Rules
+
+An observer is authorized only if all are true:
+
+- admission record exists
+- role is `observer`
+- status is `active`
+- sponsor proof level meets minimum
+- sponsor quota not exceeded
+- record not expired
+- network id matches
+
+## Rate Limiting
+
+Rate limits are enforced at three layers.
+
+### Per observer DID
+
+- max connection attempts per minute
+- max concurrent sync sessions
+- max block-range requests per minute
+- max API requests per minute
+- max bytes served per hour
+
+### Per sponsoring user DID
+
+- max active observers
+- max aggregate bytes served across all sponsored observers
+- max aggregate sync sessions
+- max failed enrollments per time window
+
+### Per source IP
+
+Fallback only:
+
+- protect against obvious floods before identity is established
+
+IP rate limiting must not be the primary trust model.
+
+## Anti-Abuse Controls
+
+Each observer and sponsor accumulates abuse signals:
+
+- repeated failed authentication
+- repeated failed sponsorship verification
+- excessive reconnect churn
+- repeated oversized or invalid requests
+- repeated sync retries without progress
+
+Response ladder:
+
+- warn
+- temporary slow-down
+- temporary suspension
+- revocation
+
+## Bootstrap And Sync Enforcement
+
+Bootstrap peers must enforce:
+
+- peer DID is registered
+- role is `observer` or other sync-allowed role
+- status is `active`
+- network matches
+
+Trusted sync sources should only serve state to admitted observers.
+
+This check must happen before:
+
+- bootstrap sync
+- gap fill
+- long-range block import
+
+## Revocation
+
+Revocation can be initiated by:
+
+- sponsoring user DID
+- governance/admin authority
+- automated abuse controls
+
+Revoking a sponsor may:
+
+- immediately revoke all child observers
+- suspend all child observers pending review
+
+V1 should support at least full child revocation.
+
+## State Machine
+
+- `unregistered`
+- `pending`
+- `active`
+- `rate_limited`
+- `suspended`
+- `revoked`
+
+Rules:
+
+- only `active` observers may sync
+- `pending` observers may poll status but may not sync
+- `suspended` observers are denied until reinstated
+- `revoked` observers require a new enrollment
+
+## Storage And Replication
+
+V1 may start with validator-governed replicated registry state, but the target model is:
+
+- deterministic registry state available to bootstrap peers
+- replay-safe revocation and admission decisions
+
+Implementation may begin as:
+
+- config-backed authority API plus replicated registry storage
+
+Later upgrade path:
+
+- on-chain admission records
+- governance-controlled updates
+
+## Rollout Plan
+
+### Phase 1
+
+- Add observer admission record model
+- Add sponsor binding
+- Add challenge/register/status API
+- Add bootstrap enforcement for `active` records
+
+### Phase 2
+
+- Add proof-level policy
+- Add per-sponsor quotas
+- Add rate-limit tiers
+
+### Phase 3
+
+- Add suspension and revocation workflows
+- Add abuse scoring
+- Add operator/admin approval paths
+
+### Phase 4
+
+- Consider optional observer bond if abuse pressure justifies economic friction
+
+## Open Questions
+
+1. Should first enrollment be auto-approved for qualifying sponsors, or always `pending`?
+2. Should sponsorship be limited to one organization or namespace per user DID?
+3. Should trusted sync sources be returned by the admission API or discovered from chain state?
+4. Should revoking a sponsor instantly revoke all observers, or suspend them first?
+5. When the identity registry is unavailable, should bootstrap peers fail closed or permit a temporary cache-based grace window?
+
+## Acceptance Criteria
+
+- An anonymous node cannot join as observer.
+- A node DID without a sponsoring user DID cannot join.
+- A sponsoring user DID below minimum proof level cannot sponsor an observer.
+- A revoked observer cannot sync.
+- A revoked sponsor disables sponsored observers.
+- Bootstrap peers deny non-admitted observers before sync begins.
+- Rate limits can be enforced both per observer and per sponsor.
+

--- a/zhtp-cli/src/commands/node.rs
+++ b/zhtp-cli/src/commands/node.rs
@@ -294,10 +294,7 @@ async fn start_node_impl(
     if let Some(network_info) = network_info_opt {
         output.success("Connected to existing ZHTP network!")?;
         output.print(&format!("Network peers: {}", network_info.peer_count))?;
-        output.print(&format!(
-            "Blockchain height: {}",
-            network_info.blockchain_height
-        ))?;
+        output.print(&format!("Remote chain state: {}", network_info.chain_state))?;
 
         output.info("Initializing blockchain for sync...")?;
         orchestrator

--- a/zhtp/src/config/aggregation.rs
+++ b/zhtp/src/config/aggregation.rs
@@ -59,6 +59,35 @@ pub struct PartialNetworkConfig {
     /// Enables proposer rotation from block 0 in multi-node setups.
     #[serde(default)]
     pub bootstrap_validators: Vec<BootstrapValidator>,
+    /// Observer admission policy and trusted sync sources.
+    #[serde(default)]
+    pub observer_admission: Option<ObserverAdmissionConfig>,
+}
+
+/// Config-backed observer admission policy.
+///
+/// This is operator-controlled until an on-chain node registry exists.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ObserverAdmissionConfig {
+    /// Require explicit local DID admission for observer/full-node startup.
+    #[serde(default)]
+    pub required: bool,
+    /// DIDs allowed to run in observer mode when admission is required.
+    #[serde(default)]
+    pub authorized_observer_dids: Vec<String>,
+    /// Explicit peers allowed to serve bootstrap state to observers.
+    #[serde(default)]
+    pub trusted_sync_sources: Vec<TrustedSyncSource>,
+}
+
+/// Trusted peer eligible to serve observer bootstrap data.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustedSyncSource {
+    /// Endpoint in `host:port` form.
+    pub address: String,
+    /// Optional expected peer DID after authenticated handshake.
+    #[serde(default)]
+    pub peer_did: Option<String>,
 }
 
 /// Partial consensus configuration (matches [consensus_config] section)
@@ -268,6 +297,10 @@ pub struct NetworkConfig {
     // Bootstrap validators for multi-node genesis (Gap 5)
     #[serde(default)]
     pub bootstrap_validators: Vec<BootstrapValidator>,
+
+    /// Observer admission and trusted sync-source policy.
+    #[serde(default)]
+    pub observer_admission: ObserverAdmissionConfig,
 }
 
 /// Blockchain configuration
@@ -722,6 +755,7 @@ impl Default for NodeConfig {
                 long_range_relays: false,
                 bootstrap_peer_pins: HashMap::new(),
                 bootstrap_validators: Vec::new(), // Gap 5: Empty by default
+                observer_admission: ObserverAdmissionConfig::default(),
             },
 
             blockchain_config: BlockchainConfig {
@@ -1089,6 +1123,10 @@ pub async fn aggregate_all_package_configs(config_path: &Path) -> Result<NodeCon
                             config.network_config.bootstrap_validators =
                                 network.bootstrap_validators;
                         }
+                        if let Some(observer_admission) = network.observer_admission {
+                            tracing::info!("Loaded observer admission policy from [network] section");
+                            config.network_config.observer_admission = observer_admission;
+                        }
                         if let Some(mesh_port) = network.mesh_port {
                             config.network_config.mesh_port = mesh_port;
                         }
@@ -1123,6 +1161,12 @@ pub async fn aggregate_all_package_configs(config_path: &Path) -> Result<NodeCon
                             );
                             config.network_config.bootstrap_validators =
                                 network.bootstrap_validators;
+                        }
+                        if let Some(observer_admission) = network.observer_admission {
+                            tracing::info!(
+                                "Loaded observer admission policy from [network_config] section"
+                            );
+                            config.network_config.observer_admission = observer_admission;
                         }
                         if let Some(mesh_port) = network.mesh_port {
                             config.network_config.mesh_port = mesh_port;

--- a/zhtp/src/config/mod.rs
+++ b/zhtp/src/config/mod.rs
@@ -17,7 +17,9 @@ use std::path::{Path, PathBuf};
 
 // Re-export configuration types
 pub use aggregation::NodeConfig;
+pub use aggregation::ObserverAdmissionConfig;
 pub use aggregation::RuntimeRole;
+pub use aggregation::TrustedSyncSource;
 pub use environment::Environment;
 pub use mesh_modes::MeshMode;
 pub use network_isolation::NetworkIsolationConfig;

--- a/zhtp/src/discovery_coordinator.rs
+++ b/zhtp/src/discovery_coordinator.rs
@@ -26,6 +26,9 @@ pub struct DiscoveryConfig {
     pub discovery_port: u16,
     /// Active discovery protocols
     pub protocols: Vec<DiscoveryProtocol>,
+
+    /// Explicit peers allowed to serve observer bootstrap state.
+    pub trusted_sync_sources: Vec<crate::config::TrustedSyncSource>,
 }
 
 impl DiscoveryConfig {
@@ -34,11 +37,13 @@ impl DiscoveryConfig {
         bootstrap_peers: Vec<String>,
         discovery_port: u16,
         protocols: Vec<DiscoveryProtocol>,
+        trusted_sync_sources: Vec<crate::config::TrustedSyncSource>,
     ) -> Self {
         Self {
             bootstrap_peers,
             discovery_port,
             protocols,
+            trusted_sync_sources,
         }
     }
 }
@@ -663,10 +668,10 @@ impl DiscoveryCoordinator {
         let blockchain_info = self.fetch_blockchain_info(&discovered_peers).await?;
 
         Ok(crate::runtime::ExistingNetworkInfo {
-            peer_count: discovered_peers.len() as u32,
-            blockchain_height: blockchain_info.height,
+            peer_count: blockchain_info.trusted_bootstrap_peers.len() as u32,
+            chain_state: blockchain_info.chain_state,
             network_id: blockchain_info.network_id,
-            bootstrap_peers: discovered_peers,
+            bootstrap_peers: blockchain_info.trusted_bootstrap_peers,
             environment: environment.clone(),
         })
     }
@@ -788,33 +793,208 @@ impl DiscoveryCoordinator {
         Ok(Vec::new())
     }
 
-    /// Get blockchain info for discovered peers
-    /// NOTE: Actual blockchain sync happens via QUIC mesh protocol, not HTTP
-    /// This just returns basic info indicating peers were found
+    /// Get blockchain info for discovered peers.
+    ///
+    /// Discovery must distinguish:
+    /// - unknown remote chain state
+    /// - explicit genesis-only peers
+    /// - peers with committed blocks beyond genesis
     async fn fetch_blockchain_info(&self, peers: &[String]) -> Result<BlockchainInfo> {
-        // Don't query via HTTP - blockchain sync will happen via QUIC mesh protocol
-        // Just return info indicating we found peers to sync with
         let network_id = if peers.is_empty() {
             "zhtp-genesis".to_string()
         } else {
             info!(
-                "      Will sync blockchain via QUIC mesh from {} peer(s)",
+                "      Probing remote chain state across {} discovered peer(s)",
                 peers.len()
             );
             "zhtp-network".to_string()
         };
 
+        let probe = self.query_remote_chain_state(peers).await?;
+        let chain_state = probe.chain_state;
+        info!("      Remote chain state: {}", chain_state);
+
         Ok(BlockchainInfo {
-            height: 0, // Will be populated during QUIC mesh sync
+            chain_state,
             network_id,
+            trusted_bootstrap_peers: probe.trusted_bootstrap_peers,
         })
+    }
+
+    async fn query_remote_chain_state(
+        &self,
+        peers: &[String],
+    ) -> Result<RemoteChainProbe> {
+        use lib_identity::{IdentityType, ZhtpIdentity};
+        use lib_network::client::{ZhtpClient, ZhtpClientConfig};
+
+        #[derive(serde::Deserialize)]
+        struct TipInfo {
+            height: u64,
+        }
+
+        if peers.is_empty() {
+            return Ok(RemoteChainProbe {
+                chain_state: crate::runtime::RemoteChainState::Unknown,
+                trusted_bootstrap_peers: Vec::new(),
+            });
+        }
+
+        let timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let temp_identity = ZhtpIdentity::new_unified(
+            IdentityType::Device,
+            None,
+            None,
+            &format!("temp-discovery-sync-probe-{timestamp}"),
+            None,
+        )
+        .context("failed to create temporary identity for discovery probe")?;
+
+        let mut observed_genesis_only = false;
+        let mut highest_committed_height = 0u64;
+        let mut trusted_bootstrap_peers = Vec::new();
+
+        for peer in peers {
+            let peer_addr = match peer.parse::<std::net::SocketAddr>() {
+                Ok(addr) => addr,
+                Err(_) => {
+                    warn!(
+                        "      Skipping invalid bootstrap peer address during probe: {}",
+                        peer
+                    );
+                    continue;
+                }
+            };
+
+            let mut client = match ZhtpClient::new_bootstrap_with_config(
+                temp_identity.clone(),
+                ZhtpClientConfig {
+                    allow_bootstrap: true,
+                },
+            )
+            .await
+            {
+                Ok(client) => client,
+                Err(e) => {
+                    warn!(
+                        "      Failed to create QUIC probe client for {}: {}",
+                        peer_addr, e
+                    );
+                    continue;
+                }
+            };
+
+            match tokio::time::timeout(Duration::from_secs(10), client.connect(peer)).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    warn!(
+                        "      Failed to connect to {} during probe: {}",
+                        peer_addr, e
+                    );
+                    continue;
+                }
+                Err(_) => {
+                    warn!("      Timed out connecting to {} during probe", peer_addr);
+                    continue;
+                }
+            }
+
+            let peer_did = client.peer_did().map(str::to_owned);
+            if !crate::runtime::is_trusted_sync_source(
+                peer,
+                peer_did.as_deref(),
+                &self.config.trusted_sync_sources,
+            ) {
+                warn!(
+                    "      Skipping untrusted observer sync source {} (peer_did={})",
+                    peer_addr,
+                    peer_did.as_deref().unwrap_or("unknown")
+                );
+                continue;
+            }
+
+            let tip_resp = match tokio::time::timeout(
+                Duration::from_secs(10),
+                client.get("/api/v1/blockchain/tip"),
+            )
+            .await
+            {
+                Ok(Ok(response)) => response,
+                Ok(Err(e)) => {
+                    warn!("      Failed to query chain tip from {}: {}", peer_addr, e);
+                    continue;
+                }
+                Err(_) => {
+                    warn!("      Timed out querying chain tip from {}", peer_addr);
+                    continue;
+                }
+            };
+
+            if !tip_resp.is_success() {
+                warn!(
+                    "      Peer {} returned non-success for /api/v1/blockchain/tip",
+                    peer_addr
+                );
+                continue;
+            }
+
+            let tip: TipInfo = match serde_json::from_slice(&tip_resp.body) {
+                Ok(tip) => tip,
+                Err(e) => {
+                    warn!("      Failed to parse chain tip from {}: {}", peer_addr, e);
+                    continue;
+                }
+            };
+
+            trusted_bootstrap_peers.push(peer.clone());
+
+            if tip.height == 0 {
+                observed_genesis_only = true;
+                debug!("      Peer {} reports genesis-only chain state", peer_addr);
+            } else {
+                highest_committed_height = highest_committed_height.max(tip.height);
+                debug!(
+                    "      Peer {} reports committed chain height {}",
+                    peer_addr, tip.height
+                );
+            }
+        }
+
+        if highest_committed_height > 0 {
+            Ok(RemoteChainProbe {
+                chain_state: crate::runtime::RemoteChainState::Committed(
+                    highest_committed_height,
+                ),
+                trusted_bootstrap_peers,
+            })
+        } else if observed_genesis_only {
+            Ok(RemoteChainProbe {
+                chain_state: crate::runtime::RemoteChainState::GenesisOnly,
+                trusted_bootstrap_peers,
+            })
+        } else {
+            Ok(RemoteChainProbe {
+                chain_state: crate::runtime::RemoteChainState::Unknown,
+                trusted_bootstrap_peers,
+            })
+        }
     }
 }
 
 #[derive(Debug)]
 struct BlockchainInfo {
-    height: u64,
+    chain_state: crate::runtime::RemoteChainState,
     network_id: String,
+    trusted_bootstrap_peers: Vec<String>,
+}
+
+#[derive(Debug)]
+struct RemoteChainProbe {
+    chain_state: crate::runtime::RemoteChainState,
+    trusted_bootstrap_peers: Vec<String>,
 }
 
 impl Default for DiscoveryCoordinator {
@@ -823,6 +1003,7 @@ impl Default for DiscoveryCoordinator {
             vec![],
             9333,
             vec![DiscoveryProtocol::UdpMulticast, DiscoveryProtocol::DHT],
+            vec![],
         );
         Self::new(config)
     }
@@ -838,6 +1019,7 @@ mod tests {
             vec!["192.168.1.1:9333".to_string()],
             9333,
             vec![DiscoveryProtocol::UdpMulticast, DiscoveryProtocol::DHT],
+            vec![],
         );
         let coordinator = DiscoveryCoordinator::new(config);
         coordinator.start_event_listener().await;
@@ -879,7 +1061,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_protocol_stats() {
-        let config = DiscoveryConfig::new(vec![], 9333, vec![]);
+        let config = DiscoveryConfig::new(vec![], 9333, vec![], vec![]);
         let coordinator = DiscoveryCoordinator::new(config);
 
         coordinator

--- a/zhtp/src/discovery_coordinator.rs
+++ b/zhtp/src/discovery_coordinator.rs
@@ -826,12 +826,7 @@ impl DiscoveryCoordinator {
         peers: &[String],
     ) -> Result<RemoteChainProbe> {
         use lib_identity::{IdentityType, ZhtpIdentity};
-        use lib_network::client::{ZhtpClient, ZhtpClientConfig};
-
-        #[derive(serde::Deserialize)]
-        struct TipInfo {
-            height: u64,
-        }
+        const MAX_CONCURRENT_PROBES: usize = 3;
 
         if peers.is_empty() {
             return Ok(RemoteChainProbe {
@@ -856,109 +851,55 @@ impl DiscoveryCoordinator {
         let mut observed_genesis_only = false;
         let mut highest_committed_height = 0u64;
         let mut trusted_bootstrap_peers = Vec::new();
+        let mut pending_peers = peers.iter().cloned();
+        let mut probe_tasks = tokio::task::JoinSet::new();
 
-        for peer in peers {
-            let peer_addr = match peer.parse::<std::net::SocketAddr>() {
-                Ok(addr) => addr,
-                Err(_) => {
-                    warn!(
-                        "      Skipping invalid bootstrap peer address during probe: {}",
-                        peer
-                    );
-                    continue;
-                }
+        while probe_tasks.len() < MAX_CONCURRENT_PROBES {
+            let Some(peer) = pending_peers.next() else {
+                break;
             };
-
-            let mut client = match ZhtpClient::new_bootstrap_with_config(
-                temp_identity.clone(),
-                ZhtpClientConfig {
-                    allow_bootstrap: true,
-                },
-            )
-            .await
-            {
-                Ok(client) => client,
-                Err(e) => {
-                    warn!(
-                        "      Failed to create QUIC probe client for {}: {}",
-                        peer_addr, e
-                    );
-                    continue;
-                }
-            };
-
-            match tokio::time::timeout(Duration::from_secs(10), client.connect(peer)).await {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => {
-                    warn!(
-                        "      Failed to connect to {} during probe: {}",
-                        peer_addr, e
-                    );
-                    continue;
-                }
-                Err(_) => {
-                    warn!("      Timed out connecting to {} during probe", peer_addr);
-                    continue;
-                }
-            }
-
-            let peer_did = client.peer_did().map(str::to_owned);
-            if !crate::runtime::is_trusted_sync_source(
+            spawn_remote_chain_probe_task(
+                &mut probe_tasks,
                 peer,
-                peer_did.as_deref(),
-                &self.config.trusted_sync_sources,
-            ) {
-                warn!(
-                    "      Skipping untrusted observer sync source {} (peer_did={})",
-                    peer_addr,
-                    peer_did.as_deref().unwrap_or("unknown")
-                );
-                continue;
-            }
+                temp_identity.clone(),
+                self.config.trusted_sync_sources.clone(),
+            );
+        }
 
-            let tip_resp = match tokio::time::timeout(
-                Duration::from_secs(10),
-                client.get("/api/v1/blockchain/tip"),
-            )
-            .await
-            {
-                Ok(Ok(response)) => response,
-                Ok(Err(e)) => {
-                    warn!("      Failed to query chain tip from {}: {}", peer_addr, e);
-                    continue;
+        while let Some(join_result) = probe_tasks.join_next().await {
+            match join_result {
+                Ok(Some(peer_probe)) => {
+                    if peer_probe.is_trusted {
+                        trusted_bootstrap_peers.push(peer_probe.peer.clone());
+                    }
+
+                    match peer_probe.chain_state {
+                        crate::runtime::RemoteChainState::Committed(height) => {
+                            highest_committed_height = highest_committed_height.max(height);
+                        }
+                        crate::runtime::RemoteChainState::GenesisOnly => {
+                            observed_genesis_only = true;
+                        }
+                        crate::runtime::RemoteChainState::Unknown => {}
+                    }
                 }
-                Err(_) => {
-                    warn!("      Timed out querying chain tip from {}", peer_addr);
-                    continue;
-                }
-            };
-
-            if !tip_resp.is_success() {
-                warn!(
-                    "      Peer {} returned non-success for /api/v1/blockchain/tip",
-                    peer_addr
-                );
-                continue;
-            }
-
-            let tip: TipInfo = match serde_json::from_slice(&tip_resp.body) {
-                Ok(tip) => tip,
+                Ok(None) => {}
                 Err(e) => {
-                    warn!("      Failed to parse chain tip from {}: {}", peer_addr, e);
-                    continue;
+                    warn!("      Discovery probe task failed: {}", e);
                 }
-            };
+            }
 
-            trusted_bootstrap_peers.push(peer.clone());
+            if highest_committed_height > 0 {
+                probe_tasks.abort_all();
+                break;
+            }
 
-            if tip.height == 0 {
-                observed_genesis_only = true;
-                debug!("      Peer {} reports genesis-only chain state", peer_addr);
-            } else {
-                highest_committed_height = highest_committed_height.max(tip.height);
-                debug!(
-                    "      Peer {} reports committed chain height {}",
-                    peer_addr, tip.height
+            if let Some(peer) = pending_peers.next() {
+                spawn_remote_chain_probe_task(
+                    &mut probe_tasks,
+                    peer,
+                    temp_identity.clone(),
+                    self.config.trusted_sync_sources.clone(),
                 );
             }
         }
@@ -995,6 +936,141 @@ struct BlockchainInfo {
 struct RemoteChainProbe {
     chain_state: crate::runtime::RemoteChainState,
     trusted_bootstrap_peers: Vec<String>,
+}
+
+#[derive(Debug)]
+struct PeerChainProbe {
+    peer: String,
+    chain_state: crate::runtime::RemoteChainState,
+    is_trusted: bool,
+}
+
+fn spawn_remote_chain_probe_task(
+    probe_tasks: &mut tokio::task::JoinSet<Option<PeerChainProbe>>,
+    peer: String,
+    temp_identity: lib_identity::ZhtpIdentity,
+    trusted_sync_sources: Vec<crate::config::TrustedSyncSource>,
+) {
+    probe_tasks.spawn(async move {
+        use lib_network::client::{ZhtpClient, ZhtpClientConfig};
+
+        #[derive(serde::Deserialize)]
+        struct TipInfo {
+            height: u64,
+        }
+
+        let peer_addr = match peer.parse::<std::net::SocketAddr>() {
+            Ok(addr) => addr,
+            Err(_) => {
+                warn!(
+                    "      Skipping invalid bootstrap peer address during probe: {}",
+                    peer
+                );
+                return None;
+            }
+        };
+
+        let mut client = match ZhtpClient::new_bootstrap_with_config(
+            temp_identity,
+            ZhtpClientConfig {
+                allow_bootstrap: true,
+            },
+        )
+        .await
+        {
+            Ok(client) => client,
+            Err(e) => {
+                warn!(
+                    "      Failed to create QUIC probe client for {}: {}",
+                    peer_addr, e
+                );
+                return None;
+            }
+        };
+
+        match tokio::time::timeout(Duration::from_secs(10), client.connect(&peer)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!(
+                    "      Failed to connect to {} during probe: {}",
+                    peer_addr, e
+                );
+                return None;
+            }
+            Err(_) => {
+                warn!("      Timed out connecting to {} during probe", peer_addr);
+                return None;
+            }
+        }
+
+        let peer_did = client.peer_did().map(str::to_owned);
+        if !crate::runtime::is_trusted_sync_source(
+            &peer,
+            peer_did.as_deref(),
+            &trusted_sync_sources,
+        ) {
+            warn!(
+                "      Skipping untrusted observer sync source {} (peer_did={})",
+                peer_addr,
+                peer_did.as_deref().unwrap_or("unknown")
+            );
+            return Some(PeerChainProbe {
+                peer,
+                chain_state: crate::runtime::RemoteChainState::Unknown,
+                is_trusted: false,
+            });
+        }
+
+        let tip_resp = match tokio::time::timeout(
+            Duration::from_secs(10),
+            client.get("/api/v1/blockchain/tip"),
+        )
+        .await
+        {
+            Ok(Ok(response)) => response,
+            Ok(Err(e)) => {
+                warn!("      Failed to query chain tip from {}: {}", peer_addr, e);
+                return None;
+            }
+            Err(_) => {
+                warn!("      Timed out querying chain tip from {}", peer_addr);
+                return None;
+            }
+        };
+
+        if !tip_resp.is_success() {
+            warn!(
+                "      Peer {} returned non-success for /api/v1/blockchain/tip",
+                peer_addr
+            );
+            return None;
+        }
+
+        let tip: TipInfo = match serde_json::from_slice(&tip_resp.body) {
+            Ok(tip) => tip,
+            Err(e) => {
+                warn!("      Failed to parse chain tip from {}: {}", peer_addr, e);
+                return None;
+            }
+        };
+
+        let chain_state = if tip.height == 0 {
+            debug!("      Peer {} reports genesis-only chain state", peer_addr);
+            crate::runtime::RemoteChainState::GenesisOnly
+        } else {
+            debug!(
+                "      Peer {} reports committed chain height {}",
+                peer_addr, tip.height
+            );
+            crate::runtime::RemoteChainState::Committed(tip.height)
+        };
+
+        Some(PeerChainProbe {
+            peer,
+            chain_state,
+            is_trusted: true,
+        })
+    });
 }
 
 impl Default for DiscoveryCoordinator {

--- a/zhtp/src/runtime/blockchain_provider.rs
+++ b/zhtp/src/runtime/blockchain_provider.rs
@@ -245,10 +245,7 @@ async fn handle_wallet_registered(
     let storage = crate::runtime::storage_provider::get_global_storage().await?;
     let mut storage = storage.write().await;
     storage
-        .add_to_wallet_index(
-            &owner_identity_id_hex,
-            &wallet_id_hex,
-        )
+        .add_to_wallet_index(&owner_identity_id_hex, &wallet_id_hex)
         .await?;
 
     let pending = pending_wallet_projections()
@@ -295,7 +292,10 @@ async fn handle_wallet_registered(
                 .await?;
             }
             if let Some(wallet_private_record) = pending.wallet_private_record {
-                let path = format!("/wallet_private/{}/{}", pending.identity_id, pending.wallet_id);
+                let path = format!(
+                    "/wallet_private/{}/{}",
+                    pending.identity_id, pending.wallet_id
+                );
                 dht.store_content("wallet.zhtp", &path, wallet_private_record, 86400)
                     .await?;
             }
@@ -628,8 +628,14 @@ mod tests {
             .unwrap()
             .expect("identity cache record should exist");
         let value: serde_json::Value = serde_json::from_slice(&record).unwrap();
-        assert_eq!(value.get("display_name").and_then(|v| v.as_str()), Some("Event User"));
-        assert_eq!(value.get("device_id").and_then(|v| v.as_str()), Some("device-a"));
+        assert_eq!(
+            value.get("display_name").and_then(|v| v.as_str()),
+            Some("Event User")
+        );
+        assert_eq!(
+            value.get("device_id").and_then(|v| v.as_str()),
+            Some("device-a")
+        );
         assert!(guard
             .list_identity_ids()
             .await
@@ -686,7 +692,8 @@ mod tests {
             .unwrap()
             .is_some());
         assert_eq!(
-            guard.get_wallet_private_record(&"11".repeat(32), &"22".repeat(32))
+            guard
+                .get_wallet_private_record(&"11".repeat(32), &"22".repeat(32))
                 .await
                 .unwrap(),
             Some(vec![1, 2, 3, 4])
@@ -694,7 +701,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn committed_wallet_event_without_pending_projection_does_not_materialize_cache_records() {
+    async fn committed_wallet_event_without_pending_projection_does_not_materialize_cache_records()
+    {
         let _guard = test_guard().lock().await;
         let storage = install_test_storage().await;
 
@@ -724,13 +732,15 @@ mod tests {
             .unwrap()
             .contains(&"22".repeat(32)));
         assert_eq!(
-            guard.get_wallet_record(&"11".repeat(32), &"22".repeat(32))
+            guard
+                .get_wallet_record(&"11".repeat(32), &"22".repeat(32))
                 .await
                 .unwrap(),
             None
         );
         assert_eq!(
-            guard.get_wallet_private_record(&"11".repeat(32), &"22".repeat(32))
+            guard
+                .get_wallet_private_record(&"11".repeat(32), &"22".repeat(32))
                 .await
                 .unwrap(),
             None

--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -523,7 +523,14 @@ async fn run_catch_up_sync_task(
         // same-height peers (e.g. other nodes on the same stale fork) from the count.
         let mut ahead_peers_rejecting: u32 = 0;
         for peer in &prioritized_peers {
-            match catchup_sync_from_peer(&peer.addr, from_height, &blockchain_slot, &bft_active_height).await {
+            match catchup_sync_from_peer(
+                &peer.addr,
+                from_height,
+                &blockchain_slot,
+                &bft_active_height,
+            )
+            .await
+            {
                 Ok(0) => {
                     debug!(
                         "Catch-up sync: peer {} at same height ({})",
@@ -772,7 +779,11 @@ async fn catchup_sync_from_peer(
             .map(|s| s.get_block_by_height(0).ok().flatten().is_none())
             .unwrap_or(false)
     };
-    let first_fetch = if no_genesis_in_sled { 0u64 } else { our_height + 1 };
+    let first_fetch = if no_genesis_in_sled {
+        0u64
+    } else {
+        our_height + 1
+    };
     if no_genesis_in_sled {
         info!(
             "⬇️  Catch-up: sled has no genesis — will fetch from block 0 (peer tip={})",
@@ -788,7 +799,9 @@ async fn catchup_sync_from_peer(
 
     while next_start <= tip.height && pages < MAX_PAGES_PER_SYNC {
         let start = next_start;
-        let end = tip.height.min(start.saturating_add(MAX_BLOCKS_PER_PAGE - 1));
+        let end = tip
+            .height
+            .min(start.saturating_add(MAX_BLOCKS_PER_PAGE - 1));
 
         info!(
             "⬇️  Catch-up: fetching blocks {}-{} from {} (peer tip={})",
@@ -835,29 +848,24 @@ async fn catchup_sync_from_peer(
             // Fallback: blocks without a proof (pre-upgrade, or peer doesn't have
             // one) are still blocked by the height guard for safety.
             let bft_height = bft_active_height.load(std::sync::atomic::Ordering::Acquire);
-            let verified_proof: Option<lib_types::consensus::BftQuorumProof> =
-                if bft_height > 0 && height >= bft_height {
-                    // Block is in the BFT-active zone.  Fetch + verify a quorum
-                    // proof from the peer BEFORE acquiring the write lock.
-                    match fetch_and_verify_quorum_proof(
-                        &mut client,
-                        &block,
-                        &blockchain_arc,
-                    )
-                    .await
-                    {
-                        Some(proof) => Some(proof),
-                        None => {
-                            debug!(
-                                "Catch-up: skipping block {} (BFT active at {}, no valid proof)",
-                                height, bft_height
-                            );
-                            break;
-                        }
+            let verified_proof: Option<lib_types::consensus::BftQuorumProof> = if bft_height > 0
+                && height >= bft_height
+            {
+                // Block is in the BFT-active zone.  Fetch + verify a quorum
+                // proof from the peer BEFORE acquiring the write lock.
+                match fetch_and_verify_quorum_proof(&mut client, &block, &blockchain_arc).await {
+                    Some(proof) => Some(proof),
+                    None => {
+                        debug!(
+                            "Catch-up: skipping block {} (BFT active at {}, no valid proof)",
+                            height, bft_height
+                        );
+                        break;
                     }
-                } else {
-                    None
-                };
+                }
+            } else {
+                None
+            };
 
             let mut bc = blockchain_arc.write().await;
 
@@ -944,7 +952,10 @@ async fn fetch_and_verify_quorum_proof(
 
     let proof: lib_types::consensus::BftQuorumProof =
         bincode::deserialize(&resp.body).ok().or_else(|| {
-            tracing::debug!("Catch-up: quorum proof deserialize failed for height {}", height);
+            tracing::debug!(
+                "Catch-up: quorum proof deserialize failed for height {}",
+                height
+            );
             None
         })?;
 
@@ -955,7 +966,8 @@ async fn fetch_and_verify_quorum_proof(
         Err(e) => {
             tracing::warn!(
                 "Catch-up: block {} quorum proof has inconsistent proposal_ids: {}",
-                height, e
+                height,
+                e
             );
             return None;
         }
@@ -1000,10 +1012,7 @@ async fn fetch_and_verify_quorum_proof(
             Some(proof)
         }
         Err(e) => {
-            tracing::warn!(
-                "Catch-up: block {} quorum proof INVALID: {}",
-                height, e
-            );
+            tracing::warn!("Catch-up: block {} quorum proof INVALID: {}", height, e);
             None
         }
     }
@@ -1107,7 +1116,8 @@ impl lib_consensus::types::BlockCommitCallback for ConsensusBlockCommitter {
                             proposal.height,
                             hex::encode(&stored_hash.0[..8]),
                             hex::encode(&bft_hash[..8]),
-                        ).into());
+                        )
+                        .into());
                     }
                 }
             }
@@ -1401,7 +1411,10 @@ impl lib_consensus::types::ConsensusBlockchainProvider for ConsensusBlockchainAd
         // This is the last-line defense: even if a stale tx slipped past
         // mempool admission, it will be filtered out here before the
         // proposer includes it in the BFT proposal.
-        let nonce_valid: Vec<bool> = pending.iter().map(|tx| blockchain.is_nonce_current(tx)).collect();
+        let nonce_valid: Vec<bool> = pending
+            .iter()
+            .map(|tx| blockchain.is_nonce_current(tx))
+            .collect();
         let previous_hash = blockchain
             .latest_block()
             .map(|b| b.hash())
@@ -1556,7 +1569,7 @@ pub fn decode_bootstrap_consensus_key(consensus_key_hex: &str) -> Option<[u8; 25
     if bytes.len() != 2592 {
         return None;
     }
-    
+
     Some(bytes.as_slice().try_into().ok()?)
 }
 
@@ -1780,13 +1793,25 @@ async fn load_local_validator_from_keystore() -> Result<(IdentityId, lib_crypto:
     }
 
     // Consensus identity uses Dilithium public key bytes for signature verification.
-    let dilithium_pk: [u8; 2592] = ks.dilithium_pk.as_slice().try_into()
+    let dilithium_pk: [u8; 2592] = ks
+        .dilithium_pk
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid dilithium_pk length, expected 2592 bytes"))?;
-    let dilithium_sk: [u8; 4896] = ks.dilithium_sk.as_slice().try_into()
+    let dilithium_sk: [u8; 4896] = ks
+        .dilithium_sk
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid dilithium_sk length, expected 4896 bytes"))?;
-    let kyber_sk: [u8; 3168] = ks.kyber_sk.as_slice().try_into()
+    let kyber_sk: [u8; 3168] = ks
+        .kyber_sk
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid kyber_sk length, expected 3168 bytes"))?;
-    let master_seed: [u8; 64] = ks.master_seed.as_slice().try_into()
+    let master_seed: [u8; 64] = ks
+        .master_seed
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid master_seed length, expected 64 bytes"))?;
     let public_key = lib_crypto::PublicKey::new(dilithium_pk);
     let private_key = lib_crypto::PrivateKey {
@@ -1989,37 +2014,43 @@ impl Component for ConsensusComponent {
         config.development_mode = is_development;
         if config.development_mode {
             info!("🔧 Development mode enabled — single-validator consensus allowed for local testing");
-            info!("   Testnet and Mainnet require minimum {} validators for BFT", lib_consensus::engines::consensus_engine::BFT_MIN_VALIDATORS);
+            info!(
+                "   Testnet and Mainnet require minimum {} validators for BFT",
+                lib_consensus::engines::consensus_engine::BFT_MIN_VALIDATORS
+            );
         } else {
-            info!("🛡️ BFT-only mode: Full consensus validation required (minimum {} validators)", lib_consensus::engines::consensus_engine::BFT_MIN_VALIDATORS);
+            info!(
+                "🛡️ BFT-only mode: Full consensus validation required (minimum {} validators)",
+                lib_consensus::engines::consensus_engine::BFT_MIN_VALIDATORS
+            );
         }
 
         // Create broadcaster — requires the mesh router set by Protocols component.
         // Protocols.start() is awaited before Consensus.start() in startup_sequence,
         // so the mesh router is guaranteed to be available here unless Protocols failed.
         // Development mode allows NoOpBroadcaster for single-node local testing.
-        let broadcaster: Arc<dyn ConsensusMessageBroadcaster> =
-            match get_global_mesh_router().await {
-                Ok(mesh_router) => {
-                    info!("Mesh router available — multi-node consensus broadcasting enabled");
-                    Arc::new(ConsensusMeshBroadcaster::new(mesh_router))
-                }
-                Err(e) if is_development => {
-                    warn!(
-                        "Mesh router not available: {} — development mode, using NoOpBroadcaster",
-                        e
-                    );
-                    Arc::new(NoOpBroadcaster)
-                }
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "Mesh router not available: {}. \
+        let broadcaster: Arc<dyn ConsensusMessageBroadcaster> = match get_global_mesh_router().await
+        {
+            Ok(mesh_router) => {
+                info!("Mesh router available — multi-node consensus broadcasting enabled");
+                Arc::new(ConsensusMeshBroadcaster::new(mesh_router))
+            }
+            Err(e) if is_development => {
+                warn!(
+                    "Mesh router not available: {} — development mode, using NoOpBroadcaster",
+                    e
+                );
+                Arc::new(NoOpBroadcaster)
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "Mesh router not available: {}. \
                          BFT consensus requires a working broadcaster to reach quorum. \
                          Ensure the Protocols component started successfully before Consensus.",
-                        e
-                    ));
-                }
-            };
+                    e
+                ));
+            }
+        };
 
         let mut consensus_engine = lib_consensus::init_consensus(config, broadcaster)?;
         let (liveness_tx, mut liveness_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -2294,8 +2325,13 @@ impl Component for ConsensusComponent {
                 std::path::Path::new(&self.environment.data_directory()).join("sled");
             let bft_height_for_sync = bft_active_height.clone();
             tokio::spawn(async move {
-                run_catch_up_sync_task(catch_up_rx, blockchain_slot_for_sync, sled_path_for_sync, bft_height_for_sync)
-                    .await;
+                run_catch_up_sync_task(
+                    catch_up_rx,
+                    blockchain_slot_for_sync,
+                    sled_path_for_sync,
+                    bft_height_for_sync,
+                )
+                .await;
             });
             info!("🔄 Catch-up sync trigger wired (height-divergence recovery active)");
         }
@@ -2374,7 +2410,10 @@ impl Component for ConsensusComponent {
                     match result {
                         Ok((added, _skipped)) => {
                             if added > 0 {
-                                info!("Periodic validator sync: {} new validator(s) from blockchain", added);
+                                info!(
+                                    "Periodic validator sync: {} new validator(s) from blockchain",
+                                    added
+                                );
                             }
                         }
                         Err(e) => {
@@ -2394,14 +2433,22 @@ impl Component for ConsensusComponent {
                     } else {
                         None
                     };
-                    let entries: Vec<lib_consensus::engines::consensus_engine::ValidatorUpdateEntry> =
-                        active_validators.iter().map(|v| {
-                            let identity_hex = v.identity_id.strip_prefix("did:zhtp:").unwrap_or(&v.identity_id);
+                    let entries: Vec<
+                        lib_consensus::engines::consensus_engine::ValidatorUpdateEntry,
+                    > = active_validators
+                        .iter()
+                        .map(|v| {
+                            let identity_hex = v
+                                .identity_id
+                                .strip_prefix("did:zhtp:")
+                                .unwrap_or(&v.identity_id);
                             let identity_id = if let Ok(bytes) = hex::decode(identity_hex) {
                                 if bytes.len() >= 32 {
                                     lib_crypto::Hash::from_bytes(&bytes[..32])
                                 } else {
-                                    lib_crypto::Hash(lib_crypto::hash_blake3(v.identity_id.as_bytes()))
+                                    lib_crypto::Hash(lib_crypto::hash_blake3(
+                                        v.identity_id.as_bytes(),
+                                    ))
                                 }
                             } else {
                                 lib_crypto::Hash(lib_crypto::hash_blake3(v.identity_id.as_bytes()))
@@ -2411,7 +2458,8 @@ impl Component for ConsensusComponent {
                                 stake: v.stake,
                                 consensus_key: v.consensus_key.clone(),
                             }
-                        }).collect();
+                        })
+                        .collect();
                     let update = lib_consensus::ValidatorSetUpdate {
                         entries,
                         local_identity,

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -361,8 +361,10 @@ fn reconstruct_identity_manager_from_blockchain_state(
     identity_registry: &HashMap<String, lib_blockchain::transaction::IdentityTransactionData>,
     wallet_registry: &HashMap<String, lib_blockchain::transaction::WalletTransactionData>,
 ) -> Result<(u32, u32)> {
-    let mut wallets_by_owner: HashMap<String, Vec<&lib_blockchain::transaction::WalletTransactionData>> =
-        HashMap::new();
+    let mut wallets_by_owner: HashMap<
+        String,
+        Vec<&lib_blockchain::transaction::WalletTransactionData>,
+    > = HashMap::new();
     for wallet in wallet_registry.values() {
         if let Some(owner_identity_id) = wallet.owner_identity_id {
             wallets_by_owner
@@ -395,7 +397,11 @@ fn reconstruct_identity_manager_from_blockchain_state(
         }
 
         let public_key = lib_crypto::PublicKey::new(
-            identity_data.public_key.as_slice().try_into().unwrap_or([0u8; 2592])
+            identity_data
+                .public_key
+                .as_slice()
+                .try_into()
+                .unwrap_or([0u8; 2592]),
         );
         let display_name = if identity_data.display_name.is_empty() {
             None
@@ -413,8 +419,9 @@ fn reconstruct_identity_manager_from_blockchain_state(
             display_name,
             identity_data.created_at,
         )?;
-        identity.did_document_hash =
-            Some(lib_crypto::Hash::from_bytes(identity_data.did_document_hash.as_bytes()));
+        identity.did_document_hash = Some(lib_crypto::Hash::from_bytes(
+            identity_data.did_document_hash.as_bytes(),
+        ));
         identity.wallet_manager.wallets.clear();
         identity.wallet_manager.total_balance = 0;
 
@@ -915,7 +922,10 @@ async fn bootstrap_identities_from_dht(
                     let pk_array: [u8; 2592] = match bytes.as_slice().try_into() {
                         Ok(arr) => arr,
                         Err(_) => {
-                            warn!("Invalid public key length for identity {}, expected 2592 bytes", id_preview);
+                            warn!(
+                                "Invalid public key length for identity {}, expected 2592 bytes",
+                                id_preview
+                            );
                             continue;
                         }
                     };
@@ -1331,8 +1341,12 @@ mod tests {
         );
 
         let (identities_loaded, wallets_loaded) =
-            reconstruct_identity_manager_from_blockchain_state(&mut manager, &identities, &HashMap::new())
-                .expect("device identities should be skipped cleanly");
+            reconstruct_identity_manager_from_blockchain_state(
+                &mut manager,
+                &identities,
+                &HashMap::new(),
+            )
+            .expect("device identities should be skipped cleanly");
 
         assert_eq!(identities_loaded, 0);
         assert_eq!(wallets_loaded, 0);

--- a/zhtp/src/runtime/did_startup.rs
+++ b/zhtp/src/runtime/did_startup.rs
@@ -127,14 +127,46 @@ fn load_from_keystore(
         .map_err(|e| KeystoreError::Corrupt(user_private_key_file.clone(), e.to_string()))?;
 
     let user_private_key = PrivateKey {
-        dilithium_sk: user_keystore_key.dilithium_sk.as_slice().try_into()
-            .map_err(|_| KeystoreError::Corrupt(user_private_key_file.clone(), "Invalid dilithium_sk length".to_string()))?,
-        dilithium_pk: user_keystore_key.dilithium_pk.as_slice().try_into()
-            .map_err(|_| KeystoreError::Corrupt(user_private_key_file.clone(), "Invalid dilithium_pk length".to_string()))?,
-        kyber_sk: user_keystore_key.kyber_sk.as_slice().try_into()
-            .map_err(|_| KeystoreError::Corrupt(user_private_key_file.clone(), "Invalid kyber_sk length".to_string()))?,
-        master_seed: user_keystore_key.master_seed.as_slice().try_into()
-            .map_err(|_| KeystoreError::Corrupt(user_private_key_file.clone(), "Invalid master_seed length".to_string()))?,
+        dilithium_sk: user_keystore_key
+            .dilithium_sk
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                KeystoreError::Corrupt(
+                    user_private_key_file.clone(),
+                    "Invalid dilithium_sk length".to_string(),
+                )
+            })?,
+        dilithium_pk: user_keystore_key
+            .dilithium_pk
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                KeystoreError::Corrupt(
+                    user_private_key_file.clone(),
+                    "Invalid dilithium_pk length".to_string(),
+                )
+            })?,
+        kyber_sk: user_keystore_key
+            .kyber_sk
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                KeystoreError::Corrupt(
+                    user_private_key_file.clone(),
+                    "Invalid kyber_sk length".to_string(),
+                )
+            })?,
+        master_seed: user_keystore_key
+            .master_seed
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                KeystoreError::Corrupt(
+                    user_private_key_file.clone(),
+                    "Invalid master_seed length".to_string(),
+                )
+            })?,
     };
 
     let mut user_identity =
@@ -152,14 +184,46 @@ fn load_from_keystore(
         .map_err(|e| KeystoreError::Corrupt(node_private_key_file.clone(), e.to_string()))?;
 
     let node_private_key = PrivateKey {
-        dilithium_sk: node_keystore_key.dilithium_sk.as_slice().try_into()
-            .map_err(|_| KeystoreError::Corrupt(node_private_key_file.clone(), "Invalid dilithium_sk length".to_string()))?,
-        dilithium_pk: node_keystore_key.dilithium_pk.as_slice().try_into()
-            .map_err(|_| KeystoreError::Corrupt(node_private_key_file.clone(), "Invalid dilithium_pk length".to_string()))?,
-        kyber_sk: node_keystore_key.kyber_sk.as_slice().try_into()
-            .map_err(|_| KeystoreError::Corrupt(node_private_key_file.clone(), "Invalid kyber_sk length".to_string()))?,
-        master_seed: node_keystore_key.master_seed.as_slice().try_into()
-            .map_err(|_| KeystoreError::Corrupt(node_private_key_file.clone(), "Invalid master_seed length".to_string()))?,
+        dilithium_sk: node_keystore_key
+            .dilithium_sk
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                KeystoreError::Corrupt(
+                    node_private_key_file.clone(),
+                    "Invalid dilithium_sk length".to_string(),
+                )
+            })?,
+        dilithium_pk: node_keystore_key
+            .dilithium_pk
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                KeystoreError::Corrupt(
+                    node_private_key_file.clone(),
+                    "Invalid dilithium_pk length".to_string(),
+                )
+            })?,
+        kyber_sk: node_keystore_key
+            .kyber_sk
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                KeystoreError::Corrupt(
+                    node_private_key_file.clone(),
+                    "Invalid kyber_sk length".to_string(),
+                )
+            })?,
+        master_seed: node_keystore_key
+            .master_seed
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                KeystoreError::Corrupt(
+                    node_private_key_file.clone(),
+                    "Invalid master_seed length".to_string(),
+                )
+            })?,
     };
 
     let node_identity = ZhtpIdentity::from_serialized(&node_identity_data, &node_private_key)
@@ -420,13 +484,25 @@ pub async fn load_node_identity_from_keystore(
         .map_err(|e| anyhow!("Failed to parse node private key: {}", e))?;
 
     let private_key = PrivateKey {
-        dilithium_sk: keystore_key.dilithium_sk.as_slice().try_into()
+        dilithium_sk: keystore_key
+            .dilithium_sk
+            .as_slice()
+            .try_into()
             .map_err(|_| anyhow!("Invalid dilithium_sk length"))?,
-        dilithium_pk: keystore_key.dilithium_pk.as_slice().try_into()
+        dilithium_pk: keystore_key
+            .dilithium_pk
+            .as_slice()
+            .try_into()
             .map_err(|_| anyhow!("Invalid dilithium_pk length"))?,
-        kyber_sk: keystore_key.kyber_sk.as_slice().try_into()
+        kyber_sk: keystore_key
+            .kyber_sk
+            .as_slice()
+            .try_into()
             .map_err(|_| anyhow!("Invalid kyber_sk length"))?,
-        master_seed: keystore_key.master_seed.as_slice().try_into()
+        master_seed: keystore_key
+            .master_seed
+            .as_slice()
+            .try_into()
             .map_err(|_| anyhow!("Invalid master_seed length"))?,
     };
 

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1346,10 +1346,10 @@ impl RuntimeOrchestrator {
             return Ok(());
         }
 
-        let keystore_path = dirs::home_dir()
-            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?
-            .join(".zhtp")
-            .join("keystore");
+        let keystore_path = std::env::var_os("ZHTP_KEYSTORE_DIR")
+            .map(std::path::PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|home| home.join(".zhtp").join("keystore")))
+            .ok_or_else(|| anyhow::anyhow!("Could not determine keystore directory"))?;
 
         let local_identity =
             crate::runtime::did_startup::load_node_identity_from_keystore(&keystore_path).await?;

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -21,10 +21,39 @@ use crate::runtime::node_identity::{
 #[derive(Debug, Clone)]
 pub struct ExistingNetworkInfo {
     pub peer_count: u32,
-    pub blockchain_height: u64,
+    pub chain_state: RemoteChainState,
     pub network_id: String,
     pub bootstrap_peers: Vec<String>,
     pub environment: crate::config::Environment,
+}
+
+/// Truth model for remote peer chain availability during startup.
+///
+/// A discovered peer address does not imply that chain state is known or syncable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteChainState {
+    /// Discovery found peers, but their chain state could not be proven yet.
+    Unknown,
+    /// At least one peer explicitly reported genesis height with no committed blocks beyond it.
+    GenesisOnly,
+    /// At least one peer proved committed blocks beyond genesis.
+    Committed(u64),
+}
+
+impl RemoteChainState {
+    pub fn has_committed_blocks(&self) -> bool {
+        matches!(self, Self::Committed(height) if *height > 0)
+    }
+}
+
+impl std::fmt::Display for RemoteChainState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unknown => write!(f, "unknown"),
+            Self::GenesisOnly => write!(f, "genesis-only"),
+            Self::Committed(height) => write!(f, "committed(height={height})"),
+        }
+    }
 }
 
 pub mod blockchain_provider;
@@ -87,6 +116,7 @@ pub use shared_dht::*;
 async fn try_initial_sync_from_peer(
     store: std::sync::Arc<lib_blockchain::storage::SledStore>,
     peers: &[String],
+    trusted_sync_sources: &[crate::config::TrustedSyncSource],
 ) -> anyhow::Result<bool> {
     use lib_blockchain::storage::BlockchainStore;
     use lib_blockchain::sync::ChainSync;
@@ -169,6 +199,16 @@ async fn try_initial_sync_from_peer(
                 warn!("⚠️  Connect timeout to {}", peer_addr);
                 continue;
             }
+        }
+
+        let peer_did = client.peer_did().map(str::to_owned);
+        if !is_trusted_sync_source(peer, peer_did.as_deref(), trusted_sync_sources) {
+            warn!(
+                "⚠️  Skipping untrusted sync source {} (peer_did={})",
+                peer_addr,
+                peer_did.as_deref().unwrap_or("unknown")
+            );
+            continue;
         }
 
         // Check the peer's chain tip.
@@ -332,6 +372,25 @@ async fn try_initial_sync_from_peer(
         // All peers were unreachable or at height 0 — safe to create genesis.
         Ok(false)
     }
+}
+
+pub(crate) fn is_trusted_sync_source(
+    peer_address: &str,
+    peer_did: Option<&str>,
+    trusted_sync_sources: &[crate::config::TrustedSyncSource],
+) -> bool {
+    if trusted_sync_sources.is_empty() {
+        return true;
+    }
+
+    trusted_sync_sources.iter().any(|trusted| {
+        trusted.address == peer_address
+            && trusted
+                .peer_did
+                .as_deref()
+                .map(|expected_did| Some(expected_did) == peer_did)
+                .unwrap_or(true)
+    })
 }
 
 /// Component status information
@@ -1227,10 +1286,96 @@ impl RuntimeOrchestrator {
 
     /// Standalone observers must join an existing network unless they already have
     /// local chain state. They are not allowed to create a fresh genesis on an
-    /// empty store, and a peer set advertising only genesis height is treated as
-    /// "not ready" until blocks beyond genesis are committed.
+    /// empty store, and discovery must distinguish unknown remote state from an
+    /// explicit genesis-only network until blocks beyond genesis are committed.
     fn observer_requires_existing_network(config: &NodeConfig, has_local_chain_data: bool) -> bool {
         matches!(config.node_type, Some(crate::config::NodeType::FullNode)) && !has_local_chain_data
+    }
+
+    fn observer_admission_required(config: &NodeConfig) -> bool {
+        matches!(config.node_type, Some(crate::config::NodeType::FullNode))
+            && config.network_config.observer_admission.required
+    }
+
+    fn trusted_sync_sources(config: &NodeConfig) -> &[crate::config::TrustedSyncSource] {
+        &config.network_config.observer_admission.trusted_sync_sources
+    }
+
+    fn validate_observer_admission_policy_config(
+        config: &NodeConfig,
+        has_local_chain_data: bool,
+    ) -> Result<()> {
+        if !Self::observer_admission_required(config) {
+            return Ok(());
+        }
+
+        if config
+            .network_config
+            .observer_admission
+            .authorized_observer_dids
+            .is_empty()
+        {
+            return Err(anyhow::anyhow!(
+                "Observer admission is required, but no authorized observer DIDs were configured."
+            ));
+        }
+
+        if Self::observer_requires_existing_network(config, has_local_chain_data)
+            && Self::trusted_sync_sources(config).is_empty()
+        {
+            return Err(anyhow::anyhow!(
+                "Observer admission is required for a fresh observer, but no trusted sync sources were configured."
+            ));
+        }
+
+        for trusted_source in Self::trusted_sync_sources(config) {
+            Self::validate_validator_endpoint(&trusted_source.address).map_err(|e| {
+                anyhow::anyhow!(
+                    "Invalid trusted observer sync source `{}`: {}",
+                    trusted_source.address,
+                    e
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+
+    async fn validate_local_observer_admission(&self) -> Result<()> {
+        if !Self::observer_admission_required(&self.config) {
+            return Ok(());
+        }
+
+        let keystore_path = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?
+            .join(".zhtp")
+            .join("keystore");
+
+        let local_identity =
+            crate::runtime::did_startup::load_node_identity_from_keystore(&keystore_path).await?;
+        let local_identity = local_identity.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Observer admission is required, but no local node DID was available in the keystore."
+            )
+        })?;
+
+        let admitted = self
+            .config
+            .network_config
+            .observer_admission
+            .authorized_observer_dids
+            .iter()
+            .any(|did| did == &local_identity.did);
+
+        if admitted {
+            info!("✓ Local observer DID admitted: {}", local_identity.did);
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "Observer DID `{}` is not admitted by config-backed observer admission policy.",
+                local_identity.did
+            ))
+        }
     }
 
     fn validate_observer_join_policy(
@@ -1243,7 +1388,7 @@ impl RuntimeOrchestrator {
         }
 
         if network_info
-            .map(|info| info.blockchain_height > 0)
+            .map(|info| info.chain_state.has_committed_blocks())
             .unwrap_or(false)
         {
             return Ok(());
@@ -1251,16 +1396,16 @@ impl RuntimeOrchestrator {
 
         let configured_bootstrap_peers = config.network_config.bootstrap_peers.len();
         let discovered_peer_count = network_info.map(|info| info.peer_count).unwrap_or(0);
-        let discovered_height = network_info
-            .map(|info| info.blockchain_height)
-            .unwrap_or_default();
+        let discovered_chain_state = network_info
+            .map(|info| info.chain_state.to_string())
+            .unwrap_or_else(|| RemoteChainState::Unknown.to_string());
 
         Err(anyhow::anyhow!(
             "Observer/full-node startup requires an existing network with committed blocks beyond genesis. \
-             Local chain state is empty, discovered peers={}, discovered_height={}, \
+             Local chain state is empty, discovered peers={}, discovered_chain_state={}, \
              configured_bootstrap_peers={}. Refusing to create genesis in observer mode.",
             discovered_peer_count,
-            discovered_height,
+            discovered_chain_state,
             configured_bootstrap_peers
         ))
     }
@@ -1673,9 +1818,13 @@ impl RuntimeOrchestrator {
             .ok()
             .flatten();
 
-        // Only join an existing network if at least one peer has committed blocks (height > 0).
-        // When all nodes start fresh simultaneously (e.g. full wipe) every peer reports height 0.
-        // In that case treat it as a new network and let this node create genesis.
+        let has_local_chain_data = self.has_local_chain_data();
+        Self::validate_observer_admission_policy_config(&self.config, has_local_chain_data)?;
+        self.validate_local_observer_admission().await?;
+
+        // Only join an existing network if at least one peer proves committed blocks.
+        // Unknown remote state and explicit genesis-only peers are both non-joinable,
+        // but they remain distinct conditions for observer startup policy and logging.
         //
         // Bootstrap leader with local chain data must NOT wait on peer startup/sync.
         // This keeps G1 deterministic across restarts and avoids startup races.
@@ -1690,14 +1839,14 @@ impl RuntimeOrchestrator {
             }
         };
         let leader_has_local_data =
-            Self::should_skip_startup_sync(local_is_bootstrap_leader, self.has_local_chain_data());
+            Self::should_skip_startup_sync(local_is_bootstrap_leader, has_local_chain_data);
         let joined_existing_network = if leader_has_local_data {
             info!("🌱 Bootstrap leader with local chain data detected - skipping startup sync");
             false
         } else {
             network_info
                 .as_ref()
-                .map(|ni| ni.blockchain_height > 0)
+                .map(|ni| ni.chain_state.has_committed_blocks())
                 .unwrap_or(false)
         };
         self.set_joined_existing_network(joined_existing_network)
@@ -1860,7 +2009,8 @@ impl RuntimeOrchestrator {
                             bc.height
                         );
                         bc.set_store(store.clone());
-                        let store_ref: &dyn lib_blockchain::storage::BlockchainStore = store.as_ref();
+                        let store_ref: &dyn lib_blockchain::storage::BlockchainStore =
+                            store.as_ref();
                         let mut migration_ok = true;
                         for block in &bc.blocks {
                             let h = block.height();
@@ -1910,6 +2060,12 @@ impl RuntimeOrchestrator {
                 // may have mined additional blocks while we were importing, so we
                 // keep draining until the peer reports no blocks ahead (Ok(false))
                 // or we've closed the gap enough (MAX_CATCHUP_ROUNDS limit).
+                let is_validator_node = self.config.consensus_config.validator_enabled;
+                let observer_requires_existing_network = Self::observer_requires_existing_network(
+                    &self.config,
+                    self.has_local_chain_data(),
+                );
+
                 if let Some(ref net_info) = network_info {
                     if !net_info.bootstrap_peers.is_empty() {
                         const MAX_CATCHUP_ROUNDS: u32 = 10;
@@ -1918,6 +2074,7 @@ impl RuntimeOrchestrator {
                             match try_initial_sync_from_peer(
                                 store.clone(),
                                 &net_info.bootstrap_peers,
+                                Self::trusted_sync_sources(&self.config),
                             )
                             .await
                             {
@@ -1960,6 +2117,11 @@ impl RuntimeOrchestrator {
                                             );
                                             synced_blockchain = Some(bc);
                                         }
+                                    } else if observer_requires_existing_network {
+                                        info!(
+                                            "ℹ️  No bootstrap peer has committed blocks yet; \
+                                             observer startup will keep waiting for an existing network."
+                                        );
                                     } else {
                                         info!("ℹ️  No peers have chain data; this node will create genesis.");
                                     }
@@ -1995,16 +2157,11 @@ impl RuntimeOrchestrator {
                     network_info.as_ref(),
                 )?;
 
-                // Non-bootstrap-leader, non-validator nodes wait here for the bootstrap
-                // leader to create genesis. Validator nodes skip this wait and will hit
-                // the genesis-gate bail! below — they need to either sync from the leader
-                // or be the leader themselves.
-                //
-                // The "independent genesis" approach caused divergent genesis blocks when
-                // nodes started with wiped sled. Now only the bootstrap leader can create
-                // genesis; all other nodes MUST sync from it.
-                let is_validator_node = self.config.consensus_config.validator_enabled;
-                if synced_blockchain.is_none() && !local_is_bootstrap_leader && !is_validator_node {
+                // Observers must never fall through to the genesis creation branch.
+                // Once startup has established that no committed peer data is available
+                // yet, stay in an explicit observer-only wait loop until a peer advances
+                // beyond genesis and can serve block data.
+                if synced_blockchain.is_none() && observer_requires_existing_network {
                     let retry_peers: Vec<_> = network_info
                         .as_ref()
                         .map(|ni| ni.bootstrap_peers.clone())
@@ -2012,8 +2169,8 @@ impl RuntimeOrchestrator {
 
                     loop {
                         info!(
-                            "⏳ Not bootstrap leader — waiting for leader to mine genesis. \
-                             Retrying peer sync in 30s (peers: {})...",
+                            "⏳ Observer has no local chain yet; waiting for bootstrap peers \
+                             to expose committed blocks. Retrying peer sync in 30s (peers: {})...",
                             retry_peers.len()
                         );
                         tokio::time::sleep(std::time::Duration::from_secs(30)).await;
@@ -2023,13 +2180,19 @@ impl RuntimeOrchestrator {
                             continue;
                         }
 
-                        match try_initial_sync_from_peer(store.clone(), &retry_peers).await {
+                        match try_initial_sync_from_peer(
+                            store.clone(),
+                            &retry_peers,
+                            Self::trusted_sync_sources(&self.config),
+                        )
+                        .await
+                        {
                             Ok(true) => {
                                 if let Some(bc) =
                                     lib_blockchain::Blockchain::load_from_store(store.clone())?
                                 {
                                     info!(
-                                        "📂 Non-leader successfully synced from leader \
+                                        "📂 Observer synced committed blocks from peer \
                                          (height: {})",
                                         bc.height
                                     );
@@ -2039,12 +2202,12 @@ impl RuntimeOrchestrator {
                             }
                             Ok(false) => {
                                 info!(
-                                    "⏳ Bootstrap leader peers still at height 0; \
-                                     leader hasn't mined yet..."
+                                    "⏳ Bootstrap peers are still advertising height 0; \
+                                     observer will keep waiting for committed blocks..."
                                 );
                             }
                             Err(e) => {
-                                warn!("⚠️  Non-leader sync retry failed: {}; will retry...", e);
+                                warn!("⚠️  Observer peer sync retry failed: {}; will retry...", e);
                             }
                         }
                     }
@@ -2074,7 +2237,7 @@ impl RuntimeOrchestrator {
                     if let Some(genesis_block) = bc.blocks.first() {
                         let genesis_hash = hex::encode(genesis_block.header.block_hash.as_bytes());
                         info!("🔗 Genesis block hash: {}", genesis_hash);
-                        
+
                         // CRITICAL: Persist genesis block (height 0) to SledStore
                         // SledStore requires sequential block storage starting from 0
                         let store_ref: &dyn lib_blockchain::storage::BlockchainStore =
@@ -2095,10 +2258,10 @@ impl RuntimeOrchestrator {
                 } else {
                     // ─────────────────────────────────────────────────────────────
                     // GENESIS GATE: Non-bootstrap leader nodes CANNOT create genesis.
-                    // 
+                    //
                     // This prevents the "divergent genesis" bug where multiple nodes
                     // starting with wiped sled produce different genesis blocks.
-                    // 
+                    //
                     // To fix this, you must either:
                     // 1. Start the bootstrap leader first (node with identity matching
                     //    the first entry in bootstrap_validators)
@@ -2110,14 +2273,20 @@ impl RuntimeOrchestrator {
                     error!("   Creating genesis is forbidden to prevent chain divergence.");
                     error!("");
                     error!("   Solutions:");
-                    error!("   1. Start the bootstrap leader first (identity: {:?})",
-                        self.config.network_config.bootstrap_validators.first().map(|v| &v.identity_id));
+                    error!(
+                        "   1. Start the bootstrap leader first (identity: {:?})",
+                        self.config
+                            .network_config
+                            .bootstrap_validators
+                            .first()
+                            .map(|v| &v.identity_id)
+                    );
                     error!("   2. Copy the 'sled/' directory from a healthy node");
                     error!("   3. Ensure at least one peer with valid chain data is reachable");
                     error!("");
                     error!("   If you ARE the bootstrap leader, verify your identity matches");
                     error!("   the first entry in bootstrap_validators config.");
-                    
+
                     bail!("Genesis creation denied: this node is not the bootstrap leader. See logs above for solutions.");
                 }
             }
@@ -2140,8 +2309,8 @@ impl RuntimeOrchestrator {
 
         if let Some(ref net_info) = network_info {
             info!(
-                "✓ Found existing network with {} peers at height {}",
-                net_info.peer_count, net_info.blockchain_height
+                "✓ Discovered network candidate with {} peers ({})",
+                net_info.peer_count, net_info.chain_state
             );
 
             // Store bootstrap peers for mesh sync
@@ -4450,11 +4619,10 @@ impl RuntimeOrchestrator {
             orchestrator.has_local_chain_data(),
         );
 
-        // Only join if peers have actual blocks (height > 0). If all peers are at height 0,
-        // treat this as a fresh network and allow this node to create genesis.
+        // Only join if peers have actual committed blocks.
         let peers_have_blocks = network_info
             .as_ref()
-            .map(|ni| ni.blockchain_height > 0)
+            .map(|ni| ni.chain_state.has_committed_blocks())
             .unwrap_or(false);
         if leader_has_local_data {
             orchestrator.set_joined_existing_network(false).await?;
@@ -4585,6 +4753,7 @@ impl RuntimeOrchestrator {
             self.config.network_config.bootstrap_peers.clone(),
             self.config.protocols_config.api_port,
             discovery_protocols,
+            Self::trusted_sync_sources(&self.config).to_vec(),
         );
         let discovery = DiscoveryCoordinator::new(config);
         discovery.start_event_listener().await;
@@ -4609,12 +4778,22 @@ impl RuntimeOrchestrator {
                 info!("📡 Discovery attempt #{}", attempt);
                 match discovery.discover_network(&self.config.environment).await {
                     Ok(network_info) => {
-                        if !is_edge_node && network_info.blockchain_height == 0 {
-                            info!(
-                                "   ⏳ Found peers on attempt #{} but chain height is 0; \
-                                 observer startup will keep waiting for committed blocks",
-                                attempt
-                            );
+                        if !is_edge_node && !network_info.chain_state.has_committed_blocks() {
+                            match &network_info.chain_state {
+                                RemoteChainState::Unknown => info!(
+                                    "   ⏳ Found peers on attempt #{} but remote chain state is still unknown; \
+                                     observer startup will keep waiting for a committed sync source",
+                                    attempt
+                                ),
+                                RemoteChainState::GenesisOnly => info!(
+                                    "   ⏳ Found peers on attempt #{} but they only advertise genesis; \
+                                     observer startup will keep waiting for committed blocks",
+                                    attempt
+                                ),
+                                RemoteChainState::Committed(_) => unreachable!(
+                                    "guard excludes committed chain state"
+                                ),
+                            }
                             tokio::time::sleep(Duration::from_secs(5)).await;
                             attempt += 1;
                             continue;
@@ -4637,9 +4816,9 @@ impl RuntimeOrchestrator {
 
             match discovery.discover_network(&self.config.environment).await {
                 Ok(network_info) => {
-                    info!("✓ Connected to existing ZHTP network!");
+                    info!("✓ Discovered ZHTP network peers");
                     info!("   Network peers: {}", network_info.peer_count);
-                    info!("   Blockchain height: {}", network_info.blockchain_height);
+                    info!("   Remote chain state: {}", network_info.chain_state);
                     Ok(Some(network_info))
                 }
                 Err(e) => {
@@ -5040,7 +5219,7 @@ mod runtime_orchestrator_tests {
 
         let network_info = crate::runtime::ExistingNetworkInfo {
             peer_count: 3,
-            blockchain_height: 42,
+            chain_state: crate::runtime::RemoteChainState::Committed(42),
             network_id: "testnet".to_string(),
             bootstrap_peers: vec!["127.0.0.1:9334".to_string()],
             environment: crate::config::Environment::Development,
@@ -5063,21 +5242,43 @@ mod runtime_orchestrator_tests {
 
         let network_info = crate::runtime::ExistingNetworkInfo {
             peer_count: 3,
-            blockchain_height: 0,
+            chain_state: crate::runtime::RemoteChainState::GenesisOnly,
             network_id: "testnet".to_string(),
             bootstrap_peers: vec!["127.0.0.1:9334".to_string()],
             environment: crate::config::Environment::Development,
         };
 
-        let err = RuntimeOrchestrator::validate_observer_join_policy(
-            &config,
-            false,
-            Some(&network_info),
-        )
-        .expect_err("observer should keep waiting when peers only advertise genesis");
+        let err =
+            RuntimeOrchestrator::validate_observer_join_policy(&config, false, Some(&network_info))
+                .expect_err("observer should keep waiting when peers only advertise genesis");
 
         assert!(
             err.to_string().contains("beyond genesis"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn observer_join_policy_rejects_unknown_remote_chain_state() {
+        let mut config = crate::config::NodeConfig::default();
+        config.node_type = Some(NodeType::FullNode);
+        config.node_role = NodeRole::Observer;
+        config.consensus_config.validator_enabled = false;
+
+        let network_info = crate::runtime::ExistingNetworkInfo {
+            peer_count: 2,
+            chain_state: crate::runtime::RemoteChainState::Unknown,
+            network_id: "testnet".to_string(),
+            bootstrap_peers: vec!["127.0.0.1:9334".to_string()],
+            environment: crate::config::Environment::Development,
+        };
+
+        let err =
+            RuntimeOrchestrator::validate_observer_join_policy(&config, false, Some(&network_info))
+                .expect_err("observer should not treat unknown remote state as sync-ready");
+
+        assert!(
+            err.to_string().contains("discovered_chain_state=unknown"),
             "unexpected error: {err}"
         );
     }
@@ -5112,11 +5313,91 @@ mod runtime_orchestrator_tests {
         );
 
         assert!(
-            RuntimeOrchestrator::should_retry_network_discovery_continuously(
-                &config, false, false
-            ),
+            RuntimeOrchestrator::should_retry_network_discovery_continuously(&config, false, false),
             "fresh observer should keep retrying peer discovery until it can bootstrap"
         );
+    }
+
+    #[test]
+    fn observer_admission_policy_requires_authorized_dids_when_enabled() {
+        let mut config = crate::config::NodeConfig::default();
+        config.node_type = Some(NodeType::FullNode);
+        config.node_role = NodeRole::Observer;
+        config.consensus_config.validator_enabled = false;
+        config.network_config.observer_admission.required = true;
+        config.network_config.observer_admission.trusted_sync_sources = vec![
+            crate::config::TrustedSyncSource {
+                address: "127.0.0.1:9334".to_string(),
+                peer_did: None,
+            },
+        ];
+
+        let err = RuntimeOrchestrator::validate_observer_admission_policy_config(&config, false)
+            .expect_err("observer admission should require an explicit local DID allowlist");
+        assert!(
+            err.to_string().contains("authorized observer DIDs"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn observer_admission_policy_requires_trusted_sync_sources_for_fresh_observer() {
+        let mut config = crate::config::NodeConfig::default();
+        config.node_type = Some(NodeType::FullNode);
+        config.node_role = NodeRole::Observer;
+        config.consensus_config.validator_enabled = false;
+        config.network_config.observer_admission.required = true;
+        config
+            .network_config
+            .observer_admission
+            .authorized_observer_dids = vec!["did:zhtp:testobserver".to_string()];
+
+        let err = RuntimeOrchestrator::validate_observer_admission_policy_config(&config, false)
+            .expect_err("fresh admitted observer should require at least one trusted sync source");
+        assert!(
+            err.to_string().contains("trusted sync sources"),
+            "unexpected error: {err}"
+        );
+
+        assert!(
+            RuntimeOrchestrator::validate_observer_admission_policy_config(&config, true).is_ok(),
+            "restarted observer with local chain should be allowed to run without remote sync sources"
+        );
+    }
+
+    #[test]
+    fn trusted_sync_source_matching_respects_endpoint_and_optional_did() {
+        let trusted = vec![
+            crate::config::TrustedSyncSource {
+                address: "10.1.2.3:9334".to_string(),
+                peer_did: Some("did:zhtp:trusted".to_string()),
+            },
+            crate::config::TrustedSyncSource {
+                address: "10.1.2.4:9334".to_string(),
+                peer_did: None,
+            },
+        ];
+
+        assert!(crate::runtime::is_trusted_sync_source(
+            "10.1.2.3:9334",
+            Some("did:zhtp:trusted"),
+            &trusted
+        ));
+        assert!(!crate::runtime::is_trusted_sync_source(
+            "10.1.2.3:9334",
+            Some("did:zhtp:other"),
+            &trusted
+        ));
+        assert!(crate::runtime::is_trusted_sync_source(
+            "10.1.2.4:9334",
+            Some("did:zhtp:anything"),
+            &trusted
+        ));
+        assert!(!crate::runtime::is_trusted_sync_source(
+            "10.1.2.5:9334",
+            Some("did:zhtp:trusted"),
+            &trusted
+        ));
     }
 
     #[test]
@@ -5129,9 +5410,7 @@ mod runtime_orchestrator_tests {
         assert!(RuntimeOrchestrator::validate_observer_startup_config(&config).is_ok());
         assert!(RuntimeOrchestrator::validate_observer_join_policy(&config, true, None).is_ok());
         assert!(
-            !RuntimeOrchestrator::should_retry_network_discovery_continuously(
-                &config, false, true
-            ),
+            !RuntimeOrchestrator::should_retry_network_discovery_continuously(&config, false, true),
             "observer restart with local chain state should not be forced back into discovery"
         );
     }
@@ -5145,7 +5424,7 @@ mod runtime_orchestrator_tests {
 
         let network_info = crate::runtime::ExistingNetworkInfo {
             peer_count: 4,
-            blockchain_height: 128,
+            chain_state: crate::runtime::RemoteChainState::Committed(128),
             network_id: "observer-testnet".to_string(),
             bootstrap_peers: vec!["127.0.0.1:9334".to_string()],
             environment: Environment::Development,
@@ -5162,9 +5441,7 @@ mod runtime_orchestrator_tests {
             "observer should be allowed to sync from an existing network instead of creating genesis"
         );
         assert!(
-            RuntimeOrchestrator::should_retry_network_discovery_continuously(
-                &config, false, false
-            ),
+            RuntimeOrchestrator::should_retry_network_discovery_continuously(&config, false, false),
             "fresh observer should continue discovery/sync attempts until chain data is local"
         );
     }
@@ -5202,19 +5479,17 @@ mod runtime_orchestrator_tests {
 
         let discovered_network = crate::runtime::ExistingNetworkInfo {
             peer_count: 4,
-            blockchain_height: 128,
+            chain_state: crate::runtime::RemoteChainState::Committed(128),
             network_id: "observer-sequence-testnet".to_string(),
-            bootstrap_peers: vec![
-                "127.0.0.1:9334".to_string(),
-                "127.0.0.1:9335".to_string(),
-            ],
+            bootstrap_peers: vec!["127.0.0.1:9334".to_string(), "127.0.0.1:9335".to_string()],
             environment: Environment::Development,
         };
 
         assert!(RuntimeOrchestrator::validate_observer_startup_config(&config).is_ok());
 
-        let fresh_start_err = RuntimeOrchestrator::validate_observer_join_policy(&config, false, None)
-            .expect_err("fresh observer without discovery must not serve");
+        let fresh_start_err =
+            RuntimeOrchestrator::validate_observer_join_policy(&config, false, None)
+                .expect_err("fresh observer without discovery must not serve");
         assert!(
             fresh_start_err
                 .to_string()
@@ -5222,9 +5497,7 @@ mod runtime_orchestrator_tests {
             "unexpected error: {fresh_start_err}"
         );
         assert!(
-            RuntimeOrchestrator::should_retry_network_discovery_continuously(
-                &config, false, false
-            ),
+            RuntimeOrchestrator::should_retry_network_discovery_continuously(&config, false, false),
             "fresh observer should stay in discovery until a network is found"
         );
 
@@ -5238,17 +5511,13 @@ mod runtime_orchestrator_tests {
             "observer should join once an existing network is discovered"
         );
         assert!(
-            RuntimeOrchestrator::should_retry_network_discovery_continuously(
-                &config, false, false
-            ),
+            RuntimeOrchestrator::should_retry_network_discovery_continuously(&config, false, false),
             "observer should keep trying until local chain state exists"
         );
 
         assert!(RuntimeOrchestrator::validate_observer_join_policy(&config, true, None).is_ok());
         assert!(
-            !RuntimeOrchestrator::should_retry_network_discovery_continuously(
-                &config, false, true
-            ),
+            !RuntimeOrchestrator::should_retry_network_discovery_continuously(&config, false, true),
             "observer restart with local chain should not fall back into endless discovery"
         );
     }
@@ -5278,7 +5547,7 @@ mod runtime_orchestrator_tests {
             .expect("observer runtime should initialize");
         let network_info = crate::runtime::ExistingNetworkInfo {
             peer_count: 1,
-            blockchain_height: 42,
+            chain_state: crate::runtime::RemoteChainState::Committed(42),
             network_id: "observer-runtime-join".to_string(),
             bootstrap_peers: vec!["127.0.0.1:1".to_string()],
             environment: Environment::Development,
@@ -5373,7 +5642,7 @@ mod runtime_orchestrator_tests {
 
         let discovered_network = crate::runtime::ExistingNetworkInfo {
             peer_count: 3,
-            blockchain_height: 64,
+            chain_state: crate::runtime::RemoteChainState::Committed(64),
             network_id: "observer-shared-network".to_string(),
             bootstrap_peers: vec![
                 "127.0.0.1:9334".to_string(),

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -15,7 +15,7 @@ pub struct GenesisValidator {
     pub node_device_id: Option<lib_identity::IdentityId>,
     pub stake: u64,
     pub storage_provided: u64,
-    pub commission_rate: u16, // basis points (e.g., 500 = 5%)
+    pub commission_rate: u16,      // basis points (e.g., 500 = 5%)
     pub consensus_key: [u8; 2592], // Dilithium5 public key
     pub network_address: String,
 }

--- a/zhtp/src/runtime/token_utils.rs
+++ b/zhtp/src/runtime/token_utils.rs
@@ -71,13 +71,25 @@ pub(crate) async fn load_validator_keypair_from_keystore() -> Result<lib_crypto:
 
     // Note: KeystorePrivateKey uses fixed arrays, so length checks are technically
     // redundant but kept for defense-in-depth in case deserialization changes.
-    let dilithium_pk: [u8; 2592] = keystore_key.dilithium_pk.as_slice().try_into()
+    let dilithium_pk: [u8; 2592] = keystore_key
+        .dilithium_pk
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid dilithium_pk length, expected 2592 bytes"))?;
-    let dilithium_sk: [u8; 4896] = keystore_key.dilithium_sk.as_slice().try_into()
+    let dilithium_sk: [u8; 4896] = keystore_key
+        .dilithium_sk
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid dilithium_sk length, expected 4896 bytes"))?;
-    let kyber_sk: [u8; 3168] = keystore_key.kyber_sk.as_slice().try_into()
+    let kyber_sk: [u8; 3168] = keystore_key
+        .kyber_sk
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid kyber_sk length, expected 3168 bytes"))?;
-    let master_seed: [u8; 64] = keystore_key.master_seed.as_slice().try_into()
+    let master_seed: [u8; 64] = keystore_key
+        .master_seed
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid master_seed length, expected 64 bytes"))?;
     let public_key = lib_crypto::PublicKey::new(dilithium_pk);
     let private_key = lib_crypto::PrivateKey {

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -372,6 +372,7 @@ impl ZhtpUnifiedServer {
                 crate::discovery_coordinator::DiscoveryProtocol::MDns,
                 crate::discovery_coordinator::DiscoveryProtocol::DHT,
             ],
+            vec![],
         );
         let discovery_coordinator = Arc::new(
             crate::discovery_coordinator::DiscoveryCoordinator::new(discovery_config),


### PR DESCRIPTION
## Summary
- distinguish unknown, genesis-only, and committed remote chain state during observer discovery
- add config-backed observer admission and trusted sync-source policy to runtime and discovery
- add the first observer admission spec at docs/specs/observer-admission-v1.md

## Why
- fixes the observer startup path so fresh observers do not treat unknown peer state as genesis
- adds a controlled path for explicit observer admission and trusted bootstrap and sync sources
- documents the intended identity-backed observer enrollment model for follow-on work

## Verification
- cargo test -p zhtp --target-dir /tmp/zhtp-admission-check observer_admission_policy_requires_authorized_dids_when_enabled -- --nocapture
- cargo test -p zhtp --target-dir /tmp/zhtp-admission-check observer_admission_policy_requires_trusted_sync_sources_for_fresh_observer -- --nocapture
- cargo test -p zhtp --target-dir /tmp/zhtp-admission-check trusted_sync_source_matching_respects_endpoint_and_optional_did -- --nocapture
- cargo test -p zhtp --target-dir /tmp/zhtp-admission-check observer_join_policy_rejects_unknown_remote_chain_state -- --nocapture
- cargo test -p zhtp --target-dir /tmp/zhtp-admission-check observer_join_policy_rejects_genesis_only_networks -- --nocapture
- cargo test -p zhtp --target-dir /tmp/zhtp-admission-check observer_sync_contract_transitions_to_bootstrap_when_network_exists -- --nocapture
- cargo test -p zhtp --target-dir /tmp/zhtp-admission-check observer_lifecycle_sequence_preserves_join_then_restart_contract -- --nocapture

## Links
- closes #2079
- epic: #2084
