### PR TITLE
feat(EPIC-001): Phase 0 — decimals unification and u128 token balances

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -901,7 +901,7 @@ impl Blockchain {
             // ONLY entries that are missing from the tree (idempotent, safe to call here
             // before begin_block sets tx_active).
             if let Some(store) = &self.store {
-                let mut seed_map: std::collections::HashMap<[u8; 32], Vec<([u8; 32], u64)>> =
+                let mut seed_map: std::collections::HashMap<[u8; 32], Vec<([u8; 32], u128)>> =
                     std::collections::HashMap::new();
                 let mut cbe_account_seed: Vec<([u8; 32], u128)> = Vec::new();
                 let cbe_token_id = self.cbe_token.token_id();
@@ -926,7 +926,7 @@ impl Blockchain {
                                     seed_map
                                         .entry(data.token_id)
                                         .or_default()
-                                        .push((data.from, mem_balance as u64));
+                                        .push((data.from, mem_balance));
                                 }
                             }
                         } else if data.token_id == cbe_token_id {
@@ -944,7 +944,7 @@ impl Blockchain {
                                     seed_map
                                         .entry(data.token_id)
                                         .or_default()
-                                        .push((data.from, mem_balance));
+                                        .push((data.from, mem_balance as u128));
                                 }
                             }
                             // If sled_bal > 0: SledStore already has the correct value;
@@ -4131,8 +4131,8 @@ impl Blockchain {
             })
             .sum();
 
-        // 1 SOV (1e8 atomic units) = 1 base vote unit
-        let base_power = (sov_balance / 100_000_000) as u64;
+        // 1 SOV (1e18 atomic units) = 1 base vote unit
+        let base_power = (sov_balance / lib_types::TOKEN_SCALE_18) as u64;
 
         // Add power from identities that delegated directly to this user (non-transitive).
         // Keys and values in vote_delegations are 64-char hex-encoded identity IDs.
@@ -4153,7 +4153,7 @@ impl Blockchain {
                         self.token_contracts.get(&sov_id).map(|t| t.balance_of(&pk))
                     })
                     .sum();
-                Some((bal / 100_000_000) as u64)
+                Some((bal / lib_types::TOKEN_SCALE_18) as u64)
             })
             .sum();
 

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -926,7 +926,7 @@ impl Blockchain {
                                     seed_map
                                         .entry(data.token_id)
                                         .or_default()
-                                        .push((data.from, mem_balance));
+                                        .push((data.from, mem_balance as u64));
                                 }
                             }
                         } else if data.token_id == cbe_token_id {
@@ -1041,7 +1041,7 @@ impl Blockchain {
                             if let Ok(balance) = store.get_token_balance(&storage_sov_id, &addr) {
                                 if let Some(token) = self.token_contracts.get_mut(&sov_id) {
                                     let pk = Self::wallet_key_for_sov(&addr_bytes);
-                                    token.balances.insert(pk, balance as u64);
+                                    token.balances.insert(pk, balance as u128);
                                 }
                             }
                         }
@@ -1887,7 +1887,7 @@ impl Blockchain {
 
             // Check sender's balance before deduction
             let sender_balance = sov_token.balance_of(&fee_payer);
-            if sender_balance < tx.fee {
+            if sender_balance < tx.fee as u128 {
                 // This shouldn't happen if validation is working correctly
                 warn!(
                     "Fee deduction failed: sender {} has insufficient balance ({}) for fee ({})",
@@ -1903,7 +1903,7 @@ impl Blockchain {
             // Note: Direct balance mutation for backward compatibility.
             // SOV token operations go through TreasuryKernel for new transactions,
             // but this historical fee deduction maintains existing behavior.
-            let new_balance = sender_balance - tx.fee;
+            let new_balance = sender_balance - tx.fee as u128;
             sov_token.balances.insert(fee_payer.clone(), new_balance);
 
             total_fees = total_fees.saturating_add(tx.fee);
@@ -1929,7 +1929,7 @@ impl Blockchain {
                         let treasury_balance = sov_token.balance_of(&treasury_key);
                         sov_token
                             .balances
-                            .insert(treasury_key, treasury_balance.saturating_add(total_fees));
+                            .insert(treasury_key, treasury_balance.saturating_add(total_fees as u128));
                         debug!(
                             "Block {} fees credited to DAO treasury: {} SOV",
                             block.height(),
@@ -2478,7 +2478,7 @@ impl Blockchain {
             return Ok(());
         }
         let sender_bal = token.balance_of(sender);
-        if sender_bal < amount {
+        if sender_bal < amount as u128 {
             return Err(anyhow::anyhow!(
                 "TokenTransfer insufficient balance: have {}, need {}",
                 sender_bal,
@@ -2488,12 +2488,12 @@ impl Blockchain {
         let sender_bal_post = token.balance_of(sender);
         token
             .balances
-            .insert(sender.clone(), sender_bal_post.saturating_sub(fee_amount));
+            .insert(sender.clone(), sender_bal_post.saturating_sub(fee_amount as u128));
         if let Some(ref tpk) = treasury_key {
             let tbal = token.balance_of(tpk);
             token
                 .balances
-                .insert(tpk.clone(), tbal.saturating_add(fee_amount));
+                .insert(tpk.clone(), tbal.saturating_add(fee_amount as u128));
             debug!(
                 "TokenTransfer: {} SOV fee → DAO treasury (height {})",
                 fee_amount, height
@@ -4121,7 +4121,7 @@ impl Blockchain {
         let user_local_id = crate::types::hash::Hash::new(user_id.0);
 
         // Sum SOV balances across all wallets owned by this identity.
-        let sov_balance: u64 = self
+        let sov_balance: u128 = self
             .get_wallets_for_owner(&user_local_id)
             .iter()
             .filter_map(|w| {
@@ -4132,7 +4132,7 @@ impl Blockchain {
             .sum();
 
         // 1 SOV (1e8 atomic units) = 1 base vote unit
-        let base_power = sov_balance / 100_000_000;
+        let base_power = (sov_balance / 100_000_000) as u64;
 
         // Add power from identities that delegated directly to this user (non-transitive).
         // Keys and values in vote_delegations are 64-char hex-encoded identity IDs.
@@ -4146,14 +4146,14 @@ impl Blockchain {
                 let delegator_bytes: [u8; 32] = bytes.try_into().ok()?;
                 let delegator_local_id = crate::types::hash::Hash::new(delegator_bytes);
                 let delegator_wallets = self.get_wallets_for_owner(&delegator_local_id);
-                let bal: u64 = delegator_wallets
+                let bal: u128 = delegator_wallets
                     .iter()
                     .filter_map(|w| {
                         let pk = Self::wallet_key_for_sov(&w.wallet_id.as_array());
                         self.token_contracts.get(&sov_id).map(|t| t.balance_of(&pk))
                     })
                     .sum();
-                Some(bal / 100_000_000)
+                Some((bal / 100_000_000) as u64)
             })
             .sum();
 
@@ -6738,7 +6738,7 @@ impl Blockchain {
             key_id: recipient_key_id,
         };
         token
-            .mint(&recipient, amount)
+            .mint(&recipient, amount as u128)
             .map_err(|e| anyhow::anyhow!("POUW SOV mint failed: {}", e))?;
         Ok(())
     }

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -287,7 +287,7 @@ impl Blockchain {
                             .get_mut(&token_id)
                             .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
                         let from_bal = token.balance_of(&from_wallet_addr);
-                        if from_bal < amount_u64 {
+                        if from_bal < amount_u64 as u128 {
                             return Err(anyhow::anyhow!(
                                 "TokenTransfer insufficient balance: have {}, need {}",
                                 from_bal,
@@ -295,7 +295,7 @@ impl Blockchain {
                             ));
                         }
                         token
-                            .transfer(&ctx, &to_wallet_addr, net_amount)
+                            .transfer(&ctx, &to_wallet_addr, net_amount as u128)
                             .map_err(|e| anyhow::anyhow!("TokenTransfer failed: {}", e))?;
                         Self::apply_token_transfer_with_fee(
                             token,
@@ -357,7 +357,7 @@ impl Blockchain {
                             .get_mut(&token_id)
                             .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
                         let sender_bal = token.balance_of(&sender_pk);
-                        if sender_bal < amount_u64 {
+                        if sender_bal < amount_u64 as u128 {
                             return Err(anyhow::anyhow!(
                                 "TokenTransfer insufficient balance: have {}, need {}",
                                 sender_bal,
@@ -365,7 +365,7 @@ impl Blockchain {
                             ));
                         }
                         token
-                            .transfer(&ctx, &recipient_pk, net_amount)
+                            .transfer(&ctx, &recipient_pk, net_amount as u128)
                             .map_err(|e| anyhow::anyhow!("TokenTransfer failed: {}", e))?;
                         Self::apply_token_transfer_with_fee(
                             token,
@@ -567,7 +567,7 @@ impl Blockchain {
                                 .token_contracts
                                 .get_mut(&token_id)
                                 .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
-                            token.burn(&from_pk, amount_u64).map_err(|e| {
+                            token.burn(&from_pk, amount_u64 as u128).map_err(|e| {
                                 anyhow::anyhow!("Token migration burn failed: {}", e)
                             })?;
                         }
@@ -600,7 +600,7 @@ impl Blockchain {
                             .get_mut(&token_id)
                             .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
                         token
-                            .mint(&recipient_pk, amount_u64)
+                            .mint(&recipient_pk, amount_u64 as u128)
                             .map_err(|e| anyhow::anyhow!("TokenMint failed: {}", e))?;
                     }
 
@@ -649,16 +649,16 @@ impl Blockchain {
                     } else {
                         payload.decimals
                     };
-                    token.max_supply = payload.initial_supply;
+                    token.max_supply = payload.initial_supply as u128;
                     token
-                        .mint(&creator, creator_allocation)
+                        .mint(&creator, creator_allocation as u128)
                         .map_err(|e| anyhow::anyhow!("TokenCreation mint failed: {}", e))?;
                     let treasury_pk = lib_crypto::types::keys::PublicKey {
                         dilithium_pk: [0u8; 2592],
                         kyber_pk: [0u8; 1568],
                         key_id: payload.treasury_recipient,
                     };
-                    token.mint(&treasury_pk, treasury_allocation).map_err(|e| {
+                    token.mint(&treasury_pk, treasury_allocation as u128).map_err(|e| {
                         anyhow::anyhow!("TokenCreation treasury mint failed: {}", e)
                     })?;
 

--- a/lib-blockchain/src/blockchain/dao.rs
+++ b/lib-blockchain/src/blockchain/dao.rs
@@ -400,11 +400,11 @@ impl Blockchain {
         Ok(approval_percent >= required_approval_percent as u64)
     }
 
-    pub fn get_circulating_sov_supply(&self) -> u64 {
+    pub fn get_circulating_sov_supply(&self) -> u128 {
         let sov_id = crate::contracts::utils::generate_lib_token_id();
         self.token_contracts
             .get(&sov_id)
-            .map(|t| t.total_supply as u64)
+            .map(|t| t.total_supply)
             .unwrap_or(0)
     }
 
@@ -419,8 +419,8 @@ impl Blockchain {
             return Ok(false);
         }
         let circulating = self.get_circulating_sov_supply().max(1);
-        let participation_pct = (total_cast * 100) / circulating;
-        if participation_pct < quorum_pct as u64 {
+        let participation_pct = (total_cast as u128 * 100) / circulating;
+        if participation_pct < quorum_pct as u128 {
             return Ok(false);
         }
         let yes_pct = (yes_votes * 100) / total_cast;
@@ -455,7 +455,7 @@ impl Blockchain {
             .ok_or_else(|| anyhow::anyhow!("Treasury wallet not found in registry"))
     }
 
-    pub fn get_dao_treasury_balance(&self) -> Result<u64> {
+    pub fn get_dao_treasury_balance(&self) -> Result<u128> {
         let treasury_wallet_id = self
             .dao_treasury_wallet_id
             .as_ref()
@@ -477,7 +477,7 @@ impl Blockchain {
 
         let sov_token_id = crate::contracts::utils::generate_lib_token_id();
         if let Some(token) = self.token_contracts.get(&sov_token_id) {
-            Ok(token.balance_of(&treasury_key) as u64)
+            Ok(token.balance_of(&treasury_key))
         } else {
             tracing::debug!(
                 "SOV token contract not found, treasury balance query returning 0 during bootstrap"
@@ -606,7 +606,7 @@ impl Blockchain {
         let recipient_pk = Self::wallet_key_for_sov(&recip_id_bytes);
 
         let treasury_balance = self.get_dao_treasury_balance()?;
-        if treasury_balance < amount {
+        if treasury_balance < amount as u128 {
             return Err(anyhow::anyhow!(
                 "Insufficient treasury balance: need {}, available {}",
                 amount,
@@ -619,7 +619,8 @@ impl Blockchain {
             if let Some(&stored) = self.treasury_epoch_start_balance.get(&epoch) {
                 stored
             } else {
-                let start = treasury_balance.saturating_add(spent_this_epoch);
+                let treasury_balance_u64 = u64::try_from(treasury_balance).unwrap_or(u64::MAX);
+                let start = treasury_balance_u64.saturating_add(spent_this_epoch);
                 self.treasury_epoch_start_balance.insert(epoch, start);
                 start
             };

--- a/lib-blockchain/src/blockchain/dao.rs
+++ b/lib-blockchain/src/blockchain/dao.rs
@@ -404,7 +404,7 @@ impl Blockchain {
         let sov_id = crate::contracts::utils::generate_lib_token_id();
         self.token_contracts
             .get(&sov_id)
-            .map(|t| t.total_supply)
+            .map(|t| t.total_supply as u64)
             .unwrap_or(0)
     }
 
@@ -477,7 +477,7 @@ impl Blockchain {
 
         let sov_token_id = crate::contracts::utils::generate_lib_token_id();
         if let Some(token) = self.token_contracts.get(&sov_token_id) {
-            Ok(token.balance_of(&treasury_key))
+            Ok(token.balance_of(&treasury_key) as u64)
         } else {
             tracing::debug!(
                 "SOV token contract not found, treasury balance query returning 0 during bootstrap"
@@ -659,10 +659,10 @@ impl Blockchain {
             .get_mut(&sov_id)
             .ok_or_else(|| anyhow::anyhow!("SOV token contract not found"))?;
         sov_token
-            .debit_balance(&treasury_pk, amount)
+            .debit_balance(&treasury_pk, amount as u128)
             .map_err(|e| anyhow::anyhow!("Treasury debit failed: {}", e))?;
         sov_token
-            .credit_balance(&recipient_pk, amount)
+            .credit_balance(&recipient_pk, amount as u128)
             .map_err(|e| anyhow::anyhow!("Recipient credit failed: {}", e))?;
 
         *self.treasury_epoch_spend.entry(epoch).or_insert(0) += amount;

--- a/lib-blockchain/src/blockchain/dao.rs
+++ b/lib-blockchain/src/blockchain/dao.rs
@@ -418,7 +418,9 @@ impl Blockchain {
         if total_cast == 0 {
             return Ok(false);
         }
-        let circulating = self.get_circulating_sov_supply().max(1);
+        // Normalize circulating supply to whole-token units for consistent comparison
+        // with voting_power (which is computed in whole-token units)
+        let circulating = (self.get_circulating_sov_supply() / lib_types::TOKEN_SCALE_18).max(1);
         let participation_pct = (total_cast as u128 * 100) / circulating;
         if participation_pct < quorum_pct as u128 {
             return Ok(false);

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -630,10 +630,10 @@ impl Blockchain {
 
         let sov_token_id = crate::contracts::utils::generate_lib_token_id();
         if let Some(sov_contract) = blockchain.token_contracts.get(&sov_token_id) {
-            let entries: Vec<([u8; 32], u64)> = sov_contract
+            let entries: Vec<([u8; 32], u128)> = sov_contract
                 .balances
                 .iter()
-                .map(|(pk, &bal)| (pk.key_id, bal as u64))
+                .map(|(pk, &bal)| (pk.key_id, bal))
                 .collect();
             let token_id = crate::storage::TokenId(sov_token_id);
             match store.backfill_token_balances_from_contract(&token_id, &entries) {

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -499,8 +499,8 @@ impl Blockchain {
                                     .get(&sov_token_id)
                                     .map(|t| t.balance_of(&recipient_pk))
                                     .unwrap_or(0);
-                                let deficit =
-                                    wallet_data.initial_balance.saturating_sub(current);
+                                let target = wallet_data.initial_balance as u128;
+                                let deficit = target.saturating_sub(current);
                                 if deficit > 0 {
                                     if let Some(token) =
                                         blockchain.token_contracts.get_mut(&sov_token_id)
@@ -633,7 +633,7 @@ impl Blockchain {
             let entries: Vec<([u8; 32], u64)> = sov_contract
                 .balances
                 .iter()
-                .map(|(pk, &bal)| (pk.key_id, bal))
+                .map(|(pk, &bal)| (pk.key_id, bal as u64))
                 .collect();
             let token_id = crate::storage::TokenId(sov_token_id);
             match store.backfill_token_balances_from_contract(&token_id, &entries) {
@@ -747,7 +747,7 @@ impl Blockchain {
                         if balance > 0 {
                             if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
                                 let pk = Self::wallet_key_for_sov(&wallet_bytes);
-                                token.balances.insert(pk, balance as u64);
+                                token.balances.insert(pk, balance as u128);
                                 synced += 1;
                             }
                         }
@@ -764,7 +764,7 @@ impl Blockchain {
             // Also sync total supply from sled
             if let Ok(Some(supply)) = store.get_token_supply(&storage_sov_id) {
                 if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
-                    token.total_supply = supply;
+                    token.total_supply = supply as u128;
                 }
             }
         }

--- a/lib-blockchain/src/blockchain/test_utils.rs
+++ b/lib-blockchain/src/blockchain/test_utils.rs
@@ -135,14 +135,14 @@ impl Blockchain {
             .get_mut(&sov_id)
             .ok_or_else(|| anyhow::anyhow!("SOV token contract not found"))?;
         token
-            .credit_balance(&pk, amount)
+            .credit_balance(&pk, amount as u128)
             .map_err(|e| anyhow::anyhow!("Treasury credit failed: {}", e))?;
         Ok(())
     }
 
     /// Query the raw SOV balance for an arbitrary 64-char hex wallet ID.
     /// For unit tests only.
-    pub fn get_wallet_sov_for_test(&self, wallet_id_hex: &str) -> Result<u64> {
+    pub fn get_wallet_sov_for_test(&self, wallet_id_hex: &str) -> Result<u128> {
         let id_bytes: [u8; 32] = hex::decode(wallet_id_hex)
             .map_err(|e| anyhow::anyhow!("Bad wallet hex: {}", e))?
             .try_into()
@@ -200,7 +200,7 @@ impl Blockchain {
             .get_mut(&sov_id)
             .ok_or_else(|| anyhow::anyhow!("SOV token contract not found"))?;
         token
-            .credit_balance(&pk, amount)
+            .credit_balance(&pk, amount as u128)
             .map_err(|e| anyhow::anyhow!("Identity SOV credit failed: {}", e))?;
         Ok(())
     }

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -152,7 +152,7 @@ impl Blockchain {
                 .credit(token, &caller, to, amount, reason)
                 .map_err(|e| e.to_string())
         } else {
-            token.credit_balance(to, amount)
+            token.credit_balance(to, amount as u128)
         }
     }
 
@@ -173,7 +173,7 @@ impl Blockchain {
                 .debit(token, &caller, from, amount, reason)
                 .map_err(|e| e.to_string())
         } else {
-            token.debit_balance(from, amount)
+            token.debit_balance(from, amount as u128)
         }
     }
 
@@ -231,8 +231,8 @@ impl Blockchain {
             }
         }
 
-        let mut migrated_total: u64 = 0;
-        let balances: Vec<(PublicKey, u64)> = token
+        let mut migrated_total: u128 = 0;
+        let balances: Vec<(PublicKey, u128)> = token
             .balances
             .iter()
             .map(|(k, v)| (k.clone(), *v))
@@ -318,12 +318,12 @@ impl Blockchain {
             };
 
             let recipient = Self::wallet_key_for_sov(&wallet_key);
-            let current_balance: u64 = if let Some(store) = self.get_store() {
+            let current_balance: u128 = if let Some(store) = self.get_store() {
                 let sov_storage_token_id = crate::storage::TokenId(sov_token_id);
                 let addr = crate::storage::Address::new(wallet_key);
                 store
                     .get_token_balance(&sov_storage_token_id, &addr)
-                    .unwrap_or(0) as u64
+                    .unwrap_or(0) as u128
             } else {
                 token_opt
                     .map(|token| token.balance_of(&recipient))
@@ -403,8 +403,8 @@ impl Blockchain {
             let wallet_key = Self::wallet_key_for_sov(bytes);
             if let Some(token) = self.token_contracts.get_mut(&sov_token_id) {
                 let bal = token.balance_of(&wallet_key);
-                if bal == WRONG_BONUS {
-                    if let Err(e) = token.burn(&wallet_key, WRONG_BONUS) {
+                if bal == WRONG_BONUS as u128 {
+                    if let Err(e) = token.burn(&wallet_key, WRONG_BONUS as u128) {
                         tracing::warn!(
                             "correct_ubi_savings_misbalances: burn failed for {}: {}",
                             &wallet_id_hex[..16.min(wallet_id_hex.len())],
@@ -574,7 +574,7 @@ impl Blockchain {
             let recipient_pk = Self::wallet_key_for_sov(&wallet_id_bytes_arr);
             if let Some(token) = self.token_contracts.get_mut(&sov_token_id) {
                 if token.balance_of(&recipient_pk) == 0 {
-                    if let Err(e) = token.mint(&recipient_pk, wallet_data.initial_balance) {
+                    if let Err(e) = token.mint(&recipient_pk, wallet_data.initial_balance as u128) {
                         warn!(
                             "register_wallet: failed to mint {} SOV for {}: {}",
                             wallet_data.initial_balance,
@@ -689,9 +689,8 @@ impl Blockchain {
                             .get(&sov_token_id)
                             .map(|token| token.balance_of(&recipient_pk))
                             .unwrap_or(0);
-                        let deficit = wallet_data
-                            .initial_balance
-                            .saturating_sub(current_balance);
+                        let target = wallet_data.initial_balance as u128;
+                        let deficit = target.saturating_sub(current_balance);
                         if deficit > 0 {
                             if let Some(token) = self.token_contracts.get_mut(&sov_token_id) {
                                 if let Err(e) = token.mint(&recipient_pk, deficit) {

--- a/lib-blockchain/src/contracts/bonding_curve/canonical.rs
+++ b/lib-blockchain/src/contracts/bonding_curve/canonical.rs
@@ -1,6 +1,6 @@
 pub use lib_types::{
     BondingCurveBand as Band, BondingCurveBuyReceipt, BondingCurveBuyTx, BondingCurveSellReceipt,
-    BondingCurveSellTx, CBE_MAX_SUPPLY, TOKEN_SCALE_18,
+    BondingCurveSellTx, TOKEN_SCALE_18,
 };
 use primitive_types::U256;
 
@@ -31,7 +31,10 @@ pub const MAX_GROSS_SOV_PER_TX: u128 = 1_000_000_000_000_000_000_000_000;
 /// Per-transaction minted-supply cap.  Changing this value is a hard fork.
 pub const MAX_DELTA_S_PER_TX: u128 = 100_000_000_000 * SCALE;
 
-pub const MAX_SUPPLY: u128 = CBE_MAX_SUPPLY;
+/// CBE max supply in 18-decimal bonding curve atoms (100B tokens × 10^18).
+/// This is the bonding curve's internal accounting unit, independent of CBE's
+/// 8-decimal display convention. Immutable — changing is a hard fork.
+pub const MAX_SUPPLY: u128 = 100_000_000_000 * SCALE;
 
 /// Band price anchors — part of the immutable curve shape.
 pub const P_START_0: u128 = 313_345_700_000_000;

--- a/lib-blockchain/src/contracts/bonding_curve/pricing.rs
+++ b/lib-blockchain/src/contracts/bonding_curve/pricing.rs
@@ -47,11 +47,13 @@ pub const BAND_4_SLOPE: u64 = 300_000; // 3.0e-11
 /// CBE Band 1 base price offset scaled by PRICE_SCALE (0.0003133457 SOV/CBE)
 pub const BAND_1_BASE_OFFSET: i64 = 31_335;
 
-/// CBE supply band upper boundaries in billions of tokens (Issue #1842)
+/// Supply band upper boundaries in billions of tokens (Issue #1842)
+/// These are CBE DAO constants — not protocol-level.
 pub const BAND_1_END_BILLIONS: u64 = 10;
 pub const BAND_2_END_BILLIONS: u64 = 30;
 pub const BAND_3_END_BILLIONS: u64 = 60;
-pub const CBE_MAX_SUPPLY_BILLIONS: u64 = 100;
+/// Total CBE supply cap in billions (must match canonical::MAX_SUPPLY / SCALE).
+pub const MAX_SUPPLY_BILLIONS: u64 = 100;
 
 /// Maximum rounding error allowed at band price boundaries (atomic units)
 pub const PRICE_CONTINUITY_TOLERANCE: u128 = 1;
@@ -153,12 +155,12 @@ impl PiecewiseLinearCurve {
                 },
                 SupplyBand {
                     start_supply: band_end(BAND_3_END_BILLIONS),
-                    end_supply: band_end(CBE_MAX_SUPPLY_BILLIONS),
+                    end_supply: band_end(MAX_SUPPLY_BILLIONS),
                     slope: BAND_4_SLOPE,
                     base_offset: base_4,
                 },
             ],
-            max_supply: band_end(CBE_MAX_SUPPLY_BILLIONS),
+            max_supply: band_end(MAX_SUPPLY_BILLIONS),
         }
     }
 

--- a/lib-blockchain/src/contracts/dev_grants/core.rs
+++ b/lib-blockchain/src/contracts/dev_grants/core.rs
@@ -289,7 +289,7 @@ impl DevGrants {
             recipient_key_id: grant.recipient_key_id,
             amount: grant.amount,
             executed_at: current_height,
-            token_burned: burned as u64,
+            token_burned: burned,
         };
 
         self.disbursements.push(disbursement);

--- a/lib-blockchain/src/contracts/dev_grants/core.rs
+++ b/lib-blockchain/src/contracts/dev_grants/core.rs
@@ -265,7 +265,7 @@ impl DevGrants {
         // Capability-bound: source is derived from ctx, not from parameter
         // ====================================================================
         let burned = token
-            .transfer(ctx, recipient, amt)
+            .transfer(ctx, recipient, amt as u128)
             .map_err(|_| Error::TokenTransferFailed)?;
 
         // ====================================================================
@@ -289,7 +289,7 @@ impl DevGrants {
             recipient_key_id: grant.recipient_key_id,
             amount: grant.amount,
             executed_at: current_height,
-            token_burned: burned,
+            token_burned: burned as u64,
         };
 
         self.disbursements.push(disbursement);

--- a/lib-blockchain/src/contracts/dev_grants/types.rs
+++ b/lib-blockchain/src/contracts/dev_grants/types.rs
@@ -120,7 +120,7 @@ pub struct Disbursement {
     /// - For deflationary tokens: `token_burned > 0` (amount transferred + fee burned)
     /// - Total deducted from sender: `amount.get() + token_burned`
     /// - Invariant: `amount.get() + token_burned <= balance_deducted`
-    pub token_burned: u64,
+    pub token_burned: u128,
 }
 
 /// Error types for DevGrants contract

--- a/lib-blockchain/src/contracts/executor/mod.rs
+++ b/lib-blockchain/src/contracts/executor/mod.rs
@@ -882,7 +882,7 @@ impl<S: ContractStorage> ContractExecutor<S> {
 
                 // Use new capability-bound transfer API with ExecutionContext
                 let _burn_amount = token
-                    .transfer(context, &to, amount)
+                    .transfer(context, &to, amount as u128)
                     .map_err(|e| anyhow!("{}", e))?;
 
                 // Stage token change for atomic commit
@@ -915,10 +915,10 @@ impl<S: ContractStorage> ContractExecutor<S> {
                 // Creator-gated tokens use mint() directly.
                 if token.kernel_mint_authority.is_some() {
                     token
-                        .mint_kernel_only(&context.caller, &to, amount)
+                        .mint_kernel_only(&context.caller, &to, amount as u128)
                         .map_err(|e| anyhow!("{}", e))?;
                 } else {
-                    token.mint(&to, amount).map_err(|e| anyhow!("{}", e))?;
+                    token.mint(&to, amount as u128).map_err(|e| anyhow!("{}", e))?;
                 }
 
                 // Stage token change for atomic commit
@@ -939,7 +939,7 @@ impl<S: ContractStorage> ContractExecutor<S> {
 
                 // Burn from caller's own balance
                 token
-                    .burn(&context.caller, amount)
+                    .burn(&context.caller, amount as u128)
                     .map_err(|e| anyhow!("{}", e))?;
 
                 // Stage token change for atomic commit

--- a/lib-blockchain/src/contracts/mod.rs
+++ b/lib-blockchain/src/contracts/mod.rs
@@ -211,7 +211,7 @@ mod tests {
     fn test_lib_constants() {
         assert_eq!(SOV_NATIVE_SYMBOL, "SOV");
         assert_eq!(SOV_NATIVE_NAME, "Sovereign");
-        assert_eq!(SOV_NATIVE_DECIMALS, 8);
-        assert_eq!(SOV_NATIVE_MAX_SUPPLY, 2_100_000_000_000_000);
+        assert_eq!(SOV_NATIVE_DECIMALS, 18);
+        assert_eq!(SOV_NATIVE_MAX_SUPPLY, lib_types::SOV_MAX_SUPPLY);
     }
 }

--- a/lib-blockchain/src/contracts/tokens/cbe_token.rs
+++ b/lib-blockchain/src/contracts/tokens/cbe_token.rs
@@ -37,8 +37,9 @@ use std::collections::HashMap;
 // CRITICAL CONSTANTS - NEVER CHANGE
 // ============================================================================
 
-/// Whole-token CBE supply target shared with the canonical tokenomics constants.
-pub const CBE_TOTAL_SUPPLY_TOKENS: u64 = lib_types::CBE_TOTAL_SUPPLY_TOKENS as u64;
+/// Whole-token CBE supply target (100 billion CBE).
+/// CBE is a DAO token — its constants are self-contained here, not in lib-types.
+pub const CBE_TOTAL_SUPPLY_TOKENS: u64 = 100_000_000_000;
 
 /// Smallest unit of legacy runtime CBE accounting: 1 CBE = 10^8 atoms.
 /// All balances and supply values are stored in atoms in this `u64` contract.

--- a/lib-blockchain/src/contracts/tokens/constants.rs
+++ b/lib-blockchain/src/contracts/tokens/constants.rs
@@ -1,8 +1,7 @@
-//! SOV token constants.
+//! SOV token constants — single source of truth for runtime.
 //!
-//! The semantic protocol values live in `lib-types::tokenomics`.
-//! This module keeps the existing `u64` runtime token-contract compatibility
-//! constants until the token core/storage model is widened to `u128`.
+//! SOV uses 18 decimals everywhere: protocol constants, runtime contracts,
+//! and storage (sled already uses u128 via `Amount`).
 
 /// Token name
 pub const SOV_TOKEN_NAME: &str = "Sovereign";
@@ -10,21 +9,21 @@ pub const SOV_TOKEN_NAME: &str = "Sovereign";
 /// Token symbol
 pub const SOV_TOKEN_SYMBOL: &str = "SOV";
 
-/// Canonical protocol decimals.
+/// Canonical protocol decimals (re-exported from lib-types).
 pub use lib_types::SOV_DECIMALS as SOV_PROTOCOL_DECIMALS;
 
 /// Canonical protocol total supply in whole tokens.
 pub use lib_types::SOV_TOTAL_SUPPLY_TOKENS;
 
-/// Canonical protocol max supply in atomic units.
+/// Canonical protocol max supply in atomic units (18 decimals).
 pub use lib_types::SOV_MAX_SUPPLY as SOV_PROTOCOL_MAX_SUPPLY;
 
-/// Legacy runtime decimals still used by the `u64` token contract.
-pub const SOV_TOKEN_DECIMALS: u8 = 8;
+/// Runtime decimals — unified with protocol (18 decimals).
+pub const SOV_TOKEN_DECIMALS: u8 = 18;
 
-/// Legacy runtime max-supply ceiling for the `u64` token contract.
-/// This is a compatibility ceiling, not the semantic SOV issuance target.
-pub const SOV_TOKEN_MAX_SUPPLY: u64 = 21_000_000 * 100_000_000;
+/// Runtime max-supply ceiling in atomic units (18 decimals).
+/// 1 trillion SOV × 10^18 atoms per token.
+pub const SOV_TOKEN_MAX_SUPPLY: u128 = lib_types::SOV_MAX_SUPPLY;
 
 /// Transaction fee rate: 100 basis points = 1%
 pub const SOV_FEE_RATE_BPS: u16 = 100;

--- a/lib-blockchain/src/contracts/tokens/core.rs
+++ b/lib-blockchain/src/contracts/tokens/core.rs
@@ -515,7 +515,9 @@ impl TokenContract {
 
     /// Check if supply can accommodate minting
     pub fn can_mint(&self, amount: u128) -> bool {
-        self.total_supply + amount <= self.max_supply
+        self.total_supply
+            .checked_add(amount)
+            .map_or(false, |sum| sum <= self.max_supply)
     }
 
     /// Get remaining mintable supply

--- a/lib-blockchain/src/contracts/tokens/core.rs
+++ b/lib-blockchain/src/contracts/tokens/core.rs
@@ -133,13 +133,14 @@ impl TokenContract {
     /// # Arguments
     /// * `kernel_authority` - The public key of the Treasury Kernel (only entity that can mint)
     pub fn new_sov_with_kernel_authority(kernel_authority: PublicKey) -> Self {
+        use super::constants::*;
         let creator = PublicKey::new([0u8; 2592]); // Mock creator for SOV
         let mut token = Self::new(
             crate::contracts::utils::generate_lib_token_id(),
             "SOV Token".to_string(),
             "SOV".to_string(),
-            8,
-            1_000_000_000 * 100_000_000, // 1B SOV with 8 decimals
+            SOV_TOKEN_DECIMALS,
+            SOV_TOKEN_MAX_SUPPLY,        // 18-decimal max supply
             false,                       // SOV is not deflationary
             0,                           // No burn rate for SOV
             creator,
@@ -814,7 +815,7 @@ mod tests {
 
         assert_eq!(token.name, "SOV Token");
         assert_eq!(token.symbol, "SOV");
-        assert_eq!(token.decimals, 8);
+        assert_eq!(token.decimals, 18);
         assert!(!token.is_deflationary);
         assert_eq!(token.kernel_mint_authority, Some(kernel_addr));
     }

--- a/lib-blockchain/src/contracts/tokens/core.rs
+++ b/lib-blockchain/src/contracts/tokens/core.rs
@@ -43,17 +43,17 @@ pub struct TokenContract {
     /// Number of decimal places
     pub decimals: u8,
     /// Current total supply in circulation
-    pub total_supply: u64,
+    pub total_supply: u128,
     /// Maximum supply that can ever exist
-    pub max_supply: u64,
+    pub max_supply: u128,
     /// Whether the token burns on transfer (deflationary)
     pub is_deflationary: bool,
     /// Amount burned per transfer (if deflationary)
-    pub burn_rate: u64,
+    pub burn_rate: u128,
     /// Account balances mapping
-    pub balances: HashMap<PublicKey, u64>,
+    pub balances: HashMap<PublicKey, u128>,
     /// Allowances for third-party transfers
-    pub allowances: HashMap<PublicKey, HashMap<PublicKey, u64>>,
+    pub allowances: HashMap<PublicKey, HashMap<PublicKey, u128>>,
     /// Token creator
     pub creator: PublicKey,
     /// Kernel minting authority (for UBI distribution)
@@ -64,7 +64,7 @@ pub struct TokenContract {
     /// Locked balances per account (non-transferable until released)
     /// Used by Treasury Kernel for staking, vesting, escrow
     #[serde(default)]
-    pub locked_balances: HashMap<PublicKey, u64>,
+    pub locked_balances: HashMap<PublicKey, u128>,
     /// When true, only Treasury Kernel (kernel_mint_authority) can call
     /// mint(), burn(), and transfer(). Defaults to false for backward compat.
     #[serde(default)]
@@ -84,9 +84,9 @@ impl TokenContract {
         name: String,
         symbol: String,
         decimals: u8,
-        max_supply: u64,
+        max_supply: u128,
         is_deflationary: bool,
-        burn_rate: u64,
+        burn_rate: u128,
         creator: PublicKey,
     ) -> Self {
         Self {
@@ -160,28 +160,28 @@ impl TokenContract {
             token_id,
             name,
             symbol,
-            8,        // Default 8 decimals
-            u64::MAX, // Very large max supply
-            false,    // Not deflationary by default
-            0,        // No burn rate
+            8,                    // Default 8 decimals
+            u64::MAX as u128,     // Very large max supply
+            false,                // Not deflationary by default
+            0,                    // No burn rate
             creator.clone(),
         );
 
         // Mint initial supply to creator
         if initial_supply > 0 {
-            let _ = token.mint(&creator, initial_supply);
+            let _ = token.mint(&creator, initial_supply as u128);
         }
 
         token
     }
 
     /// Get balance of an account
-    pub fn balance_of(&self, account: &PublicKey) -> u64 {
+    pub fn balance_of(&self, account: &PublicKey) -> u128 {
         self.balances.get(account).copied().unwrap_or(0)
     }
 
     /// Get allowance for a spender
-    pub fn allowance(&self, owner: &PublicKey, spender: &PublicKey) -> u64 {
+    pub fn allowance(&self, owner: &PublicKey, spender: &PublicKey) -> u128 {
         self.allowances
             .get(owner)
             .and_then(|spenders| spenders.get(spender))
@@ -210,8 +210,8 @@ impl TokenContract {
         &mut self,
         ctx: &ExecutionContext,
         to: &PublicKey,
-        amount: u64,
-    ) -> Result<u64, Error> {
+        amount: u128,
+    ) -> Result<u128, Error> {
         // Phase C: kernel-only mode enforcement
         if self.kernel_only_mode {
             let caller_key = match ctx.call_origin {
@@ -279,8 +279,8 @@ impl TokenContract {
         ctx: &ExecutionContext,
         owner: &PublicKey,
         to: &PublicKey,
-        amount: u64,
-    ) -> Result<u64, Error> {
+        amount: u128,
+    ) -> Result<u128, Error> {
         // Determine the spender from execution context
         let spender = match ctx.call_origin {
             CallOrigin::User => ctx.caller.clone(),
@@ -326,7 +326,7 @@ impl TokenContract {
     }
 
     /// Approve spending allowance
-    pub fn approve(&mut self, owner: &PublicKey, spender: &PublicKey, amount: u64) {
+    pub fn approve(&mut self, owner: &PublicKey, spender: &PublicKey, amount: u128) {
         self.allowances
             .entry(owner.clone())
             .or_insert_with(HashMap::new)
@@ -334,7 +334,7 @@ impl TokenContract {
     }
 
     /// Mint new tokens
-    pub fn mint(&mut self, to: &PublicKey, amount: u64) -> Result<(), String> {
+    pub fn mint(&mut self, to: &PublicKey, amount: u128) -> Result<(), String> {
         if self.kernel_only_mode {
             return Err("Direct minting disabled: use Treasury Kernel".to_string());
         }
@@ -367,7 +367,7 @@ impl TokenContract {
         &mut self,
         caller: &PublicKey,
         to: &PublicKey,
-        amount: u64,
+        amount: u128,
     ) -> Result<(), String> {
         // Check kernel authority
         match &self.kernel_mint_authority {
@@ -392,7 +392,7 @@ impl TokenContract {
     }
 
     /// Burn tokens from an account
-    pub fn burn(&mut self, from: &PublicKey, amount: u64) -> Result<(), String> {
+    pub fn burn(&mut self, from: &PublicKey, amount: u128) -> Result<(), String> {
         if self.kernel_only_mode {
             return Err("Direct burning disabled: use Treasury Kernel".to_string());
         }
@@ -427,7 +427,7 @@ impl TokenContract {
     // (except where noted).
 
     /// Credit balance without supply change (for transfers, fee distribution)
-    pub(crate) fn credit_balance(&mut self, to: &PublicKey, amount: u64) -> Result<(), String> {
+    pub(crate) fn credit_balance(&mut self, to: &PublicKey, amount: u128) -> Result<(), String> {
         let balance = self.balance_of(to);
         let new_balance = balance
             .checked_add(amount)
@@ -438,7 +438,7 @@ impl TokenContract {
 
     /// Debit balance without supply change (for transfers, fee collection)
     /// Respects locked balances: only available (balance - locked) can be debited.
-    pub(crate) fn debit_balance(&mut self, from: &PublicKey, amount: u64) -> Result<(), String> {
+    pub(crate) fn debit_balance(&mut self, from: &PublicKey, amount: u128) -> Result<(), String> {
         let balance = self.balance_of(from);
         let locked = self.locked_balances.get(from).copied().unwrap_or(0);
         let available = balance.saturating_sub(locked);
@@ -453,7 +453,7 @@ impl TokenContract {
     }
 
     /// Lock tokens in an account (cannot be transferred until released)
-    pub(crate) fn lock_balance(&mut self, account: &PublicKey, amount: u64) -> Result<(), String> {
+    pub(crate) fn lock_balance(&mut self, account: &PublicKey, amount: u128) -> Result<(), String> {
         let balance = self.balance_of(account);
         let locked = self.locked_balances.get(account).copied().unwrap_or(0);
         let available = balance.saturating_sub(locked);
@@ -474,7 +474,7 @@ impl TokenContract {
     pub(crate) fn release_balance(
         &mut self,
         account: &PublicKey,
-        amount: u64,
+        amount: u128,
     ) -> Result<(), String> {
         let locked = self.locked_balances.get(account).copied().unwrap_or(0);
         if locked < amount {
@@ -493,7 +493,7 @@ impl TokenContract {
     }
 
     /// Get available (unlocked) balance for an account
-    pub fn available_balance(&self, account: &PublicKey) -> u64 {
+    pub fn available_balance(&self, account: &PublicKey) -> u128 {
         let balance = self.balance_of(account);
         let locked = self.locked_balances.get(account).copied().unwrap_or(0);
         balance.saturating_sub(locked)
@@ -513,12 +513,12 @@ impl TokenContract {
     // ─── End Treasury Kernel internal operations ─────────────────────────
 
     /// Check if supply can accommodate minting
-    pub fn can_mint(&self, amount: u64) -> bool {
+    pub fn can_mint(&self, amount: u128) -> bool {
         self.total_supply + amount <= self.max_supply
     }
 
     /// Get remaining mintable supply
-    pub fn remaining_supply(&self) -> u64 {
+    pub fn remaining_supply(&self) -> u128 {
         self.max_supply.saturating_sub(self.total_supply)
     }
 
@@ -591,10 +591,10 @@ pub struct TokenInfo {
     pub name: String,
     pub symbol: String,
     pub decimals: u8,
-    pub total_supply: u64,
-    pub max_supply: u64,
+    pub total_supply: u128,
+    pub max_supply: u128,
     pub is_deflationary: bool,
-    pub burn_rate: u64,
+    pub burn_rate: u128,
     pub creator: PublicKey,
 }
 
@@ -640,11 +640,8 @@ mod tests {
 
         assert_eq!(token.name, "Sovereign");
         assert_eq!(token.symbol, "SOV");
-        assert_eq!(token.decimals, 8);
-        assert_eq!(
-            token.max_supply,
-            crate::contracts::tokens::constants::SOV_TOKEN_MAX_SUPPLY
-        );
+        assert_eq!(token.decimals, 18);
+        assert_eq!(token.max_supply, lib_types::SOV_MAX_SUPPLY);
         assert!(!token.is_deflationary);
         assert_eq!(token.burn_rate, 0);
     }

--- a/lib-blockchain/src/contracts/tokens/core.rs
+++ b/lib-blockchain/src/contracts/tokens/core.rs
@@ -161,10 +161,10 @@ impl TokenContract {
             token_id,
             name,
             symbol,
-            8,                    // Default 8 decimals
-            u64::MAX as u128,     // Very large max supply
-            false,                // Not deflationary by default
-            0,                    // No burn rate
+            super::constants::SOV_TOKEN_DECIMALS, // Default 18 decimals (protocol standard)
+            u64::MAX as u128,                     // Very large max supply
+            false,                                // Not deflationary by default
+            0,                                    // No burn rate
             creator.clone(),
         );
 
@@ -631,7 +631,7 @@ mod tests {
 
         assert_eq!(token.name, "Test Token");
         assert_eq!(token.symbol, "TEST");
-        assert_eq!(token.decimals, 8);
+        assert_eq!(token.decimals, 18);
         assert!(!token.is_deflationary);
         assert_eq!(token.creator, public_key);
         assert_eq!(token.total_supply, 100_000_000);

--- a/lib-blockchain/src/contracts/tokens/functions.rs
+++ b/lib-blockchain/src/contracts/tokens/functions.rs
@@ -18,7 +18,7 @@ pub fn approve_spending(
     spender: &PublicKey,
     amount: u64,
 ) {
-    contract.approve(owner, spender, amount);
+    contract.approve(owner, spender, amount as u128);
 }
 
 /// Mint new tokens
@@ -34,7 +34,7 @@ pub fn mint_tokens(
     to: &PublicKey,
     amount: u64,
 ) -> Result<(), String> {
-    contract.mint(to, amount)
+    contract.mint(to, amount as u128)
 }
 
 /// Burn tokens from account
@@ -50,7 +50,7 @@ pub fn burn_tokens(
     from: &PublicKey,
     amount: u64,
 ) -> Result<(), String> {
-    contract.burn(from, amount)
+    contract.burn(from, amount as u128)
 }
 
 /// Mint new tokens via Treasury Kernel (preferred path)
@@ -82,12 +82,12 @@ pub fn burn_tokens_via_kernel(
 }
 
 /// Get account balance
-pub fn get_balance(contract: &TokenContract, account: &PublicKey) -> u64 {
+pub fn get_balance(contract: &TokenContract, account: &PublicKey) -> u128 {
     contract.balance_of(account)
 }
 
 /// Get spending allowance
-pub fn get_allowance(contract: &TokenContract, owner: &PublicKey, spender: &PublicKey) -> u64 {
+pub fn get_allowance(contract: &TokenContract, owner: &PublicKey, spender: &PublicKey) -> u128 {
     contract.allowance(owner, spender)
 }
 
@@ -103,11 +103,11 @@ pub fn validate_token(contract: &TokenContract) -> Result<(), String> {
 
 /// Check if minting amount is possible
 pub fn can_mint_amount(contract: &TokenContract, amount: u64) -> bool {
-    contract.can_mint(amount)
+    contract.can_mint(amount as u128)
 }
 
 /// Get remaining mintable supply
-pub fn get_remaining_supply(contract: &TokenContract) -> u64 {
+pub fn get_remaining_supply(contract: &TokenContract) -> u128 {
     contract.remaining_supply()
 }
 
@@ -152,14 +152,14 @@ pub fn create_deflationary_token(
         name,
         symbol,
         decimals,
-        max_supply,
+        max_supply as u128,
         true, // is_deflationary
-        burn_rate,
+        burn_rate as u128,
         creator.clone(),
     );
 
     if initial_supply > 0 {
-        let _ = token.mint(&creator, initial_supply);
+        let _ = token.mint(&creator, initial_supply as u128);
     }
 
     token
@@ -171,7 +171,7 @@ pub fn create_deflationary_token(
 /// Batch transfers should be implemented using the new transfer(ctx, to, amount) API.
 
 /// Get all non-zero balances
-pub fn get_all_balances(contract: &TokenContract) -> HashMap<PublicKey, u64> {
+pub fn get_all_balances(contract: &TokenContract) -> HashMap<PublicKey, u128> {
     contract
         .balances
         .iter()
@@ -181,7 +181,7 @@ pub fn get_all_balances(contract: &TokenContract) -> HashMap<PublicKey, u64> {
 }
 
 /// Get all allowances for an owner
-pub fn get_all_allowances(contract: &TokenContract, owner: &PublicKey) -> HashMap<PublicKey, u64> {
+pub fn get_all_allowances(contract: &TokenContract, owner: &PublicKey) -> HashMap<PublicKey, u128> {
     contract
         .allowances
         .get(owner)
@@ -197,13 +197,13 @@ pub fn get_all_allowances(contract: &TokenContract, owner: &PublicKey) -> HashMa
 
 /// Calculate total value locked (TVL) in token (requires price)
 pub fn calculate_tvl(contract: &TokenContract, price_per_token: f64) -> f64 {
-    let total_locked: u64 = contract.balances.values().sum();
+    let total_locked: u128 = contract.balances.values().sum();
     (total_locked as f64 / 10f64.powi(contract.decimals as i32)) * price_per_token
 }
 
 /// Get token distribution statistics
 pub fn get_distribution_stats(contract: &TokenContract) -> TokenDistributionStats {
-    let balances: Vec<u64> = contract
+    let balances: Vec<u128> = contract
         .balances
         .values()
         .filter(|&&balance| balance > 0)
@@ -218,7 +218,7 @@ pub fn get_distribution_stats(contract: &TokenContract) -> TokenDistributionStat
     let total_supply = contract.total_supply;
     let largest_balance = *balances.iter().max().unwrap_or(&0);
     let smallest_balance = *balances.iter().min().unwrap_or(&0);
-    let average_balance = total_supply / total_holders as u64;
+    let average_balance = total_supply / total_holders as u128;
 
     // Calculate concentration (percentage held by top holder)
     let concentration = if total_supply > 0 {
@@ -241,11 +241,11 @@ pub fn get_distribution_stats(contract: &TokenContract) -> TokenDistributionStat
 #[derive(Debug, Clone)]
 pub struct TokenDistributionStats {
     pub total_holders: usize,
-    pub largest_balance: u64,
-    pub smallest_balance: u64,
-    pub average_balance: u64,
+    pub largest_balance: u128,
+    pub smallest_balance: u128,
+    pub average_balance: u128,
     pub concentration_percentage: f64,
-    pub total_supply: u64,
+    pub total_supply: u128,
 }
 
 impl Default for TokenDistributionStats {
@@ -276,20 +276,20 @@ pub fn token_swap(
     amount_b: u64,
 ) -> Result<(u64, u64), String> {
     // Check balances
-    if token_a.balance_of(user) < amount_a {
+    if token_a.balance_of(user) < amount_a as u128 {
         return Err("Insufficient balance in token A".to_string());
     }
-    if token_b.balance_of(user) < amount_b {
+    if token_b.balance_of(user) < amount_b as u128 {
         return Err("Insufficient balance in token B".to_string());
     }
 
     // Burn tokens from user (simplified swap mechanism)
-    token_a.burn(user, amount_a)?;
-    token_b.burn(user, amount_b)?;
+    token_a.burn(user, amount_a as u128)?;
+    token_b.burn(user, amount_b as u128)?;
 
     // Mint swapped amounts (simplified)
-    token_a.mint(user, amount_b)?;
-    token_b.mint(user, amount_a)?;
+    token_a.mint(user, amount_b as u128)?;
+    token_b.mint(user, amount_a as u128)?;
 
     Ok((amount_a, amount_b))
 }

--- a/lib-blockchain/src/contracts/tokens/mod.rs
+++ b/lib-blockchain/src/contracts/tokens/mod.rs
@@ -15,11 +15,6 @@ pub use constants::{
     SOV_FEE_RATE_BPS, SOV_PROTOCOL_DECIMALS, SOV_PROTOCOL_MAX_SUPPLY, SOV_TOKEN_DECIMALS,
     SOV_TOKEN_MAX_SUPPLY, SOV_TOKEN_NAME, SOV_TOKEN_SYMBOL, SOV_TOTAL_SUPPLY_TOKENS,
 };
-pub use lib_types::{
-    CBE_DECIMALS as CBE_PROTOCOL_DECIMALS, CBE_MAX_SUPPLY as CBE_PROTOCOL_MAX_SUPPLY,
-    CBE_TOTAL_SUPPLY_TOKENS,
-};
-
 // Re-export CBE token
 pub use cbe_token::{
     CbeToken, CbeTokenError, DistributionAllocation, VestingPool, VestingSchedule,

--- a/lib-blockchain/src/contracts/treasury_kernel/kernel_ops.rs
+++ b/lib-blockchain/src/contracts/treasury_kernel/kernel_ops.rs
@@ -40,7 +40,7 @@ impl TreasuryKernel {
 
         match reason {
             CreditReason::Mint | CreditReason::UbiDistribution => token
-                .mint_kernel_only(self.kernel_address(), to, amount)
+                .mint_kernel_only(self.kernel_address(), to, amount as u128)
                 .map_err(|e| {
                     if e.contains("exceed maximum supply") {
                         KernelOpError::ExceedsMaxSupply
@@ -51,7 +51,7 @@ impl TreasuryKernel {
                     }
                 }),
             CreditReason::FeeDistribution | CreditReason::Reward | CreditReason::Transfer => token
-                .credit_balance(to, amount)
+                .credit_balance(to, amount as u128)
                 .map_err(|_| KernelOpError::Overflow),
         }
     }
@@ -74,15 +74,15 @@ impl TreasuryKernel {
             DebitReason::Burn => {
                 // Bypass kernel_only_mode gate — kernel IS the authority
                 let balance = token.balance_of(from);
-                if balance < amount {
+                if balance < amount as u128 {
                     return Err(KernelOpError::InsufficientBalance);
                 }
-                token.balances.insert(from.clone(), balance - amount);
-                token.total_supply = token.total_supply.saturating_sub(amount);
+                token.balances.insert(from.clone(), balance - amount as u128);
+                token.total_supply = token.total_supply.saturating_sub(amount as u128);
                 Ok(())
             }
             DebitReason::FeeCollection | DebitReason::Slash | DebitReason::Transfer => token
-                .debit_balance(from, amount)
+                .debit_balance(from, amount as u128)
                 .map_err(|_| KernelOpError::InsufficientBalance),
         }
     }
@@ -99,7 +99,7 @@ impl TreasuryKernel {
         self.verify_caller(caller)?;
 
         token
-            .lock_balance(account, amount)
+            .lock_balance(account, amount as u128)
             .map_err(|_| KernelOpError::InsufficientBalance)
     }
 
@@ -115,7 +115,7 @@ impl TreasuryKernel {
         self.verify_caller(caller)?;
 
         token
-            .release_balance(account, amount)
+            .release_balance(account, amount as u128)
             .map_err(|_| KernelOpError::InsufficientLockedBalance)
     }
 
@@ -155,12 +155,12 @@ impl TreasuryKernel {
 
         // Debit source (respects locked balances)
         token
-            .debit_balance(from, amount)
+            .debit_balance(from, amount as u128)
             .map_err(|_| KernelOpError::InsufficientBalance)?;
 
         // Credit destination
         token
-            .credit_balance(to, amount)
+            .credit_balance(to, amount as u128)
             .map_err(|_| KernelOpError::Overflow)?;
 
         Ok(())

--- a/lib-blockchain/src/contracts/treasury_kernel/srv_ops.rs
+++ b/lib-blockchain/src/contracts/treasury_kernel/srv_ops.rs
@@ -174,7 +174,7 @@ impl TreasuryKernel {
         }
 
         // Get current circulating supply from token contract
-        let circulating_supply = token.total_supply as u64;
+        let circulating_supply = u64::try_from(token.total_supply).unwrap_or(u64::MAX);
 
         // Apply the update
         let new_srv = self

--- a/lib-blockchain/src/contracts/treasury_kernel/srv_ops.rs
+++ b/lib-blockchain/src/contracts/treasury_kernel/srv_ops.rs
@@ -173,8 +173,8 @@ impl TreasuryKernel {
                 .map_err(|_| KernelOpError::InvalidState)?;
         }
 
-        // Get current circulating supply from token contract
-        let circulating_supply = u64::try_from(token.total_supply).unwrap_or(u64::MAX);
+        // Get current circulating supply from token contract (full u128 precision)
+        let circulating_supply = token.total_supply;
 
         // Apply the update
         let new_srv = self
@@ -404,9 +404,10 @@ mod tests {
 
         // Pre-mint some tokens to have non-zero circulating supply
         // Use the kernel address to mint (it has kernel authority)
+        // Mint 50M SOV in 18-decimal atomic units
         let _ =
-            token.mint_kernel_only(&test_kernel_address(), &test_user(), 50_000_000_000_000_000);
-        assert_eq!(token.total_supply, 50_000_000_000_000_000); // 50M SOV
+            token.mint_kernel_only(&test_kernel_address(), &test_user(), 50_000_000_000_000_000_000_000_000);
+        assert_eq!(token.total_supply, 50_000_000_000_000_000_000_000_000); // 50M SOV
 
         // Small increase from 109M to 110M committed value
         // With circulating supply of 50M SOV, SRV changes from ~$0.0218 to ~$0.0220

--- a/lib-blockchain/src/contracts/treasury_kernel/srv_ops.rs
+++ b/lib-blockchain/src/contracts/treasury_kernel/srv_ops.rs
@@ -174,7 +174,7 @@ impl TreasuryKernel {
         }
 
         // Get current circulating supply from token contract
-        let circulating_supply = token.total_supply;
+        let circulating_supply = token.total_supply as u64;
 
         // Apply the update
         let new_srv = self

--- a/lib-blockchain/src/contracts/treasury_kernel/srv_types.rs
+++ b/lib-blockchain/src/contracts/treasury_kernel/srv_types.rs
@@ -33,8 +33,8 @@ pub struct SRVState {
     /// Example: 109_000_000 = $1,090,000
     pub committed_value_usd: u64,
 
-    /// Circulating supply at time of last SRV calculation (8 decimals)
-    pub circulating_supply_sov: u64,
+    /// Circulating supply at time of last SRV calculation (18 decimals)
+    pub circulating_supply_sov: u128,
 
     /// Stability multiplier in basis points (10000 = 1.0)
     pub stability_multiplier_bps: u16,
@@ -72,7 +72,7 @@ pub struct SRVUpdateRecord {
     /// Committed value used
     pub committed_value_usd: u64,
     /// Circulating supply used
-    pub circulating_supply_sov: u64,
+    pub circulating_supply_sov: u128,
     /// Proposal ID that authorized this update
     pub proposal_id: [u8; 32],
 }
@@ -120,7 +120,7 @@ impl SRVState {
     /// # Arguments
     /// * `initial_srv` - Initial SRV value (8 decimals)
     /// * `committed_value_usd` - Initial committed value in USD cents
-    /// * `circulating_supply_sov` - Initial circulating supply (8 decimals)
+    /// * `circulating_supply_sov` - Initial circulating supply (18 decimals)
     /// * `stability_multiplier_bps` - Initial stability multiplier (basis points)
     ///
     /// # Returns
@@ -128,7 +128,7 @@ impl SRVState {
     pub fn new(
         initial_srv: u64,
         committed_value_usd: u64,
-        circulating_supply_sov: u64,
+        circulating_supply_sov: u128,
         stability_multiplier_bps: u16,
     ) -> Self {
         Self {
@@ -149,13 +149,13 @@ impl SRVState {
     /// Default genesis values:
     /// - SRV: $0.0218 (2_180_000 with 8 decimals)
     /// - Committed value: $1,090,000 (109_000_000 cents)
-    /// - Circulating supply: 50M SOV (50_000_000_000_000_000 with 8 decimals)
+    /// - Circulating supply: 50M SOV (50_000_000_000_000_000_000_000_000 with 18 decimals)
     /// - Stability multiplier: 1.0 (10_000 basis points)
     pub fn new_genesis() -> Self {
         Self::new(
             2_180_000,              // $0.0218
             109_000_000,            // $1,090,000
-            50_000_000_000_000_000, // 50M SOV
+            50_000_000_000_000_000_000_000_000, // 50M SOV
             10_000,                 // 1.0
         )
     }
@@ -166,19 +166,19 @@ impl SRVState {
     ///
     /// Where:
     /// - Committed_Value_USD is in cents (2 decimals)
-    /// - Circulating_SOV is in atomic units (8 decimals)
+    /// - Circulating_SOV is in atomic units (18 decimals)
     /// - SRV result is in USD per SOV (8 decimals)
     ///
     /// # Arguments
     /// * `committed_value_usd` - Total committed value in USD cents
-    /// * `circulating_supply_sov` - Circulating SOV (8 decimals, atomic units)
+    /// * `circulating_supply_sov` - Circulating SOV (18 decimals, atomic units)
     /// * `multiplier_bps` - Stability multiplier in basis points
     ///
     /// # Returns
     /// SRV in USD per SOV (8 decimal precision)
     pub fn calculate_srv(
         committed_value_usd: u64,
-        circulating_supply_sov: u64,
+        circulating_supply_sov: u128,
         multiplier_bps: u16,
     ) -> Result<u64, SRVError> {
         // Prevent division by zero
@@ -192,19 +192,19 @@ impl SRVState {
         }
 
         // Integer math for determinism:
-        // SRV = committed_value_usd * 10^14 / circulating_supply_sov * multiplier_bps / 10^4
+        // SRV = committed_value_usd * 10^24 / circulating_supply_sov * multiplier_bps / 10^4
         //
         // Explanation:
         // - committed_value_usd is in cents ($1 = 100 cents)
-        // - circulating_supply_sov is in atomic units (1 SOV = 10^8)
+        // - circulating_supply_sov is in atomic units (1 SOV = 10^18)
         // - We want SRV in USD per SOV with 8 decimals
-        // - 10^14 = 10^8 (SRV decimals) * 10^8 (SOV decimals) / 10^2 (cents to USD)
+        // - 10^24 = 10^8 (SRV decimals) * 10^18 (SOV decimals) / 10^2 (cents to USD)
         //
         // Rearranging to avoid overflow:
-        // SRV = (committed_value_usd * 10^14 / circulating_supply_sov) * multiplier_bps / 10^4
+        // SRV = (committed_value_usd * 10^24 / circulating_supply_sov) * multiplier_bps / 10^4
 
         let base_srv = (committed_value_usd as u128)
-            .checked_mul(10_000_000_000_000_00u128) // 10^14
+            .checked_mul(1_000_000_000_000_000_000_000_000u128) // 10^24
             .ok_or(SRVError::Overflow)?
             .checked_div(circulating_supply_sov as u128)
             .ok_or(SRVError::Overflow)?;
@@ -260,7 +260,7 @@ impl SRVState {
     ///
     /// # Arguments
     /// * `new_committed_value` - Updated committed value in USD cents
-    /// * `circulating_supply` - Current circulating supply (8 decimals)
+    /// * `circulating_supply` - Current circulating supply (18 decimals)
     /// * `proposal_id` - Authorizing proposal ID
     /// * `height` - Current block height
     /// * `epoch` - Current epoch
@@ -270,7 +270,7 @@ impl SRVState {
     pub fn apply_update(
         &mut self,
         new_committed_value: u64,
-        circulating_supply: u64,
+        circulating_supply: u128,
         proposal_id: [u8; 32],
         height: u64,
         epoch: u64,
@@ -354,8 +354,8 @@ pub struct SRVGenesisConfig {
     pub initial_srv: u64,
     /// Initial committed value in USD cents
     pub initial_committed_value_usd: u64,
-    /// Initial circulating supply (8 decimals)
-    pub initial_circulating_supply: u64,
+    /// Initial circulating supply (18 decimals)
+    pub initial_circulating_supply: u128,
     /// Initial stability multiplier (basis points)
     pub stability_multiplier_bps: u16,
     /// Maximum change per update (basis points)
@@ -367,7 +367,7 @@ impl Default for SRVGenesisConfig {
         Self {
             initial_srv: 2_180_000,                             // $0.0218
             initial_committed_value_usd: 109_000_000,           // $1,090,000
-            initial_circulating_supply: 50_000_000_000_000_000, // 50M SOV
+            initial_circulating_supply: 50_000_000_000_000_000_000_000_000, // 50M SOV
             stability_multiplier_bps: 10_000,                   // 1.0
             max_change_bps: 100,                                // 1%
         }
@@ -392,10 +392,10 @@ mod tests {
 
     #[test]
     fn test_srv_state_new() {
-        let state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000, 10_000);
+        let state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000_000_000_000, 10_000);
         assert_eq!(state.current_srv, 2_180_000);
         assert_eq!(state.committed_value_usd, 109_000_000);
-        assert_eq!(state.circulating_supply_sov, 50_000_000_000_000_000);
+        assert_eq!(state.circulating_supply_sov, 50_000_000_000_000_000_000_000_000);
         assert_eq!(state.stability_multiplier_bps, 10_000);
         assert_eq!(state.max_change_bps, 100);
     }
@@ -405,7 +405,7 @@ mod tests {
         let state = SRVState::new_genesis();
         assert_eq!(state.current_srv, 2_180_000);
         assert_eq!(state.committed_value_usd, 109_000_000);
-        assert_eq!(state.circulating_supply_sov, 50_000_000_000_000_000);
+        assert_eq!(state.circulating_supply_sov, 50_000_000_000_000_000_000_000_000);
         assert_eq!(state.stability_multiplier_bps, 10_000);
     }
 
@@ -413,11 +413,11 @@ mod tests {
     fn test_calculate_srv_genesis_values() {
         // Test with genesis values
         // Committed: $1,090,000 = 109,000,000 cents
-        // Circulating: 50M SOV = 50,000,000,000,000,000 (8 decimals)
+        // Circulating: 50M SOV = 50_000_000_000_000_000_000_000_000 (18 decimals)
         // Multiplier: 1.0 = 10,000 bps
         // Expected: $0.0218 = 2,180,000 (8 decimals)
 
-        let srv = SRVState::calculate_srv(109_000_000, 50_000_000_000_000_000, 10_000).unwrap();
+        let srv = SRVState::calculate_srv(109_000_000, 50_000_000_000_000_000_000_000_000, 10_000).unwrap();
         assert_eq!(srv, 2_180_000);
     }
 
@@ -426,7 +426,7 @@ mod tests {
         // Test with 0.95 stability multiplier
         // Expected: $0.0218 * 0.95 = $0.02071
 
-        let srv = SRVState::calculate_srv(109_000_000, 50_000_000_000_000_000, 9_500).unwrap();
+        let srv = SRVState::calculate_srv(109_000_000, 50_000_000_000_000_000_000_000_000, 9_500).unwrap();
         assert_eq!(srv, 2_071_000); // 2,071,000 = $0.02071
     }
 
@@ -438,13 +438,13 @@ mod tests {
 
     #[test]
     fn test_calculate_srv_zero_multiplier_fails() {
-        let result = SRVState::calculate_srv(109_000_000, 50_000_000_000_000_000, 0);
+        let result = SRVState::calculate_srv(109_000_000, 50_000_000_000_000_000_000_000_000, 0);
         assert_eq!(result, Err(SRVError::InvalidStabilityMultiplier));
     }
 
     #[test]
     fn test_validate_proposed_change_within_limit() {
-        let state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000, 10_000);
+        let state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000_000_000_000, 10_000);
 
         // 0.5% increase (within 1% limit)
         let new_srv = 2_180_000 + (2_180_000 / 200); // +0.5%
@@ -457,7 +457,7 @@ mod tests {
 
     #[test]
     fn test_validate_proposed_change_exceeds_limit() {
-        let state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000, 10_000);
+        let state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000_000_000_000, 10_000);
 
         // 2% increase (exceeds 1% limit)
         let new_srv = 2_180_000 + (2_180_000 / 50); // +2%
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_validate_proposed_change_when_paused() {
-        let mut state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000, 10_000);
+        let mut state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000_000_000_000, 10_000);
         state.set_emergency_pause(true);
 
         assert_eq!(
@@ -480,13 +480,13 @@ mod tests {
 
     #[test]
     fn test_apply_update() {
-        let mut state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000, 10_000);
+        let mut state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000_000_000_000, 10_000);
 
         // Update with small committed value increase (within 1% limit)
         // Increase from $1.09M to $1.10M = ~0.9% increase
         let result = state.apply_update(
             110_000_000, // slight increase from 109M
-            50_000_000_000_000_000,
+            50_000_000_000_000_000_000_000_000,
             [1u8; 32],
             100,
             1,
@@ -502,12 +502,12 @@ mod tests {
 
     #[test]
     fn test_apply_update_exceeds_limit_fails() {
-        let mut state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000, 10_000);
+        let mut state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000_000_000_000, 10_000);
 
         // Try to increase SRV by 50% (way over 1% limit)
         let result = state.apply_update(
             163_500_000, // would give 50% increase
-            50_000_000_000_000_000,
+            50_000_000_000_000_000_000_000_000,
             [1u8; 32],
             100,
             1,
@@ -519,7 +519,7 @@ mod tests {
 
     #[test]
     fn test_update_stability_multiplier() {
-        let mut state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000, 10_000);
+        let mut state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000_000_000_000, 10_000);
 
         assert!(state.update_stability_multiplier(9_500).is_ok());
         assert_eq!(state.stability_multiplier_bps, 9_500);
@@ -533,13 +533,13 @@ mod tests {
 
     #[test]
     fn test_history_pruning() {
-        let mut state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000, 10_000);
+        let mut state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000_000_000_000, 10_000);
 
         // Add 105 updates
         for i in 0..105 {
             let _ = state.apply_update(
                 109_000_000 + i as u64,
-                50_000_000_000_000_000,
+                50_000_000_000_000_000_000_000_000,
                 [i as u8; 32],
                 i as u64,
                 i as u64,
@@ -552,7 +552,7 @@ mod tests {
 
     #[test]
     fn test_current_srv_formatted() {
-        let state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000, 10_000);
+        let state = SRVState::new(2_180_000, 109_000_000, 50_000_000_000_000_000_000_000_000, 10_000);
         assert_eq!(state.current_srv_formatted(), "$0.02180000");
     }
 
@@ -561,7 +561,7 @@ mod tests {
         let config = SRVGenesisConfig::default();
         assert_eq!(config.initial_srv, 2_180_000);
         assert_eq!(config.initial_committed_value_usd, 109_000_000);
-        assert_eq!(config.initial_circulating_supply, 50_000_000_000_000_000);
+        assert_eq!(config.initial_circulating_supply, 50_000_000_000_000_000_000_000_000);
         assert_eq!(config.stability_multiplier_bps, 10_000);
         assert_eq!(config.max_change_bps, 100);
     }

--- a/lib-blockchain/src/contracts/treasury_kernel/ubi_engine.rs
+++ b/lib-blockchain/src/contracts/treasury_kernel/ubi_engine.rs
@@ -155,7 +155,7 @@ impl KernelState {
                                 match token.as_mut().unwrap().mint_kernel_only(
                                     kernel_addr,
                                     &recipient,
-                                    claim.amount,
+                                    claim.amount as u128,
                                 ) {
                                     Ok(()) => {
                                         tracing::debug!(
@@ -527,14 +527,14 @@ mod tests {
         // Verify tokens were actually minted to citizen's balance
         let balance_after = token.balance_of(&citizen_pubkey);
         assert_eq!(
-            balance_after, ubi_amount,
+            balance_after, ubi_amount as u128,
             "Citizen should have {} SOV after UBI mint, got {}",
             ubi_amount, balance_after
         );
 
         // Verify total supply increased
         assert_eq!(
-            token.total_supply, ubi_amount,
+            token.total_supply, ubi_amount as u128,
             "Total supply should be {} after mint",
             ubi_amount
         );

--- a/lib-blockchain/src/contracts/ubi_distribution/core.rs
+++ b/lib-blockchain/src/contracts/ubi_distribution/core.rs
@@ -361,7 +361,7 @@ impl UbiDistributor {
         } else {
             // Legacy direct path
             let _burned = token
-                .transfer(ctx, citizen, amount)
+                .transfer(ctx, citizen, amount as u128)
                 .map_err(|_| Error::TokenTransferFailed)?;
         }
 
@@ -1114,14 +1114,14 @@ mod tests {
             "Test Token".to_string(),
             "TTK".to_string(),
             8,
-            u64::MAX,
+            u128::MAX,
             false,
             0,
             creator.clone(),
         );
 
         // Mint a large balance to the contract address for transfers
-        let _ = token.mint(contract_address, u64::MAX / 2);
+        let _ = token.mint(contract_address, u128::MAX / 2);
         token
     }
 
@@ -1135,7 +1135,7 @@ mod tests {
             "Test Token".to_string(),
             "TTK".to_string(),
             8,
-            u64::MAX,
+            u128::MAX,
             false,
             0,
             creator.clone(),

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -351,8 +351,7 @@ impl BlockExecutor {
         let mut contract = mutator
             .get_token_contract(&token_id)?
             .unwrap_or_else(crate::contracts::TokenContract::new_sov_native);
-        let current_supply_u64 = mutator.get_token_supply(&token_id)?.unwrap_or(contract.total_supply as u64);
-        let current_supply = current_supply_u64 as u128;
+        let current_supply = mutator.get_token_supply(&token_id)?.unwrap_or(contract.total_supply);
         let amount_u128 = amount;
         let new_supply = current_supply.checked_add(amount_u128).ok_or_else(|| {
             TxApplyError::InvalidType("SOV total supply overflow".to_string())
@@ -366,7 +365,7 @@ impl BlockExecutor {
         contract.total_supply = new_supply;
         let new_balance = balance + amount_u128;
         contract.balances.insert(recipient_pk, new_balance);
-        mutator.put_token_supply(&token_id, new_supply as u64)?;
+        mutator.put_token_supply(&token_id, new_supply)?;
         mutator.put_token_contract(&contract)?;
         Ok(())
     }

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -352,8 +352,7 @@ impl BlockExecutor {
             .get_token_contract(&token_id)?
             .unwrap_or_else(crate::contracts::TokenContract::new_sov_native);
         let current_supply = mutator.get_token_supply(&token_id)?.unwrap_or(contract.total_supply);
-        let amount_u128 = amount;
-        let new_supply = current_supply.checked_add(amount_u128).ok_or_else(|| {
+        let new_supply = current_supply.checked_add(amount).ok_or_else(|| {
             TxApplyError::InvalidType("SOV total supply overflow".to_string())
         })?;
         let balance = mutator.get_token_balance(&token_id, recipient)? as u128;
@@ -363,7 +362,7 @@ impl BlockExecutor {
             key_id: recipient.0,
         };
         contract.total_supply = new_supply;
-        let new_balance = balance + amount_u128;
+        let new_balance = balance + amount;
         contract.balances.insert(recipient_pk, new_balance);
         mutator.put_token_supply(&token_id, new_supply)?;
         mutator.put_token_contract(&contract)?;

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -347,27 +347,26 @@ impl BlockExecutor {
         recipient: &Address,
         amount: u128,
     ) -> Result<(), TxApplyError> {
-        let amount_u64 = u64::try_from(amount).map_err(|_| {
-            TxApplyError::InvalidType("SOV mint amount exceeds u64".to_string())
-        })?;
         let token_id = Self::canonical_sov_token_id();
         let mut contract = mutator
             .get_token_contract(&token_id)?
             .unwrap_or_else(crate::contracts::TokenContract::new_sov_native);
-        let current_supply = mutator.get_token_supply(&token_id)?.unwrap_or(contract.total_supply);
-        let new_supply = current_supply.checked_add(amount_u64).ok_or_else(|| {
+        let current_supply_u64 = mutator.get_token_supply(&token_id)?.unwrap_or(contract.total_supply as u64);
+        let current_supply = current_supply_u64 as u128;
+        let amount_u128 = amount;
+        let new_supply = current_supply.checked_add(amount_u128).ok_or_else(|| {
             TxApplyError::InvalidType("SOV total supply overflow".to_string())
         })?;
-        let balance = mutator.get_token_balance(&token_id, recipient)?;
+        let balance = mutator.get_token_balance(&token_id, recipient)? as u128;
         let recipient_pk = lib_crypto::PublicKey {
             dilithium_pk: [0u8; 2592],
             kyber_pk: [0u8; 1568],
             key_id: recipient.0,
         };
         contract.total_supply = new_supply;
-        let new_balance = balance + amount_u64;
+        let new_balance = balance + amount_u128;
         contract.balances.insert(recipient_pk, new_balance);
-        mutator.put_token_supply(&token_id, new_supply)?;
+        mutator.put_token_supply(&token_id, new_supply as u64)?;
         mutator.put_token_contract(&contract)?;
         Ok(())
     }
@@ -2385,8 +2384,8 @@ impl BlockExecutor {
                 } else {
                     payload.decimals
                 };
-                token.max_supply = payload.initial_supply;
-                token.mint(&creator, creator_allocation).map_err(|e| {
+                token.max_supply = payload.initial_supply as u128;
+                token.mint(&creator, creator_allocation as u128).map_err(|e| {
                     TxApplyError::Internal(format!("TokenCreation mint failed: {e}"))
                 })?;
                 let treasury_pk = lib_crypto::PublicKey {
@@ -2394,7 +2393,7 @@ impl BlockExecutor {
                     kyber_pk: [0u8; 1568],
                     key_id: payload.treasury_recipient,
                 };
-                token.mint(&treasury_pk, treasury_allocation).map_err(|e| {
+                token.mint(&treasury_pk, treasury_allocation as u128).map_err(|e| {
                     TxApplyError::Internal(format!("TokenCreation treasury mint failed: {e}"))
                 })?;
 

--- a/lib-blockchain/src/execution/tx_apply.rs
+++ b/lib-blockchain/src/execution/tx_apply.rs
@@ -173,12 +173,12 @@ impl<'a> StateMutator<'a> {
         let _burn_amount = if let Ok(Some(contract)) = self.store.get_token_contract(token) {
             if contract.is_deflationary && contract.burn_rate > 0 {
                 // burn_rate is in basis points (1/10000)
-                let burn = (amount * contract.burn_rate as u128 / 10_000) as u64;
+                let burn = amount * contract.burn_rate as u128 / 10_000;
                 if burn > 0 {
                     // Debit sender the full amount
                     self.debit_token(token, from, amount)?;
                     // Credit receiver the amount minus burn
-                    self.credit_token(token, to, amount.saturating_sub(burn as u128))?;
+                    self.credit_token(token, to, amount.saturating_sub(burn))?;
                     // Reduce total supply
                     if let Ok(Some(supply)) = self.store.get_token_supply(token) {
                         self.store
@@ -572,14 +572,14 @@ impl<'a> StateMutator<'a> {
     }
 
     /// Read token supply without mutating state.
-    pub fn get_token_supply(&self, token: &TokenId) -> TxApplyResult<Option<u64>> {
+    pub fn get_token_supply(&self, token: &TokenId) -> TxApplyResult<Option<u128>> {
         self.store
             .get_token_supply(token)
             .map_err(|e| TxApplyError::Storage(e.to_string()))
     }
 
     /// Persist token supply in canonical state storage.
-    pub fn put_token_supply(&self, token: &TokenId, supply: u64) -> TxApplyResult<()> {
+    pub fn put_token_supply(&self, token: &TokenId, supply: u128) -> TxApplyResult<()> {
         self.store
             .put_token_supply(token, supply)
             .map_err(|e| TxApplyError::Storage(e.to_string()))

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -200,7 +200,7 @@ pub struct Web4Allocation {
 pub struct SovBalanceAllocation {
     pub wallet_id: String,
     pub public_key: String,
-    pub balance: u64,
+    pub balance: u128,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/lib-blockchain/src/integration/consensus_integration.rs
+++ b/lib-blockchain/src/integration/consensus_integration.rs
@@ -1922,7 +1922,7 @@ pub struct ConsensusStatus {
     pub validator_count: usize,
     pub active_validators: usize,
     pub dao_proposals: usize,
-    pub treasury_balance: u64,
+    pub treasury_balance: u128,
     pub is_producing_blocks: bool,
 }
 

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -887,13 +887,13 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     /// Get token total supply.
     ///
     /// Returns None if no supply is tracked (token not initialized with supply).
-    fn get_token_supply(&self, token: &TokenId) -> StorageResult<Option<u64>>;
+    fn get_token_supply(&self, token: &TokenId) -> StorageResult<Option<u128>>;
 
     /// Set token total supply.
     ///
     /// # Requirements
     /// - MUST be called within begin_block/commit_block
-    fn put_token_supply(&self, token: &TokenId, supply: u64) -> StorageResult<()>;
+    fn put_token_supply(&self, token: &TokenId, supply: u128) -> StorageResult<()>;
 
     /// Get the latest persisted token subsystem snapshot.
     fn get_token_state_snapshot(&self) -> StorageResult<Option<TokenStateSnapshot>>;
@@ -1017,7 +1017,7 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     fn backfill_token_balances_from_contract(
         &self,
         _token_id: &TokenId,
-        _entries: &[([u8; 32], u64)],
+        _entries: &[([u8; 32], u128)],
     ) -> StorageResult<usize> {
         Ok(0) // Default no-op
     }

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -618,13 +618,21 @@ impl BlockchainStore for SledStore {
         Ok(())
     }
 
-    fn get_token_supply(&self, token: &TokenId) -> StorageResult<Option<u64>> {
+    fn get_token_supply(&self, token: &TokenId) -> StorageResult<Option<u128>> {
         let key = keys::token_supply_key(token);
         match self.token_supply.get(key) {
             Ok(Some(bytes)) => {
-                let supply = u64::from_le_bytes(bytes.as_ref().try_into().map_err(|_| {
-                    StorageError::Serialization("Failed to deserialize supply".into())
-                })?);
+                // Support both legacy 8-byte (u64) and new 16-byte (u128) encodings
+                let supply = if bytes.len() == 8 {
+                    let val = u64::from_le_bytes(bytes.as_ref().try_into().map_err(|_| {
+                        StorageError::Serialization("Failed to deserialize supply (u64)".into())
+                    })?);
+                    val as u128
+                } else {
+                    u128::from_le_bytes(bytes.as_ref().try_into().map_err(|_| {
+                        StorageError::Serialization("Failed to deserialize supply (u128)".into())
+                    })?)
+                };
                 Ok(Some(supply))
             }
             Ok(None) => Ok(None),
@@ -632,7 +640,7 @@ impl BlockchainStore for SledStore {
         }
     }
 
-    fn put_token_supply(&self, token: &TokenId, supply: u64) -> StorageResult<()> {
+    fn put_token_supply(&self, token: &TokenId, supply: u128) -> StorageResult<()> {
         self.require_transaction()?;
 
         let key = keys::token_supply_key(token);
@@ -910,7 +918,7 @@ impl BlockchainStore for SledStore {
     fn backfill_token_balances_from_contract(
         &self,
         token_id: &TokenId,
-        entries: &[([u8; 32], u64)],
+        entries: &[([u8; 32], u128)],
     ) -> StorageResult<usize> {
         // Must only be called during startup, before block processing begins.
         if self.tx_active.load(Ordering::SeqCst) {
@@ -928,7 +936,7 @@ impl BlockchainStore for SledStore {
             match self.token_balances.get(&key) {
                 Ok(Some(_)) => {} // Already populated, skip
                 Ok(None) => {
-                    batch.insert(key.as_ref(), &(*balance as u128).to_be_bytes());
+                    batch.insert(key.as_ref(), &balance.to_be_bytes());
                     written += 1;
                 }
                 Err(e) => return Err(StorageError::Database(e.to_string())),

--- a/lib-blockchain/tests/issue_1016_fee_deduction_tests.rs
+++ b/lib-blockchain/tests/issue_1016_fee_deduction_tests.rs
@@ -94,7 +94,7 @@ fn test_fee_deduction_reduces_sender_balance() {
 
     // Setup sender with initial balance
     let sender = create_test_pubkey(1);
-    let initial_balance: u64 = 10_000;
+    let initial_balance: u128 = 10_000;
     let fee: u64 = 100;
 
     // Credit initial balance to sender
@@ -135,9 +135,9 @@ fn test_fee_deduction_reduces_sender_balance() {
 
     assert_eq!(
         balance_after,
-        initial_balance - fee,
+        initial_balance - fee as u128,
         "Expected balance {} after fee deduction, got {}",
-        initial_balance - fee,
+        initial_balance - fee as u128,
         balance_after
     );
 }
@@ -188,7 +188,7 @@ fn test_fee_deduction_handles_insufficient_balance() {
 
     // Setup sender with low balance (less than fee)
     let sender = create_test_pubkey(1);
-    let initial_balance: u64 = 50;
+    let initial_balance: u128 = 50;
     let fee: u64 = 100; // More than balance
 
     // Credit low balance to sender
@@ -241,7 +241,7 @@ fn test_fee_deduction_accumulates_multiple_transactions() {
     let sender1 = create_test_pubkey(1);
     let sender2 = create_test_pubkey(2);
     let sender3 = create_test_pubkey(3);
-    let initial_balance: u64 = 10_000;
+    let initial_balance: u128 = 10_000;
 
     // Credit initial balances
     if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
@@ -275,7 +275,7 @@ fn test_fee_deduction_accumulates_multiple_transactions() {
 
     // Verify: each sender's balance was reduced correctly
     let token = blockchain.token_contracts.get(&sov_token_id).unwrap();
-    assert_eq!(token.balance_of(&sender1), initial_balance - fee1);
-    assert_eq!(token.balance_of(&sender2), initial_balance - fee2);
-    assert_eq!(token.balance_of(&sender3), initial_balance - fee3);
+    assert_eq!(token.balance_of(&sender1), initial_balance - fee1 as u128);
+    assert_eq!(token.balance_of(&sender2), initial_balance - fee2 as u128);
+    assert_eq!(token.balance_of(&sender3), initial_balance - fee3 as u128);
 }

--- a/lib-blockchain/tests/issue_1018_treasury_balance_tests.rs
+++ b/lib-blockchain/tests/issue_1018_treasury_balance_tests.rs
@@ -67,12 +67,12 @@ fn test_treasury_balance_uses_token_contract() {
 
     // Credit the treasury with SOV tokens
     let sov_token_id = generate_lib_token_id();
-    let treasury_amount: u64 = 1_000_000;
+    let treasury_amount: u128 = 1_000_000;
 
     if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
         token
             .balances
-            .insert(treasury_pubkey.clone(), treasury_amount as u128);
+            .insert(treasury_pubkey.clone(), treasury_amount);
     }
 
     // Query treasury balance - should reflect the credited amount
@@ -91,12 +91,12 @@ fn test_treasury_balance_not_placeholder() {
 
     // Credit treasury with specific amount
     let sov_token_id = generate_lib_token_id();
-    let expected_amount: u64 = 5_555_555;
+    let expected_amount: u128 = 5_555_555;
 
     if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
         token
             .balances
-            .insert(treasury_pubkey.clone(), expected_amount as u128);
+            .insert(treasury_pubkey.clone(), expected_amount);
     }
 
     // Query balance multiple times - should always return the exact amount

--- a/lib-blockchain/tests/issue_1018_treasury_balance_tests.rs
+++ b/lib-blockchain/tests/issue_1018_treasury_balance_tests.rs
@@ -72,7 +72,7 @@ fn test_treasury_balance_uses_token_contract() {
     if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
         token
             .balances
-            .insert(treasury_pubkey.clone(), treasury_amount);
+            .insert(treasury_pubkey.clone(), treasury_amount as u128);
     }
 
     // Query treasury balance - should reflect the credited amount
@@ -96,7 +96,7 @@ fn test_treasury_balance_not_placeholder() {
     if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
         token
             .balances
-            .insert(treasury_pubkey.clone(), expected_amount);
+            .insert(treasury_pubkey.clone(), expected_amount as u128);
     }
 
     // Query balance multiple times - should always return the exact amount

--- a/lib-blockchain/tests/issue_12_serialization_tests.rs
+++ b/lib-blockchain/tests/issue_12_serialization_tests.rs
@@ -121,23 +121,23 @@ fn test_token_contract_large_numbers() {
         "Big Token".to_string(),
         "BIG".to_string(),
         18,
-        u64::MAX, // Maximum possible supply
+        u128::MAX, // Maximum possible supply
         false,
         0,
         test_public_key(20),
     );
 
-    token.total_supply = u64::MAX - 1;
-    token.balances.insert(test_public_key(21), u64::MAX / 2);
+    token.total_supply = u128::MAX - 1;
+    token.balances.insert(test_public_key(21), u128::MAX / 2);
 
     let serialized = bincode::serialize(&token).expect("Failed to serialize");
     let deserialized: TokenContract =
         bincode::deserialize(&serialized).expect("Failed to deserialize");
 
-    assert_eq!(deserialized.total_supply, u64::MAX - 1);
+    assert_eq!(deserialized.total_supply, u128::MAX - 1);
     assert_eq!(
         deserialized.balances.get(&test_public_key(21)),
-        Some(&(u64::MAX / 2))
+        Some(&(u128::MAX / 2))
     );
 }
 

--- a/lib-blockchain/tests/sov_unit_tests.rs
+++ b/lib-blockchain/tests/sov_unit_tests.rs
@@ -69,11 +69,10 @@ mod sov_token_tests {
 
 #[cfg(test)]
 mod cbe_token_tests {
+    use lib_blockchain::contracts::tokens::cbe_token::CBE_TOTAL_SUPPLY_TOKENS;
     use lib_types::TOKEN_SCALE_18;
 
-    /// CBE is a DAO token — its supply constant is self-contained, not from lib-types.
-    const CBE_TOTAL_SUPPLY_TOKENS: u128 = 100_000_000_000;
-    const CBE_TOTAL_SUPPLY: u128 = CBE_TOTAL_SUPPLY_TOKENS;
+    const CBE_TOTAL_SUPPLY: u128 = CBE_TOTAL_SUPPLY_TOKENS as u128;
     const CBE_COMPENSATION_POOL: u128 = 40_000_000_000;
     const CBE_OPERATIONAL_TREASURY: u128 = 30_000_000_000;
     const CBE_PERFORMANCE_INCENTIVES: u128 = 20_000_000_000;
@@ -133,7 +132,7 @@ mod cbe_token_tests {
     #[test]
     fn test_cbe_atomic_supply_uses_18_decimals() {
         // CBE bonding curve uses 18-decimal internal accounting (100B × 10^18).
-        let cbe_max_supply_curve = CBE_TOTAL_SUPPLY_TOKENS * TOKEN_SCALE_18;
+        let cbe_max_supply_curve = CBE_TOTAL_SUPPLY_TOKENS as u128 * TOKEN_SCALE_18;
         assert_eq!(cbe_max_supply_curve, 100_000_000_000_000_000_000_000_000_000);
     }
 
@@ -366,11 +365,11 @@ mod fee_router_tests {
 
 #[cfg(test)]
 mod week1_financial_validation {
+    use lib_blockchain::contracts::tokens::cbe_token::CBE_TOTAL_SUPPLY_TOKENS;
     use lib_types::SOV_TOTAL_SUPPLY_TOKENS;
 
     const SOV_TOTAL_SUPPLY: u128 = SOV_TOTAL_SUPPLY_TOKENS;
-    /// CBE is a DAO token — supply constant defined locally, not from lib-types.
-    const CBE_TOTAL_SUPPLY: u128 = 100_000_000_000;
+    const CBE_TOTAL_SUPPLY: u128 = CBE_TOTAL_SUPPLY_TOKENS as u128;
     const FEE_RATE_BASIS_POINTS: u16 = 100;
     const UBI_ALLOCATION_PERCENT: u8 = 45;
     const DAO_ALLOCATION_PERCENT: u8 = 30;

--- a/lib-blockchain/tests/sov_unit_tests.rs
+++ b/lib-blockchain/tests/sov_unit_tests.rs
@@ -69,8 +69,10 @@ mod sov_token_tests {
 
 #[cfg(test)]
 mod cbe_token_tests {
-    use lib_types::{CBE_TOTAL_SUPPLY_TOKENS, TOKEN_SCALE_18};
+    use lib_types::TOKEN_SCALE_18;
 
+    /// CBE is a DAO token — its supply constant is self-contained, not from lib-types.
+    const CBE_TOTAL_SUPPLY_TOKENS: u128 = 100_000_000_000;
     const CBE_TOTAL_SUPPLY: u128 = CBE_TOTAL_SUPPLY_TOKENS;
     const CBE_COMPENSATION_POOL: u128 = 40_000_000_000;
     const CBE_OPERATIONAL_TREASURY: u128 = 30_000_000_000;
@@ -130,10 +132,9 @@ mod cbe_token_tests {
 
     #[test]
     fn test_cbe_atomic_supply_uses_18_decimals() {
-        assert_eq!(
-            CBE_TOTAL_SUPPLY_TOKENS * TOKEN_SCALE_18,
-            lib_types::CBE_MAX_SUPPLY
-        );
+        // CBE bonding curve uses 18-decimal internal accounting (100B × 10^18).
+        let cbe_max_supply_curve = CBE_TOTAL_SUPPLY_TOKENS * TOKEN_SCALE_18;
+        assert_eq!(cbe_max_supply_curve, 100_000_000_000_000_000_000_000_000_000);
     }
 
     #[test]
@@ -365,10 +366,11 @@ mod fee_router_tests {
 
 #[cfg(test)]
 mod week1_financial_validation {
-    use lib_types::{CBE_TOTAL_SUPPLY_TOKENS, SOV_TOTAL_SUPPLY_TOKENS};
+    use lib_types::SOV_TOTAL_SUPPLY_TOKENS;
 
     const SOV_TOTAL_SUPPLY: u128 = SOV_TOTAL_SUPPLY_TOKENS;
-    const CBE_TOTAL_SUPPLY: u128 = CBE_TOTAL_SUPPLY_TOKENS;
+    /// CBE is a DAO token — supply constant defined locally, not from lib-types.
+    const CBE_TOTAL_SUPPLY: u128 = 100_000_000_000;
     const FEE_RATE_BASIS_POINTS: u16 = 100;
     const UBI_ALLOCATION_PERCENT: u8 = 45;
     const DAO_ALLOCATION_PERCENT: u8 = 30;

--- a/lib-blockchain/tests/token_regression_tests.rs
+++ b/lib-blockchain/tests/token_regression_tests.rs
@@ -824,7 +824,7 @@ fn test_wallet_registration_mints_initial_balance() {
     let token = blockchain.token_contracts.get(&sov_token_id).unwrap();
     let balance = token.balance_of(&wallet_key(&wallet_id));
     assert_eq!(
-        balance, initial_balance,
+        balance, initial_balance as u128,
         "Wallet should have initial balance minted via block processing"
     );
 }

--- a/lib-blockchain/tests/treasury_dao_bootstrap_tests.rs
+++ b/lib-blockchain/tests/treasury_dao_bootstrap_tests.rs
@@ -195,7 +195,7 @@ fn test_block_fees_credited_to_treasury() {
     assert_eq!(balance_before, 0, "Treasury must start with zero balance");
 
     // Simulate what process_token_transactions does: credit fees via wallet_key_for_sov.
-    let fee_amount: u64 = 42_000_000;
+    let fee_amount: u128 = 42_000_000;
     let treasury_key = wallet_key_for_sov(&treasury_id);
     if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
         let current = token.balance_of(&treasury_key);
@@ -209,7 +209,7 @@ fn test_block_fees_credited_to_treasury() {
         .get_dao_treasury_balance()
         .expect("get_dao_treasury_balance");
     assert_eq!(
-        balance_after, fee_amount,
+        balance_after as u128, fee_amount,
         "Treasury balance must equal credited fee amount ({} SOV)",
         fee_amount
     );

--- a/lib-types/src/lib.rs
+++ b/lib-types/src/lib.rs
@@ -48,6 +48,5 @@ pub use node_id::NodeId;
 pub use peer::PeerId;
 pub use storage::ProtocolStorageStats;
 pub use tokenomics::{
-    CBE_DECIMALS, CBE_MAX_SUPPLY, CBE_TOTAL_SUPPLY_TOKENS, SOV_DECIMALS, SOV_MAX_SUPPLY,
-    SOV_TOTAL_SUPPLY_TOKENS, TOKEN_SCALE_18,
+    SOV_DECIMALS, SOV_MAX_SUPPLY, SOV_TOTAL_SUPPLY_TOKENS, TOKEN_SCALE_18,
 };

--- a/lib-types/src/tokenomics.rs
+++ b/lib-types/src/tokenomics.rs
@@ -1,10 +1,9 @@
-//! Canonical tokenomics constants.
+//! Canonical tokenomics constants — protocol-level only.
 //!
-//! These are the semantic protocol values for token supply and decimals.
-//! Domain crates that still use legacy `u64` token accounting may need
-//! compatibility adapters until they are widened to `u128`.
+//! Only the SOV system token lives here. DAO tokens (CBE, etc.) define their
+//! own constants in their respective contract modules.
 
-/// Canonical 18-decimal scale shared by CBE and SOV.
+/// Canonical 18-decimal scale for SOV.
 pub const TOKEN_SCALE_18: u128 = 1_000_000_000_000_000_000;
 
 /// SOV display decimals.
@@ -15,12 +14,3 @@ pub const SOV_TOTAL_SUPPLY_TOKENS: u128 = 1_000_000_000_000;
 
 /// Total SOV supply in atomic units.
 pub const SOV_MAX_SUPPLY: u128 = SOV_TOTAL_SUPPLY_TOKENS * TOKEN_SCALE_18;
-
-/// CBE display decimals.
-pub const CBE_DECIMALS: u8 = 18;
-
-/// Total CBE supply in whole tokens.
-pub const CBE_TOTAL_SUPPLY_TOKENS: u128 = 100_000_000_000;
-
-/// Total CBE supply in atomic units.
-pub const CBE_MAX_SUPPLY: u128 = CBE_TOTAL_SUPPLY_TOKENS * TOKEN_SCALE_18;

--- a/tools/chain_audit.rs
+++ b/tools/chain_audit.rs
@@ -162,7 +162,7 @@ fn main() -> Result<()> {
         .get(&sov_id)
         .map(|t| t.balances.len())
         .unwrap_or(0);
-    let sov_total: u64 = bc.token_contracts
+    let sov_total: u128 = bc.token_contracts
         .get(&sov_id)
         .map(|t| t.balances.values().sum())
         .unwrap_or(0);

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -430,7 +430,7 @@ struct ExplorerStatsResponse {
     latest_block_time: Option<u64>,
     total_transactions: u64,
     avg_block_time_secs: Option<u64>,
-    total_supply: u64,
+    total_supply: u128,
     total_ubi_distributed: u64,
     active_validators: usize,
     mempool_size: usize,
@@ -1100,7 +1100,7 @@ impl BlockchainHandler {
         let total_supply = blockchain
             .token_contracts
             .get(&sov_token_id)
-            .map(|token| token.total_supply as u64)
+            .map(|token| token.total_supply)
             .unwrap_or(0);
 
         let total_ubi_distributed: u64 = blockchain

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1100,7 +1100,7 @@ impl BlockchainHandler {
         let total_supply = blockchain
             .token_contracts
             .get(&sov_token_id)
-            .map(|token| token.total_supply)
+            .map(|token| token.total_supply as u64)
             .unwrap_or(0);
 
         let total_ubi_distributed: u64 = blockchain

--- a/zhtp/src/api/handlers/identity/backup_recovery.rs
+++ b/zhtp/src/api/handlers/identity/backup_recovery.rs
@@ -1453,7 +1453,7 @@ pub async fn handle_migrate_identity(
         let mut short_key_min_len: Option<usize> = None;
         let mut short_key_max_len: Option<usize> = None;
         let mut short_key_backfill_total: u64 = 0;
-        let mut movable_balance_total: u64 = 0;
+        let mut movable_balance_total: u128 = 0;
         let _has_token_contract: bool;
 
         match crate::runtime::blockchain_provider::get_global_blockchain().await {
@@ -1488,7 +1488,7 @@ pub async fn handle_migrate_identity(
                             let new_pk = lib_crypto::PublicKey::new(new_pk_bytes);
                             if old_pk != new_pk {
                                 movable_balance_total =
-                                    movable_balance_total.saturating_add(token.balance_of(&old_pk) as u64);
+                                    movable_balance_total.saturating_add(token.balance_of(&old_pk));
                             }
                         }
                     }
@@ -1760,16 +1760,17 @@ pub async fn handle_migrate_identity(
                         if existing.initial_balance > 0 {
                             let token_opt = blockchain.token_contracts.get(&sov_token_id);
                             let current_balance =
-                                token_opt.map(|t| t.balance_of(&wallet_addr) as u64).unwrap_or(0);
-                            if current_balance < existing.initial_balance {
-                                let mint_amount = existing.initial_balance - current_balance;
+                                token_opt.map(|t| t.balance_of(&wallet_addr)).unwrap_or(0);
+                            if current_balance < existing.initial_balance as u128 {
+                                let mint_amount = existing.initial_balance as u128 - current_balance;
+                                let mint_amount_u64 = u64::try_from(mint_amount).unwrap_or(u64::MAX);
                                 let memo =
                                     format!("TOKEN_BACKFILL_V1:{}", wallet_id_str).into_bytes();
                                 if let Ok(tx) = build_signed_sov_mint_tx(
                                     &migration_authority_kp,
                                     chain_id,
                                     &wallet_id_bytes,
-                                    mint_amount,
+                                    mint_amount_u64,
                                     memo,
                                 ) {
                                     mint_txs.push(tx);
@@ -1796,18 +1797,19 @@ pub async fn handle_migrate_identity(
                                 .unwrap_or([0u8; 2592]);
                             let old_pk = lib_crypto::PublicKey::new(old_pk_bytes);
                             if old_pk.key_id != wallet_addr.key_id {
-                                let old_balance = token.balance_of(&old_pk) as u64;
+                                let old_balance = token.balance_of(&old_pk);
                                 if old_balance > 0 {
                                     let memo = format!(
                                         "TOKEN_MIGRATE_V1:{}",
                                         hex::encode(&old_public_key)
                                     )
                                     .into_bytes();
+                                    let old_balance_u64 = u64::try_from(old_balance).unwrap_or(u64::MAX);
                                     if let Ok(tx) = build_signed_sov_mint_tx(
                                         &migration_authority_kp,
                                         chain_id,
                                         &wallet_id_bytes,
-                                        old_balance,
+                                        old_balance_u64,
                                         memo,
                                     ) {
                                         mint_txs.push(tx);

--- a/zhtp/src/api/handlers/identity/backup_recovery.rs
+++ b/zhtp/src/api/handlers/identity/backup_recovery.rs
@@ -1488,7 +1488,7 @@ pub async fn handle_migrate_identity(
                             let new_pk = lib_crypto::PublicKey::new(new_pk_bytes);
                             if old_pk != new_pk {
                                 movable_balance_total =
-                                    movable_balance_total.saturating_add(token.balance_of(&old_pk));
+                                    movable_balance_total.saturating_add(token.balance_of(&old_pk) as u64);
                             }
                         }
                     }
@@ -1760,7 +1760,7 @@ pub async fn handle_migrate_identity(
                         if existing.initial_balance > 0 {
                             let token_opt = blockchain.token_contracts.get(&sov_token_id);
                             let current_balance =
-                                token_opt.map(|t| t.balance_of(&wallet_addr)).unwrap_or(0);
+                                token_opt.map(|t| t.balance_of(&wallet_addr) as u64).unwrap_or(0);
                             if current_balance < existing.initial_balance {
                                 let mint_amount = existing.initial_balance - current_balance;
                                 let memo =
@@ -1796,7 +1796,7 @@ pub async fn handle_migrate_identity(
                                 .unwrap_or([0u8; 2592]);
                             let old_pk = lib_crypto::PublicKey::new(old_pk_bytes);
                             if old_pk.key_id != wallet_addr.key_id {
-                                let old_balance = token.balance_of(&old_pk);
+                                let old_balance = token.balance_of(&old_pk) as u64;
                                 if old_balance > 0 {
                                     let memo = format!(
                                         "TOKEN_MIGRATE_V1:{}",

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -77,8 +77,8 @@ pub struct TokenInfoResponse {
     pub name: String,
     pub symbol: String,
     pub decimals: u8,
-    pub total_supply: u64,
-    pub max_supply: Option<u64>,
+    pub total_supply: u128,
+    pub max_supply: Option<u128>,
     pub creator: String,
     pub is_deflationary: bool,
     pub created_at_block: Option<u64>,
@@ -91,7 +91,7 @@ pub struct TokenListItem {
     pub name: String,
     pub symbol: String,
     pub decimals: u8,
-    pub total_supply: u64,
+    pub total_supply: u128,
 }
 
 // ============================================================================
@@ -421,7 +421,7 @@ impl TokenHandler {
                 name: cbe.name().to_string(),
                 symbol: cbe.symbol().to_string(),
                 decimals: cbe.decimals(),
-                total_supply: cbe.total_supply(),
+                total_supply: cbe.total_supply() as u128,
                 max_supply: None,
                 creator: format!("0x{}", "00".repeat(32)),
                 is_deflationary: false,
@@ -441,11 +441,11 @@ impl TokenHandler {
             name: token.name.clone(),
             symbol: token.symbol.clone(),
             decimals: token.decimals,
-            total_supply: token.total_supply as u64,
-            max_supply: if token.max_supply == u64::MAX as u128 {
+            total_supply: token.total_supply,
+            max_supply: if token.max_supply == u128::MAX {
                 None
             } else {
-                Some(token.max_supply as u64)
+                Some(token.max_supply)
             },
             creator: format!("0x{}", hex::encode(&token.creator.key_id)),
             is_deflationary: token.is_deflationary,
@@ -551,7 +551,7 @@ impl TokenHandler {
                 name: token.name.clone(),
                 symbol: token.symbol.clone(),
                 decimals: token.decimals,
-                total_supply: token.total_supply as u64,
+                total_supply: token.total_supply,
             })
             .collect();
 
@@ -562,7 +562,7 @@ impl TokenHandler {
             name: blockchain.cbe_token.name().to_string(),
             symbol: blockchain.cbe_token.symbol().to_string(),
             decimals: blockchain.cbe_token.decimals(),
-            total_supply: blockchain.cbe_token.total_supply(),
+            total_supply: blockchain.cbe_token.total_supply() as u128,
         });
 
         let count = tokens.len();

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -441,11 +441,11 @@ impl TokenHandler {
             name: token.name.clone(),
             symbol: token.symbol.clone(),
             decimals: token.decimals,
-            total_supply: token.total_supply,
-            max_supply: if token.max_supply == u64::MAX {
+            total_supply: token.total_supply as u64,
+            max_supply: if token.max_supply == u64::MAX as u128 {
                 None
             } else {
-                Some(token.max_supply)
+                Some(token.max_supply as u64)
             },
             creator: format!("0x{}", hex::encode(&token.creator.key_id)),
             is_deflationary: token.is_deflationary,
@@ -511,7 +511,7 @@ impl TokenHandler {
                 let addr = lib_blockchain::storage::Address::new(wallet_id);
                 store
                     .get_token_balance(&storage_token_id, &addr)
-                    .unwrap_or(0) as u64
+                    .unwrap_or(0) as u128
             } else {
                 let wallet_key = PublicKey {
                     dilithium_pk: [0u8; 2592],
@@ -551,7 +551,7 @@ impl TokenHandler {
                 name: token.name.clone(),
                 symbol: token.symbol.clone(),
                 decimals: token.decimals,
-                total_supply: token.total_supply,
+                total_supply: token.total_supply as u64,
             })
             .collect();
 

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -152,10 +152,10 @@ impl ZhtpRequestHandler for WalletHandler {
 struct WalletInfo {
     wallet_type: String,
     wallet_id: String,
-    available_balance: u64,
+    available_balance: u128,
     staked_balance: u64,
     pending_rewards: u64,
-    total_balance: u64,
+    total_balance: u128,
     permissions: WalletPermissionsInfo,
     created_at: u64,
     description: String,
@@ -260,7 +260,7 @@ impl WalletHandler {
         let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
 
         let mut wallets = Vec::new();
-        let mut total_balance_adjusted = 0u64;
+        let mut total_balance_adjusted = 0u128;
 
         if wallet_summaries.is_empty() {
             // Fallback: surface wallets from the on-chain registry that belong to this identity.
@@ -290,14 +290,13 @@ impl WalletHandler {
                         })
                     })
                     .unwrap_or(0);
-                let effective_balance_u64 = effective_balance as u64;
                 let wallet_info = WalletInfo {
                     wallet_type: wallet_data.wallet_type.clone(),
                     wallet_id: wallet_id_hex.clone(),
-                    available_balance: effective_balance_u64,
+                    available_balance: effective_balance,
                     staked_balance: 0,
                     pending_rewards: 0,
-                    total_balance: effective_balance_u64,
+                    total_balance: effective_balance,
                     permissions: WalletPermissionsInfo {
                         can_transfer_external: true,
                         can_vote: wallet_data.wallet_type == "Primary",
@@ -309,7 +308,7 @@ impl WalletHandler {
                     created_at: wallet_data.created_at,
                     description: format!("{} wallet (recovered)", wallet_data.wallet_type),
                 };
-                total_balance_adjusted += effective_balance_u64;
+                total_balance_adjusted += effective_balance;
                 wallets.push(wallet_info);
             }
             let response_data = json!({
@@ -365,14 +364,13 @@ impl WalletHandler {
                     .unwrap_or(0)
             };
 
-            let effective_balance_u64 = effective_balance as u64;
             let wallet_info = WalletInfo {
                 wallet_type: format!("{:?}", summary.wallet_type),
                 wallet_id: wallet_id_hex.clone(), // Full 64-char hex wallet_id for transfers
-                available_balance: effective_balance_u64.saturating_sub(staked_balance),
+                available_balance: effective_balance.saturating_sub(staked_balance as u128),
                 staked_balance,
                 pending_rewards,
-                total_balance: effective_balance_u64 + pending_rewards,
+                total_balance: effective_balance + pending_rewards as u128,
                 permissions: WalletPermissionsInfo {
                     can_transfer_external: true,
                     can_vote: summary.wallet_type == lib_identity::wallets::WalletType::Primary,
@@ -384,7 +382,7 @@ impl WalletHandler {
                 created_at: summary.created_at,
                 description: format!("{:?} wallet for identity", summary.wallet_type),
             };
-            total_balance_adjusted += effective_balance_u64 + pending_rewards;
+            total_balance_adjusted += effective_balance + pending_rewards as u128;
             wallets.push(wallet_info);
         }
 
@@ -477,13 +475,13 @@ impl WalletHandler {
                 let (mut available_balance, staked_balance, pending_rewards, created_at) =
                     if let Some(wallet) = identity.wallet_manager.get_wallet(&summary.id) {
                         (
-                            wallet.balance.saturating_sub(wallet.staked_balance),
+                            wallet.balance.saturating_sub(wallet.staked_balance) as u128,
                             wallet.staked_balance,
                             wallet.pending_rewards,
                             wallet.created_at,
                         )
                     } else {
-                        (summary.balance, 0, 0, summary.created_at)
+                        (summary.balance as u128, 0, 0, summary.created_at)
                     };
 
                 // Prefer SOV token contract balance (live balance) for this wallet.
@@ -518,21 +516,20 @@ impl WalletHandler {
                                 ),
                             )
                         };
-                        let token_balance_u64 = token_balance as u64;
-                        if token_balance_u64 != available_balance {
+                        if token_balance != available_balance {
                             tracing::debug!(
                                 "Using SOV token balance for wallet {}: {} (was {})",
                                 &wallet_id_hex[..16],
-                                token_balance_u64,
+                                token_balance,
                                 available_balance
                             );
-                            available_balance = token_balance_u64;
+                            available_balance = token_balance;
                         }
                     }
                 }
                 drop(blockchain);
 
-                let total_balance = available_balance + staked_balance + pending_rewards;
+                let total_balance = available_balance + staked_balance as u128 + pending_rewards as u128;
 
                 let response_data = json!({
                     "status": "success",

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -290,13 +290,14 @@ impl WalletHandler {
                         })
                     })
                     .unwrap_or(0);
+                let effective_balance_u64 = effective_balance as u64;
                 let wallet_info = WalletInfo {
                     wallet_type: wallet_data.wallet_type.clone(),
                     wallet_id: wallet_id_hex.clone(),
-                    available_balance: effective_balance,
+                    available_balance: effective_balance_u64,
                     staked_balance: 0,
                     pending_rewards: 0,
-                    total_balance: effective_balance,
+                    total_balance: effective_balance_u64,
                     permissions: WalletPermissionsInfo {
                         can_transfer_external: true,
                         can_vote: wallet_data.wallet_type == "Primary",
@@ -308,7 +309,7 @@ impl WalletHandler {
                     created_at: wallet_data.created_at,
                     description: format!("{} wallet (recovered)", wallet_data.wallet_type),
                 };
-                total_balance_adjusted += effective_balance;
+                total_balance_adjusted += effective_balance_u64;
                 wallets.push(wallet_info);
             }
             let response_data = json!({
@@ -364,13 +365,14 @@ impl WalletHandler {
                     .unwrap_or(0)
             };
 
+            let effective_balance_u64 = effective_balance as u64;
             let wallet_info = WalletInfo {
                 wallet_type: format!("{:?}", summary.wallet_type),
                 wallet_id: wallet_id_hex.clone(), // Full 64-char hex wallet_id for transfers
-                available_balance: effective_balance.saturating_sub(staked_balance),
+                available_balance: effective_balance_u64.saturating_sub(staked_balance),
                 staked_balance,
                 pending_rewards,
-                total_balance: effective_balance + pending_rewards,
+                total_balance: effective_balance_u64 + pending_rewards,
                 permissions: WalletPermissionsInfo {
                     can_transfer_external: true,
                     can_vote: summary.wallet_type == lib_identity::wallets::WalletType::Primary,
@@ -382,7 +384,7 @@ impl WalletHandler {
                 created_at: summary.created_at,
                 description: format!("{:?} wallet for identity", summary.wallet_type),
             };
-            total_balance_adjusted += effective_balance + pending_rewards;
+            total_balance_adjusted += effective_balance_u64 + pending_rewards;
             wallets.push(wallet_info);
         }
 
@@ -516,14 +518,15 @@ impl WalletHandler {
                                 ),
                             )
                         };
-                        if token_balance != available_balance {
+                        let token_balance_u64 = token_balance as u64;
+                        if token_balance_u64 != available_balance {
                             tracing::debug!(
                                 "Using SOV token balance for wallet {}: {} (was {})",
                                 &wallet_id_hex[..16],
-                                token_balance,
+                                token_balance_u64,
                                 available_balance
                             );
-                            available_balance = token_balance;
+                            available_balance = token_balance_u64;
                         }
                     }
                 }

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -208,7 +208,7 @@ impl Web4Handler {
             DOMAIN_REGISTRATION_FEE_SOV
         );
 
-        let registration_fee_sov = DOMAIN_REGISTRATION_FEE_SOV;
+        let registration_fee_sov = DOMAIN_REGISTRATION_FEE_SOV as u128;
 
         // ========== SECURITY: SIGNATURE VERIFICATION ==========
         // Verify that the request was signed by the owner's private key
@@ -349,7 +349,7 @@ impl Web4Handler {
                 user_sov_balance, registration_fee_sov
             );
 
-            if user_sov_balance < registration_fee_sov as u128 {
+            if user_sov_balance < registration_fee_sov {
                 return Err(anyhow!(
                     "Insufficient SOV balance. Required: {} SOV, Available: {} SOV. \
                     You need SOV tokens to register domains.",
@@ -721,7 +721,7 @@ impl Web4Handler {
         let fee_tx_hash_hex = self
             .validate_and_submit_domain_fee_tx(
                 &owner_identity,
-                DOMAIN_REGISTRATION_FEE_SOV,
+                DOMAIN_REGISTRATION_FEE_SOV as u128,
                 fee_payment_tx_raw,
             )
             .await?;
@@ -872,7 +872,7 @@ impl Web4Handler {
     async fn validate_and_submit_domain_fee_tx(
         &self,
         owner_identity: &ZhtpIdentity,
-        registration_fee_sov: u64,
+        registration_fee_sov: u128,
         fee_payment_tx_raw: &str,
     ) -> anyhow::Result<String> {
         let fee_payment_tx_bytes = hex::decode(fee_payment_tx_raw)
@@ -901,7 +901,7 @@ impl Web4Handler {
         if !is_sov {
             return Err(anyhow!("fee_payment_tx must transfer SOV token"));
         }
-        if fee_transfer.amount != registration_fee_sov as u128 {
+        if fee_transfer.amount != registration_fee_sov {
             return Err(anyhow!(
                 "fee_payment_tx amount mismatch: expected {} SOV, got {}",
                 registration_fee_sov,

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -349,7 +349,7 @@ impl Web4Handler {
                 user_sov_balance, registration_fee_sov
             );
 
-            if user_sov_balance < registration_fee_sov {
+            if user_sov_balance < registration_fee_sov as u128 {
                 return Err(anyhow!(
                     "Insufficient SOV balance. Required: {} SOV, Available: {} SOV. \
                     You need SOV tokens to register domains.",

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1183,10 +1183,10 @@ impl RuntimeOrchestrator {
             if let Some(store) = blockchain.store.as_ref() {
                 let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
                 if let Some(sov_contract) = blockchain.token_contracts.get(&sov_token_id) {
-                    let entries: Vec<([u8; 32], u64)> = sov_contract
+                    let entries: Vec<([u8; 32], u128)> = sov_contract
                         .balances
                         .iter()
-                        .map(|(pk, &bal)| (pk.key_id, bal as u64))
+                        .map(|(pk, &bal)| (pk.key_id, bal))
                         .collect();
                     let token_id = lib_blockchain::storage::TokenId(sov_token_id);
                     match store.backfill_token_balances_from_contract(&token_id, &entries) {

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1186,7 +1186,7 @@ impl RuntimeOrchestrator {
                     let entries: Vec<([u8; 32], u64)> = sov_contract
                         .balances
                         .iter()
-                        .map(|(pk, &bal)| (pk.key_id, bal))
+                        .map(|(pk, &bal)| (pk.key_id, bal as u64))
                         .collect();
                     let token_id = lib_blockchain::storage::TokenId(sov_token_id);
                     match store.backfill_token_balances_from_contract(&token_id, &entries) {

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -221,7 +221,7 @@ impl GenesisFundingService {
             if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
                 if token.balance_of(&recipient_pk) == 0 {
                     token
-                        .mint(&recipient_pk, SOV_WELCOME_BONUS)
+                        .mint(&recipient_pk, SOV_WELCOME_BONUS as u128)
                         .map_err(|e| anyhow::anyhow!("failed to mint genesis wallet SOV: {}", e))?;
                 }
             }


### PR DESCRIPTION
## Summary

- Remove CBE constants from `lib-types` — CBE is a DAO token, not protocol-level
- Unify SOV to 18 decimals everywhere (was 8 in runtime, 18 in spec)
- Widen `TokenContract` balances/supply/amounts from `u64` to `u128`
- Bonding curve `MAX_SUPPLY` now self-contained (no lib-types CBE dependency)

Part of EPIC-001: Event-Driven Token Architecture (#2093)
Closes #2094

## Details

**CBE removed from lib-types:**
`CBE_DECIMALS`, `CBE_MAX_SUPPLY`, `CBE_TOTAL_SUPPLY_TOKENS` deleted from `lib-types/tokenomics.rs`. CBE constants now live exclusively in `cbe_token.rs` (self-contained). The bonding curve defines its own `MAX_SUPPLY` locally in `canonical.rs`.

**SOV decimal unification:**
`SOV_TOKEN_DECIMALS` changed from 8 to 18 in `constants.rs`. `SOV_TOKEN_MAX_SUPPLY` widened from `u64` to `u128` to match `lib_types::SOV_MAX_SUPPLY`.

**u128 widening:**
`TokenContract` fields (`balances`, `total_supply`, `max_supply`, `burn_rate`, `locked_balances`, `allowances`) and all method signatures widened from `u64` to `u128`. 37 files updated to propagate the type change through callers. The sled storage layer already used `u128` via `Amount` — this unifies the in-memory model with storage.

## Test plan

- [x] `cargo check --workspace` — zero errors
- [x] `cargo test -p lib-blockchain` — 1786 passed, 0 failed
- [ ] `cargo test -p zhtp` — test compilation verified
- [ ] Full workspace test suite
- [ ] Post-reset: balance encapsulation cleanup (#2098)