### PR TITLE
Add Chrome extension developer release packaging

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -22,3 +22,36 @@ It does not speak QUIC itself. Instead it:
 3. Visit `https://example.zhtp/` or open a domain from the popup.
 
 The canonical network path remains QUIC. The extension only bridges the browser to the local daemon.
+
+## Chrome developer release
+
+The developer release target is Chrome with an unpacked extension install.
+
+### Requirements
+
+- Google Chrome
+- local `zhtp-daemon` running on `127.0.0.1:7840`
+- daemon API version `1`
+
+The popup and viewer both check daemon compatibility through `GET /api/v1/status`. If the daemon API version does not match, the extension will show an incompatibility error instead of trying to browse.
+
+### Install in Chrome
+
+1. Open `chrome://extensions`
+2. Enable `Developer mode`
+3. Click `Load unpacked`
+4. Select the `browser-extension/` directory
+5. Pin `ZHTP Browser Bridge` if you want one-click access
+
+### Package a Chrome artifact
+
+```bash
+bash scripts/package-browser-extension-chrome.sh
+```
+
+This produces:
+
+- `target/browser-extension/zhtp-browser-bridge-chrome.zip`
+- `target/browser-extension/zhtp-browser-bridge-chrome.sha256`
+
+The zip is the developer distribution artifact for Chrome. It is intended for unpacking/install review, not store upload yet.

--- a/browser-extension/compat.js
+++ b/browser-extension/compat.js
@@ -1,0 +1,31 @@
+const EXTENSION_VERSION = chrome.runtime.getManifest().version;
+const REQUIRED_DAEMON_API_VERSION = "1";
+
+function daemonCompatibilityError(status) {
+  if (!status || typeof status !== "object") {
+    return "daemon returned an invalid status payload";
+  }
+
+  if (status.api_version !== REQUIRED_DAEMON_API_VERSION) {
+    return `daemon API ${status.api_version || "unknown"} is incompatible with extension ${EXTENSION_VERSION}`;
+  }
+
+  return null;
+}
+
+async function fetchCompatibleDaemonStatus(statusUrl) {
+  const response = await fetch(statusUrl);
+  if (!response.ok) {
+    throw new Error(`daemon returned ${response.status}`);
+  }
+
+  const status = await response.json();
+  const compatibilityError = daemonCompatibilityError(status);
+  if (compatibilityError) {
+    const error = new Error(compatibilityError);
+    error.code = "DAEMON_INCOMPATIBLE";
+    throw error;
+  }
+
+  return status;
+}

--- a/browser-extension/popup.html
+++ b/browser-extension/popup.html
@@ -23,6 +23,7 @@
       <div id="domains" class="domain-list">Loading…</div>
     </section>
   </main>
+  <script src="compat.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -1,5 +1,19 @@
 const DAEMON_STATUS_URL = "http://127.0.0.1:7840/api/v1/status";
 const DAEMON_DOMAINS_URL = "http://127.0.0.1:7840/api/v1/domains";
+const EXTENSION_VERSION = chrome.runtime.getManifest().version;
+const REQUIRED_DAEMON_API_VERSION = "1";
+
+function daemonCompatibilityError(status) {
+  if (!status || typeof status !== "object") {
+    return "daemon returned an invalid status payload";
+  }
+
+  if (status.api_version !== REQUIRED_DAEMON_API_VERSION) {
+    return `daemon API ${status.api_version || "unknown"} is incompatible with extension ${EXTENSION_VERSION}`;
+  }
+
+  return null;
+}
 
 function openViewer(domain, path = "/") {
   const viewerUrl = new URL(chrome.runtime.getURL("viewer.html"));
@@ -27,7 +41,14 @@ async function refreshStatus() {
     }
 
     const status = await response.json();
-    statusEl.textContent = `Daemon online. DID ${status.daemon_did}. Active backend ${status.active_backend || "not connected yet"}.`;
+    const compatibilityError = daemonCompatibilityError(status);
+    if (compatibilityError) {
+      throw new Error(compatibilityError);
+    }
+
+    statusEl.textContent =
+      `Daemon ${status.daemon_version}. API ${status.api_version}. ` +
+      `DID ${status.daemon_did}. Active backend ${status.active_backend || "not connected yet"}.`;
   } catch (error) {
     statusEl.textContent = `Daemon unavailable: ${error.message}`;
   }
@@ -36,7 +57,20 @@ async function refreshStatus() {
 async function refreshDomains() {
   const listEl = document.getElementById("domains");
   try {
-    const response = await fetch(DAEMON_DOMAINS_URL);
+    const [statusResponse, response] = await Promise.all([
+      fetch(DAEMON_STATUS_URL),
+      fetch(DAEMON_DOMAINS_URL),
+    ]);
+
+    if (!statusResponse.ok) {
+      throw new Error(`daemon returned ${statusResponse.status}`);
+    }
+    const status = await statusResponse.json();
+    const compatibilityError = daemonCompatibilityError(status);
+    if (compatibilityError) {
+      throw new Error(compatibilityError);
+    }
+
     if (!response.ok) {
       throw new Error(`daemon returned ${response.status}`);
     }

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -1,19 +1,5 @@
 const DAEMON_STATUS_URL = "http://127.0.0.1:7840/api/v1/status";
 const DAEMON_DOMAINS_URL = "http://127.0.0.1:7840/api/v1/domains";
-const EXTENSION_VERSION = chrome.runtime.getManifest().version;
-const REQUIRED_DAEMON_API_VERSION = "1";
-
-function daemonCompatibilityError(status) {
-  if (!status || typeof status !== "object") {
-    return "daemon returned an invalid status payload";
-  }
-
-  if (status.api_version !== REQUIRED_DAEMON_API_VERSION) {
-    return `daemon API ${status.api_version || "unknown"} is incompatible with extension ${EXTENSION_VERSION}`;
-  }
-
-  return null;
-}
 
 function openViewer(domain, path = "/") {
   const viewerUrl = new URL(chrome.runtime.getURL("viewer.html"));
@@ -35,16 +21,7 @@ function shortenOwner(owner) {
 async function refreshStatus() {
   const statusEl = document.getElementById("status");
   try {
-    const response = await fetch(DAEMON_STATUS_URL);
-    if (!response.ok) {
-      throw new Error(`daemon returned ${response.status}`);
-    }
-
-    const status = await response.json();
-    const compatibilityError = daemonCompatibilityError(status);
-    if (compatibilityError) {
-      throw new Error(compatibilityError);
-    }
+    const status = await fetchCompatibleDaemonStatus(DAEMON_STATUS_URL);
 
     statusEl.textContent =
       `Daemon ${status.daemon_version}. API ${status.api_version}. ` +
@@ -57,19 +34,9 @@ async function refreshStatus() {
 async function refreshDomains() {
   const listEl = document.getElementById("domains");
   try {
-    const [statusResponse, response] = await Promise.all([
-      fetch(DAEMON_STATUS_URL),
-      fetch(DAEMON_DOMAINS_URL),
-    ]);
+    await fetchCompatibleDaemonStatus(DAEMON_STATUS_URL);
 
-    if (!statusResponse.ok) {
-      throw new Error(`daemon returned ${statusResponse.status}`);
-    }
-    const status = await statusResponse.json();
-    const compatibilityError = daemonCompatibilityError(status);
-    if (compatibilityError) {
-      throw new Error(compatibilityError);
-    }
+    const response = await fetch(DAEMON_DOMAINS_URL);
 
     if (!response.ok) {
       throw new Error(`daemon returned ${response.status}`);

--- a/browser-extension/viewer.html
+++ b/browser-extension/viewer.html
@@ -21,6 +21,7 @@
     <iframe id="content-frame" title="ZHTP content" sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads"></iframe>
   </main>
   <aside id="inspector" class="inspector"></aside>
+  <script src="compat.js"></script>
   <script src="viewer.js"></script>
 </body>
 </html>

--- a/browser-extension/viewer.js
+++ b/browser-extension/viewer.js
@@ -1,6 +1,20 @@
 const STATUS_URL = "http://127.0.0.1:7840/api/v1/status";
 const RESOLVE_URL = "http://127.0.0.1:7840/api/v1/resolve";
 const RAW_CONTENT_BASE = "http://127.0.0.1:7840/web4/content";
+const EXTENSION_VERSION = chrome.runtime.getManifest().version;
+const REQUIRED_DAEMON_API_VERSION = "1";
+
+function daemonCompatibilityError(status) {
+  if (!status || typeof status !== "object") {
+    return "daemon returned an invalid status payload";
+  }
+
+  if (status.api_version !== REQUIRED_DAEMON_API_VERSION) {
+    return `daemon API ${status.api_version || "unknown"} is incompatible with extension ${EXTENSION_VERSION}`;
+  }
+
+  return null;
+}
 
 function query() {
   return new URLSearchParams(window.location.search);
@@ -56,9 +70,14 @@ async function loadViewer() {
     }
 
     const status = await statusResponse.json();
+    const compatibilityError = daemonCompatibilityError(status);
+    if (compatibilityError) {
+      throw new Error(compatibilityError);
+    }
     const resolved = await resolveResponse.json();
 
-    daemonStatus.textContent = `Daemon online. Backend ${status.active_backend || "pending"}.`;
+    daemonStatus.textContent =
+      `Daemon ${status.daemon_version}. Backend ${status.active_backend || "pending"}.`;
     inspector.textContent = `Owner ${resolved.owner || "unknown"} · Registered ${resolved.registered_at || "unknown"} · Expires ${resolved.expires_at || "unknown"}.`;
   } catch (error) {
     daemonStatus.textContent = "Daemon unavailable";

--- a/browser-extension/viewer.js
+++ b/browser-extension/viewer.js
@@ -1,20 +1,6 @@
 const STATUS_URL = "http://127.0.0.1:7840/api/v1/status";
 const RESOLVE_URL = "http://127.0.0.1:7840/api/v1/resolve";
 const RAW_CONTENT_BASE = "http://127.0.0.1:7840/web4/content";
-const EXTENSION_VERSION = chrome.runtime.getManifest().version;
-const REQUIRED_DAEMON_API_VERSION = "1";
-
-function daemonCompatibilityError(status) {
-  if (!status || typeof status !== "object") {
-    return "daemon returned an invalid status payload";
-  }
-
-  if (status.api_version !== REQUIRED_DAEMON_API_VERSION) {
-    return `daemon API ${status.api_version || "unknown"} is incompatible with extension ${EXTENSION_VERSION}`;
-  }
-
-  return null;
-}
 
 function query() {
   return new URLSearchParams(window.location.search);
@@ -54,34 +40,25 @@ async function loadViewer() {
 
   domainLabel.textContent = `${domain}${path}`;
   sourceLabel.textContent = source || `zhtp://${domain}${path}`;
-  frame.src = buildRawContentUrl(domain, path);
 
   try {
-    const [statusResponse, resolveResponse] = await Promise.all([
-      fetch(STATUS_URL),
-      fetch(`${RESOLVE_URL}/${encodeURIComponent(domain)}`)
-    ]);
+    const status = await fetchCompatibleDaemonStatus(STATUS_URL);
 
-    if (!statusResponse.ok) {
-      throw new Error(`daemon returned ${statusResponse.status}`);
-    }
+    const resolveResponse = await fetch(`${RESOLVE_URL}/${encodeURIComponent(domain)}`);
     if (!resolveResponse.ok) {
       throw new Error(`resolve returned ${resolveResponse.status}`);
     }
-
-    const status = await statusResponse.json();
-    const compatibilityError = daemonCompatibilityError(status);
-    if (compatibilityError) {
-      throw new Error(compatibilityError);
-    }
     const resolved = await resolveResponse.json();
 
+    frame.src = buildRawContentUrl(domain, path);
     daemonStatus.textContent =
       `Daemon ${status.daemon_version}. Backend ${status.active_backend || "pending"}.`;
     inspector.textContent = `Owner ${resolved.owner || "unknown"} · Registered ${resolved.registered_at || "unknown"} · Expires ${resolved.expires_at || "unknown"}.`;
   } catch (error) {
-    daemonStatus.textContent = "Daemon unavailable";
+    daemonStatus.textContent =
+      error.code === "DAEMON_INCOMPATIBLE" ? "Daemon incompatible" : "Daemon unavailable";
     inspector.textContent = `Resolution failed: ${error.message}`;
+    frame.removeAttribute("src");
   }
 }
 

--- a/scripts/install-zhtp-daemon-linux.sh
+++ b/scripts/install-zhtp-daemon-linux.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root: sudo bash scripts/install-zhtp-daemon-linux.sh" >&2
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKAGE_DIR="${ROOT_DIR}"
+BIN_SRC="${PACKAGE_DIR}/bin/zhtp-daemon"
+CONFIG_SRC="${PACKAGE_DIR}/config/config.toml"
+SERVICE_SRC="${PACKAGE_DIR}/systemd/zhtp-daemon.service"
+
+BIN_DST="/usr/local/bin/zhtp-daemon"
+SERVICE_DST="/etc/systemd/system/zhtp-daemon.service"
+STATE_DIR="/var/lib/zhtp-daemon"
+SERVICE_USER="zhtp-daemon"
+SERVICE_GROUP="zhtp-daemon"
+
+if [[ ! -x "${BIN_SRC}" ]]; then
+  echo "Missing binary at ${BIN_SRC}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${CONFIG_SRC}" ]]; then
+  echo "Missing config at ${CONFIG_SRC}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${SERVICE_SRC}" ]]; then
+  echo "Missing systemd unit at ${SERVICE_SRC}" >&2
+  exit 1
+fi
+
+if ! getent group "${SERVICE_GROUP}" >/dev/null 2>&1; then
+  groupadd --system "${SERVICE_GROUP}"
+fi
+
+if ! id -u "${SERVICE_USER}" >/dev/null 2>&1; then
+  useradd \
+    --system \
+    --home "${STATE_DIR}" \
+    --create-home \
+    --shell /usr/sbin/nologin \
+    --gid "${SERVICE_GROUP}" \
+    "${SERVICE_USER}"
+fi
+
+install -d -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0750 "${STATE_DIR}"
+install -m 0755 "${BIN_SRC}" "${BIN_DST}"
+
+if [[ ! -f "${STATE_DIR}/config.toml" ]]; then
+  install -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0640 "${CONFIG_SRC}" "${STATE_DIR}/config.toml"
+else
+  echo "Keeping existing config at ${STATE_DIR}/config.toml"
+fi
+
+install -m 0644 "${SERVICE_SRC}" "${SERVICE_DST}"
+
+systemctl daemon-reload
+systemctl enable --now zhtp-daemon
+systemctl status --no-pager zhtp-daemon
+
+cat <<EOF
+
+Installed zhtp-daemon.
+
+- binary: ${BIN_DST}
+- service: ${SERVICE_DST}
+- state dir: ${STATE_DIR}
+- config: ${STATE_DIR}/config.toml
+
+Inspect logs with:
+  journalctl -u zhtp-daemon -f
+EOF

--- a/scripts/package-browser-extension-chrome.sh
+++ b/scripts/package-browser-extension-chrome.sh
@@ -13,6 +13,7 @@ mkdir -p "${STAGE_DIR}"
 
 install -m 0644 "${ROOT_DIR}/browser-extension/manifest.json" "${STAGE_DIR}/manifest.json"
 install -m 0644 "${ROOT_DIR}/browser-extension/background.js" "${STAGE_DIR}/background.js"
+install -m 0644 "${ROOT_DIR}/browser-extension/compat.js" "${STAGE_DIR}/compat.js"
 install -m 0644 "${ROOT_DIR}/browser-extension/popup.html" "${STAGE_DIR}/popup.html"
 install -m 0644 "${ROOT_DIR}/browser-extension/popup.css" "${STAGE_DIR}/popup.css"
 install -m 0644 "${ROOT_DIR}/browser-extension/popup.js" "${STAGE_DIR}/popup.js"

--- a/scripts/package-browser-extension-chrome.sh
+++ b/scripts/package-browser-extension-chrome.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_DIR="${ROOT_DIR}/target/browser-extension"
+PACKAGE_NAME="zhtp-browser-bridge-chrome"
+STAGE_DIR="${TARGET_DIR}/${PACKAGE_NAME}"
+ARCHIVE_PATH="${TARGET_DIR}/${PACKAGE_NAME}.zip"
+CHECKSUM_PATH="${TARGET_DIR}/${PACKAGE_NAME}.sha256"
+
+rm -rf "${STAGE_DIR}" "${ARCHIVE_PATH}" "${CHECKSUM_PATH}"
+mkdir -p "${STAGE_DIR}"
+
+install -m 0644 "${ROOT_DIR}/browser-extension/manifest.json" "${STAGE_DIR}/manifest.json"
+install -m 0644 "${ROOT_DIR}/browser-extension/background.js" "${STAGE_DIR}/background.js"
+install -m 0644 "${ROOT_DIR}/browser-extension/popup.html" "${STAGE_DIR}/popup.html"
+install -m 0644 "${ROOT_DIR}/browser-extension/popup.css" "${STAGE_DIR}/popup.css"
+install -m 0644 "${ROOT_DIR}/browser-extension/popup.js" "${STAGE_DIR}/popup.js"
+install -m 0644 "${ROOT_DIR}/browser-extension/viewer.html" "${STAGE_DIR}/viewer.html"
+install -m 0644 "${ROOT_DIR}/browser-extension/viewer.css" "${STAGE_DIR}/viewer.css"
+install -m 0644 "${ROOT_DIR}/browser-extension/viewer.js" "${STAGE_DIR}/viewer.js"
+install -m 0644 "${ROOT_DIR}/browser-extension/README.md" "${STAGE_DIR}/README.md"
+
+(
+  cd "${TARGET_DIR}"
+  zip -rq "${PACKAGE_NAME}.zip" "${PACKAGE_NAME}"
+  sha256sum "${PACKAGE_NAME}.zip" > "${PACKAGE_NAME}.sha256"
+)

--- a/scripts/package-zhtp-daemon-linux.sh
+++ b/scripts/package-zhtp-daemon-linux.sh
@@ -9,12 +9,13 @@ ARCHIVE_PATH="${TARGET_DIR}/${PACKAGE_NAME}.tar.gz"
 CHECKSUM_PATH="${TARGET_DIR}/${PACKAGE_NAME}.sha256"
 
 rm -rf "${STAGE_DIR}" "${ARCHIVE_PATH}" "${CHECKSUM_PATH}"
-mkdir -p "${STAGE_DIR}/bin" "${STAGE_DIR}/config" "${STAGE_DIR}/systemd"
+mkdir -p "${STAGE_DIR}/bin" "${STAGE_DIR}/config" "${STAGE_DIR}/systemd" "${STAGE_DIR}/scripts"
 
 install -m 0755 "${TARGET_DIR}/zhtp-daemon" "${STAGE_DIR}/bin/zhtp-daemon"
 install -m 0644 "${ROOT_DIR}/zhtp-daemon/README.md" "${STAGE_DIR}/README.md"
 install -m 0644 "${ROOT_DIR}/zhtp-daemon/config.example.toml" "${STAGE_DIR}/config/config.toml"
 install -m 0644 "${ROOT_DIR}/deploy/zhtp-daemon.service" "${STAGE_DIR}/systemd/zhtp-daemon.service"
+install -m 0755 "${ROOT_DIR}/scripts/install-zhtp-daemon-linux.sh" "${STAGE_DIR}/scripts/install-zhtp-daemon-linux.sh"
 
 tar -C "${TARGET_DIR}" -czf "${ARCHIVE_PATH}" "${PACKAGE_NAME}"
 (

--- a/zhtp-daemon/README.md
+++ b/zhtp-daemon/README.md
@@ -54,6 +54,7 @@ Archive contents:
 - `bin/zhtp-daemon`
 - `config/config.toml`
 - `systemd/zhtp-daemon.service`
+- `scripts/install-zhtp-daemon-linux.sh`
 - `README.md`
 
 ## Linux install
@@ -72,6 +73,14 @@ sha256sum -c ../zhtp-daemon-linux-x86_64.sha256
 ```
 
 ### 2. Install the binary and service unit
+
+Fast path:
+
+```bash
+sudo bash scripts/install-zhtp-daemon-linux.sh
+```
+
+Manual path:
 
 ```bash
 sudo install -m 0755 bin/zhtp-daemon /usr/local/bin/zhtp-daemon

--- a/zhtp-daemon/src/service.rs
+++ b/zhtp-daemon/src/service.rs
@@ -12,8 +12,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
 use tracing::warn;
 
+pub const DAEMON_API_VERSION: &str = "1";
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ServiceStatus {
+    pub daemon_version: String,
+    pub api_version: String,
     pub daemon_did: String,
     pub active_backend: Option<String>,
     pub configured_backends: Vec<String>,
@@ -51,6 +55,8 @@ impl ZhtpDaemonService {
     pub async fn status(&self) -> ServiceStatus {
         let active_backend = self.session.lock().await.active_backend.clone();
         ServiceStatus {
+            daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+            api_version: DAEMON_API_VERSION.to_string(),
             daemon_did: self.identity.did.clone(),
             active_backend,
             configured_backends: self.config.backend_nodes.clone(),


### PR DESCRIPTION
## Summary
- add explicit daemon/api version fields to the zhtp-daemon status endpoint
- add extension-side compatibility checks so Chrome fails clearly on daemon version mismatch
- add a Chrome developer packaging script and documentation for the extension

## Included
- daemon status now exposes  and 
- popup and viewer validate daemon API compatibility before browsing
-  produces a zip and checksum for Chrome developer distribution
- extension README now documents Chrome install and packaging flow

## Verification
- cargo build -p zhtp-daemon
- bash -n scripts/package-browser-extension-chrome.sh
- bash scripts/package-browser-extension-chrome.sh
- unzip -l target/browser-extension/zhtp-browser-bridge-chrome.zip