### PR TITLE
fix: correct payroll mint to 2.083X, fix domain auth

### DIFF
--- a/lib-blockchain/src/contracts/bonding_curve/canonical.rs
+++ b/lib-blockchain/src/contracts/bonding_curve/canonical.rs
@@ -84,10 +84,11 @@ pub const STRATEGIC_RESERVE_CEILING: u128 = 100_000_000 * SCALE; // 100M CBE
 
 // ── Debt ceiling and safety valves (Feature #2125) ─────────────────────────
 //
-// Maximum genesis payroll debt in CBE atoms (71M × 10^18).
+// Maximum gross payroll debt in CBE atoms (147.9M × 10^18).
+// Equivalent to 71M collaborator-received CBE (147.9M × 0.48 ≈ 71M).
 // Protocol invariant — cannot be raised by governance.
 
-pub const DEBT_CEILING: u128 = 71_000_000 * SCALE;
+pub const DEBT_CEILING: u128 = 147_900_000 * SCALE;
 
 /// Genesis treasury allocation — 20B CBE minted off-curve to SOV treasury.
 ///
@@ -127,13 +128,26 @@ pub const SOV_TREASURY_SHARE_PCT: u128 = 20;
 pub const RESERVE_SHARE_PCT: u128 = 32;
 // Liquidity gets the remainder: 100 - 20 - 32 = 48
 
-/// Payroll mint multiplier: gross = amount_cbe * PAYROLL_GROSS_NUM / PAYROLL_GROSS_DEN (1.25X).
-pub const PAYROLL_GROSS_NUM: u128 = 125;
-pub const PAYROLL_GROSS_DEN: u128 = 100;
-/// Payroll SOV treasury share: 1/5 of gross (= 0.25X of the base).
-pub const PAYROLL_SOV_TREASURY_DIVISOR: u128 = 5;
-/// Payroll liquidity share: 60% of the base amount for SOVRN audit.
-pub const PAYROLL_LIQUIDITY_PCT: u128 = 60;
+// ── Payroll mint constants (CBE spec §6) ──────────────────────────────────
+//
+// Collaborator receives X CBE.  X = 48% of gross (60% of the 80% backing
+// portion).  Working backward: gross = X / 0.48 = X × 25 / 12 ≈ 2.083X.
+//
+// Split of gross:
+//   20% → SOV treasury  (DAO tax, held as CBE)
+//   32% → locked reserve (40% of 80%, backs floor price)
+//   48% → collaborator   (60% of 80%, the X they earned)
+
+/// Payroll gross multiplier numerator: gross = X × 25 / 12 (≈ 2.083X).
+pub const PAYROLL_GROSS_NUM: u128 = 25;
+/// Payroll gross multiplier denominator.
+pub const PAYROLL_GROSS_DEN: u128 = 12;
+/// Payroll SOV treasury share: 20% of gross.
+pub const PAYROLL_TREASURY_PCT: u128 = 20;
+/// Payroll locked reserve share: 32% of gross.
+pub const PAYROLL_RESERVE_PCT: u128 = 32;
+/// Payroll collaborator share: 48% of gross (= X, rounds down).
+pub const PAYROLL_COLLABORATOR_PCT: u128 = 48;
 
 // ── Upgrade-gated curve parameters ──────────────────────────────────────────
 //

--- a/lib-blockchain/src/contracts/employment/employment_registry.rs
+++ b/lib-blockchain/src/contracts/employment/employment_registry.rs
@@ -86,7 +86,7 @@ pub struct EmploymentContract {
     pub status: EmploymentStatus,
 
     // Compensation
-    pub compensation_amount: u64, // In DAO tokens per period
+    pub compensation_amount: u128, // In DAO tokens per period (18-decimal atoms)
     pub payment_period: EconomicPeriod,
 
     // Tax and compliance
@@ -97,7 +97,7 @@ pub struct EmploymentContract {
     pub profit_share_percentage: u16, // Basis points, e.g., 500 = 5%
 
     // Governance
-    pub voting_power: u64, // Based on CBE holdings + tenure
+    pub voting_power: u128, // Based on CBE holdings + tenure
 
     // Lifecycle
     pub start_height: u64,
@@ -108,9 +108,9 @@ pub struct EmploymentContract {
 /// Payment details
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaymentDetails {
-    pub gross_amount: u64,
-    pub tax_amount: u64,
-    pub net_amount: u64,
+    pub gross_amount: u128,
+    pub tax_amount: u128,
+    pub net_amount: u128,
     pub periods_elapsed: u64,
     pub payment_height: u64,
 }
@@ -118,9 +118,9 @@ pub struct PaymentDetails {
 /// Profit share calculation result
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProfitShareResult {
-    pub dao_profit: u64,
+    pub dao_profit: u128,
     pub share_percentage: u16,
-    pub share_amount: u64,
+    pub share_amount: u128,
 }
 
 /// Employment Registry main contract
@@ -151,7 +151,7 @@ impl EmploymentRegistry {
         dao_id: [u8; 32],
         employee_sid: PublicKey,
         contract_type: ContractAccessType,
-        compensation_amount: u64,
+        compensation_amount: u128,
         payment_period: EconomicPeriod,
         tax_rate_basis_points: u16,
         tax_jurisdiction: String,
@@ -245,10 +245,10 @@ impl EmploymentRegistry {
         }
 
         // Calculate amounts
-        let gross_amount = contract.compensation_amount.saturating_mul(periods_elapsed);
-        let tax_amount = (gross_amount as u128)
+        let gross_amount = contract.compensation_amount.saturating_mul(periods_elapsed as u128);
+        let tax_amount = gross_amount
             .saturating_mul(contract.tax_rate_basis_points as u128)
-            .saturating_div(10000) as u64;
+            .saturating_div(10000);
         let net_amount = gross_amount.saturating_sub(tax_amount);
 
         // Update contract
@@ -267,7 +267,7 @@ impl EmploymentRegistry {
     pub fn calculate_profit_share(
         &self,
         contract_id: [u8; 32],
-        dao_profit: u64,
+        dao_profit: u128,
     ) -> Result<ProfitShareResult> {
         let contract = self
             .contracts
@@ -275,9 +275,9 @@ impl EmploymentRegistry {
             .find(|c| c.contract_id == contract_id)
             .ok_or_else(|| anyhow!("Employment contract not found"))?;
 
-        let share_amount = (dao_profit as u128)
+        let share_amount = dao_profit
             .saturating_mul(contract.profit_share_percentage as u128)
-            .saturating_div(10000) as u64;
+            .saturating_div(10000);
 
         Ok(ProfitShareResult {
             dao_profit,
@@ -290,9 +290,9 @@ impl EmploymentRegistry {
     pub fn update_voting_power(
         &mut self,
         contract_id: [u8; 32],
-        cbe_balance: u64,
+        cbe_balance: u128,
         current_height: u64,
-    ) -> Result<u64> {
+    ) -> Result<u128> {
         let contract = self
             .contracts
             .iter_mut()
@@ -312,9 +312,9 @@ impl EmploymentRegistry {
         };
 
         // Voting power = cbe_balance * (1 + tenure_bonus / 1000)
-        let voting_power = (cbe_balance as u128)
+        let voting_power = cbe_balance
             .saturating_mul(10000 + tenure_bonus as u128)
-            .saturating_div(10000) as u64;
+            .saturating_div(10000);
 
         contract.voting_power = voting_power;
         Ok(voting_power)

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -2001,7 +2001,10 @@ impl BlockExecutor {
         tx: &crate::transaction::Transaction,
         block_height: u64,
     ) -> Result<(), TxApplyError> {
-        use crate::contracts::bonding_curve::canonical::{compute_debt_state, DEBT_CEILING};
+        use crate::contracts::bonding_curve::canonical::{
+            compute_debt_state, DEBT_CEILING, PAYROLL_COLLABORATOR_PCT, PAYROLL_GROSS_DEN,
+            PAYROLL_GROSS_NUM, PAYROLL_RESERVE_PCT, PAYROLL_TREASURY_PCT,
+        };
         use crate::transaction::core::ProcessPayrollData;
 
         let data: &ProcessPayrollData = tx
@@ -2010,7 +2013,7 @@ impl BlockExecutor {
                 TxApplyError::InvalidType("ProcessPayroll missing payload".to_string())
             })?;
 
-        let amount_cbe = data.amount_cbe;
+        let amount_cbe = data.amount_cbe; // X — what the collaborator earns
         let collaborator = data.collaborator_address;
         let deliverable_hash = data.deliverable_hash;
 
@@ -2020,10 +2023,12 @@ impl BlockExecutor {
             ));
         }
 
-        // ── 1. Compute gross mint (1.25X) and split ─────────────────────────
-        use crate::contracts::bonding_curve::canonical::{
-            PAYROLL_GROSS_DEN, PAYROLL_GROSS_NUM, PAYROLL_SOV_TREASURY_DIVISOR,
-        };
+        // ── 1. Compute gross mint (≈2.083X) and split ───────────────────────
+        //
+        // gross = X × 25 / 12  (X / 0.48)
+        //   20% gross → SOV treasury (DAO tax, held as CBE)
+        //   32% gross → locked reserve (backs floor price)
+        //   48% gross → collaborator (= X, rounds down)
 
         let gross = amount_cbe
             .checked_mul(PAYROLL_GROSS_NUM)
@@ -2032,13 +2037,11 @@ impl BlockExecutor {
                 TxApplyError::InvalidType("PAYROLL_MINT: gross overflow".to_string())
             })?;
 
-        // 0.25X → SOV treasury (held as CBE, not swapped)
-        let sov_treasury_credit = gross / PAYROLL_SOV_TREASURY_DIVISOR;
-        // Remaining X split: 40% reserve, 60% liquidity — but these are CBE-denominated
-        // obligations, not SOV. The actual reserve_balance (SOV) doesn't change because
-        // no SOV entered. We track the obligation via PRE_BACKED.
+        let treasury_credit = gross * PAYROLL_TREASURY_PCT / 100;   // 20%
+        let reserve_credit = gross * PAYROLL_RESERVE_PCT / 100;     // 32%
+        let collaborator_credit = gross * PAYROLL_COLLABORATOR_PCT / 100; // 48%
 
-        // ── 2. Debt ceiling check ───────────────────────────────────────────
+        // ── 2. Debt ceiling check (against gross) ───────────────────────────
         let mut econ = mutator.get_cbe_economic_state()?;
 
         let new_outstanding = econ
@@ -2055,20 +2058,29 @@ impl BlockExecutor {
             )));
         }
 
-        // ── 3. Update compensation pool (tracks CBE allocated to collaborators)
+        // ── 3. Update pools ─────────────────────────────────────────────────
+        // Compensation pool tracks what collaborators received.
         econ.compensation_pool
-            .mint(amount_cbe)
+            .mint(collaborator_credit)
             .map_err(|e| TxApplyError::InvalidType(format!("PAYROLL_MINT: compensation pool: {e}")))?;
 
-        // ── 4. Update SOV treasury CBE balance ──────────────────────────────
+        // SOV treasury CBE balance (20% of gross).
         econ.sov_treasury_cbe_balance = econ
             .sov_treasury_cbe_balance
-            .checked_add(sov_treasury_credit)
+            .checked_add(treasury_credit)
             .ok_or_else(|| {
                 TxApplyError::InvalidType("PAYROLL_MINT: sov_treasury overflow".to_string())
             })?;
 
-        // ── 5. Record PRE_BACKED entry ──────────────────────────────────────
+        // Locked reserve (32% of gross — backs floor price).
+        econ.reserve_balance = econ
+            .reserve_balance
+            .checked_add(reserve_credit)
+            .ok_or_else(|| {
+                TxApplyError::InvalidType("PAYROLL_MINT: reserve overflow".to_string())
+            })?;
+
+        // ── 4. Record PRE_BACKED entry ──────────────────────────────────────
         econ.pre_backed_queue.push(lib_types::PreBackedEntry {
             block_height,
             amount_cbe: gross,
@@ -2079,17 +2091,17 @@ impl BlockExecutor {
         econ.outstanding_pre_backed = new_outstanding;
         econ.debt_state = compute_debt_state(new_outstanding);
 
-        // ── 5b. SOVRN audit token (#2129) ───────────────────────────────────
-        // For payroll, 60% of X goes to liquidity as CBE obligation.
-        // SOVRN = liquidity_cbe × P(S_c) / SCALE  (SOV-denominated value).
+        // ── 5. SOVRN audit token ────────────────────────────────────────────
+        // SOVRN tracks value-weighted liquidity. For payroll the reserve portion
+        // (32% of gross) is the value that backs the floor.
+        // SOVRN_mint = reserve_credit × P(S_c) / SCALE
         {
             use crate::contracts::bonding_curve::canonical::{price_at_supply, SCALE};
             use crate::contracts::utils::u256_to_u128;
             use primitive_types::U256;
 
-            let liquidity_cbe = amount_cbe * crate::contracts::bonding_curve::canonical::PAYROLL_LIQUIDITY_PCT / 100;
             let price = price_at_supply(econ.s_c);
-            let sovrn_mint = U256::from(liquidity_cbe)
+            let sovrn_mint = U256::from(reserve_credit)
                 .checked_mul(U256::from(price))
                 .unwrap_or(U256::zero())
                 / U256::from(SCALE);
@@ -2104,27 +2116,33 @@ impl BlockExecutor {
         // ── 7. Credit CBE tokens ────────────────────────────────────────────
         let cbe_token_id = TokenId::new(crate::Blockchain::derive_cbe_token_id_pub());
 
-        // X CBE → collaborator wallet
+        // 48% gross (≈ X) → collaborator wallet
         mutator.credit_token(
             &cbe_token_id,
             &Address::new(collaborator),
-            amount_cbe,
+            collaborator_credit,
         )?;
 
-        // 0.25X CBE → SOV treasury address
+        // 20% gross → SOV treasury address (held as CBE)
         let treasury_addr = *self.fee_model.protocol_params.fee_sink_address();
         mutator.credit_token(
             &cbe_token_id,
             &treasury_addr,
-            sov_treasury_credit,
+            treasury_credit,
         )?;
 
+        // 32% gross → locked reserve (no token credit — reserve is an accounting
+        // entry in BondingCurveEconomicState, not a wallet balance; it backs the
+        // floor price and is only released at graduation or sell-back redemption).
+
         tracing::info!(
-            "PAYROLL_MINT: collaborator={} amount_cbe={} gross={} treasury_credit={} deliverable={} outstanding={}",
+            "PAYROLL_MINT: collaborator={} X={} gross={} treasury={} reserve={} collab_credit={} deliverable={} outstanding={}",
             hex::encode(&collaborator[..4]),
             amount_cbe,
             gross,
-            sov_treasury_credit,
+            treasury_credit,
+            reserve_credit,
+            collaborator_credit,
             hex::encode(&deliverable_hash[..4]),
             new_outstanding,
         );

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -2002,8 +2002,8 @@ impl BlockExecutor {
         block_height: u64,
     ) -> Result<(), TxApplyError> {
         use crate::contracts::bonding_curve::canonical::{
-            compute_debt_state, DEBT_CEILING, PAYROLL_COLLABORATOR_PCT, PAYROLL_GROSS_DEN,
-            PAYROLL_GROSS_NUM, PAYROLL_RESERVE_PCT, PAYROLL_TREASURY_PCT,
+            compute_debt_state, DEBT_CEILING, PAYROLL_GROSS_DEN, PAYROLL_GROSS_NUM,
+            PAYROLL_RESERVE_PCT, PAYROLL_TREASURY_PCT,
         };
         use crate::transaction::core::ProcessPayrollData;
 
@@ -2028,7 +2028,8 @@ impl BlockExecutor {
         // gross = X × 25 / 12  (X / 0.48)
         //   20% gross → SOV treasury (DAO tax, held as CBE)
         //   32% gross → locked reserve (backs floor price)
-        //   48% gross → collaborator (= X, rounds down)
+        //   collaborator receives exactly X (the amount they earned)
+        //   rounding dust (0–1 atoms) goes to reserve (backs floor price)
 
         let gross = amount_cbe
             .checked_mul(PAYROLL_GROSS_NUM)
@@ -2037,9 +2038,11 @@ impl BlockExecutor {
                 TxApplyError::InvalidType("PAYROLL_MINT: gross overflow".to_string())
             })?;
 
-        let treasury_credit = gross * PAYROLL_TREASURY_PCT / 100;   // 20%
-        let reserve_credit = gross * PAYROLL_RESERVE_PCT / 100;     // 32%
-        let collaborator_credit = gross * PAYROLL_COLLABORATOR_PCT / 100; // 48%
+        let treasury_credit = gross * PAYROLL_TREASURY_PCT / 100;     // 20%
+        let base_reserve = gross * PAYROLL_RESERVE_PCT / 100;         // 32%
+        let collaborator_credit = amount_cbe;                         // exactly X
+        let rounding_dust = gross - treasury_credit - base_reserve - collaborator_credit;
+        let reserve_credit = base_reserve + rounding_dust;            // 32% + dust
 
         // ── 2. Debt ceiling check (against gross) ───────────────────────────
         let mut econ = mutator.get_cbe_economic_state()?;

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -1512,7 +1512,7 @@ impl Transaction {
         dao_id: [u8; 32],
         employee_key_id: [u8; 32],
         contract_type: u8,
-        compensation_amount: u64,
+        compensation_amount: u128,
         payment_period: u8,
         tax_rate_basis_points: u16,
         tax_jurisdiction: String,
@@ -2146,8 +2146,8 @@ pub struct CreateEmploymentContractData {
     pub employee_key_id: [u8; 32],
     /// Contract type discriminant (0=PublicAccess, 1=Employment)
     pub contract_type: u8,
-    /// Compensation amount in CBE atomic units
-    pub compensation_amount: u64,
+    /// Compensation amount in CBE atomic units (18-decimal)
+    pub compensation_amount: u128,
     /// Payment period discriminant (0=Monthly, 1=Quarterly, 2=Annually)
     pub payment_period: u8,
     /// Tax rate in basis points (max 5000 = 50%)
@@ -2160,10 +2160,10 @@ pub struct CreateEmploymentContractData {
 
 /// Payroll mint as a synthetic CBE bonding curve event (CBE spec §6).
 ///
-/// Mints `amount_cbe` (X) to the collaborator and routes 0.25X to the SOV
-/// treasury, recording a PRE_BACKED entry for the full 1.25X gross.  No SOV
-/// enters the system — s_c does not change.  A governance-approved deliverable
-/// hash must be recorded on-chain before the mint fires (protocol invariant).
+/// Mints gross ≈ 2.083X CBE, split 20% SOV treasury / 32% locked reserve /
+/// 48% collaborator (= X).  Records a PRE_BACKED entry for the full gross.
+/// No SOV enters the system — s_c does not change.  Signer must be a
+/// Bootstrap Council member (governance guard).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessPayrollData {
     /// Employment contract that authorises this payroll (32-byte contract_id).

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -2369,6 +2369,31 @@ impl<'a> StatefulTransactionValidator<'a> {
             return Err(ValidationError::InvalidTransaction);
         }
 
+        // ── Governance guard: signer must be a Bootstrap Council member ──────
+        // The transaction signature already proves the signer holds the private key.
+        // We only need to verify that key belongs to a council member identity.
+        // With threshold=1 and a single council member, the tx signature suffices.
+        let blockchain = self.blockchain.ok_or(ValidationError::InvalidTransaction)?;
+        // Derive the signer's DID directly from the transaction's dilithium public key.
+        // DID = "did:zhtp:" + hex(blake3(dilithium_pk))
+        // Identity IDs are derived from dilithium_pk only (not dilithium+kyber which
+        // produces key_id). This avoids requiring the identity to be registered
+        // on-chain — the council membership is authoritative (set at genesis).
+        let signer_did = {
+            let hash = lib_crypto::hashing::hash_blake3(
+                &transaction.signature.public_key.dilithium_pk,
+            );
+            format!("did:zhtp:{}", hex::encode(hash))
+        };
+        if !blockchain.is_council_member(&signer_did) {
+            tracing::warn!(
+                "[PAYROLL] signer {} is not a council member (key_id={})",
+                &signer_did[..50.min(signer_did.len())],
+                hex::encode(&transaction.signature.public_key.key_id[..8])
+            );
+            return Err(ValidationError::Unauthorized);
+        }
+
         Ok(())
     }
 

--- a/lib-client/src/cbe_tx.rs
+++ b/lib-client/src/cbe_tx.rs
@@ -50,7 +50,10 @@ pub fn build_init_cbe_token_tx(
     chain_id: u8,
     block_height: u64,
 ) -> Result<String, String> {
-    let signer_pk = crate::token_tx::create_public_key(identity.public_key.clone());
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
     let now = now_secs();
 
     let mut tx = Transaction::new_init_cbe_token(
@@ -101,14 +104,17 @@ pub fn build_create_employment_contract_tx(
     dao_id: [u8; 32],
     employee_key_id: [u8; 32],
     contract_type: u8,
-    compensation_amount: u64,
+    compensation_amount: u128,
     payment_period: u8,
     tax_rate_basis_points: u16,
     tax_jurisdiction: String,
     profit_share_percentage: u16,
     chain_id: u8,
 ) -> Result<String, String> {
-    let signer_pk = crate::token_tx::create_public_key(identity.public_key.clone());
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
     let now = now_secs();
 
     let mut tx = Transaction::new_create_employment_contract(
@@ -142,12 +148,13 @@ pub fn build_create_employment_contract_tx(
 
 /// Build a signed `ProcessPayroll` transaction (CBE bonding curve §6 payroll mint).
 ///
-/// Triggers a synthetic curve event: mints `amount_cbe` (X) to the collaborator
-/// and routes 0.25X to the SOV treasury, recording a PRE_BACKED entry for the
-/// full 1.25X gross.
+/// Triggers a synthetic curve event: gross ≈ 2.083X CBE is minted and split
+/// 20% SOV treasury / 32% locked reserve / 48% collaborator (= X).
+/// A PRE_BACKED entry is recorded for the full gross.  Signer must be a
+/// Bootstrap Council member (governance guard).
 ///
 /// # Arguments
-/// - `identity`              — Signer (compensation pool controller or CBE DAO executor)
+/// - `identity`              — Signer (must be Bootstrap Council member)
 /// - `contract_id`           — 32-byte employment contract identifier
 /// - `amount_cbe`            — CBE amount the collaborator earns (X, 18-decimal atoms)
 /// - `collaborator_address`  — Wallet address that receives X CBE
@@ -164,7 +171,10 @@ pub fn build_process_payroll_tx(
     deliverable_hash: [u8; 32],
     chain_id: u8,
 ) -> Result<String, String> {
-    let signer_pk = crate::token_tx::create_public_key(identity.public_key.clone());
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
     let now = now_secs();
 
     let mut tx = Transaction::new_process_payroll(

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -1387,9 +1387,9 @@ pub enum CbeAction {
         /// Contract type: 0 = PublicAccess, 1 = Employment
         #[arg(long, default_value = "1")]
         contract_type: u8,
-        /// Per-period compensation in base units
+        /// Per-period compensation in CBE atomic units (18 decimals)
         #[arg(long)]
-        compensation: u64,
+        compensation: u128,
         /// Payment period: 0 = Monthly, 1 = Quarterly, 2 = Annually
         #[arg(long, default_value = "0")]
         period: u8,
@@ -1417,6 +1417,9 @@ pub enum CbeAction {
         /// Blake3 hash of the governance-approved deliverable (32-byte hex)
         #[arg(long)]
         deliverable_hash: String,
+        /// Path to keystore directory (default: ~/.zhtp/keystore)
+        #[arg(long)]
+        keystore: Option<String>,
     },
     /// Transfer CBE tokens from your wallet to another
     ///

--- a/zhtp-cli/src/commands/cbe.rs
+++ b/zhtp-cli/src/commands/cbe.rs
@@ -277,8 +277,25 @@ pub async fn handle_cbe_command_with_output<O: Output>(
             amount_cbe,
             collaborator,
             deliverable_hash,
+            keystore,
         } => {
-            let identity = load_identity()?;
+            let identity = match keystore {
+                Some(ref path) => {
+                    let loaded = load_identity_from_keystore(&PathBuf::from(path))?;
+                    zhtp_client::Identity {
+                        did: loaded.identity.did.clone(),
+                        public_key: loaded.identity.public_key.dilithium_pk.to_vec(),
+                        private_key: loaded.keypair.private_key.dilithium_sk.to_vec(),
+                        kyber_public_key: loaded.identity.public_key.kyber_pk.to_vec(),
+                        kyber_secret_key: loaded.keypair.private_key.kyber_sk.to_vec(),
+                        node_id: loaded.identity.node_id.as_bytes().to_vec(),
+                        device_id: loaded.identity.primary_device.clone(),
+                        recovery_entropy: loaded.keypair.private_key.master_seed.to_vec(),
+                        created_at: loaded.identity.created_at,
+                    }
+                }
+                None => load_identity()?,
+            };
             let contract_id_bytes = parse_hex32(&contract_id, "--contract-id")?;
             let collaborator_bytes = parse_hex32(&collaborator, "--collaborator")?;
             let deliverable_bytes = parse_hex32(&deliverable_hash, "--deliverable-hash")?;

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -966,11 +966,14 @@ impl Web4Handler {
                 ));
             }
 
-            let owner_wallet_pubkey =
-                lib_blockchain::integration::crypto_integration::PublicKey::new(
-                    owner_wallet.public_key.as_slice().try_into().unwrap_or([0u8; 2592]),
-                );
-            if fee_payment_tx.signature.public_key.key_id != owner_wallet_pubkey.key_id {
+            // Compare dilithium_pk directly: the wallet registry stores only the
+            // dilithium public key (2592 bytes), not the full composite key. Constructing
+            // a PublicKey from it would zero the kyber_pk, producing a different key_id
+            // than the transaction signature which carries both dilithium + kyber components.
+            let sig_dilithium = fee_payment_tx.signature.public_key.dilithium_pk.as_slice();
+            if owner_wallet.public_key.len() != 2592
+                || owner_wallet.public_key.as_slice() != sig_dilithium
+            {
                 return Err(anyhow!(
                     "fee_payment_tx signature does not match owner Primary wallet public key"
                 ));


### PR DESCRIPTION
## Summary

- **Payroll mint (CBE spec §6):** Fixed multiplier from 1.25X to 2.083X (gross = X × 25/12). Correct 20/32/48 split: SOV treasury / locked reserve / collaborator. Debt ceiling updated to 147.9M gross. Added governance guard requiring Bootstrap Council membership.
- **Domain registration:** Fixed fee_payment_tx ownership check — compares dilithium_pk directly instead of key_id (wallet registry only stores dilithium_pk, zeroed kyber_pk produced wrong key_id).
- **lib-client:** CBE tx builders now include kyber_pk in signatures via `create_public_key_with_kyber()`, fixing key_id mismatch for app-generated identities.
- **u128 widening:** EmploymentRegistry fields and CreateEmploymentContractData.compensation_amount.
- **CLI:** Added `--keystore` flag to payroll command for council member signing.

## Test plan

- [x] All 27 bonding curve tests pass
- [x] All 11 employment registry tests pass
- [x] `cargo check` clean (no errors)
- [x] 16 payroll mints executed on testnet (12.48M gross CBE, all finalized)
- [x] Domain registration fix deployed (dilithium_pk comparison)
- [x] Consensus stable post-deploy across all 3 validators