### PR TITLE
fix(discovery): accept hostname:port in bootstrap_peers, fix ghost wallet on observed identities

### DIFF
--- a/zhtp/src/discovery_coordinator.rs
+++ b/zhtp/src/discovery_coordinator.rs
@@ -714,9 +714,15 @@ impl DiscoveryCoordinator {
                     }
                 }
 
-                // Trust configured bootstrap peers - QUIC connection will validate reachability
-                // No TCP check needed since we use UDP/QUIC only
-                if peer.parse::<std::net::SocketAddr>().is_ok() {
+                // Trust configured bootstrap peers - QUIC connection will validate reachability.
+                // Accept both IP:port ("1.2.3.4:9334") and host:port ("node.example.com:9334").
+                // SocketAddr::parse only handles IP literals; use to_socket_addrs for DNS names.
+                let is_valid = peer.parse::<std::net::SocketAddr>().is_ok()
+                    || peer
+                        .to_socket_addrs()
+                        .map(|mut a| a.next().is_some())
+                        .unwrap_or(false);
+                if is_valid {
                     debug!(
                         "      ✓ Adding bootstrap peer {} (will verify via QUIC)",
                         peer_hash

--- a/zhtp/src/discovery_coordinator.rs
+++ b/zhtp/src/discovery_coordinator.rs
@@ -6,6 +6,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::net::ToSocketAddrs;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::sync::{mpsc, RwLock};
@@ -719,8 +720,9 @@ impl DiscoveryCoordinator {
                 // SocketAddr::parse only handles IP literals; use to_socket_addrs for DNS names.
                 let is_valid = peer.parse::<std::net::SocketAddr>().is_ok()
                     || peer
+                        .as_str()
                         .to_socket_addrs()
-                        .map(|mut a| a.next().is_some())
+                        .map(|mut a: std::vec::IntoIter<std::net::SocketAddr>| a.next().is_some())
                         .unwrap_or(false);
                 if is_valid {
                     debug!(


### PR DESCRIPTION
## Summary

- **Bootstrap peer DNS**: `SocketAddr::parse()` rejects domain names silently. All 3 validators had 0 mesh peers after the node hardening introduced domain-name `bootstrap_peers` configs, stalling consensus for hours. Fix falls back to `to_socket_addrs()` so both `IP:port` and `host:port` are accepted.

- **Ghost wallet on observed identities**: `from_observed_handshake` created a fake Primary wallet using `identity_id` as the wallet ID. This caused `handle_list_wallets` to skip the blockchain fallback and return a 0-balance wallet instead of the user's real funded wallet. Fix: observed identities start with an empty `WalletManager`.

- **Startup backfill disabled**: `backfill_identities_from_blockchain` re-linked all wallets from stale `owner_identity_id` entries on every restart when DHT sled was empty (after process user migration root→zhtp). Disabled until wallet ownership migration is fixed.

- **sled-wallet-lookup tool**: Diagnostic tool for inspecting wallet state in sled backups.

## Test plan

- [ ] Node starts with domain-name `bootstrap_peers` and establishes mesh connections
- [ ] Wallet list for a DID returns the correct funded wallet from `blockchain.wallet_registry`
- [ ] No ghost 0-balance wallet shown after node restart
- [ ] Consensus commits blocks after all validators restart