### PR TITLE
feat(pouw): public /pouw/status endpoint + active node count

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,15 @@ codegen-units = 1
 opt-level = 0
 debug = true
 
+[profile.dev-release]
+# Fast deployable build for development/testnet. Optimized but no LTO.
+# Use: cargo build --profile dev-release
+# Prod: cargo build --release (full LTO, single codegen unit)
+inherits = "release"
+opt-level = 2
+lto = false
+codegen-units = 8
+
 [profile.rpi]
 # Raspberry Pi optimized: lower memory usage during compilation
 inherits = "release"

--- a/zhtp/src/api/handlers/pouw/mod.rs
+++ b/zhtp/src/api/handlers/pouw/mod.rs
@@ -776,6 +776,7 @@ impl PouwHandler {
                 "base_pool": crate::pouw::rewards::POUW_EPOCH_POOL.to_string(),
                 "per_node_cap": crate::pouw::rewards::POUW_PER_NODE_EPOCH_CAP.to_string(),
                 "expected_active_nodes": crate::pouw::rewards::EXPECTED_ACTIVE_NODES,
+                "active_nodes": self.reward_calculator.active_nodes_current_epoch().await,
             },
             "multipliers": {
                 "hash": 1,

--- a/zhtp/src/pouw/rewards.rs
+++ b/zhtp/src/pouw/rewards.rs
@@ -521,6 +521,16 @@ impl RewardCalculator {
         }
     }
 
+    /// Count DIDs that submitted PoUW work in the current epoch.
+    pub async fn active_nodes_current_epoch(&self) -> u64 {
+        let current = self.current_epoch();
+        let history = self.did_history.read().await;
+        history
+            .values()
+            .filter(|records| records.back().map(|r| r.epoch == current).unwrap_or(false))
+            .count() as u64
+    }
+
     /// Get the set of DIDs flagged as suspicious for manual review
     pub async fn get_suspicious_dids(&self) -> Vec<String> {
         self.suspicious_dids.read().await.iter().cloned().collect()


### PR DESCRIPTION
## Summary

- Public `GET /api/v1/pouw/status` endpoint for frontend dashboard polling
- `active_nodes`: real count of DIDs that submitted PoUW work in the current epoch
- Full system state: epoch, budget, pool, multipliers, stats, eligibility

## Test plan

- [x] `cargo check -p zhtp` clean
- [x] Deployed to all 3 nodes
- [x] Consensus stable