### PR TITLE
Epic F follow-up: Wallet API endpoint for UTXO Merkle proofs

### DIFF
--- a/lib-proofs/src/backend/circuit_cache.rs
+++ b/lib-proofs/src/backend/circuit_cache.rs
@@ -149,7 +149,7 @@ pub mod real {
             pw.set_target(t.sender_secret, GF::from_canonical_u64(42)).unwrap();
             pw.set_target(t.nullifier_seed, GF::from_canonical_u64(1)).unwrap();
 
-            let siblings = [[GF::ZERO; 4]; crate::transaction::circuit::real::MERKLE_DEPTH];
+            let siblings = [[GF::ZERO; 4]; crate::transaction::circuit::MERKLE_DEPTH];
             let merkle_root = crate::transaction::circuit::real::compute_merkle_root(
                 GF::from_canonical_u64(1),
                 GF::from_canonical_u64(42),
@@ -196,7 +196,7 @@ pub mod real {
             pw.set_target(loaded_targets.nullifier_seed, GF::from_canonical_u64(1))
                 .unwrap();
 
-            let siblings = [[GF::ZERO; 4]; crate::transaction::circuit::real::MERKLE_DEPTH];
+            let siblings = [[GF::ZERO; 4]; crate::transaction::circuit::MERKLE_DEPTH];
             let merkle_root = crate::transaction::circuit::real::compute_merkle_root(
                 GF::from_canonical_u64(1),
                 GF::from_canonical_u64(42),

--- a/lib-proofs/src/backend/plonky2_backend.rs
+++ b/lib-proofs/src/backend/plonky2_backend.rs
@@ -62,7 +62,7 @@ impl ProofBackend for Plonky2Backend {
         {
             use plonky2::field::goldilocks_field::GoldilocksField;
             use plonky2::field::types::Field;
-            use crate::transaction::circuit::real::MERKLE_DEPTH;
+            use crate::transaction::circuit::MERKLE_DEPTH;
 
             if merkle_siblings.len() != MERKLE_DEPTH {
                 return Err(anyhow::anyhow!(

--- a/lib-proofs/src/transaction/circuit.rs
+++ b/lib-proofs/src/transaction/circuit.rs
@@ -6,8 +6,44 @@
 //!   3. The UTXO leaf [nullifier_seed, sender_secret, sender_balance] is present
 //!      in the Merkle tree with root `merkle_root` at `leaf_index`.
 
+/// Fixed Merkle tree depth for the UTXO set.
+/// Production will use a larger depth (e.g. 32-40); 4 is used here
+/// to keep tests and benchmarks fast while proving the concept.
+pub const MERKLE_DEPTH: usize = 4;
+
+#[cfg(not(feature = "real-proofs"))]
+pub mod real {
+    use super::MERKLE_DEPTH;
+
+    /// Stub for non-real-proofs builds.
+    pub fn build_merkle_tree(
+        _leaves: &[Vec<u64>],
+        _leaf_index: usize,
+    ) -> anyhow::Result<([u64; 4], Vec<[u64; 4]>)> {
+        Ok(([0u64; 4], vec![[0u64; 4]; MERKLE_DEPTH]))
+    }
+
+    /// Stub for non-real-proofs builds.
+    pub fn compute_leaf_commitment(
+        _nullifier_seed: u64,
+        _sender_secret: u64,
+        _sender_balance: u64,
+    ) -> [u64; 4] {
+        [0u64; 4]
+    }
+
+    /// Stub for non-real-proofs builds.
+    pub fn build_merkle_tree_from_hashes(
+        _leaves: &[[u64; 4]],
+        _leaf_index: usize,
+    ) -> anyhow::Result<([u64; 4], Vec<[u64; 4]>)> {
+        Ok(([0u64; 4], vec![[0u64; 4]; MERKLE_DEPTH]))
+    }
+}
+
 #[cfg(feature = "real-proofs")]
 pub mod real {
+    use super::MERKLE_DEPTH;
     use plonky2::{
         field::{
             goldilocks_field::GoldilocksField,
@@ -39,10 +75,6 @@ pub mod real {
     /// We use 63-bit range checks because the Goldilocks prime is
     /// `p = 2^64 - 2^32 + 1`, which is slightly less than `2^64`.
     const NUM_BITS: usize = 63;
-    /// Fixed Merkle tree depth for the UTXO set.
-    /// Production will use a larger depth (e.g. 32-40); 4 is used here
-    /// to keep tests and benchmarks fast while proving the concept.
-    pub const MERKLE_DEPTH: usize = 4;
 
     /// Public inputs for a transaction proof.
     /// Order: [sender_balance, amount, fee, nullifier_seed_hash, merkle_root (4 elements)]

--- a/lib-proofs/src/transaction/transaction_proof.rs
+++ b/lib-proofs/src/transaction/transaction_proof.rs
@@ -79,7 +79,7 @@ impl ZkTransactionProof {
         // Compute a consistent dummy Merkle proof so the circuit constraints
         // are satisfied even when no real UTXO tree is supplied.
         let leaf = vec![nullifier_seed, sender_secret, sender_balance];
-        let dummy_leaves: Vec<Vec<u64>> = (0..(1 << crate::transaction::circuit::real::MERKLE_DEPTH))
+        let dummy_leaves: Vec<Vec<u64>> = (0..(1 << crate::transaction::circuit::MERKLE_DEPTH))
             .map(|i| if i == 0 { leaf.clone() } else { vec![0u64] })
             .collect();
         let (merkle_root, siblings) =

--- a/lib-proofs/src/types/zk_proof.rs
+++ b/lib-proofs/src/types/zk_proof.rs
@@ -264,7 +264,7 @@ impl ZkProof {
         let nullifier_seed = public_inputs.get(4).copied().unwrap_or(0);
 
         let leaf = vec![nullifier_seed, sender_secret, sender_balance];
-        let dummy_leaves: Vec<Vec<u64>> = (0..(1 << crate::transaction::circuit::real::MERKLE_DEPTH))
+        let dummy_leaves: Vec<Vec<u64>> = (0..(1 << crate::transaction::circuit::MERKLE_DEPTH))
             .map(|i| if i == 0 { leaf.clone() } else { vec![0u64] })
             .collect();
         let (merkle_root, merkle_siblings) =

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -19,9 +19,10 @@ use lib_blockchain::transaction::{
     ContractDeploymentPayloadV1, DecodedContractExecutionMemo, Transaction,
     CONTRACT_DEPLOYMENT_MEMO_PREFIX,
 };
+use lib_blockchain::storage::UtxoMerkleProof;
 use lib_blockchain::types::Hash;
 use lib_blockchain::types::{transaction_type::TransactionType, ContractType};
-use lib_blockchain::Blockchain;
+use lib_blockchain::{Blockchain, storage::{OutPoint, TxHash}};
 use crate::config::Environment;
 
 // Access control imports
@@ -185,6 +186,12 @@ impl ZhtpRequestHandler for BlockchainHandler {
             }
             (ZhtpMethod::Get, path) if path.starts_with("/api/v1/blockchain/balance/") => {
                 self.handle_get_balance(request).await
+            }
+            (ZhtpMethod::Get, path)
+                if path.starts_with("/api/v1/blockchain/utxo/")
+                    && path.ends_with("/merkle-proof") =>
+            {
+                self.handle_get_utxo_merkle_proof(request).await
             }
             (ZhtpMethod::Get, "/api/v1/blockchain/mempool") => {
                 self.handle_get_mempool_status(request).await
@@ -400,6 +407,16 @@ struct BalanceResponse {
     pending_balance: u64,
     transaction_count: u64,
     note: Option<String>,
+}
+
+#[derive(Serialize)]
+struct UtxoMerkleProofResponse {
+    status: String,
+    tx_hash: String,
+    output_index: u32,
+    leaf_index: u64,
+    merkle_root: String,
+    siblings: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -1703,6 +1720,78 @@ impl BlockchainHandler {
         };
 
         let json_response = serde_json::to_vec(&balance_info)?;
+        Ok(ZhtpResponse::success_with_content_type(
+            json_response,
+            "application/json".to_string(),
+            None,
+        ))
+    }
+
+    /// Handle UTXO Merkle proof query for ZK transaction proofs.
+    ///
+    /// Path: /api/v1/blockchain/utxo/{tx_hash}/{output_index}/merkle-proof
+    async fn handle_get_utxo_merkle_proof(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        // Extract tx_hash and output_index from path
+        let path_parts: Vec<&str> = request.uri.split('/').collect();
+        let tx_hash_str = path_parts
+            .get(5)
+            .ok_or_else(|| anyhow::anyhow!("tx_hash required"))?;
+        let output_index_str = path_parts
+            .get(6)
+            .ok_or_else(|| anyhow::anyhow!("output_index required"))?;
+        let output_index: u32 = output_index_str
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid output_index"))?;
+
+        let tx_hash_bytes = if tx_hash_str.len() == 64 {
+            hex::decode(tx_hash_str)
+                .map_err(|_| anyhow::anyhow!("Invalid tx_hash hex"))?
+        } else {
+            return Err(anyhow::anyhow!("tx_hash must be 64 hex chars"));
+        };
+
+        if tx_hash_bytes.len() != 32 {
+            return Err(anyhow::anyhow!("tx_hash must decode to 32 bytes"));
+        }
+
+        let mut tx_hash_arr = [0u8; 32];
+        tx_hash_arr.copy_from_slice(&tx_hash_bytes);
+        let outpoint = OutPoint::new(TxHash::new(tx_hash_arr), output_index);
+
+        let blockchain_arc = self.get_blockchain().await?;
+        let blockchain = blockchain_arc.read().await;
+
+        let response = if let Some(ref store) = blockchain.store {
+            match store.get_utxo_merkle_proof(&outpoint)? {
+                Some(proof) => UtxoMerkleProofResponse {
+                    status: "ok".to_string(),
+                    tx_hash: tx_hash_str.to_string(),
+                    output_index,
+                    leaf_index: proof.leaf_index,
+                    merkle_root: hex::encode(&proof.root),
+                    siblings: proof.siblings.iter().map(|s| hex::encode(s)).collect(),
+                },
+                None => UtxoMerkleProofResponse {
+                    status: "not_found".to_string(),
+                    tx_hash: tx_hash_str.to_string(),
+                    output_index,
+                    leaf_index: 0,
+                    merkle_root: String::new(),
+                    siblings: vec![],
+                },
+            }
+        } else {
+            UtxoMerkleProofResponse {
+                status: "store_unavailable".to_string(),
+                tx_hash: tx_hash_str.to_string(),
+                output_index,
+                leaf_index: 0,
+                merkle_root: String::new(),
+                siblings: vec![],
+            }
+        };
+
+        let json_response = serde_json::to_vec(&response)?;
         Ok(ZhtpResponse::success_with_content_type(
             json_response,
             "application/json".to_string(),
@@ -3271,5 +3360,32 @@ mod tests {
         
         // Verify chain_id is sourced from environment
         assert_eq!(handler.chain_id(), Environment::Development.chain_id());
+    }
+
+    #[test]
+    fn handler_claims_utxo_merkle_proof_endpoint() {
+        use crate::config::Environment;
+        
+        let handler = BlockchainHandler::new(
+            Arc::new(RwLock::new(Blockchain::new().expect("Blockchain::new"))),
+            Environment::Development,
+            Arc::new(RwLock::new(lib_identity::IdentityManager::new())),
+        );
+
+        let merkle_proof_request = ZhtpRequest {
+            method: ZhtpMethod::Get,
+            uri: "/api/v1/blockchain/utxo/abcd1234/0/merkle-proof".to_string(),
+            version: "ZHTP/1.0".to_string(),
+            headers: ZhtpHeaders::default(),
+            body: Vec::new(),
+            timestamp: 0,
+            requester: None,
+            auth_proof: None,
+        };
+        
+        assert!(
+            handler.can_handle(&merkle_proof_request),
+            "handler must claim UTXO merkle-proof endpoint"
+        );
     }
 }

--- a/zhtp/src/api/handlers/identity/backup_recovery.rs
+++ b/zhtp/src/api/handlers/identity/backup_recovery.rs
@@ -2433,7 +2433,7 @@ mod tests {
             Option<String>,
             Vec<u8>,
             u64,
-            u64,
+            u128,
         )> = Vec::new();
         {
             let old = manager


### PR DESCRIPTION
## Summary

Adds a ZHTP REST endpoint so wallets can query live Merkle inclusion proofs for unspent outputs.

## Changes

- **zhtp**: New endpoint `GET /api/v1/blockchain/utxo/{tx_hash}/{output_index}/merkle-proof`
  - Returns `status`, `leaf_index`, `merkle_root` (hex), and `siblings` (hex array)
  - Queries the persistent `SledStore` via `Blockchain.store`
- **lib-proofs**: Moved `MERKLE_DEPTH` out of the `real` module so it is available in all builds; added dummy `build_merkle_tree` / `compute_leaf_commitment` stubs for non-`real-proofs` compilation.
- **zhtp tests**: Added `handler_claims_utxo_merkle_proof_endpoint` test.
- **Drive-by fix**: Resolved pre-existing `u128`/`u64` mismatches in `identity/backup_recovery.rs` tests.

## Verification

- `cargo check -p zhtp` — clean
- `cargo test -p zhtp --lib api::handlers::blockchain::tests::handler_claims_utxo_merkle_proof_endpoint` — passes
- `cargo test -p lib-blockchain --features real-proofs --lib execution::executor::tests` — 42/42 pass
- `cargo test -p lib-blockchain --features real-proofs --lib storage::sled_store::tests` — 22/22 pass

## What remains in Epic F

1. **Production Merkle depth**: `MERKLE_DEPTH = 4` → 32–40 for mainnet.
2. **Re-benchmark**: Fresh prove/verify timing after Merkle constraints.
3. **Incremental tree updates**: Full root rebuild per block is acceptable for depth 4 but must be optimized for mainnet depth.
