### PR TITLE
feat(access-control): Phase 7 — governance council integration and policy fixes

### DIFF
--- a/lib-access-control/src/policy.rs
+++ b/lib-access-control/src/policy.rs
@@ -77,6 +77,8 @@ impl AccessPolicy {
                 (_, Governance, Read | Resolve | Traverse) => {
                     if principal.has_capability(&Capability::Investigate) {
                         Allow(AllowCouncilInvestigation)
+                    } else if principal.has_capability(&Capability::VoteGovernance) {
+                        Allow(AllowGovernanceRead)
                     } else {
                         Deny(DenyMissingCapability)
                     }

--- a/lib-governance/src/council.rs
+++ b/lib-governance/src/council.rs
@@ -1,0 +1,226 @@
+//! Council action types and validation for governance oversight.
+//!
+//! Council actions are scoped investigations and interventions that elected
+//! council members may propose. Each action carries its own access-control
+//! requirements enforced by the policy engine.
+
+use lib_access_control::{AccessDomain, AccessOperation, AccessPolicy, Capability, ReasonCode, SecurityPrincipal, SubjectRelation};
+use serde::{Deserialize, Serialize};
+
+/// Scope of a council audit request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AuditScope {
+    /// Audit core identity metadata only.
+    CoreIdentity,
+    /// Audit wallet ownership and transaction history.
+    WalletGraph,
+    /// Audit node participation and control graph.
+    NodeGraph,
+    /// Audit governance voting history.
+    Governance,
+    /// Full investigation scope (all of the above).
+    Full,
+}
+
+/// A council action that may be proposed by an elected council member.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CouncilAction {
+    /// Request a scoped audit of an identity.
+    AuditRequest {
+        target_did_hash: [u8; 32],
+        scope: AuditScope,
+        reason: String,
+    },
+    /// Freeze an identity under investigation.
+    FreezeIdentity {
+        did_hash: [u8; 32],
+        reason: String,
+    },
+    /// Unfreeze an identity after investigation concludes.
+    UnfreezeIdentity {
+        did_hash: [u8; 32],
+    },
+    /// Adjust the UBI distribution rate (parts per million).
+    AdjustUbiRate {
+        new_rate_ppm: u64,
+    },
+    /// Emergency break-glass parameter change.
+    EmergencyParameterChange {
+        parameter: String,
+        new_value_hash: [u8; 32],
+    },
+}
+
+/// Council proposal wrapping an action and metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CouncilProposal {
+    /// The action being proposed.
+    pub action: CouncilAction,
+    /// DID of the proposer.
+    pub proposer_did: String,
+    /// Block height when the proposal was created.
+    pub proposed_at: u64,
+    /// Required vote threshold (e.g., simple majority = 51, super majority = 67).
+    pub required_threshold_percent: u8,
+}
+
+/// Validate whether a principal is authorized to propose a council action.
+///
+/// This is the governance integration point for the access control policy
+/// engine. Council members must hold the `Investigate` capability for
+/// identity-related actions and `VoteGovernance` for parameter changes.
+pub fn validate_council_action(
+    principal: &SecurityPrincipal,
+    action: &CouncilAction,
+) -> Result<(), (ReasonCode, String)> {
+    let policy = AccessPolicy::default();
+
+    // All council actions require the Council role as a baseline.
+    if principal.role != lib_access_control::Role::Council {
+        return Err((
+            ReasonCode::DenyInsufficientRole,
+            "Council actions require Council role".to_string(),
+        ));
+    }
+
+    match action {
+        CouncilAction::AuditRequest { scope, .. } => {
+            // Identity investigation scope requires Investigate capability.
+            if !principal.has_capability(&Capability::Investigate) {
+                return Err((
+                    ReasonCode::DenyMissingCapability,
+                    "Identity council actions require Investigate capability".to_string(),
+                ));
+            }
+
+            // Map audit scope to access domain for additional validation.
+            let domain = match scope {
+                AuditScope::CoreIdentity => AccessDomain::CoreIdentity,
+                AuditScope::WalletGraph => AccessDomain::WalletGraph,
+                AuditScope::NodeGraph => AccessDomain::NodeGraph,
+                AuditScope::Governance => AccessDomain::Governance,
+                AuditScope::Full => AccessDomain::Governance,
+            };
+
+            let decision = policy.check_access(
+                principal,
+                SubjectRelation::External,
+                domain,
+                AccessOperation::Read,
+            );
+            if !decision.is_allowed() {
+                return Err((
+                    ReasonCode::DenyInsufficientRole,
+                    "Council member lacks read access for the requested scope".to_string(),
+                ));
+            }
+        }
+        CouncilAction::FreezeIdentity { .. } | CouncilAction::UnfreezeIdentity { .. } => {
+            if !principal.has_capability(&Capability::Investigate) {
+                return Err((
+                    ReasonCode::DenyMissingCapability,
+                    "Identity council actions require Investigate capability".to_string(),
+                ));
+            }
+
+            let decision = policy.check_access(
+                principal,
+                SubjectRelation::External,
+                AccessDomain::CoreIdentity,
+                AccessOperation::Read,
+            );
+            if !decision.is_allowed() {
+                return Err((
+                    ReasonCode::DenyInsufficientRole,
+                    "Council member lacks read access for identity actions".to_string(),
+                ));
+            }
+        }
+        CouncilAction::AdjustUbiRate { .. }
+        | CouncilAction::EmergencyParameterChange { .. } => {
+            // Parameter changes require VoteGovernance capability.
+            if !principal.has_capability(&Capability::VoteGovernance) {
+                return Err((
+                    ReasonCode::DenyMissingCapability,
+                    "Parameter council actions require VoteGovernance capability".to_string(),
+                ));
+            }
+
+            let decision = policy.check_access(
+                principal,
+                SubjectRelation::External,
+                AccessDomain::Governance,
+                AccessOperation::Read,
+            );
+            if !decision.is_allowed() {
+                return Err((
+                    ReasonCode::DenyInsufficientRole,
+                    "Council member lacks governance read access".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lib_types::NodeType;
+
+    fn council(cap: Capability) -> SecurityPrincipal {
+        SecurityPrincipal::new("did:zhtp:council", lib_access_control::Role::Council, NodeType::FullNode)
+            .with_capability(cap)
+    }
+
+    fn citizen() -> SecurityPrincipal {
+        SecurityPrincipal::new("did:zhtp:citizen", lib_access_control::Role::Citizen, NodeType::FullNode)
+    }
+
+    #[test]
+    fn non_council_cannot_propose() {
+        let action = CouncilAction::AuditRequest {
+            target_did_hash: [0u8; 32],
+            scope: AuditScope::CoreIdentity,
+            reason: "test".to_string(),
+        };
+        assert!(validate_council_action(&citizen(), &action).is_err());
+    }
+
+    #[test]
+    fn council_without_investigate_denied_for_audit() {
+        let p = council(Capability::VoteGovernance);
+        let action = CouncilAction::AuditRequest {
+            target_did_hash: [0u8; 32],
+            scope: AuditScope::CoreIdentity,
+            reason: "test".to_string(),
+        };
+        assert!(validate_council_action(&p, &action).is_err());
+    }
+
+    #[test]
+    fn council_with_investigate_allowed_for_audit() {
+        let p = council(Capability::Investigate);
+        let action = CouncilAction::AuditRequest {
+            target_did_hash: [0u8; 32],
+            scope: AuditScope::CoreIdentity,
+            reason: "test".to_string(),
+        };
+        assert!(validate_council_action(&p, &action).is_ok());
+    }
+
+    #[test]
+    fn council_with_votegovernance_allowed_for_parameter_change() {
+        let p = council(Capability::VoteGovernance);
+        let action = CouncilAction::AdjustUbiRate { new_rate_ppm: 1000 };
+        assert!(validate_council_action(&p, &action).is_ok());
+    }
+
+    #[test]
+    fn council_without_votegovernance_denied_for_parameter_change() {
+        let p = council(Capability::Investigate);
+        let action = CouncilAction::AdjustUbiRate { new_rate_ppm: 1000 };
+        assert!(validate_council_action(&p, &action).is_err());
+    }
+}

--- a/lib-governance/src/lib.rs
+++ b/lib-governance/src/lib.rs
@@ -23,11 +23,13 @@
 //! };
 //! ```
 
+pub mod council;
 pub mod errors;
 pub mod fields;
 pub mod pending;
 pub mod tx;
 
+pub use council::{AuditScope, CouncilAction, CouncilProposal, validate_council_action};
 pub use errors::{GovernanceError, GovernanceResult};
 pub use fields::ConfigField;
 pub use pending::{PendingChange, PendingChanges};

--- a/lib-governance/src/pending.rs
+++ b/lib-governance/src/pending.rs
@@ -134,32 +134,14 @@ impl PendingChanges {
 
     /// Check if there's a pending change for a target+field
     pub fn has_pending(&self, target: &TokenId, field: ConfigField) -> bool {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        let mut hasher = DefaultHasher::new();
-        target.as_bytes().hash(&mut hasher);
-        field.hash(&mut hasher);
-
-        let hash = hasher.finish();
-        let mut id = [0u8; 32];
-        id[..8].copy_from_slice(&hash.to_le_bytes());
-
-        self.by_id.contains_key(&id)
+        self.lookup_change_id(target, field)
+            .map(|id| self.by_id.contains_key(&id))
+            .unwrap_or(false)
     }
 
     /// Cancel a pending change (governance veto)
     pub fn cancel(&mut self, target: &TokenId, field: ConfigField) -> Option<PendingChange> {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        let mut hasher = DefaultHasher::new();
-        target.as_bytes().hash(&mut hasher);
-        field.hash(&mut hasher);
-
-        let hash = hasher.finish();
-        let mut change_id = [0u8; 32];
-        change_id[..8].copy_from_slice(&hash.to_le_bytes());
+        let change_id = self.lookup_change_id(target, field)?;
 
         if let Some(height) = self.by_id.remove(&change_id) {
             if let Some(changes) = self.by_height.get_mut(&height) {
@@ -169,6 +151,20 @@ impl PendingChanges {
             }
         }
         None
+    }
+
+    /// Compute the deterministic change_id for a target+field combination.
+    fn lookup_change_id(&self, target: &TokenId, field: ConfigField) -> Option<[u8; 32]> {
+        use blake3::Hasher;
+
+        let mut hasher = Hasher::new();
+        hasher.update(b"ZHTP_GOVERNANCE_CHANGE_V1");
+        hasher.update(target.as_bytes());
+
+        let field_bytes = bincode::serialize(&field).ok()?;
+        hasher.update(&field_bytes);
+
+        Some(*hasher.finalize().as_bytes())
     }
 
     /// Get total number of pending changes


### PR DESCRIPTION
## Summary

Phase 7 wires `lib-governance` into the layered access control system, adds council action types, and fixes two policy/hash bugs discovered during integration.

## Changes

### Governance Council Integration
- **New module**: `lib-governance/src/council.rs`
  - `CouncilAction` enum: `AuditRequest`, `FreezeIdentity`, `UnfreezeIdentity`, `AdjustUbiRate`, `EmergencyParameterChange`
  - `AuditScope` enum: `CoreIdentity`, `WalletGraph`, `NodeGraph`, `Governance`, `Full`
  - `CouncilProposal` struct with proposer DID and vote threshold
  - `validate_council_action(principal, action)` — enforces:
    - Baseline `Council` role
    - Identity actions require `Capability::Investigate` + domain read access
    - Parameter changes require `Capability::VoteGovernance` + governance read access

### Policy Engine Fix
- `lib-access-control/src/policy.rs`: Council principals holding `VoteGovernance` (but not `Investigate`) are now allowed `Read | Resolve | Traverse` on the `Governance` domain.

### Pre-existing Bug Fix
- `lib-governance/src/pending.rs`: `has_pending()` and `cancel()` were using `std::hash::DefaultHasher` while `change_id()` used `blake3+bincode`. This caused cancellations to always return `None`.
  - Both methods now use the same `blake3+bincode` construction as `change_id()`.

## Tests
- `cargo test -p lib-access-control --lib` ✅ 9 passed
- `cargo test -p lib-governance --lib` ✅ 17 passed
- `cargo test -p lib-identity --lib` ✅ 130 passed

## Stack
- Base: `feature/layered-access-control-phase-6` (PR #2107)