### PR TITLE
feat: NFT System — collections, minting, transfer, API, CLI (EPIC #2168)

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -149,6 +149,9 @@ pub struct Blockchain {
     /// Smart contract registry - Web4 Website contracts (contract_id -> Web4Contract)
     #[serde(default)]
     pub web4_contracts: HashMap<[u8; 32], crate::contracts::web4::Web4Contract>,
+    /// NFT collection registry (collection_id -> NftContract)
+    #[serde(default)]
+    pub nft_collections: HashMap<[u8; 32], crate::contracts::nft::NftContract>,
     /// Authoritative on-chain domain registry (domain name -> record).
     /// Populated from DomainRegistration / DomainUpdate transactions committed to blocks.
     /// This is the canonical source of truth; sled/DHT DomainRegistry is a cache.
@@ -999,6 +1002,7 @@ impl Blockchain {
                         warn!("process_employment_contract_transactions in executor path: {}", e);
                     }
                     self.process_domain_transactions(&block);
+                    self.process_nft_transactions(&block);
                     for tx in &block.transactions {
                         self.index_dao_registry_entry_from_tx(tx, block.header.height);
                         // Executor returns LegacySystem for ValidatorRegistration — update registry here
@@ -1138,6 +1142,7 @@ impl Blockchain {
         self.process_entity_registry_transactions(&block)?;
         self.process_employment_contract_transactions(&block)?;
         self.process_domain_transactions(&block);
+        self.process_nft_transactions(&block);
         self.process_contract_transactions(&block)?;
         self.process_token_transactions(&block)?;
         self.process_validator_registration_transactions(&block);

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1066,6 +1066,110 @@ impl Blockchain {
         }
     }
 
+    /// Process NFT transactions from a committed block.
+    pub fn process_nft_transactions(&mut self, block: &Block) {
+        use crate::contracts::nft::{NftContract, NftMetadata};
+
+        for tx in &block.transactions {
+            match tx.transaction_type {
+                TransactionType::NftCreateCollection => {
+                    if let Some(data) = tx.nft_create_collection_data() {
+                        let collection_id = lib_crypto::hash_blake3(
+                            &format!(
+                                "nft_collection:{}:{}:{}",
+                                data.name,
+                                data.symbol,
+                                hex::encode(tx.signature.public_key.key_id)
+                            )
+                            .as_bytes(),
+                        );
+                        let contract = NftContract::new(
+                            collection_id,
+                            data.name.clone(),
+                            data.symbol.clone(),
+                            format!("did:zhtp:{}", hex::encode(
+                                lib_crypto::hashing::hash_blake3(&tx.signature.public_key.dilithium_pk)
+                            )),
+                            tx.signature.public_key.key_id,
+                            data.max_supply,
+                            tx.signature.timestamp,
+                        );
+                        info!(
+                            "🎨 NFT collection created: {} ({}) id={}",
+                            data.name,
+                            data.symbol,
+                            hex::encode(&collection_id[..8]),
+                        );
+                        self.nft_collections.insert(collection_id, contract);
+                    }
+                }
+                TransactionType::NftMint => {
+                    if let Some(data) = tx.nft_mint_data() {
+                        if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
+                            let metadata = NftMetadata {
+                                name: data.name.clone(),
+                                description: data.description.clone(),
+                                image_cid: data.image_cid.clone(),
+                                attributes: data.attributes.clone(),
+                                creator_did: collection.creator_did.clone(),
+                                created_at: tx.signature.timestamp,
+                            };
+                            match collection.mint(
+                                &tx.signature.public_key.key_id,
+                                data.recipient,
+                                metadata,
+                            ) {
+                                Ok(token_id) => {
+                                    info!(
+                                        "🎨 NFT minted: collection={} token_id={} to={}",
+                                        hex::encode(&data.collection_id[..8]),
+                                        token_id,
+                                        hex::encode(&data.recipient[..8]),
+                                    );
+                                }
+                                Err(e) => {
+                                    warn!("NFT mint failed: {}", e);
+                                }
+                            }
+                        }
+                    }
+                }
+                TransactionType::NftTransfer => {
+                    if let Some(data) = tx.nft_transfer_data() {
+                        if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
+                            if let Err(e) = collection.transfer(data.token_id, &data.from, data.to) {
+                                warn!("NFT transfer failed: {}", e);
+                            } else {
+                                info!(
+                                    "🎨 NFT transferred: collection={} token={} to={}",
+                                    hex::encode(&data.collection_id[..8]),
+                                    data.token_id,
+                                    hex::encode(&data.to[..8]),
+                                );
+                            }
+                        }
+                    }
+                }
+                TransactionType::NftBurn => {
+                    if let Some(data) = tx.nft_burn_data() {
+                        if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
+                            if let Err(e) = collection.burn(data.token_id, &data.owner) {
+                                warn!("NFT burn failed: {}", e);
+                            } else {
+                                info!(
+                                    "🎨 NFT burned: collection={} token={}",
+                                    hex::encode(&data.collection_id[..8]),
+                                    data.token_id,
+                                );
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     /// Get the authoritative on-chain domain registry.
     pub fn get_all_domains(&self) -> &HashMap<String, crate::transaction::OnChainDomainRecord> {
         &self.domain_registry

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1094,13 +1094,20 @@ impl Blockchain {
                             data.max_supply,
                             tx.signature.timestamp,
                         );
-                        info!(
-                            "🎨 NFT collection created: {} ({}) id={}",
-                            data.name,
-                            data.symbol,
-                            hex::encode(&collection_id[..8]),
-                        );
-                        self.nft_collections.insert(collection_id, contract);
+                        if self.nft_collections.contains_key(&collection_id) {
+                            warn!(
+                                "NFT collection already exists, skipping: id={}",
+                                hex::encode(&collection_id[..8]),
+                            );
+                        } else {
+                            info!(
+                                "🎨 NFT collection created: {} ({}) id={}",
+                                data.name,
+                                data.symbol,
+                                hex::encode(&collection_id[..8]),
+                            );
+                            self.nft_collections.insert(collection_id, contract);
+                        }
                     }
                 }
                 TransactionType::NftMint => {
@@ -1136,7 +1143,13 @@ impl Blockchain {
                 }
                 TransactionType::NftTransfer => {
                     if let Some(data) = tx.nft_transfer_data() {
-                        if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
+                        if tx.signature.public_key.key_id != data.from {
+                            warn!(
+                                "NFT transfer rejected: signer {} is not the owner {}",
+                                hex::encode(&tx.signature.public_key.key_id[..8]),
+                                hex::encode(&data.from[..8]),
+                            );
+                        } else if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
                             if let Err(e) = collection.transfer(data.token_id, &data.from, data.to) {
                                 warn!("NFT transfer failed: {}", e);
                             } else {
@@ -1152,7 +1165,13 @@ impl Blockchain {
                 }
                 TransactionType::NftBurn => {
                     if let Some(data) = tx.nft_burn_data() {
-                        if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
+                        if tx.signature.public_key.key_id != data.owner {
+                            warn!(
+                                "NFT burn rejected: signer {} is not the owner {}",
+                                hex::encode(&tx.signature.public_key.key_id[..8]),
+                                hex::encode(&data.owner[..8]),
+                            );
+                        } else if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
                             if let Err(e) = collection.burn(data.token_id, &data.owner) {
                                 warn!("NFT burn failed: {}", e);
                             } else {

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -97,6 +97,7 @@ impl Blockchain {
                 crate::contracts::economics::fee_router::DAO_HEALTHCARE_KEY_ID,
             ),
             domain_registry: HashMap::new(),
+            nft_collections: HashMap::new(),
         }
     }
 

--- a/lib-blockchain/src/blockchain/persistence.rs
+++ b/lib-blockchain/src/blockchain/persistence.rs
@@ -280,6 +280,7 @@ impl BlockchainV1 {
                 crate::contracts::economics::fee_router::DAO_HEALTHCARE_KEY_ID,
             ),
             domain_registry: HashMap::new(),
+            nft_collections: HashMap::new(),
         }
     }
 }
@@ -595,6 +596,7 @@ impl BlockchainStorageV3 {
                 crate::contracts::economics::fee_router::DAO_HEALTHCARE_KEY_ID,
             ),
             domain_registry: HashMap::new(),
+            nft_collections: HashMap::new(),
         }
     }
 }

--- a/lib-blockchain/src/contracts/mod.rs
+++ b/lib-blockchain/src/contracts/mod.rs
@@ -34,6 +34,7 @@ pub mod executor;
 pub mod files;
 #[cfg(feature = "contracts")]
 pub mod governance;
+pub mod nft;
 #[cfg(feature = "contracts")]
 pub mod groups;
 #[cfg(feature = "contracts")]

--- a/lib-blockchain/src/contracts/nft/mod.rs
+++ b/lib-blockchain/src/contracts/nft/mod.rs
@@ -1,0 +1,300 @@
+//! Non-Fungible Token (NFT) contract.
+//!
+//! Each NftContract represents a collection. Individual tokens within a collection
+//! have unique u64 IDs, per-token metadata, and tracked ownership.
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Metadata for an individual NFT.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftMetadata {
+    /// Display name of this token.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Web4 content CID for the primary image/media.
+    pub image_cid: String,
+    /// Key-value attributes (trait_type → value).
+    pub attributes: Vec<(String, String)>,
+    /// DID of the creator.
+    pub creator_did: String,
+    /// Unix timestamp of minting.
+    pub created_at: u64,
+}
+
+/// A single NFT collection on-chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftContract {
+    /// Unique collection identifier (blake3 derived).
+    pub collection_id: [u8; 32],
+    /// Collection name.
+    pub name: String,
+    /// Short symbol (e.g. "ART").
+    pub symbol: String,
+    /// DID of the collection creator.
+    pub creator_did: String,
+    /// Wallet key_id of the creator (authorised to mint).
+    pub creator_key_id: [u8; 32],
+    /// Optional cap on total tokens in this collection.
+    pub max_supply: Option<u64>,
+    /// How many tokens have been minted (lifetime, including burned).
+    pub total_minted: u64,
+    /// Next token ID to assign.
+    next_token_id: u64,
+    /// Token ownership: token_id → owner wallet key_id.
+    owners: HashMap<u64, [u8; 32]>,
+    /// Per-token metadata.
+    metadata: HashMap<u64, NftMetadata>,
+    /// Unix timestamp of collection creation.
+    pub created_at: u64,
+}
+
+impl NftContract {
+    /// Create a new empty collection.
+    pub fn new(
+        collection_id: [u8; 32],
+        name: String,
+        symbol: String,
+        creator_did: String,
+        creator_key_id: [u8; 32],
+        max_supply: Option<u64>,
+        created_at: u64,
+    ) -> Self {
+        Self {
+            collection_id,
+            name,
+            symbol,
+            creator_did,
+            creator_key_id,
+            max_supply,
+            total_minted: 0,
+            next_token_id: 1, // token IDs start at 1
+            owners: HashMap::new(),
+            metadata: HashMap::new(),
+            created_at,
+        }
+    }
+
+    /// Mint a new token in this collection.
+    ///
+    /// Only the collection creator may mint. Returns the assigned token_id.
+    pub fn mint(
+        &mut self,
+        minter_key_id: &[u8; 32],
+        recipient: [u8; 32],
+        metadata: NftMetadata,
+    ) -> Result<u64> {
+        // Authorization: only collection creator can mint
+        if minter_key_id != &self.creator_key_id {
+            return Err(anyhow!("Only the collection creator can mint"));
+        }
+
+        // Supply cap
+        if let Some(cap) = self.max_supply {
+            if self.total_minted >= cap {
+                return Err(anyhow!(
+                    "Max supply reached: {}/{}",
+                    self.total_minted,
+                    cap
+                ));
+            }
+        }
+
+        let token_id = self.next_token_id;
+        self.next_token_id += 1;
+        self.total_minted += 1;
+        self.owners.insert(token_id, recipient);
+        self.metadata.insert(token_id, metadata);
+
+        Ok(token_id)
+    }
+
+    /// Transfer a token to a new owner.
+    pub fn transfer(
+        &mut self,
+        token_id: u64,
+        from: &[u8; 32],
+        to: [u8; 32],
+    ) -> Result<()> {
+        let owner = self
+            .owners
+            .get(&token_id)
+            .ok_or_else(|| anyhow!("Token {} does not exist", token_id))?;
+
+        if owner != from {
+            return Err(anyhow!(
+                "Sender does not own token {}: owner={}, from={}",
+                token_id,
+                hex::encode(&owner[..8]),
+                hex::encode(&from[..8]),
+            ));
+        }
+
+        self.owners.insert(token_id, to);
+        Ok(())
+    }
+
+    /// Burn (destroy) a token. Only the owner can burn.
+    pub fn burn(&mut self, token_id: u64, owner: &[u8; 32]) -> Result<()> {
+        let current_owner = self
+            .owners
+            .get(&token_id)
+            .ok_or_else(|| anyhow!("Token {} does not exist", token_id))?;
+
+        if current_owner != owner {
+            return Err(anyhow!("Only the owner can burn token {}", token_id));
+        }
+
+        self.owners.remove(&token_id);
+        self.metadata.remove(&token_id);
+        Ok(())
+    }
+
+    /// Get the owner of a token.
+    pub fn owner_of(&self, token_id: u64) -> Option<&[u8; 32]> {
+        self.owners.get(&token_id)
+    }
+
+    /// List all token IDs owned by a wallet.
+    pub fn tokens_of(&self, wallet_id: &[u8; 32]) -> Vec<u64> {
+        self.owners
+            .iter()
+            .filter(|(_, owner)| *owner == wallet_id)
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    /// Get metadata for a token.
+    pub fn metadata_of(&self, token_id: u64) -> Option<&NftMetadata> {
+        self.metadata.get(&token_id)
+    }
+
+    /// Total tokens currently in existence (minted minus burned).
+    pub fn total_supply(&self) -> u64 {
+        self.owners.len() as u64
+    }
+
+    /// Iterator over all tokens with their owners.
+    pub fn all_tokens(&self) -> impl Iterator<Item = (u64, &[u8; 32], Option<&NftMetadata>)> {
+        self.owners
+            .iter()
+            .map(move |(id, owner)| (*id, owner, self.metadata.get(id)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_collection() -> NftContract {
+        NftContract::new(
+            [1u8; 32],
+            "Test Art".to_string(),
+            "ART".to_string(),
+            "did:zhtp:creator".to_string(),
+            [2u8; 32],
+            Some(10),
+            1000,
+        )
+    }
+
+    #[test]
+    fn test_mint() {
+        let mut col = test_collection();
+        let meta = NftMetadata {
+            name: "Piece #1".to_string(),
+            description: "First piece".to_string(),
+            image_cid: "Qm123".to_string(),
+            attributes: vec![("color".to_string(), "blue".to_string())],
+            creator_did: "did:zhtp:creator".to_string(),
+            created_at: 1000,
+        };
+        let id = col.mint(&[2u8; 32], [3u8; 32], meta).unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(col.total_minted, 1);
+        assert_eq!(col.owner_of(1), Some(&[3u8; 32]));
+    }
+
+    #[test]
+    fn test_mint_unauthorized() {
+        let mut col = test_collection();
+        let meta = NftMetadata {
+            name: "x".to_string(),
+            description: "x".to_string(),
+            image_cid: "x".to_string(),
+            attributes: vec![],
+            creator_did: "x".to_string(),
+            created_at: 0,
+        };
+        assert!(col.mint(&[99u8; 32], [3u8; 32], meta).is_err());
+    }
+
+    #[test]
+    fn test_max_supply() {
+        let mut col = NftContract::new(
+            [1u8; 32], "T".into(), "T".into(),
+            "d".into(), [2u8; 32], Some(1), 0,
+        );
+        let meta = || NftMetadata {
+            name: "x".into(), description: "x".into(), image_cid: "x".into(),
+            attributes: vec![], creator_did: "x".into(), created_at: 0,
+        };
+        col.mint(&[2u8; 32], [3u8; 32], meta()).unwrap();
+        assert!(col.mint(&[2u8; 32], [3u8; 32], meta()).is_err());
+    }
+
+    #[test]
+    fn test_transfer() {
+        let mut col = test_collection();
+        let meta = NftMetadata {
+            name: "x".into(), description: "x".into(), image_cid: "x".into(),
+            attributes: vec![], creator_did: "x".into(), created_at: 0,
+        };
+        col.mint(&[2u8; 32], [3u8; 32], meta).unwrap();
+        col.transfer(1, &[3u8; 32], [4u8; 32]).unwrap();
+        assert_eq!(col.owner_of(1), Some(&[4u8; 32]));
+    }
+
+    #[test]
+    fn test_transfer_not_owner() {
+        let mut col = test_collection();
+        let meta = NftMetadata {
+            name: "x".into(), description: "x".into(), image_cid: "x".into(),
+            attributes: vec![], creator_did: "x".into(), created_at: 0,
+        };
+        col.mint(&[2u8; 32], [3u8; 32], meta).unwrap();
+        assert!(col.transfer(1, &[99u8; 32], [4u8; 32]).is_err());
+    }
+
+    #[test]
+    fn test_burn() {
+        let mut col = test_collection();
+        let meta = NftMetadata {
+            name: "x".into(), description: "x".into(), image_cid: "x".into(),
+            attributes: vec![], creator_did: "x".into(), created_at: 0,
+        };
+        col.mint(&[2u8; 32], [3u8; 32], meta).unwrap();
+        col.burn(1, &[3u8; 32]).unwrap();
+        assert_eq!(col.owner_of(1), None);
+        assert_eq!(col.total_supply(), 0);
+        assert_eq!(col.total_minted, 1); // lifetime counter doesn't decrease
+    }
+
+    #[test]
+    fn test_tokens_of() {
+        let mut col = test_collection();
+        let meta = || NftMetadata {
+            name: "x".into(), description: "x".into(), image_cid: "x".into(),
+            attributes: vec![], creator_did: "x".into(), created_at: 0,
+        };
+        col.mint(&[2u8; 32], [3u8; 32], meta()).unwrap();
+        col.mint(&[2u8; 32], [4u8; 32], meta()).unwrap();
+        col.mint(&[2u8; 32], [3u8; 32], meta()).unwrap();
+        let owned = col.tokens_of(&[3u8; 32]);
+        assert_eq!(owned.len(), 2);
+        assert!(owned.contains(&1));
+        assert!(owned.contains(&3));
+    }
+}

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -1020,7 +1020,12 @@ impl BlockExecutor {
             | TransactionType::DaoUnstake
             // Domain registration/update - state applied by process_domain_transactions
             | TransactionType::DomainRegistration
-            | TransactionType::DomainUpdate => {
+            | TransactionType::DomainUpdate
+            // NFT operations
+            | TransactionType::NftCreateCollection
+            | TransactionType::NftMint
+            | TransactionType::NftTransfer
+            | TransactionType::NftBurn => {
                 // Fall through to the general validation flow below without
                 // treating oracle attestations as automatically valid.
             }
@@ -2699,6 +2704,18 @@ impl BlockExecutor {
 
             TransactionType::DaoUnstake => {
                 self.apply_dao_unstake(mutator, tx, block_height)?;
+                Ok(TxOutcome::LegacySystem)
+            }
+
+            // NFT types — create, mint, transfer, burn
+            TransactionType::NftCreateCollection
+            | TransactionType::NftMint
+            | TransactionType::NftTransfer
+            | TransactionType::NftBurn => {
+                // NFT operations are processed by the blockchain layer in
+                // process_nft_transactions (called after executor.apply_block).
+                // The executor accepts them as pass-through so blocks containing
+                // NFT transactions don't fail validation.
                 Ok(TxOutcome::LegacySystem)
             }
 

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -1282,6 +1282,34 @@ impl Transaction {
         }
     }
 
+    pub fn nft_create_collection_data(&self) -> Option<&NftCreateCollectionData> {
+        match &self.payload {
+            TransactionPayload::NftCreateCollection(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    pub fn nft_mint_data(&self) -> Option<&NftMintData> {
+        match &self.payload {
+            TransactionPayload::NftMint(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    pub fn nft_transfer_data(&self) -> Option<&NftTransferData> {
+        match &self.payload {
+            TransactionPayload::NftTransfer(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    pub fn nft_burn_data(&self) -> Option<&NftBurnData> {
+        match &self.payload {
+            TransactionPayload::NftBurn(d) => Some(d),
+            _ => None,
+        }
+    }
+
     /// Get the size of the transaction in bytes
     pub fn size(&self) -> usize {
         bincode::serialize(self).map(|data| data.len()).unwrap_or(0)
@@ -2225,6 +2253,46 @@ pub struct DaoUnstakeData {
 }
 
 // ============================================================================
+// NFT payload structs
+// ============================================================================
+
+/// Create a new NFT collection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftCreateCollectionData {
+    pub name: String,
+    pub symbol: String,
+    pub max_supply: Option<u64>,
+}
+
+/// Mint a new NFT in a collection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftMintData {
+    pub collection_id: [u8; 32],
+    pub recipient: [u8; 32],
+    pub name: String,
+    pub description: String,
+    pub image_cid: String,
+    pub attributes: Vec<(String, String)>,
+}
+
+/// Transfer an NFT to a new owner.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftTransferData {
+    pub collection_id: [u8; 32],
+    pub token_id: u64,
+    pub from: [u8; 32],
+    pub to: [u8; 32],
+}
+
+/// Burn (destroy) an NFT.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftBurnData {
+    pub collection_id: [u8; 32],
+    pub token_id: u64,
+    pub owner: [u8; 32],
+}
+
+// ============================================================================
 // TransactionPayload enum
 // ============================================================================
 
@@ -2267,4 +2335,12 @@ pub enum TransactionPayload {
     DaoStake(DaoStakeData),
     /// SOV unstake from a sector DAO wallet (appended after DaoStake)
     DaoUnstake(DaoUnstakeData),
+    /// Create a new NFT collection
+    NftCreateCollection(NftCreateCollectionData),
+    /// Mint a new NFT
+    NftMint(NftMintData),
+    /// Transfer an NFT
+    NftTransfer(NftTransferData),
+    /// Burn an NFT
+    NftBurn(NftBurnData),
 }

--- a/lib-blockchain/src/transaction/creation.rs
+++ b/lib-blockchain/src/transaction/creation.rs
@@ -803,6 +803,18 @@ pub mod utils {
                     return Err(TransactionCreateError::InvalidOutputs);
                 }
             }
+            TransactionType::NftCreateCollection
+            | TransactionType::NftMint
+            | TransactionType::NftTransfer
+            | TransactionType::NftBurn => {
+                // NFT transactions - no inputs/outputs required
+                if !inputs.is_empty() {
+                    return Err(TransactionCreateError::InvalidInputs);
+                }
+                if !outputs.is_empty() {
+                    return Err(TransactionCreateError::InvalidOutputs);
+                }
+            }
         }
 
         Ok(())

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -26,7 +26,7 @@ pub use domain::{
 pub use core::{
     BondingCurveBuyData, BondingCurveDeployData, BondingCurveGraduateData, BondingCurveSellData,
     CreateEmploymentContractData, DaoExecutionData, DaoProposalData, DaoStakeData, DaoUnstakeData,
-    DaoVoteData,
+    DaoVoteData, NftBurnData, NftCreateCollectionData, NftMintData, NftTransferData,
     GovernanceConfigOperation, GovernanceConfigUpdateData, IdentityTransactionData,
     InitCbeTokenData, InitEntityRegistryData, ProcessPayrollData, ProfitDeclarationData,
     RecordOnRampTradeData, RevenueSource, TokenMintData, TokenTransferData, Transaction,

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -407,12 +407,23 @@ impl TransactionValidator {
                     return Err(ValidationError::InvalidMemo);
                 }
             }
-            TransactionType::NftCreateCollection
-            | TransactionType::NftMint
-            | TransactionType::NftTransfer
-            | TransactionType::NftBurn => {
-                // NFT transactions - check payload is present
-                if transaction.memo.is_empty() && matches!(transaction.payload, crate::transaction::TransactionPayload::None) {
+            TransactionType::NftCreateCollection => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftCreateCollection(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftMint => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftMint(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftTransfer => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftTransfer(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftBurn => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftBurn(_)) {
                     return Err(ValidationError::MissingRequiredData);
                 }
             }
@@ -666,12 +677,23 @@ impl TransactionValidator {
                     return Err(ValidationError::InvalidMemo);
                 }
             }
-            TransactionType::NftCreateCollection
-            | TransactionType::NftMint
-            | TransactionType::NftTransfer
-            | TransactionType::NftBurn => {
-                // NFT transactions - check payload is present
-                if transaction.memo.is_empty() && matches!(transaction.payload, crate::transaction::TransactionPayload::None) {
+            TransactionType::NftCreateCollection => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftCreateCollection(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftMint => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftMint(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftTransfer => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftTransfer(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftBurn => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftBurn(_)) {
                     return Err(ValidationError::MissingRequiredData);
                 }
             }
@@ -1913,12 +1935,23 @@ impl<'a> StatefulTransactionValidator<'a> {
                     }
                 }
             }
-            TransactionType::NftCreateCollection
-            | TransactionType::NftMint
-            | TransactionType::NftTransfer
-            | TransactionType::NftBurn => {
-                // NFT transactions - full validation deferred to executor
-                if transaction.memo.is_empty() && matches!(transaction.payload, crate::transaction::TransactionPayload::None) {
+            TransactionType::NftCreateCollection => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftCreateCollection(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftMint => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftMint(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftTransfer => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftTransfer(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftBurn => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftBurn(_)) {
                     return Err(ValidationError::MissingRequiredData);
                 }
             }
@@ -3171,12 +3204,17 @@ pub mod utils {
                     && transaction.inputs.is_empty()
                     && transaction.outputs.is_empty()
             }
-            TransactionType::NftCreateCollection
-            | TransactionType::NftMint
-            | TransactionType::NftTransfer
-            | TransactionType::NftBurn => {
-                // NFT transactions - payload must be present
-                !transaction.memo.is_empty() || !matches!(transaction.payload, crate::transaction::TransactionPayload::None)
+            TransactionType::NftCreateCollection => {
+                matches!(transaction.payload, crate::transaction::TransactionPayload::NftCreateCollection(_))
+            }
+            TransactionType::NftMint => {
+                matches!(transaction.payload, crate::transaction::TransactionPayload::NftMint(_))
+            }
+            TransactionType::NftTransfer => {
+                matches!(transaction.payload, crate::transaction::TransactionPayload::NftTransfer(_))
+            }
+            TransactionType::NftBurn => {
+                matches!(transaction.payload, crate::transaction::TransactionPayload::NftBurn(_))
             }
         }
     }

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -407,6 +407,15 @@ impl TransactionValidator {
                     return Err(ValidationError::InvalidMemo);
                 }
             }
+            TransactionType::NftCreateCollection
+            | TransactionType::NftMint
+            | TransactionType::NftTransfer
+            | TransactionType::NftBurn => {
+                // NFT transactions - check payload is present
+                if transaction.memo.is_empty() && matches!(transaction.payload, crate::transaction::TransactionPayload::None) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
         }
 
         // Signature validation:
@@ -655,6 +664,15 @@ impl TransactionValidator {
                     .starts_with(crate::transaction::DOMAIN_UPDATE_PREFIX)
                 {
                     return Err(ValidationError::InvalidMemo);
+                }
+            }
+            TransactionType::NftCreateCollection
+            | TransactionType::NftMint
+            | TransactionType::NftTransfer
+            | TransactionType::NftBurn => {
+                // NFT transactions - check payload is present
+                if transaction.memo.is_empty() && matches!(transaction.payload, crate::transaction::TransactionPayload::None) {
+                    return Err(ValidationError::MissingRequiredData);
                 }
             }
         }
@@ -1893,6 +1911,15 @@ impl<'a> StatefulTransactionValidator<'a> {
                             return Err(ValidationError::InvalidTransaction);
                         }
                     }
+                }
+            }
+            TransactionType::NftCreateCollection
+            | TransactionType::NftMint
+            | TransactionType::NftTransfer
+            | TransactionType::NftBurn => {
+                // NFT transactions - full validation deferred to executor
+                if transaction.memo.is_empty() && matches!(transaction.payload, crate::transaction::TransactionPayload::None) {
+                    return Err(ValidationError::MissingRequiredData);
                 }
             }
         }
@@ -3143,6 +3170,13 @@ pub mod utils {
                     .starts_with(crate::transaction::DOMAIN_UPDATE_PREFIX)
                     && transaction.inputs.is_empty()
                     && transaction.outputs.is_empty()
+            }
+            TransactionType::NftCreateCollection
+            | TransactionType::NftMint
+            | TransactionType::NftTransfer
+            | TransactionType::NftBurn => {
+                // NFT transactions - payload must be present
+                !transaction.memo.is_empty() || !matches!(transaction.payload, crate::transaction::TransactionPayload::None)
             }
         }
     }

--- a/lib-blockchain/src/types/transaction_type.rs
+++ b/lib-blockchain/src/types/transaction_type.rs
@@ -162,6 +162,15 @@ pub enum TransactionType {
     /// Payload: `DOMUPD1:` prefix + bincode(DomainUpdatePayload) in memo field.
     /// Block processor updates record in `Blockchain::domain_registry`.
     DomainUpdate = 47,
+
+    /// Create a new NFT collection.
+    NftCreateCollection = 48,
+    /// Mint a new NFT in a collection.
+    NftMint = 49,
+    /// Transfer NFT ownership.
+    NftTransfer = 50,
+    /// Burn (destroy) an NFT.
+    NftBurn = 51,
 }
 
 impl TransactionType {
@@ -328,6 +337,10 @@ impl TransactionType {
             TransactionType::DomainUpdate => {
                 "Update Web4 domain manifest (new deployment)"
             }
+            TransactionType::NftCreateCollection => "Create a new NFT collection",
+            TransactionType::NftMint => "Mint a new NFT in a collection",
+            TransactionType::NftTransfer => "Transfer NFT ownership",
+            TransactionType::NftBurn => "Burn (destroy) an NFT",
         }
     }
 
@@ -382,6 +395,10 @@ impl TransactionType {
             TransactionType::DaoUnstake => "dao_unstake",
             TransactionType::DomainRegistration => "domain_registration",
             TransactionType::DomainUpdate => "domain_update",
+            TransactionType::NftCreateCollection => "nft_create_collection",
+            TransactionType::NftMint => "nft_mint",
+            TransactionType::NftTransfer => "nft_transfer",
+            TransactionType::NftBurn => "nft_burn",
         }
     }
 
@@ -436,6 +453,10 @@ impl TransactionType {
             "dao_unstake" => Some(TransactionType::DaoUnstake),
             "domain_registration" => Some(TransactionType::DomainRegistration),
             "domain_update" => Some(TransactionType::DomainUpdate),
+            "nft_create_collection" => Some(TransactionType::NftCreateCollection),
+            "nft_mint" => Some(TransactionType::NftMint),
+            "nft_transfer" => Some(TransactionType::NftTransfer),
+            "nft_burn" => Some(TransactionType::NftBurn),
             _ => None,
         }
     }

--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -46,6 +46,7 @@ pub mod crypto;
 pub mod dao_tx;
 pub mod error;
 pub mod handshake;
+pub mod nft_tx;
 pub mod identity;
 pub mod request;
 pub mod session;

--- a/lib-client/src/nft_tx.rs
+++ b/lib-client/src/nft_tx.rs
@@ -1,0 +1,173 @@
+//! NFT transaction builders for lib-client.
+
+use lib_blockchain::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+use lib_blockchain::transaction::{
+    NftBurnData, NftCreateCollectionData, NftMintData, NftTransferData, Transaction,
+    TransactionPayload, TX_VERSION_V8,
+};
+use lib_blockchain::types::transaction_type::TransactionType;
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn empty_sig(pk: PublicKey) -> Signature {
+    Signature {
+        signature: Vec::new(),
+        public_key: pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: now_secs(),
+    }
+}
+
+/// Build a signed NftCreateCollection transaction.
+pub fn build_nft_create_collection_tx(
+    identity: &crate::Identity,
+    name: String,
+    symbol: String,
+    max_supply: Option<u64>,
+    chain_id: u8,
+) -> Result<String, String> {
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
+
+    let data = NftCreateCollectionData {
+        name,
+        symbol,
+        max_supply,
+    };
+
+    let mut tx = Transaction {
+        version: TX_VERSION_V8,
+        chain_id,
+        transaction_type: TransactionType::NftCreateCollection,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: empty_sig(signer_pk.clone()),
+        memo: b"nft:create_collection".to_vec(),
+        payload: TransactionPayload::NftCreateCollection(data),
+    };
+
+    let tx_hash = tx.signing_hash();
+    let sig_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
+        .map_err(|e| format!("Failed to sign: {}", e))?;
+
+    tx.signature = Signature {
+        signature: sig_bytes,
+        public_key: signer_pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: now_secs(),
+    };
+
+    bincode::serialize(&tx)
+        .map(hex::encode)
+        .map_err(|e| format!("Failed to serialize: {}", e))
+}
+
+/// Build a signed NftMint transaction.
+pub fn build_nft_mint_tx(
+    identity: &crate::Identity,
+    collection_id: [u8; 32],
+    recipient: [u8; 32],
+    name: String,
+    description: String,
+    image_cid: String,
+    attributes: Vec<(String, String)>,
+    chain_id: u8,
+) -> Result<String, String> {
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
+
+    let data = NftMintData {
+        collection_id,
+        recipient,
+        name,
+        description,
+        image_cid,
+        attributes,
+    };
+
+    let mut tx = Transaction {
+        version: TX_VERSION_V8,
+        chain_id,
+        transaction_type: TransactionType::NftMint,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: empty_sig(signer_pk.clone()),
+        memo: b"nft:mint".to_vec(),
+        payload: TransactionPayload::NftMint(data),
+    };
+
+    let tx_hash = tx.signing_hash();
+    let sig_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
+        .map_err(|e| format!("Failed to sign: {}", e))?;
+
+    tx.signature = Signature {
+        signature: sig_bytes,
+        public_key: signer_pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: now_secs(),
+    };
+
+    bincode::serialize(&tx)
+        .map(hex::encode)
+        .map_err(|e| format!("Failed to serialize: {}", e))
+}
+
+/// Build a signed NftTransfer transaction.
+pub fn build_nft_transfer_tx(
+    identity: &crate::Identity,
+    collection_id: [u8; 32],
+    token_id: u64,
+    from: [u8; 32],
+    to: [u8; 32],
+    chain_id: u8,
+) -> Result<String, String> {
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
+
+    let data = NftTransferData {
+        collection_id,
+        token_id,
+        from,
+        to,
+    };
+
+    let mut tx = Transaction {
+        version: TX_VERSION_V8,
+        chain_id,
+        transaction_type: TransactionType::NftTransfer,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: empty_sig(signer_pk.clone()),
+        memo: b"nft:transfer".to_vec(),
+        payload: TransactionPayload::NftTransfer(data),
+    };
+
+    let tx_hash = tx.signing_hash();
+    let sig_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
+        .map_err(|e| format!("Failed to sign: {}", e))?;
+
+    tx.signature = Signature {
+        signature: sig_bytes,
+        public_key: signer_pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: now_secs(),
+    };
+
+    bincode::serialize(&tx)
+        .map(hex::encode)
+        .map_err(|e| format!("Failed to serialize: {}", e))
+}

--- a/lib-client/src/nft_tx.rs
+++ b/lib-client/src/nft_tx.rs
@@ -171,3 +171,50 @@ pub fn build_nft_transfer_tx(
         .map(hex::encode)
         .map_err(|e| format!("Failed to serialize: {}", e))
 }
+
+/// Build a signed NftBurn transaction.
+pub fn build_nft_burn_tx(
+    identity: &crate::Identity,
+    collection_id: [u8; 32],
+    token_id: u64,
+    owner: [u8; 32],
+    chain_id: u8,
+) -> Result<String, String> {
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
+
+    let data = NftBurnData {
+        collection_id,
+        token_id,
+        owner,
+    };
+
+    let mut tx = Transaction {
+        version: TX_VERSION_V8,
+        chain_id,
+        transaction_type: TransactionType::NftBurn,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: empty_sig(signer_pk.clone()),
+        memo: b"nft:burn".to_vec(),
+        payload: TransactionPayload::NftBurn(data),
+    };
+
+    let tx_hash = tx.signing_hash();
+    let sig_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
+        .map_err(|e| format!("Failed to sign: {}", e))?;
+
+    tx.signature = Signature {
+        signature: sig_bytes,
+        public_key: signer_pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: now_secs(),
+    };
+
+    bincode::serialize(&tx)
+        .map(hex::encode)
+        .map_err(|e| format!("Failed to serialize: {}", e))
+}

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -185,6 +185,33 @@ pub enum NftAction {
         #[arg(long)]
         keystore: Option<String>,
     },
+    /// Transfer an NFT to another wallet
+    Transfer {
+        /// Collection ID (64-char hex)
+        #[arg(long)]
+        collection: String,
+        /// Token ID (integer)
+        #[arg(long)]
+        token_id: u64,
+        /// Recipient wallet ID (64-char hex)
+        #[arg(long)]
+        to: String,
+        /// Path to keystore directory
+        #[arg(long)]
+        keystore: Option<String>,
+    },
+    /// Burn (destroy) an NFT
+    Burn {
+        /// Collection ID (64-char hex)
+        #[arg(long)]
+        collection: String,
+        /// Token ID (integer)
+        #[arg(long)]
+        token_id: u64,
+        /// Path to keystore directory
+        #[arg(long)]
+        keystore: Option<String>,
+    },
     /// List collections
     List,
     /// List NFTs owned by a wallet

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -135,6 +135,63 @@ pub enum ZhtpCommand {
 
     /// CBE token operations (init pools, employment, payroll)
     Cbe(CbeArgs),
+
+    /// NFT operations (create collection, mint, transfer)
+    Nft(NftArgs),
+}
+
+/// NFT operation commands
+#[derive(Args, Debug, Clone)]
+pub struct NftArgs {
+    #[command(subcommand)]
+    pub action: NftAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum NftAction {
+    /// Create a new NFT collection
+    CreateCollection {
+        /// Collection name
+        #[arg(long)]
+        name: String,
+        /// Short symbol (e.g. ART)
+        #[arg(long)]
+        symbol: String,
+        /// Max tokens in collection (omit for unlimited)
+        #[arg(long)]
+        max_supply: Option<u64>,
+        /// Path to keystore directory
+        #[arg(long)]
+        keystore: Option<String>,
+    },
+    /// Mint a new NFT in a collection
+    Mint {
+        /// Collection ID (64-char hex)
+        #[arg(long)]
+        collection: String,
+        /// Recipient wallet ID (64-char hex)
+        #[arg(long)]
+        to: String,
+        /// Token name
+        #[arg(long)]
+        name: String,
+        /// Description
+        #[arg(long, default_value = "")]
+        description: String,
+        /// Web4 content CID for the image
+        #[arg(long, default_value = "")]
+        image_cid: String,
+        /// Path to keystore directory
+        #[arg(long)]
+        keystore: Option<String>,
+    },
+    /// List collections
+    List,
+    /// List NFTs owned by a wallet
+    Owned {
+        /// Wallet ID (64-char hex)
+        wallet_id: String,
+    },
 }
 
 /// Node management commands
@@ -1789,6 +1846,9 @@ pub async fn run_cli() -> Result<()> {
             .await
             .map_err(anyhow::Error::msg),
         ZhtpCommand::Cbe(args) => commands::cbe::handle_cbe_command(args.clone(), &cli)
+            .await
+            .map_err(anyhow::Error::msg),
+        ZhtpCommand::Nft(args) => commands::nft::handle_nft_command(args.clone(), &cli)
             .await
             .map_err(anyhow::Error::msg),
     }

--- a/zhtp-cli/src/commands/mod.rs
+++ b/zhtp-cli/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod interactive;
 pub mod isolation;
 pub mod man;
 pub mod monitor;
+pub mod nft;
 pub mod network;
 pub mod node;
 pub mod oracle;

--- a/zhtp-cli/src/commands/nft.rs
+++ b/zhtp-cli/src/commands/nft.rs
@@ -1,0 +1,172 @@
+//! NFT CLI commands.
+
+use crate::argument_parsing::{format_output, NftAction, NftArgs, ZhtpCli};
+use crate::commands::web4_utils::{connect_default, load_identity_from_keystore};
+use crate::error::{CliError, CliResult};
+use lib_network::client::ZhtpClient;
+use std::path::PathBuf;
+
+fn default_keystore_path() -> CliResult<PathBuf> {
+    dirs::home_dir()
+        .map(|h| h.join(".zhtp").join("keystore"))
+        .ok_or_else(|| CliError::ConfigError("Cannot determine home directory".to_string()))
+}
+
+fn load_identity(keystore: &Option<String>) -> CliResult<zhtp_client::Identity> {
+    let keystore_path = match keystore {
+        Some(p) => PathBuf::from(p),
+        None => default_keystore_path()?,
+    };
+    let loaded = load_identity_from_keystore(&keystore_path)?;
+    Ok(zhtp_client::Identity {
+        did: loaded.identity.did.clone(),
+        public_key: loaded.identity.public_key.dilithium_pk.to_vec(),
+        private_key: loaded.keypair.private_key.dilithium_sk.to_vec(),
+        kyber_public_key: loaded.identity.public_key.kyber_pk.to_vec(),
+        kyber_secret_key: loaded.keypair.private_key.kyber_sk.to_vec(),
+        node_id: loaded.identity.node_id.as_bytes().to_vec(),
+        device_id: loaded.identity.primary_device.clone(),
+        recovery_entropy: loaded.keypair.private_key.master_seed.to_vec(),
+        created_at: loaded.identity.created_at,
+    })
+}
+
+fn parse_hex32(value: &str, field: &str) -> CliResult<[u8; 32]> {
+    let s = value.strip_prefix("0x").unwrap_or(value);
+    let bytes = hex::decode(s)
+        .map_err(|_| CliError::ConfigError(format!("{} is not valid hex", field)))?;
+    bytes
+        .try_into()
+        .map_err(|_| CliError::ConfigError(format!("{} must be exactly 32 bytes", field)))
+}
+
+pub async fn handle_nft_command(args: NftArgs, cli: &ZhtpCli) -> CliResult<()> {
+    let client = connect_default(&cli.server).await?;
+
+    match args.action {
+        NftAction::CreateCollection {
+            name,
+            symbol,
+            max_supply,
+            keystore,
+        } => {
+            let identity = load_identity(&keystore)?;
+            eprintln!("Creating NFT collection: {} ({})", name, symbol);
+
+            let tx_hex = zhtp_client::nft_tx::build_nft_create_collection_tx(
+                &identity,
+                name,
+                symbol,
+                max_supply,
+                3,
+            )
+            .map_err(|e| CliError::ConfigError(e))?;
+
+            let body = serde_json::json!({ "signed_tx": tx_hex });
+            let response = client
+                .post_json("/api/v1/nft/collection/create", &body)
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/collection/create".to_string(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/collection/create".to_string(),
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+
+        NftAction::Mint {
+            collection,
+            to,
+            name,
+            description,
+            image_cid,
+            keystore,
+        } => {
+            let identity = load_identity(&keystore)?;
+            let collection_id = parse_hex32(&collection, "--collection")?;
+            let recipient = parse_hex32(&to, "--to")?;
+
+            eprintln!("Minting NFT: {} in collection {}", name, &collection[..16]);
+
+            let tx_hex = zhtp_client::nft_tx::build_nft_mint_tx(
+                &identity,
+                collection_id,
+                recipient,
+                name,
+                description,
+                image_cid,
+                vec![],
+                3,
+            )
+            .map_err(|e| CliError::ConfigError(e))?;
+
+            let body = serde_json::json!({ "signed_tx": tx_hex });
+            let response = client
+                .post_json("/api/v1/nft/mint", &body)
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/mint".to_string(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/mint".to_string(),
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+
+        NftAction::List => {
+            let response = client
+                .get("/api/v1/nft/collections")
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/collections".to_string(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/collections".to_string(),
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+
+        NftAction::Owned { wallet_id } => {
+            let endpoint = format!("/api/v1/nft/owned/{}", wallet_id);
+            let response = client
+                .get(&endpoint)
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: endpoint.clone(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint,
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+    }
+}

--- a/zhtp-cli/src/commands/nft.rs
+++ b/zhtp-cli/src/commands/nft.rs
@@ -128,6 +128,108 @@ pub async fn handle_nft_command(args: NftArgs, cli: &ZhtpCli) -> CliResult<()> {
             Ok(())
         }
 
+        NftAction::Transfer {
+            collection,
+            token_id,
+            to,
+            keystore,
+        } => {
+            let identity = load_identity(&keystore)?;
+            let collection_id = parse_hex32(&collection, "--collection")?;
+            let recipient = parse_hex32(&to, "--to")?;
+            // The 'from' is the signer's own key_id
+            let signer_pk = zhtp_client::token_tx::create_public_key_with_kyber(
+                identity.public_key.clone(),
+                identity.kyber_public_key.clone(),
+            );
+            let from = signer_pk.key_id;
+
+            eprintln!(
+                "Transferring NFT token {} from collection {} to {}",
+                token_id,
+                &collection[..16],
+                &to[..16.min(to.len())],
+            );
+
+            let tx_hex = zhtp_client::nft_tx::build_nft_transfer_tx(
+                &identity,
+                collection_id,
+                token_id,
+                from,
+                recipient,
+                3,
+            )
+            .map_err(|e| CliError::ConfigError(e))?;
+
+            let body = serde_json::json!({ "signed_tx": tx_hex });
+            let response = client
+                .post_json("/api/v1/nft/transfer", &body)
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/transfer".to_string(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/transfer".to_string(),
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+
+        NftAction::Burn {
+            collection,
+            token_id,
+            keystore,
+        } => {
+            let identity = load_identity(&keystore)?;
+            let collection_id = parse_hex32(&collection, "--collection")?;
+            // The 'owner' is the signer's own key_id
+            let signer_pk = zhtp_client::token_tx::create_public_key_with_kyber(
+                identity.public_key.clone(),
+                identity.kyber_public_key.clone(),
+            );
+            let owner = signer_pk.key_id;
+
+            eprintln!(
+                "Burning NFT token {} from collection {}",
+                token_id,
+                &collection[..16],
+            );
+
+            let tx_hex = zhtp_client::nft_tx::build_nft_burn_tx(
+                &identity,
+                collection_id,
+                token_id,
+                owner,
+                3,
+            )
+            .map_err(|e| CliError::ConfigError(e))?;
+
+            let body = serde_json::json!({ "signed_tx": tx_hex });
+            let response = client
+                .post_json("/api/v1/nft/burn", &body)
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/burn".to_string(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/burn".to_string(),
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+
         NftAction::List => {
             let response = client
                 .get("/api/v1/nft/collections")

--- a/zhtp/src/api/handlers/mod.rs
+++ b/zhtp/src/api/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod guardian;
 pub mod identity;
 pub mod marketplace;
 pub mod mesh;
+pub mod nft;
 pub mod mobile_auth;
 pub mod monitor;
 pub mod network;

--- a/zhtp/src/api/handlers/nft/mod.rs
+++ b/zhtp/src/api/handlers/nft/mod.rs
@@ -1,0 +1,312 @@
+//! NFT API handler — create collections, mint, transfer, burn, query.
+
+use anyhow::Result;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use lib_blockchain::Blockchain;
+use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
+use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
+
+fn json_ok(data: serde_json::Value) -> Result<ZhtpResponse> {
+    let bytes = serde_json::to_vec(&data)?;
+    Ok(ZhtpResponse::success_with_content_type(
+        bytes,
+        "application/json".to_string(),
+        None,
+    ))
+}
+
+fn err(status: ZhtpStatus, msg: String) -> ZhtpResponse {
+    ZhtpResponse::error(status, msg)
+}
+
+pub struct NftHandler {
+    blockchain: Arc<RwLock<Blockchain>>,
+}
+
+impl NftHandler {
+    pub fn new(blockchain: Arc<RwLock<Blockchain>>) -> Self {
+        Self { blockchain }
+    }
+
+    /// GET /api/v1/nft/collections
+    async fn handle_list_collections(&self) -> Result<ZhtpResponse> {
+        let bc = self.blockchain.read().await;
+        let collections: Vec<serde_json::Value> = bc
+            .nft_collections
+            .values()
+            .map(|c| {
+                json!({
+                    "collection_id": hex::encode(c.collection_id),
+                    "name": c.name,
+                    "symbol": c.symbol,
+                    "creator_did": c.creator_did,
+                    "total_supply": c.total_supply(),
+                    "total_minted": c.total_minted,
+                    "max_supply": c.max_supply,
+                    "created_at": c.created_at,
+                })
+            })
+            .collect();
+        json_ok(json!({ "collections": collections, "count": collections.len() }))
+    }
+
+    /// GET /api/v1/nft/collection/{id}
+    async fn handle_get_collection(&self, collection_id_hex: &str) -> Result<ZhtpResponse> {
+        let id = hex::decode(collection_id_hex)
+            .map_err(|_| anyhow::anyhow!("invalid collection_id hex"))?;
+        if id.len() != 32 {
+            return Ok(err(ZhtpStatus::BadRequest, "collection_id must be 32 bytes".into()));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&id);
+
+        let bc = self.blockchain.read().await;
+        match bc.nft_collections.get(&arr) {
+            Some(c) => {
+                let tokens: Vec<serde_json::Value> = c
+                    .all_tokens()
+                    .map(|(id, owner, meta)| {
+                        json!({
+                            "token_id": id,
+                            "owner": hex::encode(owner),
+                            "name": meta.map(|m| m.name.as_str()).unwrap_or(""),
+                            "image_cid": meta.map(|m| m.image_cid.as_str()).unwrap_or(""),
+                        })
+                    })
+                    .collect();
+                json_ok(json!({
+                    "collection_id": collection_id_hex,
+                    "name": c.name,
+                    "symbol": c.symbol,
+                    "creator_did": c.creator_did,
+                    "total_supply": c.total_supply(),
+                    "total_minted": c.total_minted,
+                    "max_supply": c.max_supply,
+                    "created_at": c.created_at,
+                    "tokens": tokens,
+                }))
+            }
+            None => Ok(err(ZhtpStatus::NotFound, "Collection not found".into())),
+        }
+    }
+
+    /// GET /api/v1/nft/{collection}/{token_id}
+    async fn handle_get_token(
+        &self,
+        collection_id_hex: &str,
+        token_id_str: &str,
+    ) -> Result<ZhtpResponse> {
+        let id = hex::decode(collection_id_hex)
+            .map_err(|_| anyhow::anyhow!("invalid collection_id hex"))?;
+        if id.len() != 32 {
+            return Ok(err(ZhtpStatus::BadRequest, "collection_id must be 32 bytes".into()));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&id);
+
+        let token_id: u64 = token_id_str
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid token_id"))?;
+
+        let bc = self.blockchain.read().await;
+        match bc.nft_collections.get(&arr) {
+            Some(c) => {
+                let owner = c.owner_of(token_id);
+                let meta = c.metadata_of(token_id);
+                if owner.is_none() {
+                    return Ok(err(ZhtpStatus::NotFound, "Token not found".into()));
+                }
+                json_ok(json!({
+                    "collection_id": collection_id_hex,
+                    "collection_name": c.name,
+                    "token_id": token_id,
+                    "owner": hex::encode(owner.unwrap()),
+                    "metadata": meta.map(|m| json!({
+                        "name": m.name,
+                        "description": m.description,
+                        "image_cid": m.image_cid,
+                        "attributes": m.attributes,
+                        "creator_did": m.creator_did,
+                        "created_at": m.created_at,
+                    })),
+                }))
+            }
+            None => Ok(err(ZhtpStatus::NotFound, "Collection not found".into())),
+        }
+    }
+
+    /// GET /api/v1/nft/owned/{wallet_id}
+    async fn handle_get_owned(&self, wallet_id_hex: &str) -> Result<ZhtpResponse> {
+        let id = hex::decode(wallet_id_hex)
+            .map_err(|_| anyhow::anyhow!("invalid wallet_id hex"))?;
+        if id.len() != 32 {
+            return Ok(err(ZhtpStatus::BadRequest, "wallet_id must be 32 bytes".into()));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&id);
+
+        let bc = self.blockchain.read().await;
+        let mut owned: Vec<serde_json::Value> = Vec::new();
+        for (col_id, collection) in &bc.nft_collections {
+            for token_id in collection.tokens_of(&arr) {
+                let meta = collection.metadata_of(token_id);
+                owned.push(json!({
+                    "collection_id": hex::encode(col_id),
+                    "collection_name": collection.name,
+                    "token_id": token_id,
+                    "name": meta.map(|m| m.name.as_str()).unwrap_or(""),
+                    "image_cid": meta.map(|m| m.image_cid.as_str()).unwrap_or(""),
+                }));
+            }
+        }
+        json_ok(json!({ "wallet_id": wallet_id_hex, "owned": owned, "count": owned.len() }))
+    }
+
+    /// POST /api/v1/nft/collection/create
+    async fn handle_create_collection(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        #[derive(serde::Deserialize)]
+        struct Req {
+            signed_tx: String,
+        }
+        let body: Req = serde_json::from_slice(&request.body)
+            .map_err(|e| anyhow::anyhow!("invalid request: {}", e))?;
+
+        let tx_bytes = hex::decode(&body.signed_tx)
+            .map_err(|_| anyhow::anyhow!("invalid hex"))?;
+        let tx: lib_blockchain::transaction::Transaction = bincode::deserialize(&tx_bytes)
+            .map_err(|e| anyhow::anyhow!("invalid transaction: {}", e))?;
+
+        if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftCreateCollection {
+            return Ok(err(ZhtpStatus::BadRequest, "Expected NftCreateCollection tx".into()));
+        }
+
+        let tx_hash = hex::encode(tx.hash().as_bytes());
+        let mut bc = self.blockchain.write().await;
+        bc.add_system_transaction(tx)
+            .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
+
+        info!("NFT collection creation submitted: {}", tx_hash);
+        json_ok(json!({ "success": true, "tx_hash": tx_hash }))
+    }
+
+    /// POST /api/v1/nft/mint
+    async fn handle_mint(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        #[derive(serde::Deserialize)]
+        struct Req {
+            signed_tx: String,
+        }
+        let body: Req = serde_json::from_slice(&request.body)
+            .map_err(|e| anyhow::anyhow!("invalid request: {}", e))?;
+
+        let tx_bytes = hex::decode(&body.signed_tx)
+            .map_err(|_| anyhow::anyhow!("invalid hex"))?;
+        let tx: lib_blockchain::transaction::Transaction = bincode::deserialize(&tx_bytes)
+            .map_err(|e| anyhow::anyhow!("invalid transaction: {}", e))?;
+
+        if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftMint {
+            return Ok(err(ZhtpStatus::BadRequest, "Expected NftMint tx".into()));
+        }
+
+        let tx_hash = hex::encode(tx.hash().as_bytes());
+        let mut bc = self.blockchain.write().await;
+        bc.add_system_transaction(tx)
+            .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
+
+        info!("NFT mint submitted: {}", tx_hash);
+        json_ok(json!({ "success": true, "tx_hash": tx_hash }))
+    }
+
+    /// POST /api/v1/nft/transfer
+    async fn handle_transfer(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        #[derive(serde::Deserialize)]
+        struct Req {
+            signed_tx: String,
+        }
+        let body: Req = serde_json::from_slice(&request.body)
+            .map_err(|e| anyhow::anyhow!("invalid request: {}", e))?;
+
+        let tx_bytes = hex::decode(&body.signed_tx)
+            .map_err(|_| anyhow::anyhow!("invalid hex"))?;
+        let tx: lib_blockchain::transaction::Transaction = bincode::deserialize(&tx_bytes)
+            .map_err(|e| anyhow::anyhow!("invalid transaction: {}", e))?;
+
+        if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftTransfer {
+            return Ok(err(ZhtpStatus::BadRequest, "Expected NftTransfer tx".into()));
+        }
+
+        let tx_hash = hex::encode(tx.hash().as_bytes());
+        let mut bc = self.blockchain.write().await;
+        bc.add_system_transaction(tx)
+            .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
+
+        info!("NFT transfer submitted: {}", tx_hash);
+        json_ok(json!({ "success": true, "tx_hash": tx_hash }))
+    }
+}
+
+#[async_trait::async_trait]
+impl ZhtpRequestHandler for NftHandler {
+    async fn handle_request(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        info!("NFT handler: {} {}", request.method, request.uri);
+
+        let result = match (request.method.clone(), request.uri.as_str()) {
+            (ZhtpMethod::Get, "/api/v1/nft/collections") => {
+                self.handle_list_collections().await
+            }
+            (ZhtpMethod::Get, path) if path.starts_with("/api/v1/nft/owned/") => {
+                let wallet_id = path.strip_prefix("/api/v1/nft/owned/").unwrap_or("");
+                self.handle_get_owned(wallet_id).await
+            }
+            (ZhtpMethod::Get, path) if path.starts_with("/api/v1/nft/collection/") => {
+                let id = path.strip_prefix("/api/v1/nft/collection/").unwrap_or("");
+                self.handle_get_collection(id).await
+            }
+            (ZhtpMethod::Get, path) if path.starts_with("/api/v1/nft/") => {
+                // /api/v1/nft/{collection_id}/{token_id}
+                let parts: Vec<&str> = path
+                    .strip_prefix("/api/v1/nft/")
+                    .unwrap_or("")
+                    .split('/')
+                    .collect();
+                if parts.len() == 2 {
+                    self.handle_get_token(parts[0], parts[1]).await
+                } else {
+                    Ok(err(ZhtpStatus::BadRequest, "Expected /api/v1/nft/{collection}/{token_id}".into()))
+                }
+            }
+            (ZhtpMethod::Post, "/api/v1/nft/collection/create") => {
+                self.handle_create_collection(request).await
+            }
+            (ZhtpMethod::Post, "/api/v1/nft/mint") => {
+                self.handle_mint(request).await
+            }
+            (ZhtpMethod::Post, "/api/v1/nft/transfer") => {
+                self.handle_transfer(request).await
+            }
+            _ => Ok(err(
+                ZhtpStatus::NotFound,
+                format!("NFT endpoint not found: {} {}", request.method, request.uri),
+            )),
+        };
+
+        match result {
+            Ok(resp) => Ok(resp),
+            Err(e) => {
+                tracing::error!("NFT handler error: {}", e);
+                Ok(err(ZhtpStatus::InternalServerError, format!("NFT error: {}", e)))
+            }
+        }
+    }
+
+    fn can_handle(&self, request: &ZhtpRequest) -> bool {
+        request.uri.starts_with("/api/v1/nft")
+    }
+
+    fn priority(&self) -> u32 {
+        100
+    }
+}

--- a/zhtp/src/api/handlers/nft/mod.rs
+++ b/zhtp/src/api/handlers/nft/mod.rs
@@ -56,8 +56,10 @@ impl NftHandler {
 
     /// GET /api/v1/nft/collection/{id}
     async fn handle_get_collection(&self, collection_id_hex: &str) -> Result<ZhtpResponse> {
-        let id = hex::decode(collection_id_hex)
-            .map_err(|_| anyhow::anyhow!("invalid collection_id hex"))?;
+        let id = match hex::decode(collection_id_hex) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid collection_id hex".into())),
+        };
         if id.len() != 32 {
             return Ok(err(ZhtpStatus::BadRequest, "collection_id must be 32 bytes".into()));
         }
@@ -100,17 +102,20 @@ impl NftHandler {
         collection_id_hex: &str,
         token_id_str: &str,
     ) -> Result<ZhtpResponse> {
-        let id = hex::decode(collection_id_hex)
-            .map_err(|_| anyhow::anyhow!("invalid collection_id hex"))?;
+        let id = match hex::decode(collection_id_hex) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid collection_id hex".into())),
+        };
         if id.len() != 32 {
             return Ok(err(ZhtpStatus::BadRequest, "collection_id must be 32 bytes".into()));
         }
         let mut arr = [0u8; 32];
         arr.copy_from_slice(&id);
 
-        let token_id: u64 = token_id_str
-            .parse()
-            .map_err(|_| anyhow::anyhow!("invalid token_id"))?;
+        let token_id: u64 = match token_id_str.parse() {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid token_id".into())),
+        };
 
         let bc = self.blockchain.read().await;
         match bc.nft_collections.get(&arr) {
@@ -141,8 +146,10 @@ impl NftHandler {
 
     /// GET /api/v1/nft/owned/{wallet_id}
     async fn handle_get_owned(&self, wallet_id_hex: &str) -> Result<ZhtpResponse> {
-        let id = hex::decode(wallet_id_hex)
-            .map_err(|_| anyhow::anyhow!("invalid wallet_id hex"))?;
+        let id = match hex::decode(wallet_id_hex) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid wallet_id hex".into())),
+        };
         if id.len() != 32 {
             return Ok(err(ZhtpStatus::BadRequest, "wallet_id must be 32 bytes".into()));
         }
@@ -172,13 +179,19 @@ impl NftHandler {
         struct Req {
             signed_tx: String,
         }
-        let body: Req = serde_json::from_slice(&request.body)
-            .map_err(|e| anyhow::anyhow!("invalid request: {}", e))?;
+        let body: Req = match serde_json::from_slice(&request.body) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid request: {}", e))),
+        };
 
-        let tx_bytes = hex::decode(&body.signed_tx)
-            .map_err(|_| anyhow::anyhow!("invalid hex"))?;
-        let tx: lib_blockchain::transaction::Transaction = bincode::deserialize(&tx_bytes)
-            .map_err(|e| anyhow::anyhow!("invalid transaction: {}", e))?;
+        let tx_bytes = match hex::decode(&body.signed_tx) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid hex".into())),
+        };
+        let tx: lib_blockchain::transaction::Transaction = match bincode::deserialize(&tx_bytes) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid transaction: {}", e))),
+        };
 
         if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftCreateCollection {
             return Ok(err(ZhtpStatus::BadRequest, "Expected NftCreateCollection tx".into()));
@@ -186,7 +199,7 @@ impl NftHandler {
 
         let tx_hash = hex::encode(tx.hash().as_bytes());
         let mut bc = self.blockchain.write().await;
-        bc.add_system_transaction(tx)
+        bc.add_pending_transaction(tx)
             .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
 
         info!("NFT collection creation submitted: {}", tx_hash);
@@ -199,13 +212,19 @@ impl NftHandler {
         struct Req {
             signed_tx: String,
         }
-        let body: Req = serde_json::from_slice(&request.body)
-            .map_err(|e| anyhow::anyhow!("invalid request: {}", e))?;
+        let body: Req = match serde_json::from_slice(&request.body) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid request: {}", e))),
+        };
 
-        let tx_bytes = hex::decode(&body.signed_tx)
-            .map_err(|_| anyhow::anyhow!("invalid hex"))?;
-        let tx: lib_blockchain::transaction::Transaction = bincode::deserialize(&tx_bytes)
-            .map_err(|e| anyhow::anyhow!("invalid transaction: {}", e))?;
+        let tx_bytes = match hex::decode(&body.signed_tx) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid hex".into())),
+        };
+        let tx: lib_blockchain::transaction::Transaction = match bincode::deserialize(&tx_bytes) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid transaction: {}", e))),
+        };
 
         if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftMint {
             return Ok(err(ZhtpStatus::BadRequest, "Expected NftMint tx".into()));
@@ -213,7 +232,7 @@ impl NftHandler {
 
         let tx_hash = hex::encode(tx.hash().as_bytes());
         let mut bc = self.blockchain.write().await;
-        bc.add_system_transaction(tx)
+        bc.add_pending_transaction(tx)
             .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
 
         info!("NFT mint submitted: {}", tx_hash);
@@ -226,13 +245,19 @@ impl NftHandler {
         struct Req {
             signed_tx: String,
         }
-        let body: Req = serde_json::from_slice(&request.body)
-            .map_err(|e| anyhow::anyhow!("invalid request: {}", e))?;
+        let body: Req = match serde_json::from_slice(&request.body) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid request: {}", e))),
+        };
 
-        let tx_bytes = hex::decode(&body.signed_tx)
-            .map_err(|_| anyhow::anyhow!("invalid hex"))?;
-        let tx: lib_blockchain::transaction::Transaction = bincode::deserialize(&tx_bytes)
-            .map_err(|e| anyhow::anyhow!("invalid transaction: {}", e))?;
+        let tx_bytes = match hex::decode(&body.signed_tx) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid hex".into())),
+        };
+        let tx: lib_blockchain::transaction::Transaction = match bincode::deserialize(&tx_bytes) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid transaction: {}", e))),
+        };
 
         if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftTransfer {
             return Ok(err(ZhtpStatus::BadRequest, "Expected NftTransfer tx".into()));
@@ -240,10 +265,43 @@ impl NftHandler {
 
         let tx_hash = hex::encode(tx.hash().as_bytes());
         let mut bc = self.blockchain.write().await;
-        bc.add_system_transaction(tx)
+        bc.add_pending_transaction(tx)
             .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
 
         info!("NFT transfer submitted: {}", tx_hash);
+        json_ok(json!({ "success": true, "tx_hash": tx_hash }))
+    }
+
+    /// POST /api/v1/nft/burn
+    async fn handle_burn(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        #[derive(serde::Deserialize)]
+        struct Req {
+            signed_tx: String,
+        }
+        let body: Req = match serde_json::from_slice(&request.body) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid request: {}", e))),
+        };
+
+        let tx_bytes = match hex::decode(&body.signed_tx) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid hex".into())),
+        };
+        let tx: lib_blockchain::transaction::Transaction = match bincode::deserialize(&tx_bytes) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid transaction: {}", e))),
+        };
+
+        if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftBurn {
+            return Ok(err(ZhtpStatus::BadRequest, "Expected NftBurn tx".into()));
+        }
+
+        let tx_hash = hex::encode(tx.hash().as_bytes());
+        let mut bc = self.blockchain.write().await;
+        bc.add_pending_transaction(tx)
+            .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
+
+        info!("NFT burn submitted: {}", tx_hash);
         json_ok(json!({ "success": true, "tx_hash": tx_hash }))
     }
 }
@@ -286,6 +344,9 @@ impl ZhtpRequestHandler for NftHandler {
             }
             (ZhtpMethod::Post, "/api/v1/nft/transfer") => {
                 self.handle_transfer(request).await
+            }
+            (ZhtpMethod::Post, "/api/v1/nft/burn") => {
+                self.handle_burn(request).await
             }
             _ => Ok(err(
                 ZhtpStatus::NotFound,


### PR DESCRIPTION
## Summary

Complete NFT system for The Sovereign Network. Closes #2169, #2170, #2171, #2172, #2173.

### Core data model (#2169)
- `NftContract`: per-collection, auto-incrementing token IDs, ownership tracking, optional max_supply
- `NftMetadata`: name, description, image_cid (Web4), attributes
- 7 unit tests

### Transaction types + executor (#2170)
- `NftCreateCollection` (48), `NftMint` (49), `NftTransfer` (50), `NftBurn` (51)
- Payload structs + accessor methods on Transaction
- Executor accepts NFT types, block processor applies them via `process_nft_transactions()`

### Storage (#2171)
- `nft_collections: HashMap<[u8; 32], NftContract>` on Blockchain struct
- Populated from committed blocks, survives restarts via blockchain.dat serialization

### API endpoints (#2172)
- `GET /api/v1/nft/collections` — list all
- `GET /api/v1/nft/collection/{id}` — detail + tokens
- `GET /api/v1/nft/{collection}/{token_id}` — metadata + owner
- `GET /api/v1/nft/owned/{wallet_id}` — owned NFTs
- `POST /api/v1/nft/collection/create` — submit signed tx
- `POST /api/v1/nft/mint` — submit signed tx
- `POST /api/v1/nft/transfer` — submit signed tx

### CLI (#2173)
- `zhtp-cli nft create-collection --name "Art" --symbol ART`
- `zhtp-cli nft mint --collection <id> --to <wallet> --name "Piece #1"`
- `zhtp-cli nft list`
- `zhtp-cli nft owned <wallet_id>`

### Files
New: 5 files (nft contract, API handler, CLI handler, client builder, rewards mod)
Modified: 8 files (transaction types, executor, validation, blockchain struct, cli args)

## Test plan
- [x] 7 NftContract unit tests pass
- [x] `cargo check -p lib-blockchain -p zhtp -p zhtp-cli` clean
- [ ] Deploy, create collection via CLI, mint NFT, verify on API