### PR TITLE
feat(access-control): Phase 6 — API handler and graph-traversal gating

### DIFF
--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1234,6 +1234,8 @@ impl BlockchainHandler {
             search_type = Some(explicit);
         }
 
+        let principal = self.extract_principal(&request);
+
         let blockchain_arc = self.get_blockchain().await?;
         let blockchain = blockchain_arc.read().await;
         let latest_height = blockchain
@@ -1301,14 +1303,15 @@ impl BlockchainHandler {
 
         let resolve_identity = |did: &str| -> Option<serde_json::Value> {
             let identity = blockchain.identity_registry.get(&did.to_string())?;
+            let is_public = principal.role == lib_access_control::Role::Public;
             Some(serde_json::json!({
                 "did": identity.did,
                 "display_name": identity.display_name,
                 "identity_type": identity.identity_type,
                 "registration_fee": identity.registration_fee,
                 "created_at": identity.created_at,
-                "controlled_nodes": identity.controlled_nodes,
-                "owned_wallets": identity.owned_wallets,
+                "controlled_nodes": if is_public { None::<Vec<String>> } else { Some(identity.controlled_nodes.clone()) },
+                "owned_wallets": if is_public { None::<Vec<String>> } else { Some(identity.owned_wallets.clone()) },
             }))
         };
 

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -25,8 +25,8 @@ use lib_blockchain::Blockchain;
 use crate::config::Environment;
 
 // Access control imports
+use crate::api::principal::extract_principal_from_request;
 use lib_access_control::{AccessDomain, AccessOperation, AccessPolicy, SecurityPrincipal, SubjectRelation};
-use lib_types::NodeType;
 
 /// Clean blockchain handler implementation
 ///
@@ -54,20 +54,7 @@ impl BlockchainHandler {
 
     /// Extract a SecurityPrincipal from an incoming request.
     fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
-        if let Some(node_type_str) = request.headers.get("x-node-type") {
-            let node_type = NodeType::from_config(Some(&node_type_str));
-            return SecurityPrincipal::new("did:zhtp:node", lib_access_control::Role::Node, node_type);
-        }
-        if let Some(auth) = request.headers.get("authorization") {
-            if auth.to_lowercase().starts_with("bearer ") {
-                return SecurityPrincipal::new(
-                    "did:zhtp:session",
-                    lib_access_control::Role::Citizen,
-                    NodeType::FullNode,
-                );
-            }
-        }
-        SecurityPrincipal::new("did:zhtp:public", lib_access_control::Role::Public, NodeType::Relay)
+        extract_principal_from_request(request)
     }
 
     /// Check if the principal is allowed to read wallet graph data for the given identity.

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -24,6 +24,10 @@ use lib_blockchain::types::{transaction_type::TransactionType, ContractType};
 use lib_blockchain::Blockchain;
 use crate::config::Environment;
 
+// Access control imports
+use lib_access_control::{AccessDomain, AccessOperation, AccessPolicy, SecurityPrincipal, SubjectRelation};
+use lib_types::NodeType;
+
 /// Clean blockchain handler implementation
 ///
 /// NOTE: This handler does NOT store a blockchain reference.
@@ -32,12 +36,76 @@ use crate::config::Environment;
 /// added via mesh protocol).
 pub struct BlockchainHandler {
     environment: Environment,
+    identity_manager: Arc<RwLock<lib_identity::IdentityManager>>,
 }
 
 impl BlockchainHandler {
-    pub fn new(_blockchain: Arc<RwLock<Blockchain>>, environment: Environment) -> Self {
+    pub fn new(
+        _blockchain: Arc<RwLock<Blockchain>>,
+        environment: Environment,
+        identity_manager: Arc<RwLock<lib_identity::IdentityManager>>,
+    ) -> Self {
         // We ignore the passed blockchain reference and always fetch from global provider
-        Self { environment }
+        Self {
+            environment,
+            identity_manager,
+        }
+    }
+
+    /// Extract a SecurityPrincipal from an incoming request.
+    fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
+        if let Some(node_type_str) = request.headers.get("x-node-type") {
+            let node_type = NodeType::from_config(Some(&node_type_str));
+            return SecurityPrincipal::new("did:zhtp:node", lib_access_control::Role::Node, node_type);
+        }
+        if let Some(auth) = request.headers.get("authorization") {
+            if auth.to_lowercase().starts_with("bearer ") {
+                return SecurityPrincipal::new(
+                    "did:zhtp:session",
+                    lib_access_control::Role::Citizen,
+                    NodeType::FullNode,
+                );
+            }
+        }
+        SecurityPrincipal::new("did:zhtp:public", lib_access_control::Role::Public, NodeType::Relay)
+    }
+
+    /// Check if the principal is allowed to read wallet graph data for the given identity.
+    async fn check_wallet_graph_access(
+        &self,
+        principal: &SecurityPrincipal,
+        identity_id: &lib_crypto::Hash,
+    ) -> Result<bool> {
+        let identity_manager = self.identity_manager.read().await;
+        let identity = match identity_manager.get_identity(identity_id) {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+
+        let relation = if principal.did == identity.did {
+            SubjectRelation::Self_
+        } else if let Ok(principal_id) = lib_identity::did::parse_did_to_identity_id(&principal.did) {
+            if let Some(ref owner_id) = identity.owner_identity_id {
+                if principal_id == *owner_id {
+                    SubjectRelation::Owner
+                } else {
+                    SubjectRelation::External
+                }
+            } else {
+                SubjectRelation::External
+            }
+        } else {
+            if principal.role == lib_access_control::Role::Public {
+                SubjectRelation::Public
+            } else {
+                SubjectRelation::External
+            }
+        };
+
+        let policy = AccessPolicy::default();
+        Ok(policy
+            .check_access(principal, relation, AccessDomain::WalletGraph, AccessOperation::Read)
+            .is_allowed())
     }
 
     /// Get the current shared blockchain instance
@@ -2814,21 +2882,55 @@ impl BlockchainHandler {
             .get(5)
             .ok_or_else(|| anyhow::anyhow!("DID required"))?;
 
+        let principal = self.extract_principal(&request);
+        let identity_manager = self.identity_manager.read().await;
+
+        // Gate blockchain identity metadata behind the same view system.
+        let view = identity_manager.get_identity_view_by_did(&principal, did);
+        drop(identity_manager);
+
         let blockchain_arc = self.get_blockchain().await?;
         let blockchain = blockchain_arc.read().await;
 
         // Query identity from registry
         if let Some(identity) = blockchain.identity_registry.get(&did.to_string()) {
-            let response_data = serde_json::json!({
-                "status": "identity_found",
-                "did": identity.did,
-                "display_name": identity.display_name,
-                "identity_type": identity.identity_type,
-                "registration_fee": identity.registration_fee,
-                "created_at": identity.created_at,
-                "controlled_nodes": identity.controlled_nodes,
-                "owned_wallets": identity.owned_wallets,
-            });
+            let response_data = match view {
+                Some(lib_identity::types::IdentityView::Public(_)) => {
+                    serde_json::json!({
+                        "status": "identity_found",
+                        "did": identity.did,
+                        "display_name": identity.display_name,
+                        "identity_type": identity.identity_type,
+                        "registration_fee": identity.registration_fee,
+                        "created_at": identity.created_at,
+                    })
+                }
+                Some(_) => {
+                    serde_json::json!({
+                        "status": "identity_found",
+                        "did": identity.did,
+                        "display_name": identity.display_name,
+                        "identity_type": identity.identity_type,
+                        "registration_fee": identity.registration_fee,
+                        "created_at": identity.created_at,
+                        "controlled_nodes": identity.controlled_nodes,
+                        "owned_wallets": identity.owned_wallets,
+                    })
+                }
+                None => {
+                    let response_data = serde_json::json!({
+                        "status": "identity_not_found",
+                        "did": did,
+                        "message": format!("Identity not found for DID: {}", did),
+                    });
+                    let json_response = serde_json::to_vec(&response_data)?;
+                    return Ok(ZhtpResponse::success_with_content_type(
+                        json_response,
+                        "application/json".to_string(),
+                        None,
+                    ));
+                }
+            };
 
             let json_response = serde_json::to_vec(&response_data)?;
             return Ok(ZhtpResponse::success_with_content_type(
@@ -2855,6 +2957,8 @@ impl BlockchainHandler {
 
     /// List wallets, optionally filtered by owner identity
     async fn handle_list_wallets(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        let principal = self.extract_principal(&request);
+
         let blockchain_arc = self.get_blockchain().await?;
         let blockchain = blockchain_arc.read().await;
 
@@ -2870,6 +2974,36 @@ impl BlockchainHandler {
         } else {
             None
         };
+
+        // Access control: unfiltered enumeration is restricted to elevated roles.
+        if owner_filter.is_none() {
+            let allowed = matches!(
+                principal.role,
+                lib_access_control::Role::System
+                    | lib_access_control::Role::Node
+                    | lib_access_control::Role::InfraAdmin
+                    | lib_access_control::Role::Council
+                    | lib_access_control::Role::Emergency
+            );
+            if !allowed {
+                return Ok(ZhtpResponse::error(
+                    ZhtpStatus::Forbidden,
+                    "Unfiltered wallet enumeration requires elevated privileges".to_string(),
+                ));
+            }
+        } else {
+            // Filtered enumeration: check WalletGraph access for the specified owner.
+            let owner_id_hex = owner_filter.as_ref().unwrap();
+            if let Ok(owner_hash) = lib_blockchain::types::Hash::from_hex(owner_id_hex) {
+                let crypto_hash = lib_crypto::Hash::from_bytes(owner_hash.as_bytes());
+                if !self.check_wallet_graph_access(&principal, &crypto_hash).await? {
+                    return Ok(ZhtpResponse::error(
+                        ZhtpStatus::Forbidden,
+                        "Access denied to wallet list for this owner".to_string(),
+                    ));
+                }
+            }
+        }
 
         // Collect wallets, optionally filtering by owner_identity_id
         let wallets: Vec<serde_json::Value> = blockchain
@@ -3151,6 +3285,7 @@ mod tests {
         let handler = BlockchainHandler::new(
             Arc::new(RwLock::new(Blockchain::new().expect("Blockchain::new"))),
             Environment::Development,
+            Arc::new(RwLock::new(lib_identity::IdentityManager::new())),
         );
 
         let chain_info_request = ZhtpRequest {

--- a/zhtp/src/api/handlers/crypto/mod.rs
+++ b/zhtp/src/api/handlers/crypto/mod.rs
@@ -22,6 +22,11 @@ use lib_crypto::KeyPair;
 
 // Identity imports
 use lib_identity::IdentityManager;
+use lib_identity::types::IdentityView;
+
+// Access control imports
+use lib_access_control::{SecurityPrincipal, Role};
+use lib_types::NodeType;
 
 /// Crypto utilities handler for signing, verification, and key generation
 pub struct CryptoHandler {
@@ -31,6 +36,24 @@ pub struct CryptoHandler {
 impl CryptoHandler {
     pub fn new(identity_manager: Arc<RwLock<IdentityManager>>) -> Self {
         Self { identity_manager }
+    }
+
+    /// Extract a SecurityPrincipal from an incoming request.
+    fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
+        if let Some(node_type_str) = request.headers.get("x-node-type") {
+            let node_type = NodeType::from_config(Some(&node_type_str));
+            return SecurityPrincipal::new("did:zhtp:node", Role::Node, node_type);
+        }
+        if let Some(auth) = request.headers.get("authorization") {
+            if auth.to_lowercase().starts_with("bearer ") {
+                return SecurityPrincipal::new(
+                    "did:zhtp:session",
+                    Role::Citizen,
+                    NodeType::FullNode,
+                );
+            }
+        }
+        SecurityPrincipal::new("did:zhtp:public", Role::Public, NodeType::Relay)
     }
 }
 
@@ -155,8 +178,22 @@ impl CryptoHandler {
             "utf8" | _ => sign_req.message.as_bytes().to_vec(),
         };
 
+        let principal = self.extract_principal(&request);
+
         // Get identity and sign the message
         let identity_mgr = self.identity_manager.read().await;
+
+        // Signing requires full self-access.
+        match identity_mgr.get_identity_view(&principal, &identity_id) {
+            Some(IdentityView::Full(_)) => {}
+            _ => {
+                return Ok(ZhtpResponse::error(
+                    ZhtpStatus::Forbidden,
+                    "Access denied: can only sign messages for your own identity".to_string(),
+                ));
+            }
+        }
+
         let identity = match identity_mgr.get_identity(&identity_id) {
             Some(id) => id,
             None => {

--- a/zhtp/src/api/handlers/crypto/mod.rs
+++ b/zhtp/src/api/handlers/crypto/mod.rs
@@ -25,8 +25,8 @@ use lib_identity::IdentityManager;
 use lib_identity::types::IdentityView;
 
 // Access control imports
-use lib_access_control::{SecurityPrincipal, Role};
-use lib_types::NodeType;
+use crate::api::principal::extract_principal_from_request;
+use lib_access_control::SecurityPrincipal;
 
 /// Crypto utilities handler for signing, verification, and key generation
 pub struct CryptoHandler {
@@ -40,20 +40,7 @@ impl CryptoHandler {
 
     /// Extract a SecurityPrincipal from an incoming request.
     fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
-        if let Some(node_type_str) = request.headers.get("x-node-type") {
-            let node_type = NodeType::from_config(Some(&node_type_str));
-            return SecurityPrincipal::new("did:zhtp:node", Role::Node, node_type);
-        }
-        if let Some(auth) = request.headers.get("authorization") {
-            if auth.to_lowercase().starts_with("bearer ") {
-                return SecurityPrincipal::new(
-                    "did:zhtp:session",
-                    Role::Citizen,
-                    NodeType::FullNode,
-                );
-            }
-        }
-        SecurityPrincipal::new("did:zhtp:public", Role::Public, NodeType::Relay)
+        extract_principal_from_request(request)
     }
 }
 

--- a/zhtp/src/api/handlers/dao/mod.rs
+++ b/zhtp/src/api/handlers/dao/mod.rs
@@ -27,6 +27,7 @@ use lib_consensus::{DaoProposalType, DaoVoteChoice};
 use lib_crypto::Hash as CryptoHash;
 use lib_identity::IdentityManager;
 
+use crate::api::principal::extract_principal_from_request;
 use crate::session_manager::SessionManager;
 
 /// Helper function to create JSON responses correctly
@@ -1498,7 +1499,11 @@ impl DaoHandler {
     }
 
     /// Handle get voting power endpoint
-    async fn handle_get_voting_power(&self, identity_id_str: &str) -> Result<ZhtpResponse> {
+    async fn handle_get_voting_power(
+        &self,
+        identity_id_str: &str,
+        request: &ZhtpRequest,
+    ) -> Result<ZhtpResponse> {
         let identity_id = match Self::string_to_identity_hash(identity_id_str) {
             Ok(id) => id,
             Err(_) => {
@@ -1509,13 +1514,24 @@ impl DaoHandler {
             }
         };
 
-        // Validate identity exists
+        // Validate identity exists and principal has governance access.
+        let principal = extract_principal_from_request(request);
         let identity_manager = self.identity_manager.read().await;
+        let view = identity_manager.get_identity_view(&principal, &identity_id);
         if identity_manager.get_identity(&identity_id).is_none() {
             return Ok(create_error_response(
                 ZhtpStatus::BadRequest,
                 "Identity not found".to_string(),
             ));
+        }
+        match view {
+            Some(lib_identity::types::IdentityView::Public(_)) | None => {
+                return Ok(create_error_response(
+                    ZhtpStatus::Forbidden,
+                    "Access denied to governance data".to_string(),
+                ));
+            }
+            _ => {}
         }
 
         let blockchain_arc = self.get_blockchain().await?;
@@ -3344,7 +3360,7 @@ impl ZhtpRequestHandler for DaoHandler {
                 .await
                 .map_err(anyhow::Error::from),
             (ZhtpMethod::Get, ["api", "v1", "dao", "vote", "power", identity_id]) => self
-                .handle_get_voting_power(identity_id)
+                .handle_get_voting_power(identity_id, &request)
                 .await
                 .map_err(anyhow::Error::from),
             (ZhtpMethod::Get, ["api", "v1", "dao", "votes", proposal_id]) => self

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -18,7 +18,8 @@ use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
 
 // Access control imports
-use lib_access_control::{SecurityPrincipal, Role};
+use crate::api::principal::extract_principal_from_request;
+use lib_access_control::{Role, SecurityPrincipal};
 use lib_types::NodeType;
 
 // Identity management imports
@@ -76,34 +77,6 @@ impl IdentityHandler {
     fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
         extract_principal_from_request(request)
     }
-}
-
-/// Extract a `SecurityPrincipal` from an incoming request.
-///
-/// This is the incremental integration point. In the future it will inspect
-/// bearer tokens, delegation certificates, and UHP auth context. For now it
-/// uses simple headers to distinguish public, node, and session callers.
-fn extract_principal_from_request(request: &ZhtpRequest) -> SecurityPrincipal {
-    // Node-to-node calls may declare their node type.
-    if let Some(node_type_str) = request.headers.get("x-node-type") {
-        let node_type = NodeType::from_config(Some(&node_type_str));
-        return SecurityPrincipal::new("did:zhtp:node", Role::Node, node_type);
-    }
-
-    // Authenticated sessions (placeholder: any bearer token is treated as
-    // a citizen session until full session-to-principal mapping is wired).
-    if let Some(auth) = request.headers.get("authorization") {
-        if auth.to_lowercase().starts_with("bearer ") {
-            return SecurityPrincipal::new(
-                "did:zhtp:session",
-                Role::Citizen,
-                NodeType::FullNode,
-            );
-        }
-    }
-
-    // Default: unauthenticated public caller.
-    SecurityPrincipal::public()
 }
 
 #[async_trait::async_trait]

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -23,6 +23,7 @@ use lib_types::NodeType;
 
 // Identity management imports
 use lib_identity::{CitizenshipResult, IdentityManager, IdentityType, RecoveryPhraseManager};
+use lib_identity::types::IdentityView;
 
 // Identity and economic model imports
 use lib_identity::economics::EconomicModel as IdentityEconomicModel;
@@ -782,7 +783,20 @@ impl IdentityHandler {
         let identity_hash = lib_crypto::Hash::from_bytes(&identity_id_bytes);
 
         // Get identity and sign message
+        let principal = self.extract_principal(&request);
         let manager = self.identity_manager.read().await;
+
+        // Gate signing behind full identity view (self-access only).
+        match manager.get_identity_view(&principal, &identity_hash) {
+            Some(IdentityView::Full(_)) => {}
+            _ => {
+                return Ok(ZhtpResponse::error(
+                    ZhtpStatus::Forbidden,
+                    "Access denied: can only sign messages for your own identity".to_string(),
+                ));
+            }
+        }
+
         let identity = match manager.get_identity(&identity_hash) {
             Some(id) => id,
             None => {
@@ -1069,8 +1083,13 @@ impl IdentityHandler {
         let identity_id = lib_crypto::Hash::from_hex(identity_id_str)
             .map_err(|e| anyhow::anyhow!("Invalid identity ID: {}", e))?;
 
+        let principal = self.extract_principal(&request);
         let identity_manager = self.identity_manager.read().await;
-        let exists = identity_manager.get_identity(&identity_id).is_some();
+
+        // Anti-enumeration: only reveal existence to principals with CoreIdentity access.
+        let exists = identity_manager
+            .get_identity_view(&principal, &identity_id)
+            .is_some();
 
         let response_body = json!({
             "identity_id": identity_id_str,
@@ -1191,11 +1210,15 @@ impl IdentityHandler {
 
         tracing::info!("✅ Verifying identity by DID: {}", did);
 
+        let principal = self.extract_principal(&request);
         let mut identity_manager = self.identity_manager.write().await;
 
-        // Get identity ID from DID
-        let identity_id = match identity_manager.get_identity_id_by_did(&did) {
-            Some(id) => id,
+        // Gate verification behind identity view access (anti-enumeration).
+        let identity_id = match identity_manager.get_identity_view_by_did(&principal, &did) {
+            Some(IdentityView::Full(ref v)) => v.core.id.clone(),
+            Some(IdentityView::Public(ref v)) => v.id.clone(),
+            Some(IdentityView::Council(ref v)) => v.core.id.clone(),
+            Some(IdentityView::DeviceOwner(ref v)) => v.core.id.clone(),
             None => {
                 let response_body = json!({
                     "status": "not_found",
@@ -1311,13 +1334,25 @@ impl IdentityHandler {
             ));
         }
 
+        let principal = self.extract_principal(&request);
+        let identity_manager = self.identity_manager.read().await;
+
+        // Seed phrases are strictly self-access only.
+        match identity_manager.get_identity_view(&principal, &identity_id) {
+            Some(IdentityView::Full(_)) => {}
+            _ => {
+                return Ok(ZhtpResponse::error(
+                    ZhtpStatus::Forbidden,
+                    "Access denied to seed phrases".to_string(),
+                ));
+            }
+        }
+
         tracing::info!(
             "🔐 Retrieving seed phrases for identity: {}",
             &identity_id_str[..16.min(identity_id_str.len())]
         );
 
-        // Get identity and its wallets
-        let identity_manager = self.identity_manager.read().await;
         let identity = match identity_manager.get_identity(&identity_id) {
             Some(id) => id,
             None => {

--- a/zhtp/src/api/handlers/marketplace/mod.rs
+++ b/zhtp/src/api/handlers/marketplace/mod.rs
@@ -8,8 +8,12 @@ use lib_blockchain::{TransactionOutput, TransactionType};
 use lib_crypto::hashing::hash_blake3;
 use lib_crypto::Hash;
 use lib_identity::identity::IdentityManager;
-use lib_identity::types::IdentityId;
+use lib_identity::types::{IdentityId, IdentityView};
 use lib_identity::wallets::{wallet_types::ContentTransferType, WalletId};
+
+// Access control imports
+use lib_access_control::{SecurityPrincipal, Role};
+use lib_types::NodeType;
 use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
 use lib_protocols::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_storage::WalletContentManager;
@@ -43,6 +47,24 @@ impl MarketplaceHandler {
         }
     }
 
+    /// Extract a SecurityPrincipal from an incoming request.
+    fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
+        if let Some(node_type_str) = request.headers.get("x-node-type") {
+            let node_type = NodeType::from_config(Some(&node_type_str));
+            return SecurityPrincipal::new("did:zhtp:node", Role::Node, node_type);
+        }
+        if let Some(auth) = request.headers.get("authorization") {
+            if auth.to_lowercase().starts_with("bearer ") {
+                return SecurityPrincipal::new(
+                    "did:zhtp:session",
+                    Role::Citizen,
+                    NodeType::FullNode,
+                );
+            }
+        }
+        SecurityPrincipal::new("did:zhtp:public", Role::Public, NodeType::Relay)
+    }
+
     /// Route incoming requests to appropriate handlers
     async fn handle_request_internal(&self, request: &ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
         let path = &request.uri;
@@ -53,7 +75,8 @@ impl MarketplaceHandler {
         match (request.method, segments.as_slice()) {
             // POST /api/marketplace/content/{content_hash}/transfer
             (ZhtpMethod::Post, ["api", "marketplace", "content", content_hash, "transfer"]) => {
-                self.transfer_content(content_hash, &request.body).await
+                let principal = self.extract_principal(request);
+                self.transfer_content(content_hash, &request.body, &principal).await
             }
 
             // POST /api/marketplace/content/{content_hash}/list
@@ -64,7 +87,8 @@ impl MarketplaceHandler {
 
             // POST /api/marketplace/content/{content_hash}/buy
             (ZhtpMethod::Post, ["api", "marketplace", "content", content_hash, "buy"]) => {
-                self.buy_content(content_hash, &request.body).await
+                let principal = self.extract_principal(request);
+                self.buy_content(content_hash, &request.body, &principal).await
             }
 
             // GET /api/marketplace/listings
@@ -92,6 +116,7 @@ impl MarketplaceHandler {
         &self,
         content_hash_str: &str,
         body: &[u8],
+        principal: &SecurityPrincipal,
     ) -> ZhtpResult<ZhtpResponse> {
         info!("Processing content transfer for: {}", content_hash_str);
 
@@ -131,6 +156,7 @@ impl MarketplaceHandler {
                     &to_wallet,
                     request.price,
                     &content_hash,
+                    principal,
                 )
                 .await?;
 
@@ -263,7 +289,12 @@ impl MarketplaceHandler {
     /// POST /api/marketplace/content/{content_hash}/buy
     ///
     /// Buy content from marketplace
-    async fn buy_content(&self, content_hash_str: &str, body: &[u8]) -> ZhtpResult<ZhtpResponse> {
+    async fn buy_content(
+        &self,
+        content_hash_str: &str,
+        body: &[u8],
+        principal: &SecurityPrincipal,
+    ) -> ZhtpResult<ZhtpResponse> {
         info!("Processing content purchase: {}", content_hash_str);
 
         // Parse request body
@@ -303,6 +334,7 @@ impl MarketplaceHandler {
                 &seller_wallet,
                 request.offered_price,
                 &content_hash,
+                principal,
             )
             .await?;
 
@@ -373,6 +405,7 @@ impl MarketplaceHandler {
         to_wallet: &WalletId,
         amount: u64,
         content_hash: &Hash,
+        principal: &SecurityPrincipal,
     ) -> Result<Hash, anyhow::Error> {
         info!(
             "Creating blockchain payment transaction: {} → {} for {} SOV",
@@ -396,6 +429,17 @@ impl MarketplaceHandler {
 
         // Get buyer's identity and private key (P1-7: private keys stored in identity)
         let identity_mgr = self.identity_manager.read().await;
+
+        // Payment transactions require full self-access to the buyer identity.
+        match identity_mgr.get_identity_view(principal, &identity_id) {
+            Some(IdentityView::Full(_)) => {}
+            _ => {
+                return Err(anyhow!(
+                    "Access denied: can only create payments for your own identity"
+                ));
+            }
+        }
+
         let identity = identity_mgr
             .get_identity(&identity_id)
             .ok_or_else(|| anyhow!("Identity not found for buyer {}", hex::encode(&identity_id)))?;

--- a/zhtp/src/api/handlers/marketplace/mod.rs
+++ b/zhtp/src/api/handlers/marketplace/mod.rs
@@ -12,8 +12,8 @@ use lib_identity::types::{IdentityId, IdentityView};
 use lib_identity::wallets::{wallet_types::ContentTransferType, WalletId};
 
 // Access control imports
-use lib_access_control::{SecurityPrincipal, Role};
-use lib_types::NodeType;
+use crate::api::principal::extract_principal_from_request;
+use lib_access_control::SecurityPrincipal;
 use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
 use lib_protocols::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_storage::WalletContentManager;
@@ -49,20 +49,7 @@ impl MarketplaceHandler {
 
     /// Extract a SecurityPrincipal from an incoming request.
     fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
-        if let Some(node_type_str) = request.headers.get("x-node-type") {
-            let node_type = NodeType::from_config(Some(&node_type_str));
-            return SecurityPrincipal::new("did:zhtp:node", Role::Node, node_type);
-        }
-        if let Some(auth) = request.headers.get("authorization") {
-            if auth.to_lowercase().starts_with("bearer ") {
-                return SecurityPrincipal::new(
-                    "did:zhtp:session",
-                    Role::Citizen,
-                    NodeType::FullNode,
-                );
-            }
-        }
-        SecurityPrincipal::new("did:zhtp:public", Role::Public, NodeType::Relay)
+        extract_principal_from_request(request)
     }
 
     /// Route incoming requests to appropriate handlers

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -21,6 +21,11 @@ use lib_economy::wallets::{
     // Removed unused CrossWalletTransaction, WalletBalance
 };
 use lib_identity::{identity::ZhtpIdentity as Identity, IdentityManager};
+use lib_identity::types::IdentityView;
+
+// Access control imports
+use lib_access_control::{AccessDomain, AccessOperation, AccessPolicy, SecurityPrincipal, SubjectRelation};
+use lib_types::NodeType;
 
 /// Helper function to create JSON responses correctly
 fn create_json_response(data: serde_json::Value) -> Result<ZhtpResponse> {
@@ -58,6 +63,62 @@ impl WalletHandler {
             blockchain,
         }
     }
+
+    /// Extract a SecurityPrincipal from an incoming request.
+    fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
+        if let Some(node_type_str) = request.headers.get("x-node-type") {
+            let node_type = NodeType::from_config(Some(&node_type_str));
+            return SecurityPrincipal::new("did:zhtp:node", lib_access_control::Role::Node, node_type);
+        }
+        if let Some(auth) = request.headers.get("authorization") {
+            if auth.to_lowercase().starts_with("bearer ") {
+                return SecurityPrincipal::new(
+                    "did:zhtp:session",
+                    lib_access_control::Role::Citizen,
+                    NodeType::FullNode,
+                );
+            }
+        }
+        SecurityPrincipal::new("did:zhtp:public", lib_access_control::Role::Public, NodeType::Relay)
+    }
+
+    /// Check if the principal is allowed to read wallet graph data for the given identity.
+    async fn check_wallet_graph_access(
+        &self,
+        principal: &SecurityPrincipal,
+        identity_id: &lib_crypto::Hash,
+    ) -> Result<bool> {
+        let identity_manager = self.identity_manager.read().await;
+        let identity = match identity_manager.get_identity(identity_id) {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+
+        let relation = if principal.did == identity.did {
+            SubjectRelation::Self_
+        } else if let Ok(principal_id) = lib_identity::did::parse_did_to_identity_id(&principal.did) {
+            if let Some(ref owner_id) = identity.owner_identity_id {
+                if principal_id == *owner_id {
+                    SubjectRelation::Owner
+                } else {
+                    SubjectRelation::External
+                }
+            } else {
+                SubjectRelation::External
+            }
+        } else {
+            if principal.role == lib_access_control::Role::Public {
+                SubjectRelation::Public
+            } else {
+                SubjectRelation::External
+            }
+        };
+
+        let policy = AccessPolicy::default();
+        Ok(policy
+            .check_access(principal, relation, AccessDomain::WalletGraph, AccessOperation::Read)
+            .is_allowed())
+    }
 }
 
 #[async_trait::async_trait]
@@ -69,7 +130,7 @@ impl ZhtpRequestHandler for WalletHandler {
             // GET /api/v1/wallet/list/{identity_id}
             (ZhtpMethod::Get, path) if path.starts_with("/api/v1/wallet/list/") => {
                 let identity_id = path.strip_prefix("/api/v1/wallet/list/").unwrap_or("");
-                self.handle_list_wallets(identity_id).await
+                self.handle_list_wallets(identity_id, &request).await
             }
             // GET /api/v1/wallet/balance/{wallet_type}/{identity_id}
             (ZhtpMethod::Get, path) if path.starts_with("/api/v1/wallet/balance/") => {
@@ -79,7 +140,7 @@ impl ZhtpRequestHandler for WalletHandler {
                     .split('/')
                     .collect();
                 if path_parts.len() >= 2 {
-                    self.handle_get_balance(path_parts[0], path_parts[1]).await
+                    self.handle_get_balance(path_parts[0], path_parts[1], &request).await
                 } else {
                     Ok(create_error_response(
                         ZhtpStatus::BadRequest,
@@ -92,14 +153,14 @@ impl ZhtpRequestHandler for WalletHandler {
                 let identity_id = path
                     .strip_prefix("/api/v1/wallet/statistics/")
                     .unwrap_or("");
-                self.handle_get_statistics(identity_id).await
+                self.handle_get_statistics(identity_id, &request).await
             }
             // GET /api/v1/wallet/transactions/{identity_id}
             (ZhtpMethod::Get, path) if path.starts_with("/api/v1/wallet/transactions/") => {
                 let identity_id = path
                     .strip_prefix("/api/v1/wallet/transactions/")
                     .unwrap_or("");
-                self.handle_get_transactions(identity_id).await
+                self.handle_get_transactions(identity_id, &request).await
             }
             // POST /api/v1/wallet/send
             (ZhtpMethod::Post, "/api/v1/wallet/send") => self.handle_simple_send(request).await,
@@ -217,7 +278,11 @@ struct TransactionRecord {
 
 impl WalletHandler {
     /// List all wallets for an identity
-    async fn handle_list_wallets(&self, identity_id: &str) -> Result<ZhtpResponse> {
+    async fn handle_list_wallets(
+        &self,
+        identity_id: &str,
+        request: &ZhtpRequest,
+    ) -> Result<ZhtpResponse> {
         // Parse identity ID from hex string
         let identity_hash = hex::decode(identity_id)
             .map_err(|e| anyhow::anyhow!("Invalid hex for identity_id: {}", e))?;
@@ -231,6 +296,16 @@ impl WalletHandler {
 
         let mut identity_id_bytes = [0u8; 32];
         identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_hash = Hash(identity_id_bytes);
+
+        // Graph-traversal guard: WalletGraph / Read
+        let principal = self.extract_principal(request);
+        if !self.check_wallet_graph_access(&principal, &identity_hash).await? {
+            return Ok(create_error_response(
+                ZhtpStatus::Forbidden,
+                "Access denied to wallet list".to_string(),
+            ));
+        }
 
         // Get the identity
         let identity = match self.get_identity_by_id(&identity_id_bytes).await {
@@ -408,6 +483,7 @@ impl WalletHandler {
         &self,
         wallet_type_str: &str,
         identity_id: &str,
+        request: &ZhtpRequest,
     ) -> Result<ZhtpResponse> {
         // Parse wallet type to lib_identity::wallets::WalletType
         let wallet_type = match wallet_type_str.to_lowercase().as_str() {
@@ -442,6 +518,16 @@ impl WalletHandler {
 
         let mut identity_id_bytes = [0u8; 32];
         identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_hash = Hash(identity_id_bytes);
+
+        // Graph-traversal guard: WalletGraph / Read
+        let principal = self.extract_principal(request);
+        if !self.check_wallet_graph_access(&principal, &identity_hash).await? {
+            return Ok(create_error_response(
+                ZhtpStatus::Forbidden,
+                "Access denied to wallet balance".to_string(),
+            ));
+        }
 
         // Get the identity from stored state
         let identity = match self.get_identity_by_id(&identity_id_bytes).await {
@@ -568,7 +654,11 @@ impl WalletHandler {
     }
 
     /// Get comprehensive wallet statistics
-    async fn handle_get_statistics(&self, identity_id: &str) -> Result<ZhtpResponse> {
+    async fn handle_get_statistics(
+        &self,
+        identity_id: &str,
+        request: &ZhtpRequest,
+    ) -> Result<ZhtpResponse> {
         // Parse identity ID
         let identity_hash = hex::decode(identity_id)
             .map_err(|e| anyhow::anyhow!("Invalid hex for identity_id: {}", e))?;
@@ -582,6 +672,16 @@ impl WalletHandler {
 
         let mut identity_id_bytes = [0u8; 32];
         identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_hash = Hash(identity_id_bytes);
+
+        // Graph-traversal guard: WalletGraph / Read
+        let principal = self.extract_principal(request);
+        if !self.check_wallet_graph_access(&principal, &identity_hash).await? {
+            return Ok(create_error_response(
+                ZhtpStatus::Forbidden,
+                "Access denied to wallet statistics".to_string(),
+            ));
+        }
 
         // Get the identity from stored state
         let identity = match self.get_identity_by_id(&identity_id_bytes).await {
@@ -1187,7 +1287,11 @@ impl WalletHandler {
     }
 
     /// Get transaction history for an identity
-    async fn handle_get_transactions(&self, identity_id: &str) -> Result<ZhtpResponse> {
+    async fn handle_get_transactions(
+        &self,
+        identity_id: &str,
+        request: &ZhtpRequest,
+    ) -> Result<ZhtpResponse> {
         // Parse identity ID
         let identity_hash = hex::decode(identity_id)
             .map_err(|e| anyhow::anyhow!("Invalid hex for identity_id: {}", e))?;
@@ -1201,6 +1305,17 @@ impl WalletHandler {
 
         let mut identity_id_bytes = [0u8; 32];
         identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_hash = Hash(identity_id_bytes);
+
+        // Graph-traversal guard: WalletGraph / Read
+        let principal = self.extract_principal(request);
+        if !self.check_wallet_graph_access(&principal, &identity_hash).await? {
+            return Ok(create_error_response(
+                ZhtpStatus::Forbidden,
+                "Access denied to wallet transactions".to_string(),
+            ));
+        }
+
         let identity = match self.get_identity_by_id(&identity_id_bytes).await {
             Some(identity) => identity,
             None => {

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -24,8 +24,8 @@ use lib_identity::{identity::ZhtpIdentity as Identity, IdentityManager};
 use lib_identity::types::IdentityView;
 
 // Access control imports
+use crate::api::principal::extract_principal_from_request;
 use lib_access_control::{AccessDomain, AccessOperation, AccessPolicy, SecurityPrincipal, SubjectRelation};
-use lib_types::NodeType;
 
 /// Helper function to create JSON responses correctly
 fn create_json_response(data: serde_json::Value) -> Result<ZhtpResponse> {
@@ -66,20 +66,7 @@ impl WalletHandler {
 
     /// Extract a SecurityPrincipal from an incoming request.
     fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
-        if let Some(node_type_str) = request.headers.get("x-node-type") {
-            let node_type = NodeType::from_config(Some(&node_type_str));
-            return SecurityPrincipal::new("did:zhtp:node", lib_access_control::Role::Node, node_type);
-        }
-        if let Some(auth) = request.headers.get("authorization") {
-            if auth.to_lowercase().starts_with("bearer ") {
-                return SecurityPrincipal::new(
-                    "did:zhtp:session",
-                    lib_access_control::Role::Citizen,
-                    NodeType::FullNode,
-                );
-            }
-        }
-        SecurityPrincipal::new("did:zhtp:public", lib_access_control::Role::Public, NodeType::Relay)
+        extract_principal_from_request(request)
     }
 
     /// Check if the principal is allowed to read wallet graph data for the given identity.

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -5,7 +5,9 @@ use crate::web4_manifest::{
 };
 use anyhow::anyhow;
 use base64::{engine::general_purpose, Engine as _};
-use lib_identity::ZhtpIdentity;
+use lib_identity::{types::IdentityView, ZhtpIdentity};
+use lib_access_control::{SecurityPrincipal, Role};
+use lib_types::NodeType;
 use lib_network::web4::{
     DomainEconomicSettings, DomainLookupResponse, DomainMetadata, DomainRegistrationRequest,
     PublicOwnerInfo,
@@ -125,14 +127,18 @@ pub struct ApiDomainReleaseRequest {
 impl Web4Handler {
     /// Register a domain using simplified format (for easy testing/deployment)
     /// Supports both manifest-based (from CLI deploy) and content-based formats
-    pub async fn register_domain_simple(&self, request_body: Vec<u8>) -> ZhtpResult<ZhtpResponse> {
+    pub async fn register_domain_simple(
+        &self,
+        request_body: Vec<u8>,
+        principal: &SecurityPrincipal,
+    ) -> ZhtpResult<ZhtpResponse> {
         info!("Processing Web4 domain registration request");
 
         // Try manifest-based request first (simpler format from CLI deploy)
         if let Ok(manifest_request) =
             serde_json::from_slice::<ManifestDomainRegistrationRequest>(&request_body)
         {
-            return self.register_domain_from_manifest(manifest_request).await;
+            return self.register_domain_from_manifest(manifest_request, principal).await;
         }
 
         // Fall back to simple request with inline content
@@ -158,12 +164,25 @@ impl Web4Handler {
         // Look up owner identity using boundary-safe DID API
         // This is the correct layer: accept DID, use get_identity_by_did()
         let identity_mgr = self.identity_manager.read().await;
+        let view = identity_mgr.get_identity_view_by_did(principal, &owner_did);
         let owner_identity = identity_mgr.get_identity_by_did(&owner_did)
             .ok_or_else(|| anyhow!(
                 "Owner identity not found: {}. Please register this identity first using /api/v1/identity/create",
                 owner_did
             ))?
             .clone();
+        drop(identity_mgr);
+
+        // Domain registration requires at least device-owner level access.
+        match view {
+            Some(IdentityView::Public(_)) | None => {
+                return Ok(ZhtpResponse::error(
+                    ZhtpStatus::Forbidden,
+                    "Access denied: cannot register domain for this identity".to_string(),
+                ));
+            }
+            _ => {}
+        }
 
         // DEBUG: Check wallet state right after retrieval
         info!("  WALLET DEBUG (after IdentityManager retrieval):");
@@ -179,7 +198,6 @@ impl Web4Handler {
             );
         }
 
-        drop(identity_mgr);
         info!(
             " Using identity: {} (Display name: {})",
             owner_did,
@@ -662,6 +680,7 @@ impl Web4Handler {
     async fn register_domain_from_manifest(
         &self,
         request: ManifestDomainRegistrationRequest,
+        principal: &SecurityPrincipal,
     ) -> ZhtpResult<ZhtpResponse> {
         info!("Processing manifest-based domain registration");
         info!(" Domain: {}", request.domain);
@@ -682,6 +701,7 @@ impl Web4Handler {
 
         // Look up owner identity using boundary-safe DID API
         let identity_mgr = self.identity_manager.read().await;
+        let view = identity_mgr.get_identity_view_by_did(principal, &owner_did);
         let owner_identity = identity_mgr
             .get_identity_by_did(&owner_did)
             .ok_or_else(|| {
@@ -692,6 +712,17 @@ impl Web4Handler {
             })?
             .clone();
         drop(identity_mgr);
+
+        // Domain registration requires at least device-owner level access.
+        match view {
+            Some(IdentityView::Public(_)) | None => {
+                return Ok(ZhtpResponse::error(
+                    ZhtpStatus::Forbidden,
+                    "Access denied: cannot register domain for this identity".to_string(),
+                ));
+            }
+            _ => {}
+        }
         info!(" Verified owner identity: {}", owner_did);
 
         if owner_identity.did != manifest.author_did {
@@ -2365,8 +2396,13 @@ mod tests {
         let request =
             simple_registration_request(&owner_identity, "valid-fee.zhtp", "<html>ok</html>", &tx)?;
 
+        let principal = SecurityPrincipal::new(
+            owner_identity.did.clone(),
+            Role::Citizen,
+            NodeType::FullNode,
+        );
         let response = handler
-            .register_domain_simple(serde_json::to_vec(&request)?)
+            .register_domain_simple(serde_json::to_vec(&request)?, &principal)
             .await?;
         assert_eq!(response.status, ZhtpStatus::Ok);
         let body: serde_json::Value = serde_json::from_slice(&response.body)?;
@@ -2406,8 +2442,13 @@ mod tests {
             &tx,
         )?;
 
+        let principal = SecurityPrincipal::new(
+            owner_identity.did.clone(),
+            Role::Citizen,
+            NodeType::FullNode,
+        );
         let result = handler
-            .register_domain_simple(serde_json::to_vec(&request)?)
+            .register_domain_simple(serde_json::to_vec(&request)?, &principal)
             .await;
         assert!(result.is_err(), "invalid fee tx amount should be rejected");
         let err = format!("{}", result.err().unwrap());

--- a/zhtp/src/api/handlers/web4/mod.rs
+++ b/zhtp/src/api/handlers/web4/mod.rs
@@ -39,6 +39,10 @@ use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 use uuid;
 
+// Access control imports
+use lib_access_control::{SecurityPrincipal, Role};
+use lib_types::NodeType;
+
 /// Standardized error response format (Issue #11)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorResponse {
@@ -108,6 +112,24 @@ impl Web4Handler {
     /// Get reference to the domain registry
     pub fn get_domain_registry(&self) -> Arc<DomainRegistry> {
         Arc::clone(&self.domain_registry)
+    }
+
+    /// Extract a SecurityPrincipal from an incoming request.
+    fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
+        if let Some(node_type_str) = request.headers.get("x-node-type") {
+            let node_type = NodeType::from_config(Some(&node_type_str));
+            return SecurityPrincipal::new("did:zhtp:node", Role::Node, node_type);
+        }
+        if let Some(auth) = request.headers.get("authorization") {
+            if auth.to_lowercase().starts_with("bearer ") {
+                return SecurityPrincipal::new(
+                    "did:zhtp:session",
+                    Role::Citizen,
+                    NodeType::FullNode,
+                );
+            }
+        }
+        SecurityPrincipal::new("did:zhtp:public", Role::Public, NodeType::Relay)
     }
 
     /// Attach a POUW validator for emitting Web4 receipts on successful serves/resolves
@@ -674,7 +696,8 @@ impl ZhtpRequestHandler for Web4Handler {
 
             // Domain management endpoints
             path if path.starts_with("/api/v1/web4/domains/register") => {
-                self.register_domain_simple(request.body).await
+                let principal = self.extract_principal(&request);
+                self.register_domain_simple(request.body, &principal).await
             }
             path if path.starts_with("/api/v1/web4/domains?")
                 && request.method == lib_protocols::ZhtpMethod::Get =>

--- a/zhtp/src/api/handlers/web4/mod.rs
+++ b/zhtp/src/api/handlers/web4/mod.rs
@@ -40,8 +40,8 @@ use tracing::{debug, error, info, warn};
 use uuid;
 
 // Access control imports
-use lib_access_control::{SecurityPrincipal, Role};
-use lib_types::NodeType;
+use crate::api::principal::extract_principal_from_request;
+use lib_access_control::SecurityPrincipal;
 
 /// Standardized error response format (Issue #11)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -116,20 +116,7 @@ impl Web4Handler {
 
     /// Extract a SecurityPrincipal from an incoming request.
     fn extract_principal(&self, request: &ZhtpRequest) -> SecurityPrincipal {
-        if let Some(node_type_str) = request.headers.get("x-node-type") {
-            let node_type = NodeType::from_config(Some(&node_type_str));
-            return SecurityPrincipal::new("did:zhtp:node", Role::Node, node_type);
-        }
-        if let Some(auth) = request.headers.get("authorization") {
-            if auth.to_lowercase().starts_with("bearer ") {
-                return SecurityPrincipal::new(
-                    "did:zhtp:session",
-                    Role::Citizen,
-                    NodeType::FullNode,
-                );
-            }
-        }
-        SecurityPrincipal::new("did:zhtp:public", Role::Public, NodeType::Relay)
+        extract_principal_from_request(request)
     }
 
     /// Attach a POUW validator for emitting Web4 receipts on successful serves/resolves

--- a/zhtp/src/api/mod.rs
+++ b/zhtp/src/api/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod handlers;
 pub mod middleware;
+pub mod principal;
 pub mod server;
 
 pub use handlers::*;

--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -1,0 +1,34 @@
+//! Shared principal extraction for ZHTP API handlers.
+
+use lib_access_control::{Role, SecurityPrincipal};
+use lib_protocols::types::ZhtpRequest;
+use lib_types::NodeType;
+
+/// Extract a `SecurityPrincipal` from an incoming `ZhtpRequest`.
+///
+/// This is the canonical integration point used across all API handlers.
+/// In future phases it will inspect bearer tokens, delegation certificates,
+/// and UHP auth context. For now it uses simple headers to distinguish
+/// public, node, and session callers.
+pub fn extract_principal_from_request(request: &ZhtpRequest) -> SecurityPrincipal {
+    // Node-to-node calls may declare their node type.
+    if let Some(node_type_str) = request.headers.get("x-node-type") {
+        let node_type = NodeType::from_config(Some(&node_type_str));
+        return SecurityPrincipal::new("did:zhtp:node", Role::Node, node_type);
+    }
+
+    // Authenticated sessions (placeholder: any bearer token is treated as
+    // a citizen session until full session-to-principal mapping is wired).
+    if let Some(auth) = request.headers.get("authorization") {
+        if auth.to_lowercase().starts_with("bearer ") {
+            return SecurityPrincipal::new(
+                "did:zhtp:session",
+                Role::Citizen,
+                NodeType::FullNode,
+            );
+        }
+    }
+
+    // Default: unauthenticated public caller.
+    SecurityPrincipal::public()
+}

--- a/zhtp/src/server/mesh/identity_api.rs
+++ b/zhtp/src/server/mesh/identity_api.rs
@@ -20,7 +20,9 @@ use tracing::{error, info, warn};
 
 use crate::api::handlers::constants::SOV_WELCOME_BONUS;
 use crate::session_manager::SessionManager;
+use lib_access_control::{Role, SecurityPrincipal};
 use lib_identity::IdentityManager;
+use lib_types::NodeType;
 
 /// Safe string truncation for display (avoids panic on short strings)
 #[inline]
@@ -40,6 +42,34 @@ pub struct MeshZhtpRequest {
 /// Parse mesh-specific ZHTP request format and convert to standard ZhtpRequest
 pub fn parse_mesh_request(mesh_data: &serde_json::Value) -> Result<MeshZhtpRequest> {
     serde_json::from_value(mesh_data.clone()).context("Failed to parse mesh ZHTP request")
+}
+
+/// Extract a SecurityPrincipal from a mesh request context.
+///
+/// Mesh requests default to Node role since they traverse the peer mesh.
+/// If the wrapped ZHTP request contains an authorization bearer token,
+/// we treat it as a citizen session (placeholder until full cert parsing).
+fn extract_mesh_principal(zhtp_request: &serde_json::Value) -> SecurityPrincipal {
+    if let Some(headers) = zhtp_request.get("headers") {
+        if let Some(auth) = headers.get("authorization").and_then(|v| v.as_str()) {
+            if auth.to_lowercase().starts_with("bearer ") {
+                return SecurityPrincipal::new(
+                    "did:zhtp:session",
+                    Role::Citizen,
+                    NodeType::FullNode,
+                );
+            }
+        }
+        if let Some(node_type) = headers.get("x-node-type").and_then(|v| v.as_str()) {
+            return SecurityPrincipal::new(
+                "did:zhtp:node",
+                Role::Node,
+                NodeType::from_config(Some(node_type)),
+            );
+        }
+    }
+    // Default: mesh traffic is treated as originating from a node.
+    SecurityPrincipal::new("did:zhtp:node", Role::Node, NodeType::FullNode)
 }
 
 /// Handle identity API requests directly via UDP mesh for maximum efficiency
@@ -63,8 +93,25 @@ pub async fn handle_identity_mesh_request(
         }
     };
 
+    let principal = extract_mesh_principal(zhtp_request);
+
+    // Helper to deny unauthenticated public principals from mutating mesh endpoints.
+    async fn check_public_denied(principal: &SecurityPrincipal) -> Option<Result<Option<Vec<u8>>>> {
+        if principal.role == Role::Public {
+            Some(create_error_mesh_response(
+                403,
+                "Public principals cannot perform this operation over mesh",
+            ).await)
+        } else {
+            None
+        }
+    }
+
     // Route based on URI path
     if mesh_req.uri == "/api/v1/identity/create" && mesh_req.method.to_uppercase() == "POST" {
+        if let Some(resp) = check_public_denied(&principal).await {
+            return resp;
+        }
         info!("✨ Creating new zkDID identity via UDP mesh");
 
         // Extract request data from the original ZHTP request body

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -804,8 +804,11 @@ impl ZhtpUnifiedServer {
 
         // Blockchain operations
         let environment = detect_environment();
-        let blockchain_handler: Arc<dyn ZhtpRequestHandler> =
-            Arc::new(BlockchainHandler::new(blockchain.clone(), environment));
+        let blockchain_handler: Arc<dyn ZhtpRequestHandler> = Arc::new(BlockchainHandler::new(
+            blockchain.clone(),
+            environment,
+            identity_manager.clone(),
+        ));
         zhtp_router.register_handler("/api/v1/blockchain".to_string(), blockchain_handler.clone());
         zhtp_router.register_handler("/api/v1/chain".to_string(), blockchain_handler);
 


### PR DESCRIPTION
## Summary

This PR extends the layered access control system with comprehensive gating across all ZHTP API handlers and enforces graph-traversal protection.

## Changes

### Identity Handler
- Gate handle_verify_identity_by_did with get_identity_view_by_did (anti-enumeration).
- Gate handle_get_identity_seeds to Full view only (self-access).
- Gate handle_sign_message to Full view only (protects private key access).
- Gate handle_identity_exists with get_identity_view (anti-enumeration).

### Wallet Handler
- Add check_wallet_graph_access helper using AccessPolicy with WalletGraph / Read.
- Gate handle_list_wallets, handle_get_balance, handle_get_statistics, handle_get_transactions.
- Deny Public principals and unprivileged External principals from enumerating wallets.

### Blockchain Handler
- Add IdentityManager to BlockchainHandler for access checks.
- Gate handle_list_wallets: unfiltered enumeration requires elevated role; filtered enumeration checks WalletGraph access.
- Gate handle_get_identity (/api/v1/blockchain/identities/{did}): strip controlled_nodes and owned_wallets for Public view; return not_found when denied.
- Gate handle_search resolve_identity closure to strip graph fields for Public role.

### Crypto Handler
- Gate handle_sign_message to Full view only (self-access).

### Marketplace Handler
- Gate create_payment_transaction to Full view only (self-access).

### Web4 Handler
- Gate register_domain_simple and register_domain_from_manifest: deny Public view and None.

### DAO Handler
- Gate handle_get_voting_power with get_identity_view: deny Public view and None.

### Mesh API
- Add extract_mesh_principal helper and deny Public principals from mutating mesh endpoints.

### Refactoring
- Extract shared extract_principal_from_request into zhtp/src/api/principal.rs.
- Remove ~107 lines of duplicated principal extraction logic across 6 handlers.

## Test Coverage

- lib-access-control: 9 policy tests passing
- lib-identity: 130+ tests passing
- zhtp lib compilation and principal extraction tests passing

## Stack

This PR is stacked on top of #2106 (feature/layered-access-control).