### PR TITLE
Browser daemon hardening and Linux release packaging

### DIFF
--- a/scripts/install-zhtp-daemon-linux.sh
+++ b/scripts/install-zhtp-daemon-linux.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root: sudo bash scripts/install-zhtp-daemon-linux.sh" >&2
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKAGE_DIR="${ROOT_DIR}"
+BIN_SRC="${PACKAGE_DIR}/bin/zhtp-daemon"
+CONFIG_SRC="${PACKAGE_DIR}/config/config.toml"
+SERVICE_SRC="${PACKAGE_DIR}/systemd/zhtp-daemon.service"
+
+BIN_DST="/usr/local/bin/zhtp-daemon"
+SERVICE_DST="/etc/systemd/system/zhtp-daemon.service"
+STATE_DIR="/var/lib/zhtp-daemon"
+SERVICE_USER="zhtp-daemon"
+SERVICE_GROUP="zhtp-daemon"
+
+if [[ ! -x "${BIN_SRC}" ]]; then
+  echo "Missing binary at ${BIN_SRC}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${CONFIG_SRC}" ]]; then
+  echo "Missing config at ${CONFIG_SRC}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${SERVICE_SRC}" ]]; then
+  echo "Missing systemd unit at ${SERVICE_SRC}" >&2
+  exit 1
+fi
+
+if ! getent group "${SERVICE_GROUP}" >/dev/null 2>&1; then
+  groupadd --system "${SERVICE_GROUP}"
+fi
+
+if ! id -u "${SERVICE_USER}" >/dev/null 2>&1; then
+  useradd \
+    --system \
+    --home "${STATE_DIR}" \
+    --create-home \
+    --shell /usr/sbin/nologin \
+    --gid "${SERVICE_GROUP}" \
+    "${SERVICE_USER}"
+fi
+
+install -d -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0750 "${STATE_DIR}"
+install -m 0755 "${BIN_SRC}" "${BIN_DST}"
+
+if [[ ! -f "${STATE_DIR}/config.toml" ]]; then
+  install -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0640 "${CONFIG_SRC}" "${STATE_DIR}/config.toml"
+else
+  echo "Keeping existing config at ${STATE_DIR}/config.toml"
+fi
+
+install -m 0644 "${SERVICE_SRC}" "${SERVICE_DST}"
+
+systemctl daemon-reload
+systemctl enable --now zhtp-daemon
+systemctl status --no-pager zhtp-daemon
+
+cat <<EOF
+
+Installed zhtp-daemon.
+
+- binary: ${BIN_DST}
+- service: ${SERVICE_DST}
+- state dir: ${STATE_DIR}
+- config: ${STATE_DIR}/config.toml
+
+Inspect logs with:
+  journalctl -u zhtp-daemon -f
+EOF

--- a/scripts/package-zhtp-daemon-linux.sh
+++ b/scripts/package-zhtp-daemon-linux.sh
@@ -9,12 +9,13 @@ ARCHIVE_PATH="${TARGET_DIR}/${PACKAGE_NAME}.tar.gz"
 CHECKSUM_PATH="${TARGET_DIR}/${PACKAGE_NAME}.sha256"
 
 rm -rf "${STAGE_DIR}" "${ARCHIVE_PATH}" "${CHECKSUM_PATH}"
-mkdir -p "${STAGE_DIR}/bin" "${STAGE_DIR}/config" "${STAGE_DIR}/systemd"
+mkdir -p "${STAGE_DIR}/bin" "${STAGE_DIR}/config" "${STAGE_DIR}/systemd" "${STAGE_DIR}/scripts"
 
 install -m 0755 "${TARGET_DIR}/zhtp-daemon" "${STAGE_DIR}/bin/zhtp-daemon"
 install -m 0644 "${ROOT_DIR}/zhtp-daemon/README.md" "${STAGE_DIR}/README.md"
 install -m 0644 "${ROOT_DIR}/zhtp-daemon/config.example.toml" "${STAGE_DIR}/config/config.toml"
 install -m 0644 "${ROOT_DIR}/deploy/zhtp-daemon.service" "${STAGE_DIR}/systemd/zhtp-daemon.service"
+install -m 0755 "${ROOT_DIR}/scripts/install-zhtp-daemon-linux.sh" "${STAGE_DIR}/scripts/install-zhtp-daemon-linux.sh"
 
 tar -C "${TARGET_DIR}" -czf "${ARCHIVE_PATH}" "${PACKAGE_NAME}"
 (

--- a/zhtp-daemon/README.md
+++ b/zhtp-daemon/README.md
@@ -54,6 +54,7 @@ Archive contents:
 - `bin/zhtp-daemon`
 - `config/config.toml`
 - `systemd/zhtp-daemon.service`
+- `scripts/install-zhtp-daemon-linux.sh`
 - `README.md`
 
 ## Linux install
@@ -72,6 +73,14 @@ sha256sum -c ../zhtp-daemon-linux-x86_64.sha256
 ```
 
 ### 2. Install the binary and service unit
+
+Fast path:
+
+```bash
+sudo bash scripts/install-zhtp-daemon-linux.sh
+```
+
+Manual path:
 
 ```bash
 sudo install -m 0755 bin/zhtp-daemon /usr/local/bin/zhtp-daemon


### PR DESCRIPTION
## Summary
- carry forward the QUIC browser daemon and Chrome extension bridge work on the current branch
- harden the localhost/browser surface after review feedback
- add Linux release packaging, systemd unit, config example, and installer for zhtp-daemon

## Included
- narrowed extension permissions and sandboxed viewer iframe
- removed permissive daemon CORS and cleaned request/auth plumbing
- reduced daemon mutex contention during network I/O and added route-resolution tests
- added Linux release workflow, packaging script, install script, service unit, and docs

## Verification
- cargo test -p zhtp-daemon
- cargo build -p zhtp-daemon
- cargo build --release -p zhtp-daemon
- bash scripts/package-zhtp-daemon-linux.sh
- bash -n scripts/install-zhtp-daemon-linux.sh

## Context
PR #2091 was already merged and closed while this branch continued to evolve. This PR carries the remaining work for current review and checks.