### PR TITLE
fix: CLI identity register command + observed→citizen upgrade

### DIFF
--- a/lib-identity/src/identity/manager.rs
+++ b/lib-identity/src/identity/manager.rs
@@ -327,7 +327,14 @@ impl IdentityManager {
 
     /// Remove an identity (used to clear observed stubs before upgrading to full citizen).
     pub fn remove_identity(&mut self, identity_id: &IdentityId) {
+        // Remove the primary identity record.
         self.identities.remove(identity_id);
+
+        // Clear all additional per-identity state to avoid leaving stale data behind.
+        self.private_data.remove(identity_id);
+        self.trusted_issuers.remove(identity_id);
+        self.verification_cache.remove(identity_id);
+        self.password_manager.remove_identity(identity_id);
     }
 
     /// Register an externally-created identity WITH full citizenship benefits (3 wallets)

--- a/lib-identity/src/identity/manager.rs
+++ b/lib-identity/src/identity/manager.rs
@@ -325,6 +325,11 @@ impl IdentityManager {
         Ok(())
     }
 
+    /// Remove an identity (used to clear observed stubs before upgrading to full citizen).
+    pub fn remove_identity(&mut self, identity_id: &IdentityId) {
+        self.identities.remove(identity_id);
+    }
+
     /// Register an externally-created identity WITH full citizenship benefits (3 wallets)
     ///
     /// This method registers an identity where the keys were generated on the client

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -498,6 +498,22 @@ pub enum IdentityAction {
         #[arg(short, long)]
         recovery_options: Vec<String>,
     },
+    /// Register identity on-chain (creates identity + wallets + SOV welcome bonus)
+    ///
+    /// If no local keystore exists, generates keys first. Then calls the node's
+    /// /api/v1/identity/register endpoint to register on-chain with 3 wallets
+    /// (Primary, UBI, Savings) and receive the SOV welcome bonus.
+    Register {
+        /// Display name
+        #[arg(short, long)]
+        display_name: String,
+        /// Device identifier
+        #[arg(long, default_value = "cli-device")]
+        device_id: String,
+        /// Path to identity keystore directory
+        #[arg(short, long)]
+        keystore: Option<String>,
+    },
     /// Verify identity (orchestrated)
     Verify {
         /// Identity ID

--- a/zhtp-cli/src/commands/domain.rs
+++ b/zhtp-cli/src/commands/domain.rs
@@ -279,7 +279,7 @@ async fn register_domain_impl(
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| CliError::ConfigError(format!("Time error: {}", e)))?
         .as_secs();
-    let fee = minimum_registration_fee();
+    let fee = 10u64; // Domain registration fee: 10 SOV (matches server DOMAIN_REGISTRATION_FEE_SOV)
     let message = format!("{}|{}|{}", domain, timestamp, fee);
     let signature = sign_message(&loaded.keypair, message.as_bytes())
         .map_err(|e| CliError::ConfigError(format!("Failed to sign registration: {}", e)))?;

--- a/zhtp-cli/src/commands/identity.rs
+++ b/zhtp-cli/src/commands/identity.rs
@@ -231,49 +231,68 @@ async fn register_identity_on_chain(
 
     let identity_file = keystore.join(USER_IDENTITY_FILENAME);
     let private_key_file = keystore.join(USER_PRIVATE_KEY_FILENAME);
+    let identity_exists = identity_file.exists();
+    let private_key_exists = private_key_file.exists();
 
-    // Generate keys if no local identity exists
-    if identity_file.exists() {
-        output.info("Using existing identity from keystore...")?;
-    } else {
-        output.info("Generating cryptographic keys (Dilithium5 + Kyber1024)...")?;
-        std::fs::create_dir_all(&keystore).map_err(|e| {
-            CliError::IdentityError(format!("Failed to create keystore directory: {}", e))
-        })?;
-        let id = ZhtpIdentity::new_unified(
-            lib_identity::IdentityType::Device,
-            None,
-            None,
-            display_name,
-            None,
-        )
-        .map_err(|e| CliError::IdentityError(format!("Failed to generate identity: {}", e)))?;
-
-        // Save private key
-        let pk = id
-            .private_key
-            .as_ref()
-            .ok_or_else(|| CliError::IdentityError("Missing private key".to_string()))?;
-        save_private_key_to_file(pk, &private_key_file)?;
-
-        // Save identity
-        let json = serde_json::to_string_pretty(&id)
-            .map_err(|e| CliError::IdentityError(format!("Failed to serialize: {}", e)))?;
-        std::fs::write(&identity_file, &json).map_err(|e| {
-            CliError::IdentityError(format!("Failed to write identity: {}", e))
-        })?;
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(
-                &private_key_file,
-                std::fs::Permissions::from_mode(0o600),
-            );
+    // Use an existing identity only when the keystore is complete.
+    // If only one file exists, fail early with a targeted error instead of
+    // proceeding and surfacing a less actionable load/parsing failure later.
+    match (identity_exists, private_key_exists) {
+        (true, true) => {
+            output.info("Using existing identity from keystore...")?;
         }
+        (false, false) => {
+            output.info("Generating cryptographic keys (Dilithium5 + Kyber1024)...")?;
+            std::fs::create_dir_all(&keystore).map_err(|e| {
+                CliError::IdentityError(format!("Failed to create keystore directory: {}", e))
+            })?;
+            let id = ZhtpIdentity::new_unified(
+                lib_identity::IdentityType::Device,
+                None,
+                None,
+                display_name,
+                None,
+            )
+            .map_err(|e| CliError::IdentityError(format!("Failed to generate identity: {}", e)))?;
 
-        output.success(&format!("DID: {}", id.did))?;
-        output.success(&format!("Keys saved to: {:?}", keystore))?;
+            // Save private key
+            let pk = id
+                .private_key
+                .as_ref()
+                .ok_or_else(|| CliError::IdentityError("Missing private key".to_string()))?;
+            save_private_key_to_file(pk, &private_key_file)?;
+
+            // Save identity
+            let json = serde_json::to_string_pretty(&id)
+                .map_err(|e| CliError::IdentityError(format!("Failed to serialize: {}", e)))?;
+            std::fs::write(&identity_file, &json).map_err(|e| {
+                CliError::IdentityError(format!("Failed to write identity: {}", e))
+            })?;
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(
+                    &private_key_file,
+                    std::fs::Permissions::from_mode(0o600),
+                );
+            }
+
+            output.success(&format!("DID: {}", id.did))?;
+            output.success(&format!("Keys saved to: {:?}", keystore))?;
+        }
+        (true, false) => {
+            return Err(CliError::IdentityError(format!(
+                "Inconsistent keystore at {:?}: found {} but missing {}. Remove the incomplete keystore files or restore the missing file, then try again.",
+                keystore, USER_IDENTITY_FILENAME, USER_PRIVATE_KEY_FILENAME
+            )));
+        }
+        (false, true) => {
+            return Err(CliError::IdentityError(format!(
+                "Inconsistent keystore at {:?}: found {} but missing {}. Remove the incomplete keystore files or restore the missing file, then try again.",
+                keystore, USER_PRIVATE_KEY_FILENAME, USER_IDENTITY_FILENAME
+            )));
+        }
     }
 
     // Load keypair for signing (this works with both hex and array formats)

--- a/zhtp-cli/src/commands/identity.rs
+++ b/zhtp-cli/src/commands/identity.rs
@@ -55,6 +55,7 @@ pub fn action_to_operation(action: &IdentityAction) -> IdentityOperation {
     match action {
         IdentityAction::Create { .. } => IdentityOperation::Create,
         IdentityAction::CreateDid { .. } => IdentityOperation::CreateWithType,
+        IdentityAction::Register { .. } => IdentityOperation::Create,
         IdentityAction::Verify { .. } => IdentityOperation::Verify,
         IdentityAction::List => IdentityOperation::List,
         IdentityAction::SimulateMessage { .. }
@@ -106,6 +107,20 @@ async fn handle_identity_command_impl(
 
             // Imperative: File I/O
             create_identity_with_type_impl(&name, &identity_type, output).await
+        }
+        IdentityAction::Register {
+            display_name,
+            device_id,
+            keystore,
+        } => {
+            register_identity_on_chain(
+                &display_name,
+                &device_id,
+                keystore.as_deref(),
+                cli,
+                output,
+            )
+            .await
         }
         IdentityAction::Verify { identity_id } => {
             // Pure validation
@@ -195,6 +210,140 @@ async fn create_identity_impl(
     output.success(&format!("Identity saved to: {:?}", identity_file))?;
     output.success(&format!("Private key saved to: {:?}", private_key_file))?;
     output.warning("Keep your identity secure! It contains cryptographic material.")?;
+
+    Ok(())
+}
+
+/// Register identity on-chain: generates keys (if needed), then calls
+/// POST /api/v1/identity/register to create identity + 3 wallets + SOV welcome bonus.
+/// This matches the app's identity creation flow — the single canonical path.
+async fn register_identity_on_chain(
+    display_name: &str,
+    device_id: &str,
+    keystore_path: Option<&str>,
+    cli: &ZhtpCli,
+    output: &dyn Output,
+) -> CliResult<()> {
+    let keystore = match keystore_path {
+        Some(path) => PathBuf::from(path),
+        None => get_default_keystore_path()?,
+    };
+
+    let identity_file = keystore.join(USER_IDENTITY_FILENAME);
+    let private_key_file = keystore.join(USER_PRIVATE_KEY_FILENAME);
+
+    // Generate keys if no local identity exists
+    if identity_file.exists() {
+        output.info("Using existing identity from keystore...")?;
+    } else {
+        output.info("Generating cryptographic keys (Dilithium5 + Kyber1024)...")?;
+        std::fs::create_dir_all(&keystore).map_err(|e| {
+            CliError::IdentityError(format!("Failed to create keystore directory: {}", e))
+        })?;
+        let id = ZhtpIdentity::new_unified(
+            lib_identity::IdentityType::Device,
+            None,
+            None,
+            display_name,
+            None,
+        )
+        .map_err(|e| CliError::IdentityError(format!("Failed to generate identity: {}", e)))?;
+
+        // Save private key
+        let pk = id
+            .private_key
+            .as_ref()
+            .ok_or_else(|| CliError::IdentityError("Missing private key".to_string()))?;
+        save_private_key_to_file(pk, &private_key_file)?;
+
+        // Save identity
+        let json = serde_json::to_string_pretty(&id)
+            .map_err(|e| CliError::IdentityError(format!("Failed to serialize: {}", e)))?;
+        std::fs::write(&identity_file, &json).map_err(|e| {
+            CliError::IdentityError(format!("Failed to write identity: {}", e))
+        })?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(
+                &private_key_file,
+                std::fs::Permissions::from_mode(0o600),
+            );
+        }
+
+        output.success(&format!("DID: {}", id.did))?;
+        output.success(&format!("Keys saved to: {:?}", keystore))?;
+    }
+
+    // Load keypair for signing (this works with both hex and array formats)
+    let loaded = load_identity_from_keystore(&keystore)?;
+    output.info(&format!("DID: {}", loaded.identity.did))?;
+    output.info("Registering on-chain (identity + wallets + SOV welcome bonus)...")?;
+
+    // Build registration proof: sign "ZHTP_REGISTER:{timestamp}"
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| CliError::ConfigError(format!("Time error: {}", e)))?
+        .as_secs();
+    let proof_message = format!("ZHTP_REGISTER:{}", timestamp);
+    let proof_sig = lib_crypto::sign_message(&loaded.keypair, proof_message.as_bytes())
+        .map_err(|e| CliError::IdentityError(format!("Failed to sign proof: {}", e)))?;
+
+    // Base64-encode public keys
+    let dilithium_pk_b64 = base64::engine::general_purpose::STANDARD
+        .encode(&loaded.keypair.public_key.dilithium_pk);
+    let kyber_pk_b64 = base64::engine::general_purpose::STANDARD
+        .encode(&loaded.keypair.public_key.kyber_pk);
+    let proof_b64 =
+        base64::engine::general_purpose::STANDARD.encode(&proof_sig.signature);
+
+    let body = serde_json::json!({
+        "public_key": dilithium_pk_b64,
+        "kyber_public_key": kyber_pk_b64,
+        "device_id": device_id,
+        "display_name": display_name,
+        "identity_type": "human",
+        "registration_proof": proof_b64,
+        "timestamp": timestamp,
+    });
+
+    // Connect and POST
+    let trust_config = build_trust_config(None, None, false, true)?;
+    let client = connect_client(loaded.identity.clone(), trust_config, &cli.server).await?;
+    let response = client
+        .post_json("/api/v1/identity/register", &body)
+        .await
+        .map_err(|e| CliError::ConfigError(format!("Registration failed: {}", e)))?;
+
+    let result: serde_json::Value = ZhtpClient::parse_json(&response)
+        .map_err(|e| CliError::ConfigError(format!("Failed to parse response: {}", e)))?;
+
+    if result.get("status").and_then(|s| s.as_str()) == Some("success") {
+        output.success("Identity registered on-chain")?;
+        if let Some(did) = result.get("did").and_then(|d| d.as_str()) {
+            output.print(&format!("DID: {}", did))?;
+        }
+        if let Some(primary) = result.get("primary_wallet_id").and_then(|w| w.as_str()) {
+            output.print(&format!("Primary wallet: {}", primary))?;
+        }
+        if let Some(ubi) = result.get("ubi_wallet_id").and_then(|w| w.as_str()) {
+            output.print(&format!("UBI wallet: {}", ubi))?;
+        }
+        if let Some(savings) = result.get("savings_wallet_id").and_then(|w| w.as_str()) {
+            output.print(&format!("Savings wallet: {}", savings))?;
+        }
+    } else {
+        let err = result
+            .get("message")
+            .or_else(|| result.get("error"))
+            .and_then(|m| m.as_str())
+            .unwrap_or("Unknown error");
+        return Err(CliError::IdentityError(format!(
+            "On-chain registration failed: {}",
+            err
+        )));
+    }
 
     Ok(())
 }

--- a/zhtp-cli/src/commands/identity.rs
+++ b/zhtp-cli/src/commands/identity.rs
@@ -224,10 +224,7 @@ async fn register_identity_on_chain(
     cli: &ZhtpCli,
     output: &dyn Output,
 ) -> CliResult<()> {
-    let keystore = match keystore_path {
-        Some(path) => PathBuf::from(path),
-        None => get_default_keystore_path()?,
-    };
+    let keystore = logic::resolve_keystore_path(cli, keystore_path, false)?;
 
     let identity_file = keystore.join(USER_IDENTITY_FILENAME);
     let private_key_file = keystore.join(USER_PRIVATE_KEY_FILENAME);

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1590,15 +1590,41 @@ impl IdentityHandler {
             }
         };
 
-        // Check if identity already exists
+        // Check if identity already exists with wallets (fully registered).
+        // An "observed" identity from UHP handshake auto-registration has no wallets —
+        // allow upgrading it to full citizen status.
         {
-            let identity_manager = self.identity_manager.read().await;
-            if identity_manager.get_identity(&identity_id).is_some() {
+            let has_wallets = if let Ok(blockchain_arc) =
+                crate::runtime::blockchain_provider::get_global_blockchain().await
+            {
+                let blockchain = blockchain_arc.read().await;
+                let id_hash = lib_blockchain::Hash::from_slice(&identity_id.0);
+                blockchain
+                    .wallet_registry
+                    .values()
+                    .any(|w| w.owner_identity_id.as_ref() == Some(&id_hash))
+            } else {
+                false
+            };
+
+            if has_wallets {
                 return Ok(ZhtpResponse::error(
                     ZhtpStatus::Conflict,
                     "Identity already registered".to_string(),
                 ));
             }
+
+            // If an observed stub exists from UHP auto-registration, remove it
+            // so register_external_citizen_identity can create the full citizen entry.
+            let mut identity_manager = self.identity_manager.write().await;
+            if identity_manager.get_identity(&identity_id).is_some() {
+                tracing::info!(
+                    "📱 Removing observed stub to upgrade to full citizen: {}",
+                    &did[..did.len().min(32)]
+                );
+                identity_manager.remove_identity(&identity_id);
+            }
+            drop(identity_manager);
         }
 
         // Create identity record (without private key - client keeps it)

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1594,17 +1594,28 @@ impl IdentityHandler {
         // An "observed" identity from UHP handshake auto-registration has no wallets —
         // allow upgrading it to full citizen status.
         {
-            let has_wallets = if let Ok(blockchain_arc) =
-                crate::runtime::blockchain_provider::get_global_blockchain().await
+            let blockchain_arc = match crate::runtime::blockchain_provider::get_global_blockchain().await
             {
+                Ok(blockchain_arc) => blockchain_arc,
+                Err(err) => {
+                    tracing::error!(
+                        "Failed to access blockchain for wallet check during identity registration: {}",
+                        err
+                    );
+                    return Ok(ZhtpResponse::error(
+                        ZhtpStatus::ServiceUnavailable,
+                        "Unable to verify identity registration state".to_string(),
+                    ));
+                }
+            };
+
+            let has_wallets = {
                 let blockchain = blockchain_arc.read().await;
                 let id_hash = lib_blockchain::Hash::from_slice(&identity_id.0);
                 blockchain
                     .wallet_registry
                     .values()
                     .any(|w| w.owner_identity_id.as_ref() == Some(&id_hash))
-            } else {
-                false
             };
 
             if has_wallets {


### PR DESCRIPTION
## Summary

- Add `identity register` CLI command — single entry point matching app's canonical path
- Server: upgrade observed identity stubs to full citizens (fixes 409 race condition)
- Fix domain registration fee calculation (10 SOV, was 1090)

Closes #2101 (partially — domain fee_payment_tx and backup import still open)

## Changes

- `zhtp-cli/src/argument_parsing.rs` — `Register` variant in `IdentityAction`
- `zhtp-cli/src/commands/identity.rs` — `register_identity_on_chain()`: loads or generates keys, signs `ZHTP_REGISTER:{timestamp}` proof, calls `/api/v1/identity/register`
- `zhtp/src/api/handlers/identity/mod.rs` — checks wallet_registry for existing wallets before rejecting; removes observed stub to allow citizen upgrade
- `lib-identity/src/identity/manager.rs` — `remove_identity()` method
- `zhtp-cli/src/commands/domain.rs` — fee hardcoded to 10 SOV (was `minimum_registration_fee()` = 1090)

## Test plan

- [x] `cargo check --workspace` passes
- [x] `identity register --display-name Hugo` creates identity + 3 wallets + 5000 SOV on g3
- [x] Server logs confirm: citizen registration, 3 wallets, welcome bonus
- [ ] Domain registration (blocked on fee_payment_tx — tracked in #2101)