### PR TITLE
docs(mac): tooling/script hygiene and validated bring-up quickstart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9339,6 +9339,7 @@ dependencies = [
  "warp",
  "windows 0.51.1",
  "zeroize",
+ "zhtp-daemon",
 ]
 
 [[package]]
@@ -9396,6 +9397,7 @@ dependencies = [
  "anyhow",
  "axum",
  "base64 0.22.1",
+ "ciborium",
  "dirs",
  "hex",
  "lib-crypto",
@@ -9403,6 +9405,10 @@ dependencies = [
  "lib-network",
  "lib-protocols",
  "lib-types",
+ "quinn",
+ "rcgen 0.14.7",
+ "rustls",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All proof serialization includes version markers for forward compatibility.
 ## 🚀 Quick Start
 
 ### Prerequisites
-- **Rust** 1.70+ (install from [rustup.rs](https://rustup.rs/))
+- **Rust nightly** (repository pins `channel = "nightly"` in `rust-toolchain.toml`)
 - **Git**
 
 ### Build & Run
@@ -72,6 +72,23 @@ cargo build --release --workspace
 
 # Or start from the CLI command surface
 ./target/release/zhtp-cli node start --config zhtp/configs/test-node1.toml
+```
+
+### macOS Quickstart (Validated)
+
+```bash
+# Ensure nightly toolchain is installed and active
+rustup toolchain install nightly
+rustup default nightly
+
+# Build binaries
+cargo build --release --workspace
+
+# Validate the mac baseline config
+bash zhtp/configs/validate-config.sh zhtp/configs/mac-bootstrap.toml
+
+# Start a mac node with the stable QUIC-first profile
+./target/release/zhtp --config zhtp/configs/mac-bootstrap.toml
 ```
 
 ### Multi-node Testing
@@ -182,7 +199,7 @@ When a node starts successfully, you'll see:
 ## 🛠️ Troubleshooting
 
 ### Build Errors
-- Ensure Rust 1.70+ is installed: `rustc --version`
+- Ensure Rust nightly is active: `rustup show active-toolchain`
 - Update Rust: `rustup update`
 - Clean build: `cargo clean && cargo build --release`
 

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -36,6 +36,7 @@ mod init;
 mod oracle;
 mod persistence;
 mod validators;
+mod gateways;
 mod wallets;
 
 pub use persistence::PersistenceStats;
@@ -169,6 +170,12 @@ pub struct Blockchain {
     /// Validator registration block heights (identity_id -> block_height)
     #[serde(default)]
     pub validator_blocks: HashMap<String, u64>,
+    /// On-chain gateway registry (identity_id -> Gateway info)
+    #[serde(default)]
+    pub gateway_registry: HashMap<String, GatewayInfo>,
+    /// Gateway registration block heights (identity_id -> block_height)
+    #[serde(default)]
+    pub gateway_blocks: HashMap<String, u64>,
     /// DAO treasury wallet ID (stores collected fees for governance)
     #[serde(default)]
     pub dao_treasury_wallet_id: Option<String>,
@@ -522,6 +529,39 @@ pub struct ValidatorInfo {
     pub oracle_key_id: Option<[u8; 32]>,
 }
 
+/// Gateway registry entry
+/// Tracks a gateway node's registration, stake, and operational status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayInfo {
+    /// Gateway identity ID (same as DID)
+    pub identity_id: String,
+    /// Staked amount (in micro-SOV)
+    pub stake: u64,
+    /// Dilithium5 public key used to sign forwarded client context.
+    /// Fixed size [u8; 2592].
+    #[serde(with = "serde_arrays")]
+    pub gateway_key: [u8; 2592],
+    /// Public QUIC endpoint(s) for clients (comma-separated host:port)
+    pub endpoints: String,
+    /// Commission rate percentage (0-100) taken from routed DAO fees
+    pub commission_rate: u8,
+    /// Gateway status: "active", "inactive", "slashed"
+    pub status: String,
+    /// Registration timestamp (block height)
+    pub registered_at: u64,
+    /// Last heartbeat / activity timestamp (block height)
+    pub last_activity: u64,
+    /// Total requests forwarded (approximate counter)
+    pub requests_forwarded: u64,
+    /// Slash count
+    pub slash_count: u32,
+    /// Revenue earned in micro-SOV (accumulated, not yet claimed)
+    pub accumulated_revenue: u64,
+    /// Source of gateway admission
+    #[serde(default)]
+    pub admission_source: String,
+}
+
 /// UBI (Universal Basic Income) registry entry
 /// Tracks a citizen's UBI eligibility and payout status
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -575,6 +615,8 @@ pub struct BlockchainImport {
     pub identity_registry: HashMap<String, IdentityTransactionData>,
     pub wallet_references: HashMap<String, crate::transaction::WalletReference>, // Only minimal references
     pub validator_registry: HashMap<String, ValidatorInfo>,
+    #[serde(default)]
+    pub gateway_registry: HashMap<String, GatewayInfo>,
     pub token_contracts: HashMap<[u8; 32], crate::contracts::TokenContract>,
     pub web4_contracts: HashMap<[u8; 32], crate::contracts::web4::Web4Contract>,
     pub contract_blocks: HashMap<[u8; 32], u64>,
@@ -988,6 +1030,7 @@ impl Blockchain {
                     self.blocks.push(block.clone());
                     self.height += 1;
                     self.process_validator_registration_transactions(&block);
+                    self.process_gateway_transactions(&block);
                     // Rebuild wallet_registry and in-memory SOV balances from WalletRegistration
                     // transactions in this block. The BlockExecutor handles SledStore state but
                     // does NOT update the in-memory wallet_registry or token_contracts mints.
@@ -1146,6 +1189,7 @@ impl Blockchain {
         self.process_contract_transactions(&block)?;
         self.process_token_transactions(&block)?;
         self.process_validator_registration_transactions(&block);
+        self.process_gateway_transactions(&block);
         for tx in &block.transactions {
             self.index_dao_registry_entry_from_tx(tx, block.header.height);
         }
@@ -4293,6 +4337,7 @@ impl Blockchain {
             identity_registry: HashMap<String, IdentityTransactionData>,
             wallet_references: HashMap<String, crate::transaction::WalletReference>, // Only public references
             validator_registry: HashMap<String, ValidatorInfo>,
+            gateway_registry: HashMap<String, GatewayInfo>,
             token_contracts: HashMap<[u8; 32], crate::contracts::TokenContract>,
             web4_contracts: HashMap<[u8; 32], crate::contracts::web4::Web4Contract>,
             contract_blocks: HashMap<[u8; 32], u64>,
@@ -4326,6 +4371,7 @@ impl Blockchain {
             identity_registry: self.identity_registry.clone(),
             wallet_references, // Only minimal wallet references (no sensitive data)
             validator_registry: self.validator_registry.clone(),
+            gateway_registry: self.gateway_registry.clone(),
             token_contracts: self.token_contracts.clone(),
             web4_contracts: self.web4_contracts.clone(),
             contract_blocks: self.contract_blocks.clone(),

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -149,6 +149,9 @@ pub struct Blockchain {
     /// Smart contract registry - Web4 Website contracts (contract_id -> Web4Contract)
     #[serde(default)]
     pub web4_contracts: HashMap<[u8; 32], crate::contracts::web4::Web4Contract>,
+    /// NFT collection registry (collection_id -> NftContract)
+    #[serde(default)]
+    pub nft_collections: HashMap<[u8; 32], crate::contracts::nft::NftContract>,
     /// Authoritative on-chain domain registry (domain name -> record).
     /// Populated from DomainRegistration / DomainUpdate transactions committed to blocks.
     /// This is the canonical source of truth; sled/DHT DomainRegistry is a cache.
@@ -999,6 +1002,7 @@ impl Blockchain {
                         warn!("process_employment_contract_transactions in executor path: {}", e);
                     }
                     self.process_domain_transactions(&block);
+                    self.process_nft_transactions(&block);
                     for tx in &block.transactions {
                         self.index_dao_registry_entry_from_tx(tx, block.header.height);
                         // Executor returns LegacySystem for ValidatorRegistration — update registry here
@@ -1138,6 +1142,7 @@ impl Blockchain {
         self.process_entity_registry_transactions(&block)?;
         self.process_employment_contract_transactions(&block)?;
         self.process_domain_transactions(&block);
+        self.process_nft_transactions(&block);
         self.process_contract_transactions(&block)?;
         self.process_token_transactions(&block)?;
         self.process_validator_registration_transactions(&block);

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1066,6 +1066,129 @@ impl Blockchain {
         }
     }
 
+    /// Process NFT transactions from a committed block.
+    pub fn process_nft_transactions(&mut self, block: &Block) {
+        use crate::contracts::nft::{NftContract, NftMetadata};
+
+        for tx in &block.transactions {
+            match tx.transaction_type {
+                TransactionType::NftCreateCollection => {
+                    if let Some(data) = tx.nft_create_collection_data() {
+                        let collection_id = lib_crypto::hash_blake3(
+                            &format!(
+                                "nft_collection:{}:{}:{}",
+                                data.name,
+                                data.symbol,
+                                hex::encode(tx.signature.public_key.key_id)
+                            )
+                            .as_bytes(),
+                        );
+                        let contract = NftContract::new(
+                            collection_id,
+                            data.name.clone(),
+                            data.symbol.clone(),
+                            format!("did:zhtp:{}", hex::encode(
+                                lib_crypto::hashing::hash_blake3(&tx.signature.public_key.dilithium_pk)
+                            )),
+                            tx.signature.public_key.key_id,
+                            data.max_supply,
+                            tx.signature.timestamp,
+                        );
+                        if self.nft_collections.contains_key(&collection_id) {
+                            warn!(
+                                "NFT collection already exists, skipping: id={}",
+                                hex::encode(&collection_id[..8]),
+                            );
+                        } else {
+                            info!(
+                                "🎨 NFT collection created: {} ({}) id={}",
+                                data.name,
+                                data.symbol,
+                                hex::encode(&collection_id[..8]),
+                            );
+                            self.nft_collections.insert(collection_id, contract);
+                        }
+                    }
+                }
+                TransactionType::NftMint => {
+                    if let Some(data) = tx.nft_mint_data() {
+                        if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
+                            let metadata = NftMetadata {
+                                name: data.name.clone(),
+                                description: data.description.clone(),
+                                image_cid: data.image_cid.clone(),
+                                attributes: data.attributes.clone(),
+                                creator_did: collection.creator_did.clone(),
+                                created_at: tx.signature.timestamp,
+                            };
+                            match collection.mint(
+                                &tx.signature.public_key.key_id,
+                                data.recipient,
+                                metadata,
+                            ) {
+                                Ok(token_id) => {
+                                    info!(
+                                        "🎨 NFT minted: collection={} token_id={} to={}",
+                                        hex::encode(&data.collection_id[..8]),
+                                        token_id,
+                                        hex::encode(&data.recipient[..8]),
+                                    );
+                                }
+                                Err(e) => {
+                                    warn!("NFT mint failed: {}", e);
+                                }
+                            }
+                        }
+                    }
+                }
+                TransactionType::NftTransfer => {
+                    if let Some(data) = tx.nft_transfer_data() {
+                        if tx.signature.public_key.key_id != data.from {
+                            warn!(
+                                "NFT transfer rejected: signer {} is not the owner {}",
+                                hex::encode(&tx.signature.public_key.key_id[..8]),
+                                hex::encode(&data.from[..8]),
+                            );
+                        } else if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
+                            if let Err(e) = collection.transfer(data.token_id, &data.from, data.to) {
+                                warn!("NFT transfer failed: {}", e);
+                            } else {
+                                info!(
+                                    "🎨 NFT transferred: collection={} token={} to={}",
+                                    hex::encode(&data.collection_id[..8]),
+                                    data.token_id,
+                                    hex::encode(&data.to[..8]),
+                                );
+                            }
+                        }
+                    }
+                }
+                TransactionType::NftBurn => {
+                    if let Some(data) = tx.nft_burn_data() {
+                        if tx.signature.public_key.key_id != data.owner {
+                            warn!(
+                                "NFT burn rejected: signer {} is not the owner {}",
+                                hex::encode(&tx.signature.public_key.key_id[..8]),
+                                hex::encode(&data.owner[..8]),
+                            );
+                        } else if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
+                            if let Err(e) = collection.burn(data.token_id, &data.owner) {
+                                warn!("NFT burn failed: {}", e);
+                            } else {
+                                info!(
+                                    "🎨 NFT burned: collection={} token={}",
+                                    hex::encode(&data.collection_id[..8]),
+                                    data.token_id,
+                                );
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     /// Get the authoritative on-chain domain registry.
     pub fn get_all_domains(&self) -> &HashMap<String, crate::transaction::OnChainDomainRecord> {
         &self.domain_registry

--- a/lib-blockchain/src/blockchain/gateways.rs
+++ b/lib-blockchain/src/blockchain/gateways.rs
@@ -1,0 +1,325 @@
+use super::*;
+
+/// Minimum stake required for gateway registration (micro-SOV).
+/// 10 000 SOV = 10 000_000_000 micro-SOV.
+pub const GATEWAY_MIN_STAKE: u64 = 10_000_000_000;
+
+/// Minimum stake for testnet / genesis (micro-SOV).
+pub const GATEWAY_MIN_STAKE_GENESIS: u64 = 1_000;
+
+/// Number of blocks without heartbeat before a gateway is considered stale.
+pub const GATEWAY_HEARTBEAT_BLOCKS: u64 = 720; // ~1 hour at 5s block time
+
+/// Number of slash events before a gateway is permanently removed.
+pub const GATEWAY_MAX_SLASHES: u32 = 3;
+
+impl Blockchain {
+    /// Register a new gateway on-chain.
+    ///
+    /// Requirements:
+    /// - Identity must already exist in `identity_registry`.
+    /// - Gateway key must be a full Dilithium5 public key (2592 bytes).
+    /// - Stake must meet minimum.
+    pub fn register_gateway(&mut self, gateway_info: GatewayInfo) -> Result<Hash> {
+        if self.gateway_registry.contains_key(&gateway_info.identity_id) {
+            return Err(anyhow::anyhow!(
+                "Gateway {} already exists on blockchain",
+                gateway_info.identity_id
+            ));
+        }
+
+        if !self.identity_registry.contains_key(&gateway_info.identity_id) {
+            return Err(anyhow::anyhow!(
+                "Identity {} must be registered before becoming a gateway",
+                gateway_info.identity_id
+            ));
+        }
+
+        if gateway_info.gateway_key == [0u8; 2592] {
+            return Err(anyhow::anyhow!("Gateway key must not be empty"));
+        }
+
+        let min_stake = if self.height == 0 {
+            GATEWAY_MIN_STAKE_GENESIS
+        } else {
+            GATEWAY_MIN_STAKE
+        };
+        if gateway_info.stake < min_stake {
+            return Err(anyhow::anyhow!(
+                "Insufficient stake for gateway: {} micro-SOV (minimum: {} required)",
+                gateway_info.stake,
+                min_stake
+            ));
+        }
+
+        let gateway_tx_data = IdentityTransactionData {
+            did: gateway_info.identity_id.clone(),
+            display_name: format!("Gateway: {}", gateway_info.endpoints),
+            public_key: gateway_info.gateway_key.to_vec(),
+            ownership_proof: vec![],
+            identity_type: "gateway".to_string(),
+            did_document_hash: crate::types::hash::blake3_hash(
+                format!(
+                    "gateway:{}:{}",
+                    gateway_info.identity_id, gateway_info.registered_at
+                )
+                .as_bytes(),
+            ),
+            created_at: gateway_info.registered_at,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_nodes: Vec::new(),
+            owned_wallets: Vec::new(),
+        };
+
+        let registration_tx = Transaction::new_identity_registration(
+            gateway_tx_data,
+            vec![],
+            Signature {
+                signature: gateway_info.gateway_key.to_vec(),
+                public_key: PublicKey::new(gateway_info.gateway_key),
+                algorithm: SignatureAlgorithm::DEFAULT,
+                timestamp: gateway_info.registered_at,
+            },
+            format!(
+                "Gateway registration for {} with stake {}",
+                gateway_info.identity_id, gateway_info.stake
+            )
+            .into_bytes(),
+        );
+
+        self.add_pending_transaction(registration_tx.clone())?;
+        self.gateway_registry
+            .insert(gateway_info.identity_id.clone(), gateway_info.clone());
+        self.gateway_blocks
+            .insert(gateway_info.identity_id.clone(), self.height + 1);
+
+        info!(
+            " Gateway {} registered with {} micro-SOV stake at endpoints {}",
+            gateway_info.identity_id, gateway_info.stake, gateway_info.endpoints
+        );
+
+        Ok(registration_tx.hash())
+    }
+
+    pub fn get_gateway(&self, identity_id: &str) -> Option<&GatewayInfo> {
+        self.gateway_registry.get(identity_id)
+    }
+
+    pub fn gateway_exists(&self, identity_id: &str) -> bool {
+        self.gateway_registry.contains_key(identity_id)
+    }
+
+    pub fn list_all_gateways(&self) -> Vec<&GatewayInfo> {
+        self.gateway_registry.values().collect()
+    }
+
+    pub fn get_active_gateways(&self) -> Vec<&GatewayInfo> {
+        self.gateway_registry
+            .values()
+            .filter(|g| g.status == "active")
+            .collect()
+    }
+
+    pub fn get_all_gateways(&self) -> &HashMap<String, GatewayInfo> {
+        &self.gateway_registry
+    }
+
+    pub fn update_gateway(
+        &mut self,
+        identity_id: &str,
+        updated_info: GatewayInfo,
+    ) -> Result<Hash> {
+        if !self.gateway_registry.contains_key(identity_id) {
+            return Err(anyhow::anyhow!(
+                "Gateway {} not found on blockchain",
+                identity_id
+            ));
+        }
+
+        let gateway_tx_data = IdentityTransactionData {
+            did: updated_info.identity_id.clone(),
+            display_name: format!("Gateway Update: {}", updated_info.endpoints),
+            public_key: updated_info.gateway_key.to_vec(),
+            ownership_proof: vec![],
+            identity_type: "gateway".to_string(),
+            did_document_hash: crate::types::hash::blake3_hash(
+                format!(
+                    "gateway_update:{}:{}",
+                    updated_info.identity_id, updated_info.last_activity
+                )
+                .as_bytes(),
+            ),
+            created_at: updated_info.last_activity,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_nodes: Vec::new(),
+            owned_wallets: Vec::new(),
+        };
+
+        let update_tx = Transaction::new_identity_update(
+            gateway_tx_data,
+            vec![],
+            vec![],
+            100,
+            Signature {
+                signature: updated_info.gateway_key.to_vec(),
+                public_key: PublicKey::new(updated_info.gateway_key),
+                algorithm: SignatureAlgorithm::DEFAULT,
+                timestamp: updated_info.last_activity,
+            },
+            format!("Gateway update for {}", identity_id).into_bytes(),
+        );
+
+        self.add_pending_transaction(update_tx.clone())?;
+        self.gateway_registry
+            .insert(identity_id.to_string(), updated_info);
+
+        Ok(update_tx.hash())
+    }
+
+    pub fn unregister_gateway(&mut self, identity_id: &str) -> Result<Hash> {
+        if !self.gateway_registry.contains_key(identity_id) {
+            return Err(anyhow::anyhow!(
+                "Gateway {} not found on blockchain",
+                identity_id
+            ));
+        }
+
+        let mut gateway_info = self.gateway_registry.get(identity_id).unwrap().clone();
+        gateway_info.status = "inactive".to_string();
+
+        let unregister_tx = Transaction::new_identity_revocation(
+            identity_id.to_string(),
+            vec![],
+            100,
+            Signature {
+                signature: gateway_info.gateway_key.to_vec(),
+                public_key: PublicKey::new(gateway_info.gateway_key),
+                algorithm: SignatureAlgorithm::DEFAULT,
+                timestamp: gateway_info.last_activity,
+            },
+            format!("Gateway unregistration for {}", identity_id).into_bytes(),
+        );
+
+        self.add_pending_transaction(unregister_tx.clone())?;
+        self.gateway_registry
+            .insert(identity_id.to_string(), gateway_info);
+
+        info!("Gateway {} unregistered", identity_id);
+
+        Ok(unregister_tx.hash())
+    }
+
+    /// Slash a gateway for misbehavior.
+    ///
+    /// Each slash increments `slash_count`. After `GATEWAY_MAX_SLASHES`
+    /// the gateway status is set to "slashed" and it can no longer forward
+    /// traffic.  A portion of stake may be burned or redirected to the DAO
+    /// treasury (governance decides exact economics).
+    pub fn slash_gateway(&mut self, identity_id: &str, _reason: &str) -> Result<()> {
+        let gateway_info = self
+            .gateway_registry
+            .get_mut(identity_id)
+            .ok_or_else(|| anyhow::anyhow!("Gateway {} not found", identity_id))?;
+
+        gateway_info.slash_count += 1;
+        gateway_info.last_activity = self.height;
+
+        if gateway_info.slash_count >= GATEWAY_MAX_SLASHES {
+            gateway_info.status = "slashed".to_string();
+            warn!(
+                "Gateway {} slashed permanently ({} / {} offenses)",
+                identity_id, gateway_info.slash_count, GATEWAY_MAX_SLASHES
+            );
+        } else {
+            gateway_info.status = "jailed".to_string();
+            warn!(
+                "Gateway {} jailed ({} / {} offenses)",
+                identity_id, gateway_info.slash_count, GATEWAY_MAX_SLASHES
+            );
+        }
+
+        Ok(())
+    }
+
+    pub fn get_gateway_confirmations(&self, identity_id: &str) -> Option<u64> {
+        self.gateway_blocks.get(identity_id).map(|block_height| {
+            if self.height >= *block_height {
+                self.height - block_height + 1
+            } else {
+                0
+            }
+        })
+    }
+
+    pub fn is_gateway_active(&self, identity_id: &str) -> bool {
+        self.gateway_registry
+            .get(identity_id)
+            .map(|g| g.status == "active" && g.stake > 0)
+            .unwrap_or(false)
+    }
+
+    pub fn is_gateway_heartbeat_current(&self, identity_id: &str) -> bool {
+        self.gateway_registry
+            .get(identity_id)
+            .map(|g| {
+                g.status == "active"
+                    && self.height.saturating_sub(g.last_activity) <= GATEWAY_HEARTBEAT_BLOCKS
+            })
+            .unwrap_or(false)
+    }
+
+    /// Process gateway transactions from a block (registration / update / unregister).
+    pub fn process_gateway_transactions(&mut self, block: &Block) {
+        let height = block.height();
+        for tx in &block.transactions {
+            if let Some(gateway_data) = tx.gateway_data() {
+                let status = match gateway_data.operation {
+                    crate::transaction::GatewayOperation::Register => "active",
+                    crate::transaction::GatewayOperation::Update => "active",
+                    crate::transaction::GatewayOperation::Unregister => "inactive",
+                };
+                let gateway_info = GatewayInfo {
+                    identity_id: gateway_data.identity_id.clone(),
+                    stake: gateway_data.stake,
+                    gateway_key: gateway_data.gateway_key.as_slice().try_into().unwrap_or([0u8; 2592]),
+                    endpoints: gateway_data.endpoints.clone(),
+                    commission_rate: gateway_data.commission_rate,
+                    status: status.to_string(),
+                    registered_at: height,
+                    last_activity: height,
+                    requests_forwarded: 0,
+                    slash_count: 0,
+                    accumulated_revenue: 0,
+                    admission_source: ADMISSION_SOURCE_ONCHAIN_GOVERNANCE.to_string(),
+                };
+                self.gateway_registry
+                    .insert(gateway_data.identity_id.clone(), gateway_info);
+                self.gateway_blocks
+                    .insert(gateway_data.identity_id.clone(), height);
+                info!(
+                    "Registered new gateway {} with {} micro-SOV stake at {}",
+                    &gateway_data.identity_id[..gateway_data.identity_id.len().min(40)],
+                    gateway_data.stake,
+                    gateway_data.endpoints
+                );
+            }
+        }
+    }
+
+    /// Record a forwarded request for revenue tracking.
+    /// Called by validators when they receive traffic with valid gateway context.
+    pub fn record_gateway_request(&mut self, identity_id: &str) {
+        if let Some(gateway) = self.gateway_registry.get_mut(identity_id) {
+            gateway.requests_forwarded = gateway.requests_forwarded.saturating_add(1);
+        }
+    }
+
+    /// Accrue revenue to a gateway (in micro-SOV).
+    pub fn accrue_gateway_revenue(&mut self, identity_id: &str, amount: u64) {
+        if let Some(gateway) = self.gateway_registry.get_mut(identity_id) {
+            gateway.accumulated_revenue = gateway.accumulated_revenue.saturating_add(amount);
+        }
+    }
+}

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -97,6 +97,7 @@ impl Blockchain {
                 crate::contracts::economics::fee_router::DAO_HEALTHCARE_KEY_ID,
             ),
             domain_registry: HashMap::new(),
+            nft_collections: HashMap::new(),
         }
     }
 

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -26,6 +26,8 @@ impl Blockchain {
             dao_registry_index: HashMap::new(),
             validator_registry: HashMap::new(),
             validator_blocks: HashMap::new(),
+            gateway_registry: HashMap::new(),
+            gateway_blocks: HashMap::new(),
             dao_treasury_wallet_id: None,
             welfare_services: HashMap::new(),
             welfare_service_blocks: HashMap::new(),
@@ -470,6 +472,9 @@ impl Blockchain {
                     // Replay CBE pool initialization from on-chain InitCbeToken transactions.
                     // Replay domain registration/update transactions.
                     blockchain.process_domain_transactions(&block);
+
+                    // Replay gateway registration/update transactions.
+                    blockchain.process_gateway_transactions(&block);
 
                     // Replay employment contract creation so employment_registry is populated.
                     if let Err(e) = blockchain.process_employment_contract_transactions(&block) {

--- a/lib-blockchain/src/blockchain/persistence.rs
+++ b/lib-blockchain/src/blockchain/persistence.rs
@@ -280,6 +280,7 @@ impl BlockchainV1 {
                 crate::contracts::economics::fee_router::DAO_HEALTHCARE_KEY_ID,
             ),
             domain_registry: HashMap::new(),
+            nft_collections: HashMap::new(),
         }
     }
 }
@@ -595,6 +596,7 @@ impl BlockchainStorageV3 {
                 crate::contracts::economics::fee_router::DAO_HEALTHCARE_KEY_ID,
             ),
             domain_registry: HashMap::new(),
+            nft_collections: HashMap::new(),
         }
     }
 }

--- a/lib-blockchain/src/blockchain/persistence.rs
+++ b/lib-blockchain/src/blockchain/persistence.rs
@@ -149,6 +149,10 @@ pub(super) struct BlockchainV1 {
     pub contract_blocks: HashMap<[u8; 32], u64>,
     pub validator_registry: HashMap<String, ValidatorInfo>,
     pub validator_blocks: HashMap<String, u64>,
+    #[serde(default)]
+    pub gateway_registry: HashMap<String, super::GatewayInfo>,
+    #[serde(default)]
+    pub gateway_blocks: HashMap<String, u64>,
     pub dao_treasury_wallet_id: Option<String>,
     pub welfare_services: HashMap<String, lib_consensus::WelfareService>,
     pub welfare_service_blocks: HashMap<String, u64>,
@@ -209,6 +213,8 @@ impl BlockchainV1 {
             dao_registry_index: HashMap::new(),
             validator_registry: self.validator_registry,
             validator_blocks: self.validator_blocks,
+            gateway_registry: self.gateway_registry,
+            gateway_blocks: self.gateway_blocks,
             dao_treasury_wallet_id: self.dao_treasury_wallet_id,
             welfare_services: self.welfare_services,
             welfare_service_blocks: self.welfare_service_blocks,
@@ -318,6 +324,10 @@ pub(super) struct BlockchainStorageV3 {
     pub validator_registry: HashMap<String, ValidatorInfo>,
     #[serde(default)]
     pub validator_blocks: HashMap<String, u64>,
+    #[serde(default)]
+    pub gateway_registry: HashMap<String, super::GatewayInfo>,
+    #[serde(default)]
+    pub gateway_blocks: HashMap<String, u64>,
     #[serde(default)]
     pub dao_treasury_wallet_id: Option<String>,
     #[serde(default)]
@@ -452,6 +462,8 @@ impl BlockchainStorageV3 {
             dao_registry_index: bc.dao_registry_index.clone(),
             validator_registry: bc.validator_registry.clone(),
             validator_blocks: bc.validator_blocks.clone(),
+            gateway_registry: bc.gateway_registry.clone(),
+            gateway_blocks: bc.gateway_blocks.clone(),
             dao_treasury_wallet_id: bc.dao_treasury_wallet_id.clone(),
             welfare_services: bc.welfare_services.clone(),
             welfare_service_blocks: bc.welfare_service_blocks.clone(),
@@ -525,6 +537,8 @@ impl BlockchainStorageV3 {
             dao_registry_index: self.dao_registry_index,
             validator_registry: self.validator_registry,
             validator_blocks: self.validator_blocks,
+            gateway_registry: self.gateway_registry,
+            gateway_blocks: self.gateway_blocks,
             dao_treasury_wallet_id: self.dao_treasury_wallet_id,
             welfare_services: self.welfare_services,
             welfare_service_blocks: self.welfare_service_blocks,

--- a/lib-blockchain/src/contracts/mod.rs
+++ b/lib-blockchain/src/contracts/mod.rs
@@ -34,6 +34,7 @@ pub mod executor;
 pub mod files;
 #[cfg(feature = "contracts")]
 pub mod governance;
+pub mod nft;
 #[cfg(feature = "contracts")]
 pub mod groups;
 #[cfg(feature = "contracts")]

--- a/lib-blockchain/src/contracts/nft/mod.rs
+++ b/lib-blockchain/src/contracts/nft/mod.rs
@@ -1,0 +1,300 @@
+//! Non-Fungible Token (NFT) contract.
+//!
+//! Each NftContract represents a collection. Individual tokens within a collection
+//! have unique u64 IDs, per-token metadata, and tracked ownership.
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Metadata for an individual NFT.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftMetadata {
+    /// Display name of this token.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Web4 content CID for the primary image/media.
+    pub image_cid: String,
+    /// Key-value attributes (trait_type → value).
+    pub attributes: Vec<(String, String)>,
+    /// DID of the creator.
+    pub creator_did: String,
+    /// Unix timestamp of minting.
+    pub created_at: u64,
+}
+
+/// A single NFT collection on-chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftContract {
+    /// Unique collection identifier (blake3 derived).
+    pub collection_id: [u8; 32],
+    /// Collection name.
+    pub name: String,
+    /// Short symbol (e.g. "ART").
+    pub symbol: String,
+    /// DID of the collection creator.
+    pub creator_did: String,
+    /// Wallet key_id of the creator (authorised to mint).
+    pub creator_key_id: [u8; 32],
+    /// Optional cap on total tokens in this collection.
+    pub max_supply: Option<u64>,
+    /// How many tokens have been minted (lifetime, including burned).
+    pub total_minted: u64,
+    /// Next token ID to assign.
+    next_token_id: u64,
+    /// Token ownership: token_id → owner wallet key_id.
+    owners: HashMap<u64, [u8; 32]>,
+    /// Per-token metadata.
+    metadata: HashMap<u64, NftMetadata>,
+    /// Unix timestamp of collection creation.
+    pub created_at: u64,
+}
+
+impl NftContract {
+    /// Create a new empty collection.
+    pub fn new(
+        collection_id: [u8; 32],
+        name: String,
+        symbol: String,
+        creator_did: String,
+        creator_key_id: [u8; 32],
+        max_supply: Option<u64>,
+        created_at: u64,
+    ) -> Self {
+        Self {
+            collection_id,
+            name,
+            symbol,
+            creator_did,
+            creator_key_id,
+            max_supply,
+            total_minted: 0,
+            next_token_id: 1, // token IDs start at 1
+            owners: HashMap::new(),
+            metadata: HashMap::new(),
+            created_at,
+        }
+    }
+
+    /// Mint a new token in this collection.
+    ///
+    /// Only the collection creator may mint. Returns the assigned token_id.
+    pub fn mint(
+        &mut self,
+        minter_key_id: &[u8; 32],
+        recipient: [u8; 32],
+        metadata: NftMetadata,
+    ) -> Result<u64> {
+        // Authorization: only collection creator can mint
+        if minter_key_id != &self.creator_key_id {
+            return Err(anyhow!("Only the collection creator can mint"));
+        }
+
+        // Supply cap
+        if let Some(cap) = self.max_supply {
+            if self.total_minted >= cap {
+                return Err(anyhow!(
+                    "Max supply reached: {}/{}",
+                    self.total_minted,
+                    cap
+                ));
+            }
+        }
+
+        let token_id = self.next_token_id;
+        self.next_token_id += 1;
+        self.total_minted += 1;
+        self.owners.insert(token_id, recipient);
+        self.metadata.insert(token_id, metadata);
+
+        Ok(token_id)
+    }
+
+    /// Transfer a token to a new owner.
+    pub fn transfer(
+        &mut self,
+        token_id: u64,
+        from: &[u8; 32],
+        to: [u8; 32],
+    ) -> Result<()> {
+        let owner = self
+            .owners
+            .get(&token_id)
+            .ok_or_else(|| anyhow!("Token {} does not exist", token_id))?;
+
+        if owner != from {
+            return Err(anyhow!(
+                "Sender does not own token {}: owner={}, from={}",
+                token_id,
+                hex::encode(&owner[..8]),
+                hex::encode(&from[..8]),
+            ));
+        }
+
+        self.owners.insert(token_id, to);
+        Ok(())
+    }
+
+    /// Burn (destroy) a token. Only the owner can burn.
+    pub fn burn(&mut self, token_id: u64, owner: &[u8; 32]) -> Result<()> {
+        let current_owner = self
+            .owners
+            .get(&token_id)
+            .ok_or_else(|| anyhow!("Token {} does not exist", token_id))?;
+
+        if current_owner != owner {
+            return Err(anyhow!("Only the owner can burn token {}", token_id));
+        }
+
+        self.owners.remove(&token_id);
+        self.metadata.remove(&token_id);
+        Ok(())
+    }
+
+    /// Get the owner of a token.
+    pub fn owner_of(&self, token_id: u64) -> Option<&[u8; 32]> {
+        self.owners.get(&token_id)
+    }
+
+    /// List all token IDs owned by a wallet.
+    pub fn tokens_of(&self, wallet_id: &[u8; 32]) -> Vec<u64> {
+        self.owners
+            .iter()
+            .filter(|(_, owner)| *owner == wallet_id)
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    /// Get metadata for a token.
+    pub fn metadata_of(&self, token_id: u64) -> Option<&NftMetadata> {
+        self.metadata.get(&token_id)
+    }
+
+    /// Total tokens currently in existence (minted minus burned).
+    pub fn total_supply(&self) -> u64 {
+        self.owners.len() as u64
+    }
+
+    /// Iterator over all tokens with their owners.
+    pub fn all_tokens(&self) -> impl Iterator<Item = (u64, &[u8; 32], Option<&NftMetadata>)> {
+        self.owners
+            .iter()
+            .map(move |(id, owner)| (*id, owner, self.metadata.get(id)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_collection() -> NftContract {
+        NftContract::new(
+            [1u8; 32],
+            "Test Art".to_string(),
+            "ART".to_string(),
+            "did:zhtp:creator".to_string(),
+            [2u8; 32],
+            Some(10),
+            1000,
+        )
+    }
+
+    #[test]
+    fn test_mint() {
+        let mut col = test_collection();
+        let meta = NftMetadata {
+            name: "Piece #1".to_string(),
+            description: "First piece".to_string(),
+            image_cid: "Qm123".to_string(),
+            attributes: vec![("color".to_string(), "blue".to_string())],
+            creator_did: "did:zhtp:creator".to_string(),
+            created_at: 1000,
+        };
+        let id = col.mint(&[2u8; 32], [3u8; 32], meta).unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(col.total_minted, 1);
+        assert_eq!(col.owner_of(1), Some(&[3u8; 32]));
+    }
+
+    #[test]
+    fn test_mint_unauthorized() {
+        let mut col = test_collection();
+        let meta = NftMetadata {
+            name: "x".to_string(),
+            description: "x".to_string(),
+            image_cid: "x".to_string(),
+            attributes: vec![],
+            creator_did: "x".to_string(),
+            created_at: 0,
+        };
+        assert!(col.mint(&[99u8; 32], [3u8; 32], meta).is_err());
+    }
+
+    #[test]
+    fn test_max_supply() {
+        let mut col = NftContract::new(
+            [1u8; 32], "T".into(), "T".into(),
+            "d".into(), [2u8; 32], Some(1), 0,
+        );
+        let meta = || NftMetadata {
+            name: "x".into(), description: "x".into(), image_cid: "x".into(),
+            attributes: vec![], creator_did: "x".into(), created_at: 0,
+        };
+        col.mint(&[2u8; 32], [3u8; 32], meta()).unwrap();
+        assert!(col.mint(&[2u8; 32], [3u8; 32], meta()).is_err());
+    }
+
+    #[test]
+    fn test_transfer() {
+        let mut col = test_collection();
+        let meta = NftMetadata {
+            name: "x".into(), description: "x".into(), image_cid: "x".into(),
+            attributes: vec![], creator_did: "x".into(), created_at: 0,
+        };
+        col.mint(&[2u8; 32], [3u8; 32], meta).unwrap();
+        col.transfer(1, &[3u8; 32], [4u8; 32]).unwrap();
+        assert_eq!(col.owner_of(1), Some(&[4u8; 32]));
+    }
+
+    #[test]
+    fn test_transfer_not_owner() {
+        let mut col = test_collection();
+        let meta = NftMetadata {
+            name: "x".into(), description: "x".into(), image_cid: "x".into(),
+            attributes: vec![], creator_did: "x".into(), created_at: 0,
+        };
+        col.mint(&[2u8; 32], [3u8; 32], meta).unwrap();
+        assert!(col.transfer(1, &[99u8; 32], [4u8; 32]).is_err());
+    }
+
+    #[test]
+    fn test_burn() {
+        let mut col = test_collection();
+        let meta = NftMetadata {
+            name: "x".into(), description: "x".into(), image_cid: "x".into(),
+            attributes: vec![], creator_did: "x".into(), created_at: 0,
+        };
+        col.mint(&[2u8; 32], [3u8; 32], meta).unwrap();
+        col.burn(1, &[3u8; 32]).unwrap();
+        assert_eq!(col.owner_of(1), None);
+        assert_eq!(col.total_supply(), 0);
+        assert_eq!(col.total_minted, 1); // lifetime counter doesn't decrease
+    }
+
+    #[test]
+    fn test_tokens_of() {
+        let mut col = test_collection();
+        let meta = || NftMetadata {
+            name: "x".into(), description: "x".into(), image_cid: "x".into(),
+            attributes: vec![], creator_did: "x".into(), created_at: 0,
+        };
+        col.mint(&[2u8; 32], [3u8; 32], meta()).unwrap();
+        col.mint(&[2u8; 32], [4u8; 32], meta()).unwrap();
+        col.mint(&[2u8; 32], [3u8; 32], meta()).unwrap();
+        let owned = col.tokens_of(&[3u8; 32]);
+        assert_eq!(owned.len(), 2);
+        assert!(owned.contains(&1));
+        assert!(owned.contains(&3));
+    }
+}

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -1020,7 +1020,12 @@ impl BlockExecutor {
             | TransactionType::DaoUnstake
             // Domain registration/update - state applied by process_domain_transactions
             | TransactionType::DomainRegistration
-            | TransactionType::DomainUpdate => {
+            | TransactionType::DomainUpdate
+            // NFT operations
+            | TransactionType::NftCreateCollection
+            | TransactionType::NftMint
+            | TransactionType::NftTransfer
+            | TransactionType::NftBurn => {
                 // Fall through to the general validation flow below without
                 // treating oracle attestations as automatically valid.
             }
@@ -2699,6 +2704,18 @@ impl BlockExecutor {
 
             TransactionType::DaoUnstake => {
                 self.apply_dao_unstake(mutator, tx, block_height)?;
+                Ok(TxOutcome::LegacySystem)
+            }
+
+            // NFT types — create, mint, transfer, burn
+            TransactionType::NftCreateCollection
+            | TransactionType::NftMint
+            | TransactionType::NftTransfer
+            | TransactionType::NftBurn => {
+                // NFT operations are processed by the blockchain layer in
+                // process_nft_transactions (called after executor.apply_block).
+                // The executor accepts them as pass-through so blocks containing
+                // NFT transactions don't fail validation.
                 Ok(TxOutcome::LegacySystem)
             }
 

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -143,6 +143,9 @@ impl FeeModelV2 {
             | TransactionType::IdentityRevocation => TxKind::Governance,
             TransactionType::ValidatorRegistration
             | TransactionType::ValidatorUpdate
+            | TransactionType::GatewayRegistration
+            | TransactionType::GatewayUpdate
+            | TransactionType::GatewayUnregister
             | TransactionType::DaoProposal
             | TransactionType::DaoVote
             | TransactionType::DaoExecution
@@ -983,6 +986,9 @@ impl BlockExecutor {
             | TransactionType::ValidatorRegistration
             | TransactionType::ValidatorUpdate
             | TransactionType::ValidatorUnregister
+            | TransactionType::GatewayRegistration
+            | TransactionType::GatewayUpdate
+            | TransactionType::GatewayUnregister
             | TransactionType::SessionCreation
             | TransactionType::SessionTermination
             | TransactionType::ContentUpload

--- a/lib-blockchain/src/lib.rs
+++ b/lib-blockchain/src/lib.rs
@@ -93,7 +93,7 @@ pub use block::{
 // Blockchain module
 pub use blockchain::{
     Blockchain, BlockchainBroadcastMessage, BlockchainImport, ConsensusCheckpoint,
-    EconomicsTransaction, ValidatorInfo, ADMISSION_SOURCE_BOOTSTRAP_GENESIS,
+    EconomicsTransaction, ValidatorInfo, GatewayInfo, ADMISSION_SOURCE_BOOTSTRAP_GENESIS,
 };
 #[cfg(feature = "contracts")]
 pub use contracts::AmmPool;

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -579,6 +579,42 @@ pub enum ValidatorOperation {
     Unregister,
 }
 
+/// Gateway registration transaction data.
+///
+/// Gateways are remote QUIC ingress nodes that forward native ZHTP traffic
+/// to validators.  They must stake SOV, maintain liveness, and sign all
+/// forwarded client context with their Dilithium5 key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayTransactionData {
+    /// Identity ID of the gateway (must be pre-registered)
+    pub identity_id: String,
+    /// Staked amount in micro-SOV
+    pub stake: u64,
+    /// Dilithium5 public key used to sign forwarded client context.
+    /// Fixed size [u8; 2592] on-chain; serialized as Vec<u8> in tx.
+    pub gateway_key: Vec<u8>,
+    /// Public QUIC endpoint(s) for clients to connect to.
+    /// Comma-separated host:port list.
+    pub endpoints: String,
+    /// Commission rate percentage (0-100) taken from routed DAO fees.
+    pub commission_rate: u8,
+    /// Gateway operation type
+    pub operation: GatewayOperation,
+    /// Timestamp of registration/update
+    pub timestamp: u64,
+}
+
+/// Gateway operation types
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum GatewayOperation {
+    /// Register as a new gateway
+    Register,
+    /// Update gateway information
+    Update,
+    /// Unregister and exit
+    Unregister,
+}
+
 impl Transaction {
     /// Create a new standard transfer transaction
     pub fn new(
@@ -884,6 +920,70 @@ impl Transaction {
         }
     }
 
+    /// Create a new gateway registration transaction
+    pub fn new_gateway_registration(
+        gateway_data: GatewayTransactionData,
+        outputs: Vec<TransactionOutput>, // For stake locking
+        signature: Signature,
+        memo: Vec<u8>,
+    ) -> Self {
+        Transaction {
+            version: TX_VERSION_V8,
+            chain_id: 0x03, // Default to development network
+            transaction_type: TransactionType::GatewayRegistration,
+            inputs: Vec::new(), // Gateway registration via staking
+            outputs,
+            fee: 0, // Fee paid via stake
+            signature,
+            memo,
+            payload: TransactionPayload::Gateway(gateway_data),
+        }
+    }
+
+    /// Create a new gateway update transaction
+    pub fn new_gateway_update(
+        gateway_data: GatewayTransactionData,
+        inputs: Vec<TransactionInput>, // Authorization
+        outputs: Vec<TransactionOutput>,
+        fee: u64,
+        signature: Signature,
+        memo: Vec<u8>,
+    ) -> Self {
+        Transaction {
+            version: TX_VERSION_V8,
+            chain_id: 0x03, // Default to development network
+            transaction_type: TransactionType::GatewayUpdate,
+            inputs,
+            outputs,
+            fee,
+            signature,
+            memo,
+            payload: TransactionPayload::Gateway(gateway_data),
+        }
+    }
+
+    /// Create a new gateway unregister transaction
+    pub fn new_gateway_unregister(
+        gateway_data: GatewayTransactionData,
+        inputs: Vec<TransactionInput>,   // Authorization
+        outputs: Vec<TransactionOutput>, // Stake return
+        fee: u64,
+        signature: Signature,
+        memo: Vec<u8>,
+    ) -> Self {
+        Transaction {
+            version: TX_VERSION_V8,
+            chain_id: 0x03, // Default to development network
+            transaction_type: TransactionType::GatewayUnregister,
+            inputs,
+            outputs,
+            fee,
+            signature,
+            memo,
+            payload: TransactionPayload::Gateway(gateway_data),
+        }
+    }
+
     /// Create a new DAO proposal transaction
     pub fn new_dao_proposal(
         proposal_data: DaoProposalData,
@@ -1132,6 +1232,12 @@ impl Transaction {
     pub fn validator_data(&self) -> Option<&ValidatorTransactionData> {
         match &self.payload {
             TransactionPayload::Validator(d) => Some(d),
+            _ => None,
+        }
+    }
+    pub fn gateway_data(&self) -> Option<&GatewayTransactionData> {
+        match &self.payload {
+            TransactionPayload::Gateway(d) => Some(d),
             _ => None,
         }
     }
@@ -2309,6 +2415,7 @@ pub enum TransactionPayload {
     Identity(IdentityTransactionData),
     Wallet(WalletTransactionData),
     Validator(ValidatorTransactionData),
+    Gateway(GatewayTransactionData),
     DaoProposal(DaoProposalData),
     DaoVote(DaoVoteData),
     DaoExecution(DaoExecutionData),

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -1282,6 +1282,34 @@ impl Transaction {
         }
     }
 
+    pub fn nft_create_collection_data(&self) -> Option<&NftCreateCollectionData> {
+        match &self.payload {
+            TransactionPayload::NftCreateCollection(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    pub fn nft_mint_data(&self) -> Option<&NftMintData> {
+        match &self.payload {
+            TransactionPayload::NftMint(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    pub fn nft_transfer_data(&self) -> Option<&NftTransferData> {
+        match &self.payload {
+            TransactionPayload::NftTransfer(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    pub fn nft_burn_data(&self) -> Option<&NftBurnData> {
+        match &self.payload {
+            TransactionPayload::NftBurn(d) => Some(d),
+            _ => None,
+        }
+    }
+
     /// Get the size of the transaction in bytes
     pub fn size(&self) -> usize {
         bincode::serialize(self).map(|data| data.len()).unwrap_or(0)
@@ -2225,6 +2253,46 @@ pub struct DaoUnstakeData {
 }
 
 // ============================================================================
+// NFT payload structs
+// ============================================================================
+
+/// Create a new NFT collection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftCreateCollectionData {
+    pub name: String,
+    pub symbol: String,
+    pub max_supply: Option<u64>,
+}
+
+/// Mint a new NFT in a collection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftMintData {
+    pub collection_id: [u8; 32],
+    pub recipient: [u8; 32],
+    pub name: String,
+    pub description: String,
+    pub image_cid: String,
+    pub attributes: Vec<(String, String)>,
+}
+
+/// Transfer an NFT to a new owner.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftTransferData {
+    pub collection_id: [u8; 32],
+    pub token_id: u64,
+    pub from: [u8; 32],
+    pub to: [u8; 32],
+}
+
+/// Burn (destroy) an NFT.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NftBurnData {
+    pub collection_id: [u8; 32],
+    pub token_id: u64,
+    pub owner: [u8; 32],
+}
+
+// ============================================================================
 // TransactionPayload enum
 // ============================================================================
 
@@ -2267,4 +2335,12 @@ pub enum TransactionPayload {
     DaoStake(DaoStakeData),
     /// SOV unstake from a sector DAO wallet (appended after DaoStake)
     DaoUnstake(DaoUnstakeData),
+    /// Create a new NFT collection
+    NftCreateCollection(NftCreateCollectionData),
+    /// Mint a new NFT
+    NftMint(NftMintData),
+    /// Transfer an NFT
+    NftTransfer(NftTransferData),
+    /// Burn an NFT
+    NftBurn(NftBurnData),
 }

--- a/lib-blockchain/src/transaction/creation.rs
+++ b/lib-blockchain/src/transaction/creation.rs
@@ -710,6 +710,11 @@ pub mod utils {
                 // Validator transactions - no specific validation needed here
                 // Validation will be handled during transaction validation
             }
+            TransactionType::GatewayRegistration
+            | TransactionType::GatewayUpdate
+            | TransactionType::GatewayUnregister => {
+                // Gateway transactions - validation handled during transaction validation
+            }
             TransactionType::DaoProposal
             | TransactionType::DaoVote
             | TransactionType::DaoExecution

--- a/lib-blockchain/src/transaction/creation.rs
+++ b/lib-blockchain/src/transaction/creation.rs
@@ -803,6 +803,18 @@ pub mod utils {
                     return Err(TransactionCreateError::InvalidOutputs);
                 }
             }
+            TransactionType::NftCreateCollection
+            | TransactionType::NftMint
+            | TransactionType::NftTransfer
+            | TransactionType::NftBurn => {
+                // NFT transactions - no inputs/outputs required
+                if !inputs.is_empty() {
+                    return Err(TransactionCreateError::InvalidInputs);
+                }
+                if !outputs.is_empty() {
+                    return Err(TransactionCreateError::InvalidOutputs);
+                }
+            }
         }
 
         Ok(())

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -26,7 +26,8 @@ pub use domain::{
 pub use core::{
     BondingCurveBuyData, BondingCurveDeployData, BondingCurveGraduateData, BondingCurveSellData,
     CreateEmploymentContractData, DaoExecutionData, DaoProposalData, DaoStakeData, DaoUnstakeData,
-    DaoVoteData, NftBurnData, NftCreateCollectionData, NftMintData, NftTransferData,
+    DaoVoteData, GatewayOperation, GatewayTransactionData,
+    NftBurnData, NftCreateCollectionData, NftMintData, NftTransferData,
     GovernanceConfigOperation, GovernanceConfigUpdateData, IdentityTransactionData,
     InitCbeTokenData, InitEntityRegistryData, ProcessPayrollData, ProfitDeclarationData,
     RecordOnRampTradeData, RevenueSource, TokenMintData, TokenTransferData, Transaction,

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -26,7 +26,7 @@ pub use domain::{
 pub use core::{
     BondingCurveBuyData, BondingCurveDeployData, BondingCurveGraduateData, BondingCurveSellData,
     CreateEmploymentContractData, DaoExecutionData, DaoProposalData, DaoStakeData, DaoUnstakeData,
-    DaoVoteData,
+    DaoVoteData, NftBurnData, NftCreateCollectionData, NftMintData, NftTransferData,
     GovernanceConfigOperation, GovernanceConfigUpdateData, IdentityTransactionData,
     InitCbeTokenData, InitEntityRegistryData, ProcessPayrollData, ProfitDeclarationData,
     RecordOnRampTradeData, RevenueSource, TokenMintData, TokenTransferData, Transaction,

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -407,6 +407,26 @@ impl TransactionValidator {
                     return Err(ValidationError::InvalidMemo);
                 }
             }
+            TransactionType::NftCreateCollection => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftCreateCollection(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftMint => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftMint(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftTransfer => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftTransfer(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftBurn => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftBurn(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
         }
 
         // Signature validation:
@@ -655,6 +675,26 @@ impl TransactionValidator {
                     .starts_with(crate::transaction::DOMAIN_UPDATE_PREFIX)
                 {
                     return Err(ValidationError::InvalidMemo);
+                }
+            }
+            TransactionType::NftCreateCollection => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftCreateCollection(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftMint => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftMint(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftTransfer => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftTransfer(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftBurn => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftBurn(_)) {
+                    return Err(ValidationError::MissingRequiredData);
                 }
             }
         }
@@ -1893,6 +1933,26 @@ impl<'a> StatefulTransactionValidator<'a> {
                             return Err(ValidationError::InvalidTransaction);
                         }
                     }
+                }
+            }
+            TransactionType::NftCreateCollection => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftCreateCollection(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftMint => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftMint(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftTransfer => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftTransfer(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::NftBurn => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::NftBurn(_)) {
+                    return Err(ValidationError::MissingRequiredData);
                 }
             }
         }
@@ -3143,6 +3203,18 @@ pub mod utils {
                     .starts_with(crate::transaction::DOMAIN_UPDATE_PREFIX)
                     && transaction.inputs.is_empty()
                     && transaction.outputs.is_empty()
+            }
+            TransactionType::NftCreateCollection => {
+                matches!(transaction.payload, crate::transaction::TransactionPayload::NftCreateCollection(_))
+            }
+            TransactionType::NftMint => {
+                matches!(transaction.payload, crate::transaction::TransactionPayload::NftMint(_))
+            }
+            TransactionType::NftTransfer => {
+                matches!(transaction.payload, crate::transaction::TransactionPayload::NftTransfer(_))
+            }
+            TransactionType::NftBurn => {
+                matches!(transaction.payload, crate::transaction::TransactionPayload::NftBurn(_))
             }
         }
     }

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -246,6 +246,21 @@ impl TransactionValidator {
                     return Err(ValidationError::InvalidValidatorData);
                 }
             }
+            TransactionType::GatewayRegistration => {
+                if transaction.gateway_data().is_none() {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::GatewayUpdate => {
+                if transaction.gateway_data().is_none() {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::GatewayUnregister => {
+                if transaction.gateway_data().is_none() {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
             TransactionType::DaoProposal
             | TransactionType::DaoVote
             | TransactionType::DaoExecution
@@ -537,6 +552,21 @@ impl TransactionValidator {
                 // Validator unregister - validate validator data exists
                 if transaction.validator_data().is_none() {
                     return Err(ValidationError::InvalidValidatorData);
+                }
+            }
+            TransactionType::GatewayRegistration => {
+                if transaction.gateway_data().is_none() {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::GatewayUpdate => {
+                if transaction.gateway_data().is_none() {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::GatewayUnregister => {
+                if transaction.gateway_data().is_none() {
+                    return Err(ValidationError::MissingRequiredData);
                 }
             }
             TransactionType::DaoProposal
@@ -1637,6 +1667,12 @@ impl<'a> StatefulTransactionValidator<'a> {
             | TransactionType::ValidatorUpdate
             | TransactionType::ValidatorUnregister => {
                 // Validator transactions - validate with stateless validator
+                stateless_validator.validate_transaction(transaction)?;
+            }
+            TransactionType::GatewayRegistration
+            | TransactionType::GatewayUpdate
+            | TransactionType::GatewayUnregister => {
+                // Gateway transactions - validate with stateless validator
                 stateless_validator.validate_transaction(transaction)?;
             }
             TransactionType::DaoProposal
@@ -3079,6 +3115,12 @@ pub mod utils {
             | TransactionType::ValidatorUnregister => {
                 // Validator transactions should have validator_data
                 transaction.validator_data().is_some()
+            }
+            TransactionType::GatewayRegistration
+            | TransactionType::GatewayUpdate
+            | TransactionType::GatewayUnregister => {
+                // Gateway transactions should have gateway_data
+                transaction.gateway_data().is_some()
             }
             TransactionType::DaoProposal => transaction.dao_proposal_data().is_some(),
             TransactionType::DaoVote => transaction.dao_vote_data().is_some(),

--- a/lib-blockchain/src/types/transaction_type.rs
+++ b/lib-blockchain/src/types/transaction_type.rs
@@ -163,14 +163,19 @@ pub enum TransactionType {
     /// Block processor updates record in `Blockchain::domain_registry`.
     DomainUpdate = 47,
 
+    // Gateway registry (remote QUIC ingress nodes)
+    GatewayRegistration = 48,
+    GatewayUpdate = 49,
+    GatewayUnregister = 50,
+
     /// Create a new NFT collection.
-    NftCreateCollection = 48,
+    NftCreateCollection = 51,
     /// Mint a new NFT in a collection.
-    NftMint = 49,
+    NftMint = 52,
     /// Transfer NFT ownership.
-    NftTransfer = 50,
+    NftTransfer = 53,
     /// Burn (destroy) an NFT.
-    NftBurn = 51,
+    NftBurn = 54,
 }
 
 impl TransactionType {
@@ -337,6 +342,9 @@ impl TransactionType {
             TransactionType::DomainUpdate => {
                 "Update Web4 domain manifest (new deployment)"
             }
+            TransactionType::GatewayRegistration => "Gateway node registration",
+            TransactionType::GatewayUpdate => "Gateway node information update",
+            TransactionType::GatewayUnregister => "Gateway node unregistration",
             TransactionType::NftCreateCollection => "Create a new NFT collection",
             TransactionType::NftMint => "Mint a new NFT in a collection",
             TransactionType::NftTransfer => "Transfer NFT ownership",
@@ -395,6 +403,9 @@ impl TransactionType {
             TransactionType::DaoUnstake => "dao_unstake",
             TransactionType::DomainRegistration => "domain_registration",
             TransactionType::DomainUpdate => "domain_update",
+            TransactionType::GatewayRegistration => "gateway_registration",
+            TransactionType::GatewayUpdate => "gateway_update",
+            TransactionType::GatewayUnregister => "gateway_unregister",
             TransactionType::NftCreateCollection => "nft_create_collection",
             TransactionType::NftMint => "nft_mint",
             TransactionType::NftTransfer => "nft_transfer",
@@ -453,6 +464,9 @@ impl TransactionType {
             "dao_unstake" => Some(TransactionType::DaoUnstake),
             "domain_registration" => Some(TransactionType::DomainRegistration),
             "domain_update" => Some(TransactionType::DomainUpdate),
+            "gateway_registration" => Some(TransactionType::GatewayRegistration),
+            "gateway_update" => Some(TransactionType::GatewayUpdate),
+            "gateway_unregister" => Some(TransactionType::GatewayUnregister),
             "nft_create_collection" => Some(TransactionType::NftCreateCollection),
             "nft_mint" => Some(TransactionType::NftMint),
             "nft_transfer" => Some(TransactionType::NftTransfer),

--- a/lib-blockchain/src/types/transaction_type.rs
+++ b/lib-blockchain/src/types/transaction_type.rs
@@ -162,6 +162,15 @@ pub enum TransactionType {
     /// Payload: `DOMUPD1:` prefix + bincode(DomainUpdatePayload) in memo field.
     /// Block processor updates record in `Blockchain::domain_registry`.
     DomainUpdate = 47,
+
+    /// Create a new NFT collection.
+    NftCreateCollection = 48,
+    /// Mint a new NFT in a collection.
+    NftMint = 49,
+    /// Transfer NFT ownership.
+    NftTransfer = 50,
+    /// Burn (destroy) an NFT.
+    NftBurn = 51,
 }
 
 impl TransactionType {
@@ -328,6 +337,10 @@ impl TransactionType {
             TransactionType::DomainUpdate => {
                 "Update Web4 domain manifest (new deployment)"
             }
+            TransactionType::NftCreateCollection => "Create a new NFT collection",
+            TransactionType::NftMint => "Mint a new NFT in a collection",
+            TransactionType::NftTransfer => "Transfer NFT ownership",
+            TransactionType::NftBurn => "Burn (destroy) an NFT",
         }
     }
 
@@ -382,6 +395,10 @@ impl TransactionType {
             TransactionType::DaoUnstake => "dao_unstake",
             TransactionType::DomainRegistration => "domain_registration",
             TransactionType::DomainUpdate => "domain_update",
+            TransactionType::NftCreateCollection => "nft_create_collection",
+            TransactionType::NftMint => "nft_mint",
+            TransactionType::NftTransfer => "nft_transfer",
+            TransactionType::NftBurn => "nft_burn",
         }
     }
 
@@ -436,6 +453,10 @@ impl TransactionType {
             "dao_unstake" => Some(TransactionType::DaoUnstake),
             "domain_registration" => Some(TransactionType::DomainRegistration),
             "domain_update" => Some(TransactionType::DomainUpdate),
+            "nft_create_collection" => Some(TransactionType::NftCreateCollection),
+            "nft_mint" => Some(TransactionType::NftMint),
+            "nft_transfer" => Some(TransactionType::NftTransfer),
+            "nft_burn" => Some(TransactionType::NftBurn),
             _ => None,
         }
     }

--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -46,6 +46,7 @@ pub mod crypto;
 pub mod dao_tx;
 pub mod error;
 pub mod handshake;
+pub mod nft_tx;
 pub mod identity;
 pub mod request;
 pub mod session;

--- a/lib-client/src/nft_tx.rs
+++ b/lib-client/src/nft_tx.rs
@@ -1,0 +1,220 @@
+//! NFT transaction builders for lib-client.
+
+use lib_blockchain::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+use lib_blockchain::transaction::{
+    NftBurnData, NftCreateCollectionData, NftMintData, NftTransferData, Transaction,
+    TransactionPayload, TX_VERSION_V8,
+};
+use lib_blockchain::types::transaction_type::TransactionType;
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn empty_sig(pk: PublicKey) -> Signature {
+    Signature {
+        signature: Vec::new(),
+        public_key: pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: now_secs(),
+    }
+}
+
+/// Build a signed NftCreateCollection transaction.
+pub fn build_nft_create_collection_tx(
+    identity: &crate::Identity,
+    name: String,
+    symbol: String,
+    max_supply: Option<u64>,
+    chain_id: u8,
+) -> Result<String, String> {
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
+
+    let data = NftCreateCollectionData {
+        name,
+        symbol,
+        max_supply,
+    };
+
+    let mut tx = Transaction {
+        version: TX_VERSION_V8,
+        chain_id,
+        transaction_type: TransactionType::NftCreateCollection,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: empty_sig(signer_pk.clone()),
+        memo: b"nft:create_collection".to_vec(),
+        payload: TransactionPayload::NftCreateCollection(data),
+    };
+
+    let tx_hash = tx.signing_hash();
+    let sig_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
+        .map_err(|e| format!("Failed to sign: {}", e))?;
+
+    tx.signature = Signature {
+        signature: sig_bytes,
+        public_key: signer_pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: now_secs(),
+    };
+
+    bincode::serialize(&tx)
+        .map(hex::encode)
+        .map_err(|e| format!("Failed to serialize: {}", e))
+}
+
+/// Build a signed NftMint transaction.
+pub fn build_nft_mint_tx(
+    identity: &crate::Identity,
+    collection_id: [u8; 32],
+    recipient: [u8; 32],
+    name: String,
+    description: String,
+    image_cid: String,
+    attributes: Vec<(String, String)>,
+    chain_id: u8,
+) -> Result<String, String> {
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
+
+    let data = NftMintData {
+        collection_id,
+        recipient,
+        name,
+        description,
+        image_cid,
+        attributes,
+    };
+
+    let mut tx = Transaction {
+        version: TX_VERSION_V8,
+        chain_id,
+        transaction_type: TransactionType::NftMint,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: empty_sig(signer_pk.clone()),
+        memo: b"nft:mint".to_vec(),
+        payload: TransactionPayload::NftMint(data),
+    };
+
+    let tx_hash = tx.signing_hash();
+    let sig_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
+        .map_err(|e| format!("Failed to sign: {}", e))?;
+
+    tx.signature = Signature {
+        signature: sig_bytes,
+        public_key: signer_pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: now_secs(),
+    };
+
+    bincode::serialize(&tx)
+        .map(hex::encode)
+        .map_err(|e| format!("Failed to serialize: {}", e))
+}
+
+/// Build a signed NftTransfer transaction.
+pub fn build_nft_transfer_tx(
+    identity: &crate::Identity,
+    collection_id: [u8; 32],
+    token_id: u64,
+    from: [u8; 32],
+    to: [u8; 32],
+    chain_id: u8,
+) -> Result<String, String> {
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
+
+    let data = NftTransferData {
+        collection_id,
+        token_id,
+        from,
+        to,
+    };
+
+    let mut tx = Transaction {
+        version: TX_VERSION_V8,
+        chain_id,
+        transaction_type: TransactionType::NftTransfer,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: empty_sig(signer_pk.clone()),
+        memo: b"nft:transfer".to_vec(),
+        payload: TransactionPayload::NftTransfer(data),
+    };
+
+    let tx_hash = tx.signing_hash();
+    let sig_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
+        .map_err(|e| format!("Failed to sign: {}", e))?;
+
+    tx.signature = Signature {
+        signature: sig_bytes,
+        public_key: signer_pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: now_secs(),
+    };
+
+    bincode::serialize(&tx)
+        .map(hex::encode)
+        .map_err(|e| format!("Failed to serialize: {}", e))
+}
+
+/// Build a signed NftBurn transaction.
+pub fn build_nft_burn_tx(
+    identity: &crate::Identity,
+    collection_id: [u8; 32],
+    token_id: u64,
+    owner: [u8; 32],
+    chain_id: u8,
+) -> Result<String, String> {
+    let signer_pk = crate::token_tx::create_public_key_with_kyber(
+        identity.public_key.clone(),
+        identity.kyber_public_key.clone(),
+    );
+
+    let data = NftBurnData {
+        collection_id,
+        token_id,
+        owner,
+    };
+
+    let mut tx = Transaction {
+        version: TX_VERSION_V8,
+        chain_id,
+        transaction_type: TransactionType::NftBurn,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: empty_sig(signer_pk.clone()),
+        memo: b"nft:burn".to_vec(),
+        payload: TransactionPayload::NftBurn(data),
+    };
+
+    let tx_hash = tx.signing_hash();
+    let sig_bytes = crate::identity::sign_message(identity, tx_hash.as_bytes())
+        .map_err(|e| format!("Failed to sign: {}", e))?;
+
+    tx.signature = Signature {
+        signature: sig_bytes,
+        public_key: signer_pk,
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: now_secs(),
+    };
+
+    bincode::serialize(&tx)
+        .map(hex::encode)
+        .map_err(|e| format!("Failed to serialize: {}", e))
+}

--- a/tools/register_gateway.rs
+++ b/tools/register_gateway.rs
@@ -1,0 +1,123 @@
+//! Standalone tool to register a gateway node on-chain.
+//!
+//! Usage:
+//!   register_gateway --identity-dir /root/.zhtp/keystore \
+//!                    --endpoint 91.98.113.188:7840 \
+//!                    --stake 10000 \
+//!                    --validator 77.42.37.161:9334
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    let args = parse_args();
+
+    // Load identity
+    let identity_path = args.identity_dir.join("daemon_identity.json");
+    let private_key_path = args.identity_dir.join("daemon_private_key.json");
+
+    let identity_json = std::fs::read_to_string(&identity_path)
+        .with_context(|| format!("Failed to read {}", identity_path.display()))?;
+    let key_json = std::fs::read_to_string(&private_key_path)
+        .with_context(|| format!("Failed to read {}", private_key_path.display()))?;
+
+    let stored_key: zhtp_daemon::identity::StoredPrivateKey = serde_json::from_str(&key_json)
+        .context("Failed to parse private key")?;
+    let private_key = lib_crypto::types::PrivateKey::try_from(stored_key)
+        .context("Failed to decode private key")?;
+
+    let identity = lib_identity::ZhtpIdentity::from_serialized(&identity_json, &private_key)
+        .context("Failed to restore identity")?;
+
+    println!("Identity loaded: {}", identity.did);
+
+    // Build gateway registration transaction
+    let gateway_key = identity.public_key.dilithium_pk;
+    if gateway_key.len() != 2592 {
+        anyhow::bail!("Gateway key must be 2592 bytes (Dilithium5), got {}", gateway_key.len());
+    }
+
+    let gateway_data = lib_blockchain::transaction::GatewayTransactionData {
+        identity_id: identity.did.clone(),
+        stake: args.stake,
+        gateway_key: gateway_key.to_vec(),
+        endpoints: args.endpoint,
+        commission_rate: args.commission_rate,
+        operation: lib_blockchain::transaction::GatewayOperation::Register,
+        timestamp: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    };
+
+    let signature = lib_crypto::sign_message(
+        &private_key,
+        format!("gateway_register:{}", identity.did).as_bytes(),
+    )
+    .context("Failed to sign registration")?;
+
+    let tx = lib_blockchain::transaction::Transaction::new_gateway_registration(
+        gateway_data,
+        vec![], // outputs — stake locking would go here
+        lib_blockchain::transaction::Signature {
+            signature: signature.signature.clone(),
+            public_key: lib_crypto::PublicKey::new(identity.public_key.dilithium_pk),
+            algorithm: lib_blockchain::transaction::SignatureAlgorithm::DEFAULT,
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        },
+        format!("Gateway registration for {}", identity.did).into_bytes(),
+    );
+
+    println!("Transaction created: hash={}", hex::encode(tx.hash().as_bytes()));
+    println!("Broadcasting to validator {}...", args.validator);
+
+    // TODO: Broadcast via Web4Client to validator
+    // For now, just serialize and print
+    let tx_bytes = bincode::serialize(&tx).context("Failed to serialize transaction")?;
+    println!("Transaction bytes ({} bytes): {}", tx_bytes.len(), hex::encode(&tx_bytes));
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Args {
+    identity_dir: PathBuf,
+    endpoint: String,
+    stake: u64,
+    commission_rate: u8,
+    validator: String,
+}
+
+fn parse_args() -> Args {
+    let mut identity_dir = PathBuf::from(".");
+    let mut endpoint = String::new();
+    let mut stake = 10_000u64;
+    let mut commission_rate = 5u8;
+    let mut validator = String::new();
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--identity-dir" => identity_dir = PathBuf::from(args.next().expect("--identity-dir requires a value")),
+            "--endpoint" => endpoint = args.next().expect("--endpoint requires a value"),
+            "--stake" => stake = args.next().expect("--stake requires a value").parse().expect("invalid number"),
+            "--commission-rate" => commission_rate = args.next().expect("--commission-rate requires a value").parse().expect("invalid number"),
+            "--validator" => validator = args.next().expect("--validator requires a value"),
+            _ => {}
+        }
+    }
+
+    if endpoint.is_empty() {
+        eprintln!("Usage: register_gateway --identity-dir <dir> --endpoint <host:port> --validator <host:port> [--stake <micro-SOV>] [--commission-rate <0-100>]");
+        std::process::exit(1);
+    }
+    if validator.is_empty() {
+        eprintln!("Usage: register_gateway --identity-dir <dir> --endpoint <host:port> --validator <host:port> [--stake <micro-SOV>] [--commission-rate <0-100>]");
+        std::process::exit(1);
+    }
+
+    Args { identity_dir, endpoint, stake, commission_rate, validator }
+}

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -135,6 +135,90 @@ pub enum ZhtpCommand {
 
     /// CBE token operations (init pools, employment, payroll)
     Cbe(CbeArgs),
+
+    /// NFT operations (create collection, mint, transfer)
+    Nft(NftArgs),
+}
+
+/// NFT operation commands
+#[derive(Args, Debug, Clone)]
+pub struct NftArgs {
+    #[command(subcommand)]
+    pub action: NftAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum NftAction {
+    /// Create a new NFT collection
+    CreateCollection {
+        /// Collection name
+        #[arg(long)]
+        name: String,
+        /// Short symbol (e.g. ART)
+        #[arg(long)]
+        symbol: String,
+        /// Max tokens in collection (omit for unlimited)
+        #[arg(long)]
+        max_supply: Option<u64>,
+        /// Path to keystore directory
+        #[arg(long)]
+        keystore: Option<String>,
+    },
+    /// Mint a new NFT in a collection
+    Mint {
+        /// Collection ID (64-char hex)
+        #[arg(long)]
+        collection: String,
+        /// Recipient wallet ID (64-char hex)
+        #[arg(long)]
+        to: String,
+        /// Token name
+        #[arg(long)]
+        name: String,
+        /// Description
+        #[arg(long, default_value = "")]
+        description: String,
+        /// Web4 content CID for the image
+        #[arg(long, default_value = "")]
+        image_cid: String,
+        /// Path to keystore directory
+        #[arg(long)]
+        keystore: Option<String>,
+    },
+    /// Transfer an NFT to another wallet
+    Transfer {
+        /// Collection ID (64-char hex)
+        #[arg(long)]
+        collection: String,
+        /// Token ID (integer)
+        #[arg(long)]
+        token_id: u64,
+        /// Recipient wallet ID (64-char hex)
+        #[arg(long)]
+        to: String,
+        /// Path to keystore directory
+        #[arg(long)]
+        keystore: Option<String>,
+    },
+    /// Burn (destroy) an NFT
+    Burn {
+        /// Collection ID (64-char hex)
+        #[arg(long)]
+        collection: String,
+        /// Token ID (integer)
+        #[arg(long)]
+        token_id: u64,
+        /// Path to keystore directory
+        #[arg(long)]
+        keystore: Option<String>,
+    },
+    /// List collections
+    List,
+    /// List NFTs owned by a wallet
+    Owned {
+        /// Wallet ID (64-char hex)
+        wallet_id: String,
+    },
 }
 
 /// Node management commands
@@ -1789,6 +1873,9 @@ pub async fn run_cli() -> Result<()> {
             .await
             .map_err(anyhow::Error::msg),
         ZhtpCommand::Cbe(args) => commands::cbe::handle_cbe_command(args.clone(), &cli)
+            .await
+            .map_err(anyhow::Error::msg),
+        ZhtpCommand::Nft(args) => commands::nft::handle_nft_command(args.clone(), &cli)
             .await
             .map_err(anyhow::Error::msg),
     }

--- a/zhtp-cli/src/commands/mod.rs
+++ b/zhtp-cli/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod interactive;
 pub mod isolation;
 pub mod man;
 pub mod monitor;
+pub mod nft;
 pub mod network;
 pub mod node;
 pub mod oracle;

--- a/zhtp-cli/src/commands/nft.rs
+++ b/zhtp-cli/src/commands/nft.rs
@@ -1,0 +1,274 @@
+//! NFT CLI commands.
+
+use crate::argument_parsing::{format_output, NftAction, NftArgs, ZhtpCli};
+use crate::commands::web4_utils::{connect_default, load_identity_from_keystore};
+use crate::error::{CliError, CliResult};
+use lib_network::client::ZhtpClient;
+use std::path::PathBuf;
+
+fn default_keystore_path() -> CliResult<PathBuf> {
+    dirs::home_dir()
+        .map(|h| h.join(".zhtp").join("keystore"))
+        .ok_or_else(|| CliError::ConfigError("Cannot determine home directory".to_string()))
+}
+
+fn load_identity(keystore: &Option<String>) -> CliResult<zhtp_client::Identity> {
+    let keystore_path = match keystore {
+        Some(p) => PathBuf::from(p),
+        None => default_keystore_path()?,
+    };
+    let loaded = load_identity_from_keystore(&keystore_path)?;
+    Ok(zhtp_client::Identity {
+        did: loaded.identity.did.clone(),
+        public_key: loaded.identity.public_key.dilithium_pk.to_vec(),
+        private_key: loaded.keypair.private_key.dilithium_sk.to_vec(),
+        kyber_public_key: loaded.identity.public_key.kyber_pk.to_vec(),
+        kyber_secret_key: loaded.keypair.private_key.kyber_sk.to_vec(),
+        node_id: loaded.identity.node_id.as_bytes().to_vec(),
+        device_id: loaded.identity.primary_device.clone(),
+        recovery_entropy: loaded.keypair.private_key.master_seed.to_vec(),
+        created_at: loaded.identity.created_at,
+    })
+}
+
+fn parse_hex32(value: &str, field: &str) -> CliResult<[u8; 32]> {
+    let s = value.strip_prefix("0x").unwrap_or(value);
+    let bytes = hex::decode(s)
+        .map_err(|_| CliError::ConfigError(format!("{} is not valid hex", field)))?;
+    bytes
+        .try_into()
+        .map_err(|_| CliError::ConfigError(format!("{} must be exactly 32 bytes", field)))
+}
+
+pub async fn handle_nft_command(args: NftArgs, cli: &ZhtpCli) -> CliResult<()> {
+    let client = connect_default(&cli.server).await?;
+
+    match args.action {
+        NftAction::CreateCollection {
+            name,
+            symbol,
+            max_supply,
+            keystore,
+        } => {
+            let identity = load_identity(&keystore)?;
+            eprintln!("Creating NFT collection: {} ({})", name, symbol);
+
+            let tx_hex = zhtp_client::nft_tx::build_nft_create_collection_tx(
+                &identity,
+                name,
+                symbol,
+                max_supply,
+                3,
+            )
+            .map_err(|e| CliError::ConfigError(e))?;
+
+            let body = serde_json::json!({ "signed_tx": tx_hex });
+            let response = client
+                .post_json("/api/v1/nft/collection/create", &body)
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/collection/create".to_string(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/collection/create".to_string(),
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+
+        NftAction::Mint {
+            collection,
+            to,
+            name,
+            description,
+            image_cid,
+            keystore,
+        } => {
+            let identity = load_identity(&keystore)?;
+            let collection_id = parse_hex32(&collection, "--collection")?;
+            let recipient = parse_hex32(&to, "--to")?;
+
+            eprintln!("Minting NFT: {} in collection {}", name, &collection[..16]);
+
+            let tx_hex = zhtp_client::nft_tx::build_nft_mint_tx(
+                &identity,
+                collection_id,
+                recipient,
+                name,
+                description,
+                image_cid,
+                vec![],
+                3,
+            )
+            .map_err(|e| CliError::ConfigError(e))?;
+
+            let body = serde_json::json!({ "signed_tx": tx_hex });
+            let response = client
+                .post_json("/api/v1/nft/mint", &body)
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/mint".to_string(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/mint".to_string(),
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+
+        NftAction::Transfer {
+            collection,
+            token_id,
+            to,
+            keystore,
+        } => {
+            let identity = load_identity(&keystore)?;
+            let collection_id = parse_hex32(&collection, "--collection")?;
+            let recipient = parse_hex32(&to, "--to")?;
+            // The 'from' is the signer's own key_id
+            let signer_pk = zhtp_client::token_tx::create_public_key_with_kyber(
+                identity.public_key.clone(),
+                identity.kyber_public_key.clone(),
+            );
+            let from = signer_pk.key_id;
+
+            eprintln!(
+                "Transferring NFT token {} from collection {} to {}",
+                token_id,
+                &collection[..16],
+                &to[..16.min(to.len())],
+            );
+
+            let tx_hex = zhtp_client::nft_tx::build_nft_transfer_tx(
+                &identity,
+                collection_id,
+                token_id,
+                from,
+                recipient,
+                3,
+            )
+            .map_err(|e| CliError::ConfigError(e))?;
+
+            let body = serde_json::json!({ "signed_tx": tx_hex });
+            let response = client
+                .post_json("/api/v1/nft/transfer", &body)
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/transfer".to_string(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/transfer".to_string(),
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+
+        NftAction::Burn {
+            collection,
+            token_id,
+            keystore,
+        } => {
+            let identity = load_identity(&keystore)?;
+            let collection_id = parse_hex32(&collection, "--collection")?;
+            // The 'owner' is the signer's own key_id
+            let signer_pk = zhtp_client::token_tx::create_public_key_with_kyber(
+                identity.public_key.clone(),
+                identity.kyber_public_key.clone(),
+            );
+            let owner = signer_pk.key_id;
+
+            eprintln!(
+                "Burning NFT token {} from collection {}",
+                token_id,
+                &collection[..16],
+            );
+
+            let tx_hex = zhtp_client::nft_tx::build_nft_burn_tx(
+                &identity,
+                collection_id,
+                token_id,
+                owner,
+                3,
+            )
+            .map_err(|e| CliError::ConfigError(e))?;
+
+            let body = serde_json::json!({ "signed_tx": tx_hex });
+            let response = client
+                .post_json("/api/v1/nft/burn", &body)
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/burn".to_string(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/burn".to_string(),
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+
+        NftAction::List => {
+            let response = client
+                .get("/api/v1/nft/collections")
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/collections".to_string(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: "/api/v1/nft/collections".to_string(),
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+
+        NftAction::Owned { wallet_id } => {
+            let endpoint = format!("/api/v1/nft/owned/{}", wallet_id);
+            let response = client
+                .get(&endpoint)
+                .await
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint: endpoint.clone(),
+                    status: 0,
+                    reason: e.to_string(),
+                })?;
+
+            let result: serde_json::Value = ZhtpClient::parse_json(&response)
+                .map_err(|e| CliError::ApiCallFailed {
+                    endpoint,
+                    status: 0,
+                    reason: format!("Failed to parse response: {}", e),
+                })?;
+            println!("{}", format_output(&result, &cli.format)?);
+            Ok(())
+        }
+    }
+}

--- a/zhtp-daemon/Cargo.toml
+++ b/zhtp-daemon/Cargo.toml
@@ -6,6 +6,10 @@ authors = ["Sovereign Network Team"]
 license = "MIT"
 description = "Local browser companion daemon for QUIC-native ZHTP/Web4 access"
 
+[lib]
+name = "zhtp_daemon"
+path = "src/lib.rs"
+
 [[bin]]
 name = "zhtp-daemon"
 path = "src/main.rs"
@@ -21,8 +25,13 @@ lib-identity = { path = "../lib-identity" }
 lib-network = { path = "../lib-network" }
 lib-protocols = { path = "../lib-protocols" }
 lib-types = { path = "../lib-types" }
+quinn = "0.11"
+rcgen = "0.14.5"
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls-pemfile = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+ciborium = "0.2"
 tokio = { version = "1.0", features = ["full"] }
 toml = "0.8"
 uuid = { version = "1.0", features = ["v4"] }

--- a/zhtp-daemon/src/backend_pool.rs
+++ b/zhtp-daemon/src/backend_pool.rs
@@ -450,7 +450,7 @@ impl BackendPool {
         // First try to send a lightweight request through the existing client.
         let existing_ok = {
             let client_guard = entry.client.read().await;
-            let req = ZhtpRequest::get("/healthz".to_string(), Some(identity.id.clone()))?;
+            let req = ZhtpRequest::get("/api/v1/network/ping".to_string(), Some(identity.id.clone()))?;
             match tokio::time::timeout(
                 Duration::from_millis(2000),
                 client_guard.request(req),
@@ -472,7 +472,7 @@ impl BackendPool {
         *client_guard = new_client;
 
         // Verify with a request after reconnect.
-        let req = ZhtpRequest::get("/healthz".to_string(), Some(identity.id.clone()))?;
+        let req = ZhtpRequest::get("/api/v1/network/ping".to_string(), Some(identity.id.clone()))?;
         let resp = tokio::time::timeout(Duration::from_millis(2000), client_guard.request(req))
             .await
             .map_err(|_| anyhow!("Health probe request timed out after reconnect"))?
@@ -495,7 +495,7 @@ impl BackendPool {
     ) -> Result<Web4Client> {
         let client_config = Web4ClientConfig {
             allow_bootstrap: trust_config.bootstrap_mode,
-            cache_dir: Some(crate::config::DaemonConfig::root_dir()?.join("client-cache")),
+            cache_dir: Some(crate::config::DaemonConfig::root_dir()?.join("client-cache").join(addr.replace(['/', ':'], "_"))),
             session_id: Some(format!("gateway-backend-{}", addr.replace(['/', ':'], "_"))),
         };
 

--- a/zhtp-daemon/src/config.rs
+++ b/zhtp-daemon/src/config.rs
@@ -31,6 +31,10 @@ pub struct GatewayConfig {
     /// Public listen address for incoming client connections.
     #[serde(default = "default_listen_addr")]
     pub listen_addr: String,
+    /// QUIC listen address for incoming native ZHTP connections.
+    /// Defaults to the same value as `listen_addr` so UDP and TCP share the port.
+    #[serde(default = "default_listen_addr")]
+    pub quic_listen_addr: String,
     /// Total request timeout in milliseconds.
     #[serde(default = "default_request_timeout_ms")]
     pub request_timeout_ms: u64,
@@ -109,6 +113,7 @@ impl Default for GatewayConfig {
     fn default() -> Self {
         Self {
             listen_addr: default_listen_addr(),
+            quic_listen_addr: default_listen_addr(),
             request_timeout_ms: default_request_timeout_ms(),
             connect_timeout_ms: default_connect_timeout_ms(),
             backend_selection: BackendSelectionPolicy::default(),

--- a/zhtp-daemon/src/lib.rs
+++ b/zhtp-daemon/src/lib.rs
@@ -1,0 +1,16 @@
+//! zhtp-daemon library — reusable gateway service and QUIC server.
+//!
+//! When used as a library from the `zhtp` binary, only the gateway/ingress
+//! parts are typically needed.  The HTTP server (browser-extension API) is
+//! kept in `main.rs` and is NOT re-exported here.
+
+pub mod backend_pool;
+pub mod config;
+pub mod discovery;
+pub mod identity;
+pub mod metrics;
+pub mod quic_server;
+pub mod service;
+
+// api module is HTTP-only; not re-exported for library use.
+mod api;

--- a/zhtp-daemon/src/main.rs
+++ b/zhtp-daemon/src/main.rs
@@ -4,11 +4,13 @@ mod config;
 mod discovery;
 mod identity;
 mod metrics;
+mod quic_server;
 mod service;
 
 use anyhow::{Context, Result};
 use axum::Router;
 use config::DaemonConfig;
+use quic_server::QuicGatewayServer;
 use service::ZhtpDaemonService;
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -37,23 +39,66 @@ async fn async_main() -> Result<()> {
     let (config, config_path) = DaemonConfig::load_or_create()?;
     let root_dir = DaemonConfig::root_dir()?;
     let identity = identity::load_or_create(&root_dir)?;
-    let service = Arc::new(ZhtpDaemonService::new(config.clone(), identity).await?);
+
+    // Initialize network genesis so Web4Client can derive the network epoch.
+    let _ = lib_identity::types::node_id::try_set_network_genesis(
+        lib_identity::constants::TESTNET_GENESIS_HASH,
+    );
+
+    let service = Arc::new(ZhtpDaemonService::new(config.clone(), identity.clone()).await?);
+
+    let gateway_cfg = config.effective_gateway_config();
 
     info!(
         config_path = %config_path.display(),
         listen_addr = %config.listen_addr,
+        quic_listen_addr = %gateway_cfg.quic_listen_addr,
         backend_count = config.static_backends().len(),
         "Starting zhtp-daemon"
     );
 
-    let app = build_router(service);
+    // Start HTTP server (local loopback for browser extension)
+    let app = build_router(service.clone());
     let listener = TcpListener::bind(&config.listen_addr)
         .await
-        .with_context(|| format!("Failed to bind {}", config.listen_addr))?;
+        .with_context(|| format!("Failed to bind TCP {}", config.listen_addr))?;
 
-    axum::serve(listener, app)
-        .await
-        .context("Daemon server failed")?;
+    let http_task = tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            tracing::error!("HTTP server error: {}", e);
+        }
+    });
+
+    // Start QUIC gateway server (for native app connections)
+    let quic_bind: std::net::SocketAddr = gateway_cfg
+        .quic_listen_addr
+        .parse()
+        .with_context(|| format!("Invalid quic_listen_addr: {}", gateway_cfg.quic_listen_addr))?;
+
+    let cert_path = root_dir.join("gateway-cert.pem");
+    let key_path = root_dir.join("gateway-key.pem");
+
+    let quic_server = QuicGatewayServer::new(
+        quic_bind,
+        service.clone(),
+        Arc::new(identity),
+        &cert_path,
+        &key_path,
+    )
+    .await
+    .context("Failed to start QUIC gateway server")?;
+
+    let quic_task = tokio::spawn(async move {
+        if let Err(e) = quic_server.run().await {
+            tracing::error!("QUIC server error: {}", e);
+        }
+    });
+
+    tokio::select! {
+        _ = http_task => {},
+        _ = quic_task => {},
+    }
+
     Ok(())
 }
 

--- a/zhtp-daemon/src/quic_server.rs
+++ b/zhtp-daemon/src/quic_server.rs
@@ -1,0 +1,774 @@
+//! QUIC Gateway Server
+//!
+//! Accepts native ZHTP connections over QUIC and transparently forwards requests
+//! to backend validators via the existing `BackendPool` / `Web4Client` infrastructure.
+//!
+//! Supports two connection modes:
+//! - **Public** (`zhtp-public/1`): No UHP handshake; wire-format ZHTP requests are
+//!   read directly, forwarded, and responses written back.
+//! - **ControlPlane** (`zhtp-uhp/1` or `zhtp-uhp/2`): Full UHP v2 handshake as
+//!   responder.  Incoming requests are authenticated (v2 MAC + monotonic counter)
+//!   before forwarding.  The gateway strips `auth_context` and attaches a signed
+//!   `ForwardedClientContext` for the backend.
+
+use anyhow::{anyhow, Context, Result};
+use quinn::{Connection, Endpoint, ServerConfig};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::time::{timeout, Duration};
+use tracing::{debug, info, warn};
+
+use lib_identity::ZhtpIdentity;
+use lib_network::handshake::HandshakeContext;
+use lib_network::protocols::quic_handshake;
+use lib_network::protocols::types::session::V2Session;
+use lib_protocols::types::{ZhtpRequest, ZhtpResponse, ZhtpStatus};
+use lib_protocols::wire::{read_request, write_response, ZhtpResponseWire};
+
+/// ZHTP native protocol magic bytes (used by mobile app public requests).
+const ZHTP_MAGIC: &[u8; 4] = b"ZHTP";
+const ZHTP_VERSION: u8 = 1;
+const MAX_ZHTP_MESSAGE_SIZE: usize = 10 * 1024 * 1024;
+
+/// Payload format inside a ZHTP frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PayloadFormat {
+    Cbor,
+    Json,
+}
+
+impl PayloadFormat {
+    fn detect(data: &[u8]) -> Self {
+        if data.is_empty() {
+            return PayloadFormat::Cbor;
+        }
+        let first_non_ws = data
+            .iter()
+            .find(|&&b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'))
+            .copied()
+            .unwrap_or(0);
+        if first_non_ws == b'{' || first_non_ws == b'[' {
+            return PayloadFormat::Json;
+        }
+        let major_type = data[0] >> 5;
+        if major_type == 5 || major_type == 4 {
+            return PayloadFormat::Cbor;
+        }
+        PayloadFormat::Cbor
+    }
+}
+
+/// Read a ZHTP-framed request ([ZHTP][ver][len][payload]) from a QUIC stream.
+async fn read_zhtp_frame<R: AsyncReadExt + Unpin>(reader: &mut R) -> Result<(ZhtpRequest, PayloadFormat)> {
+    let mut header = [0u8; 9];
+    reader
+        .read_exact(&mut header)
+        .await
+        .context("Failed to read ZHTP header")?;
+
+    if &header[0..4] != ZHTP_MAGIC {
+        return Err(anyhow!(
+            "Invalid ZHTP magic: expected ZHTP, got {:?}",
+            &header[0..4]
+        ));
+    }
+    if header[4] != ZHTP_VERSION {
+        return Err(anyhow!("Unsupported ZHTP version: {}", header[4]));
+    }
+
+    let len = u32::from_be_bytes([header[5], header[6], header[7], header[8]]) as usize;
+    if len > MAX_ZHTP_MESSAGE_SIZE {
+        return Err(anyhow!(
+            "Message too large: {} bytes (max {})",
+            len,
+            MAX_ZHTP_MESSAGE_SIZE
+        ));
+    }
+
+    let mut payload = vec![0u8; len];
+    reader
+        .read_exact(&mut payload)
+        .await
+        .context("Failed to read ZHTP payload")?;
+
+    let format = PayloadFormat::detect(&payload);
+    let request = match format {
+        PayloadFormat::Cbor => ciborium::from_reader(&payload[..])
+            .context("Failed to deserialize ZhtpRequest from CBOR")?,
+        PayloadFormat::Json => serde_json::from_slice(&payload)
+            .context("Failed to deserialize ZhtpRequest from JSON")?,
+    };
+
+    Ok((request, format))
+}
+
+/// Write a ZHTP-framed response ([ZHTP][ver][len][payload]) to a QUIC stream.
+async fn write_zhtp_frame<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    response: &ZhtpResponse,
+    format: PayloadFormat,
+) -> Result<()> {
+    let payload = match format {
+        PayloadFormat::Cbor => {
+            let mut buf = Vec::new();
+            ciborium::into_writer(response, &mut buf)
+                .context("Failed to serialize ZhtpResponse as CBOR")?;
+            buf
+        }
+        PayloadFormat::Json => serde_json::to_vec(response)
+            .context("Failed to serialize ZhtpResponse as JSON")?,
+    };
+
+    if payload.len() > MAX_ZHTP_MESSAGE_SIZE {
+        return Err(anyhow!(
+            "Response too large: {} bytes (max {})",
+            payload.len(),
+            MAX_ZHTP_MESSAGE_SIZE
+        ));
+    }
+
+    let mut frame = Vec::with_capacity(9 + payload.len());
+    frame.extend_from_slice(ZHTP_MAGIC);
+    frame.push(ZHTP_VERSION);
+    frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    frame.extend_from_slice(&payload);
+
+    writer
+        .write_all(&frame)
+        .await
+        .context("Failed to write ZHTP frame")?;
+    Ok(())
+}
+
+use crate::service::ZhtpDaemonService;
+
+/// Idle timeout while waiting for the next bidirectional stream.
+const CLIENT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+/// Maximum time allowed for the UHP v2 handshake.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Parsed connection mode from the negotiated ALPN.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionMode {
+    Public,
+    ControlPlane,
+    Mesh,
+}
+
+impl ConnectionMode {
+    fn from_alpn(alpn: Option<&[u8]>) -> Self {
+        match alpn {
+            Some(b"zhtp-public/1") => ConnectionMode::Public,
+            Some(b"zhtp-uhp/1") | Some(b"zhtp-uhp/2") => ConnectionMode::ControlPlane,
+            Some(b"zhtp-mesh/1") => ConnectionMode::Mesh,
+            // Legacy / HTTP-compat identifiers map to public read-only.
+            Some(b"zhtp-http/1") | Some(b"zhtp/1.0") | Some(b"h3") => ConnectionMode::Public,
+            _ => ConnectionMode::Public,
+        }
+    }
+}
+
+/// Self-signed TLS certificate material.
+struct SelfSignedCert {
+    cert: CertificateDer<'static>,
+    key: PrivateKeyDer<'static>,
+}
+
+/// QUIC server that proxies native ZHTP traffic to backend validators.
+#[derive(Clone)]
+pub struct QuicGatewayServer {
+    service: Arc<ZhtpDaemonService>,
+    identity: Arc<ZhtpIdentity>,
+    endpoint: Endpoint,
+}
+
+impl QuicGatewayServer {
+    /// Create a new QUIC gateway endpoint.
+    ///
+    /// If `cert_path` / `key_path` do not exist a fresh self-signed certificate
+    /// is generated and persisted.
+    pub async fn new(
+        bind_addr: SocketAddr,
+        service: Arc<ZhtpDaemonService>,
+        identity: Arc<ZhtpIdentity>,
+        cert_path: &Path,
+        key_path: &Path,
+    ) -> Result<Self> {
+        // rustls 0.23+ requires a crypto provider to be installed.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let cert = load_or_generate_cert(cert_path, key_path)
+            .with_context(|| "Failed to load or generate TLS certificate")?;
+
+        let mut rustls_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert.cert], cert.key)
+            .context("Failed to build rustls ServerConfig")?;
+
+        rustls_config.alpn_protocols = lib_network::constants::server_alpns();
+
+        let quic_crypto = quinn::crypto::rustls::QuicServerConfig::try_from(rustls_config)
+            .context("Failed to create Quinn crypto config")?;
+        let mut server_config = ServerConfig::with_crypto(Arc::new(quic_crypto));
+
+        let mut transport = quinn::TransportConfig::default();
+        transport.max_concurrent_bidi_streams(100u32.into());
+        transport.max_concurrent_uni_streams(10u32.into());
+        transport.max_idle_timeout(Some(Duration::from_secs(300).try_into().unwrap()));
+        server_config.transport_config(Arc::new(transport));
+
+        let endpoint = Endpoint::server(server_config, bind_addr)
+            .with_context(|| format!("Failed to bind QUIC endpoint to {}", bind_addr))?;
+
+        info!("🔐 QUIC gateway listening on {}", endpoint.local_addr()?);
+
+        Ok(Self {
+            service,
+            identity,
+            endpoint,
+        })
+    }
+
+    /// Run the accept loop until the endpoint is closed.
+    pub async fn run(&self) -> Result<()> {
+        info!("🌐 QUIC gateway accept loop started");
+        loop {
+            match self.endpoint.accept().await {
+                Some(incoming) => {
+                    let this = self.clone();
+                    tokio::spawn(async move {
+                        match incoming.await {
+                            Ok(connection) => {
+                                if let Err(e) = this.handle_connection(connection).await {
+                                    debug!("QUIC connection handler ended: {}", e);
+                                }
+                            }
+                            Err(e) => {
+                                warn!("QUIC incoming connection failed: {}", e);
+                            }
+                        }
+                    });
+                }
+                None => {
+                    info!("QUIC endpoint closed");
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Dispatch an established connection based on ALPN.
+    async fn handle_connection(&self, connection: Connection) -> Result<()> {
+        let peer_addr = connection.remote_address();
+
+        let alpn = connection
+            .handshake_data()
+            .and_then(|hd| hd.downcast::<quinn::crypto::rustls::HandshakeData>().ok())
+            .and_then(|hd| hd.protocol.clone());
+
+        let mode = ConnectionMode::from_alpn(alpn.as_deref());
+
+        info!(
+            "📡 QUIC connection from {} (mode: {:?}, alpn: {:?})",
+            peer_addr,
+            mode,
+            alpn.as_ref().map(|a| String::from_utf8_lossy(a))
+        );
+
+        match mode {
+            ConnectionMode::Public => self.handle_public_connection(connection, peer_addr).await,
+            ConnectionMode::ControlPlane => {
+                self.handle_control_plane_connection(connection, peer_addr)
+                    .await
+            }
+            ConnectionMode::Mesh => {
+                warn!("Mesh connections are not supported on gateway");
+                connection.close(0u32.into(), b"mesh not supported");
+                Ok(())
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Public mode (no UHP handshake)
+    // ------------------------------------------------------------------
+
+    async fn handle_public_connection(
+        &self,
+        connection: Connection,
+        peer_addr: SocketAddr,
+    ) -> Result<()> {
+        loop {
+            match timeout(CLIENT_IDLE_TIMEOUT, connection.accept_bi()).await {
+                Ok(Ok((send, recv))) => {
+                    let this = self.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = this.handle_public_stream(recv, send, peer_addr).await {
+                            debug!("Public stream from {} ended: {}", peer_addr, e);
+                        }
+                    });
+                }
+                Ok(Err(quinn::ConnectionError::ApplicationClosed(_))) => {
+                    debug!("Public connection closed by {}", peer_addr);
+                    break;
+                }
+                Ok(Err(quinn::ConnectionError::TimedOut)) => {
+                    debug!("Public connection timed out from {}", peer_addr);
+                    break;
+                }
+                Ok(Err(e)) => {
+                    debug!("Public connection error from {}: {}", peer_addr, e);
+                    break;
+                }
+                Err(_) => {
+                    debug!("Public connection idle timeout from {}", peer_addr);
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_public_stream(
+        &self,
+        mut recv: quinn::RecvStream,
+        mut send: quinn::SendStream,
+        peer_addr: SocketAddr,
+    ) -> Result<()> {
+        let (request, format) = read_zhtp_frame(&mut recv)
+            .await
+            .context("Failed to read public ZHTP request")?;
+
+        debug!(
+            uri = %request.uri,
+            method = ?request.method,
+            format = ?format,
+            "Public ZHTP request"
+        );
+
+        let response = self
+            .forward_request(request, peer_addr)
+            .await
+            .unwrap_or_else(|e| {
+                warn!("Forward failed: {}", e);
+                ZhtpResponse::error(ZhtpStatus::BadGateway, format!("Gateway forward error: {}", e))
+            });
+
+        write_zhtp_frame(&mut send, &response, format)
+            .await
+            .context("Failed to write public ZHTP response")?;
+
+        send.finish().ok();
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // ControlPlane mode (UHP v2 handshake + authenticated streams)
+    // ------------------------------------------------------------------
+
+    async fn handle_control_plane_connection(
+        &self,
+        connection: Connection,
+        peer_addr: SocketAddr,
+    ) -> Result<()> {
+        info!(
+            "🔐 ControlPlane connection from {} — starting UHP v2 handshake",
+            peer_addr
+        );
+
+        let (_identity, handshake_result) = self
+            .perform_uhp_handshake(&connection, &peer_addr)
+            .await?;
+
+        let peer_did = handshake_result.verified_peer.identity.did.clone();
+        let session_key = handshake_result.session_key;
+        let transcript_hash = handshake_result.handshake_hash;
+        let session_id = handshake_result.session_id;
+
+        let v2_keys = lib_network::handshake::security::derive_v2_session_keys(
+            &session_key,
+            &transcript_hash,
+        )
+        .context("Failed to derive v2 session keys")?;
+
+        let v2_session = V2Session::new(session_id, v2_keys.mac_key, peer_did.clone(), None);
+
+        info!(
+            peer_did = %peer_did,
+            session_id = %hex::encode(&session_id[..8]),
+            "✅ UHP v2 authenticated from {}",
+            peer_addr
+        );
+
+        let session = Arc::new(v2_session);
+
+        loop {
+            match timeout(CLIENT_IDLE_TIMEOUT, connection.accept_bi()).await {
+                Ok(Ok((send, recv))) => {
+                    let this = self.clone();
+                    let session = session.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = this
+                            .handle_control_plane_stream(recv, send, &session, peer_addr)
+                            .await
+                        {
+                            debug!(
+                                "ControlPlane stream from {} ended: {}",
+                                peer_addr, e
+                            );
+                        }
+                    });
+                }
+                Ok(Err(quinn::ConnectionError::ApplicationClosed(_))) => {
+                    debug!("ControlPlane connection closed by {}", peer_addr);
+                    break;
+                }
+                Ok(Err(quinn::ConnectionError::TimedOut)) => {
+                    debug!("ControlPlane connection timed out from {}", peer_addr);
+                    break;
+                }
+                Ok(Err(e)) => {
+                    debug!("ControlPlane connection error from {}: {}", peer_addr, e);
+                    break;
+                }
+                Err(_) => {
+                    debug!("ControlPlane idle timeout from {}", peer_addr);
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn perform_uhp_handshake(
+        &self,
+        connection: &Connection,
+        _peer_addr: &SocketAddr,
+    ) -> Result<(
+        ZhtpIdentity,
+        lib_network::protocols::quic_handshake::QuicHandshakeResult,
+    )> {
+        let nonce_cache =
+            lib_network::handshake::get_or_init_global_nonce_cache(3600, 100_000)
+                .context("Failed to get global nonce cache")?;
+        let handshake_ctx = HandshakeContext::new(nonce_cache.clone());
+
+        let result = timeout(
+            HANDSHAKE_TIMEOUT,
+            quic_handshake::handshake_as_responder(
+                connection,
+                &self.identity,
+                &handshake_ctx,
+            ),
+        )
+        .await
+        .context("UHP handshake timed out")?
+        .context("UHP handshake failed")?;
+
+        Ok(((*self.identity).clone(), result))
+    }
+
+    async fn handle_control_plane_stream(
+        &self,
+        mut recv: quinn::RecvStream,
+        mut send: quinn::SendStream,
+        session: &V2Session,
+        peer_addr: SocketAddr,
+    ) -> Result<()> {
+        use lib_network::handshake::security::{verify_v2_mac, CanonicalRequest};
+
+        let wire_request = read_request(&mut recv)
+            .await
+            .context("Failed to read authenticated v2 request")?;
+
+        let auth_ctx = match &wire_request.auth_context {
+            Some(ctx) => ctx,
+            None => {
+                warn!("V2 request missing auth_context — rejecting");
+                let err = ZhtpResponseWire::error(
+                    wire_request.request_id,
+                    ZhtpStatus::Unauthorized,
+                    "V2 requires authentication context".into(),
+                );
+                write_response(&mut send, &err).await?;
+                send.finish().ok();
+                return Ok(());
+            }
+        };
+
+        // Verify DID matches session.
+        if auth_ctx.client_did != session.peer_did() {
+            warn!(
+                expected = %session.peer_did(),
+                received = %auth_ctx.client_did,
+                "Client DID mismatch"
+            );
+            let err = ZhtpResponseWire::error(
+                wire_request.request_id,
+                ZhtpStatus::Unauthorized,
+                "Invalid client identity".into(),
+            );
+            write_response(&mut send, &err).await?;
+            send.finish().ok();
+            return Ok(());
+        }
+
+        // Verify session_id matches.
+        if auth_ctx.session_id != *session.session_id() {
+            warn!("Session ID mismatch in v2 request");
+            let err = ZhtpResponseWire::error(
+                wire_request.request_id,
+                ZhtpStatus::Unauthorized,
+                "Invalid session".into(),
+            );
+            write_response(&mut send, &err).await?;
+            send.finish().ok();
+            return Ok(());
+        }
+
+        // Build canonical request and verify MAC.
+        let method_byte = method_to_byte(wire_request.request.method);
+        let canonical = CanonicalRequest {
+            method: method_byte,
+            path: wire_request.request.uri.clone(),
+            body: wire_request.request.body.clone(),
+        };
+
+        if !verify_v2_mac(
+            session.mac_key(),
+            &canonical,
+            auth_ctx.sequence,
+            session.session_id(),
+            &auth_ctx.request_mac,
+        ) {
+            warn!("V2 MAC verification failed");
+            let err = ZhtpResponseWire::error(
+                wire_request.request_id,
+                ZhtpStatus::Unauthorized,
+                "MAC verification failed".into(),
+            );
+            write_response(&mut send, &err).await?;
+            send.finish().ok();
+            return Ok(());
+        }
+
+        // Validate counter (replay protection).
+        if let Err(e) = session.validate_counter(auth_ctx.sequence) {
+            warn!("Counter validation failed: {}", e);
+            let err = ZhtpResponseWire::error(
+                wire_request.request_id,
+                ZhtpStatus::Unauthorized,
+                "Invalid counter — possible replay".into(),
+            );
+            write_response(&mut send, &err).await?;
+            send.finish().ok();
+            return Ok(());
+        }
+
+        // Forward the request (auth_context is intentionally dropped).
+        let mut request = wire_request.request;
+        request.requester =
+            lib_identity::did::parse_did_to_identity_id(session.peer_did()).ok();
+        request
+            .headers
+            .custom
+            .insert("peer_addr".to_string(), peer_addr.to_string());
+        request
+            .headers
+            .custom
+            .insert("peer_addr_source".to_string(), "quic".to_string());
+
+        let response = self
+            .forward_request(request, peer_addr)
+            .await
+            .unwrap_or_else(|e| {
+                warn!("Forward failed: {}", e);
+                ZhtpResponse::error(
+                    ZhtpStatus::BadGateway,
+                    format!("Gateway forward error: {}", e),
+                )
+            });
+
+        let wire_response = ZhtpResponseWire::success(wire_request.request_id, response);
+        write_response(&mut send, &wire_response)
+            .await
+            .context("Failed to write v2 wire response")?;
+        send.finish().ok();
+
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // Shared helpers
+    // ------------------------------------------------------------------
+
+    /// Forward a `ZhtpRequest` to a backend via the service layer.
+    async fn forward_request(
+        &self,
+        request: ZhtpRequest,
+        peer_addr: SocketAddr,
+    ) -> Result<ZhtpResponse> {
+        self.service
+            .forward_zhtp_request(request, Some(peer_addr.to_string()))
+            .await
+    }
+}
+
+// ------------------------------------------------------------------
+// Certificate management
+// ------------------------------------------------------------------
+
+fn load_or_generate_cert(cert_path: &Path, key_path: &Path) -> Result<SelfSignedCert> {
+    if cert_path.exists() && key_path.exists() {
+        let cert_pem = std::fs::read(cert_path).context("Failed to read certificate file")?;
+        let key_pem = std::fs::read(key_path).context("Failed to read key file")?;
+
+        let cert_der = rustls_pemfile::certs(&mut cert_pem.as_slice())
+            .next()
+            .ok_or_else(|| anyhow!("No certificate found in PEM file"))?
+            .context("Failed to parse certificate PEM")?;
+
+        let key_der = rustls_pemfile::private_key(&mut key_pem.as_slice())
+            .context("Failed to parse private key PEM")?
+            .ok_or_else(|| anyhow!("No private key found in PEM file"))?;
+
+        return Ok(SelfSignedCert {
+            cert: cert_der,
+            key: key_der,
+        });
+    }
+
+    let subject_alt_names = vec![
+        "zhtp-gateway".to_string(),
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "*.local".to_string(),
+        "*".to_string(),
+    ];
+
+    let rcgen::CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(subject_alt_names)
+            .context("Failed to generate self-signed certificate")?;
+
+    if let Some(parent) = cert_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+
+    std::fs::write(cert_path, cert.pem()).context("Failed to write certificate file")?;
+    std::fs::write(key_path, signing_key.serialize_pem()).context("Failed to write key file")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(key_path, std::fs::Permissions::from_mode(0o600))
+            .context("Failed to set private key permissions")?;
+    }
+
+    let cert_der = rustls_pemfile::certs(&mut cert.pem().as_bytes())
+        .next()
+        .ok_or_else(|| anyhow!("No certificate found in generated PEM"))?
+        .context("Failed to parse generated certificate")?;
+
+    let key_der = rustls_pemfile::private_key(&mut signing_key.serialize_pem().as_bytes())
+        .context("Failed to parse generated key PEM")?
+        .ok_or_else(|| anyhow!("No private key found in generated PEM"))?;
+
+    Ok(SelfSignedCert {
+        cert: cert_der,
+        key: key_der,
+    })
+}
+
+// ------------------------------------------------------------------
+// Utilities
+// ------------------------------------------------------------------
+
+fn method_to_byte(method: lib_protocols::types::ZhtpMethod) -> u8 {
+    use lib_protocols::types::ZhtpMethod;
+    match method {
+        ZhtpMethod::Get => 0,
+        ZhtpMethod::Post => 1,
+        ZhtpMethod::Put => 2,
+        ZhtpMethod::Delete => 3,
+        ZhtpMethod::Patch => 4,
+        ZhtpMethod::Head => 5,
+        ZhtpMethod::Options => 6,
+        _ => 255,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_mode_from_alpn_public() {
+        assert_eq!(ConnectionMode::from_alpn(Some(b"zhtp-public/1")), ConnectionMode::Public);
+    }
+
+    #[test]
+    fn connection_mode_from_alpn_control_plane_v1() {
+        assert_eq!(ConnectionMode::from_alpn(Some(b"zhtp-uhp/1")), ConnectionMode::ControlPlane);
+    }
+
+    #[test]
+    fn connection_mode_from_alpn_control_plane_v2() {
+        assert_eq!(ConnectionMode::from_alpn(Some(b"zhtp-uhp/2")), ConnectionMode::ControlPlane);
+    }
+
+    #[test]
+    fn connection_mode_from_alpn_mesh() {
+        assert_eq!(ConnectionMode::from_alpn(Some(b"zhtp-mesh/1")), ConnectionMode::Mesh);
+    }
+
+    #[test]
+    fn connection_mode_from_alpn_legacy_http() {
+        assert_eq!(ConnectionMode::from_alpn(Some(b"zhtp-http/1")), ConnectionMode::Public);
+        assert_eq!(ConnectionMode::from_alpn(Some(b"h3")), ConnectionMode::Public);
+    }
+
+    #[test]
+    fn connection_mode_from_alpn_unknown_defaults_to_public() {
+        assert_eq!(ConnectionMode::from_alpn(Some(b"unknown/1")), ConnectionMode::Public);
+        assert_eq!(ConnectionMode::from_alpn(None), ConnectionMode::Public);
+    }
+
+    #[test]
+    fn method_to_byte_maps_correctly() {
+        use lib_protocols::types::ZhtpMethod;
+        assert_eq!(method_to_byte(ZhtpMethod::Get), 0);
+        assert_eq!(method_to_byte(ZhtpMethod::Post), 1);
+        assert_eq!(method_to_byte(ZhtpMethod::Put), 2);
+        assert_eq!(method_to_byte(ZhtpMethod::Delete), 3);
+        assert_eq!(method_to_byte(ZhtpMethod::Patch), 4);
+        assert_eq!(method_to_byte(ZhtpMethod::Head), 5);
+        assert_eq!(method_to_byte(ZhtpMethod::Options), 6);
+        assert_eq!(method_to_byte(ZhtpMethod::Trace), 255);
+    }
+
+    #[test]
+    fn load_or_generate_cert_creates_valid_certificate() {
+        let tmp = std::env::temp_dir().join(format!("zhtp-test-certs-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let cert_path = tmp.join("test-cert.pem");
+        let key_path = tmp.join("test-key.pem");
+
+        // First call should generate
+        let cert1 = load_or_generate_cert(&cert_path, &key_path).unwrap();
+        assert!(cert_path.exists());
+        assert!(key_path.exists());
+
+        // Second call should load existing
+        let cert2 = load_or_generate_cert(&cert_path, &key_path).unwrap();
+        assert_eq!(cert1.cert.as_ref(), cert2.cert.as_ref());
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/zhtp-daemon/src/service.rs
+++ b/zhtp-daemon/src/service.rs
@@ -337,7 +337,29 @@ impl ZhtpDaemonService {
         Ok(response.body)
     }
 
-    async fn attach_forwarded_context(&self, request: ZhtpRequest, client_ip: Option<String>) -> Result<ZhtpRequest> {
+    /// Forward a generic ZHTP request to a backend, attaching the gateway forwarding context.
+    pub async fn forward_zhtp_request(&self, request: ZhtpRequest, client_ip: Option<String>) -> Result<ZhtpResponse> {
+        let request = self.attach_forwarded_context(request, client_ip).await?;
+
+        let backend = self.backend_pool.pick_backend(&request).await?;
+        let start = std::time::Instant::now();
+
+        let result = backend.client.read().await.request(request).await;
+        match result {
+            Ok(response) => {
+                self.backend_pool
+                    .report_success(&backend.addr, start.elapsed().as_millis() as u64)
+                    .await;
+                Ok(response)
+            }
+            Err(e) => {
+                self.backend_pool.report_failure(&backend.addr).await;
+                Err(anyhow!("Backend request failed on {}: {}", backend.addr, e))
+            }
+        }
+    }
+
+    pub(crate) async fn attach_forwarded_context(&self, request: ZhtpRequest, client_ip: Option<String>) -> Result<ZhtpRequest> {
         let ttl_ms = self.config.effective_gateway_config().request_timeout_ms;
         let ctx = ForwardedClientContext::new(
             self.identity.did.clone(),

--- a/zhtp/Cargo.toml
+++ b/zhtp/Cargo.toml
@@ -32,6 +32,7 @@ lib-blockchain = { path = "../lib-blockchain", features = ["contracts"], optiona
 lib-consensus = { path = "../lib-consensus" }
 lib-economy = { path = "../lib-economy" }
 lib-protocols = { path = "../lib-protocols" }
+zhtp-daemon = { path = "../zhtp-daemon" }
 # Note: lib-api and lib-contracts will be added when available
 
 # Core async runtime

--- a/zhtp/README.md
+++ b/zhtp/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[![Rust](https://img.shields.io/badge/rust-1.70+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-nightly-orange.svg)](https://www.rust-lang.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/zhtp/zhtp)
 
@@ -114,7 +114,7 @@ The ZHTP orchestrator contains sophisticated internal systems:
 
 ### Prerequisites
 
-1. **Rust 1.70+** - Install from [rustup.rs](https://rustup.rs/)
+1. **Rust nightly** - Install from [rustup.rs](https://rustup.rs/) (repository uses `rust-toolchain.toml`)
 2. **All ZHTP Libraries** - Ensure all 9 lib-* packages are available in parent directory
 3. **System Requirements** - 4GB RAM, 10GB storage minimum
 
@@ -142,7 +142,7 @@ cargo build --release
 4. **Run initial setup:**
 ```bash
 # Create default configuration
-cargo run -- node start --dev
+cargo run -- --config zhtp/configs/dev-node.toml
 ```
 
 ### Quick Start
@@ -166,7 +166,7 @@ zhtp> network status          # Check mesh network status
 #### Method 2: Direct Commands
 ```bash
 # Execute single commands directly
-cargo run -- node start --config config.toml
+cargo run -- --config config.toml
 cargo run -- wallet balance <address>
 cargo run -- dao claim-ubi
 cargo run -- network peers
@@ -178,13 +178,13 @@ cargo run -- network peers
 
 ```bash
 # Start with default settings
-cargo run -- node start
+cargo run -- --config zhtp/configs/dev-node.toml
 
 # Start with custom configuration
-cargo run -- node start --config custom.toml --port 9334 --dev
+cargo run -- --config custom.toml --mesh-port 9334
 
 # Start in pure mesh mode (no TCP/IP fallback)
-cargo run -- node start --pure-mesh
+cargo run -- --config zhtp/configs/edge-node.toml --pure-mesh
 ```
 
 ### Identity Management
@@ -403,10 +403,10 @@ cargo test -- --nocapture
 
 ```bash
 # Start in development mode with enhanced logging
-cargo run -- node start --dev
+cargo run -- --config zhtp/configs/dev-node.toml
 
 # Use custom configuration for development
-cargo run -- node start --config dev-config.toml --dev
+cargo run -- --config dev-config.toml
 ```
 
 ## Security Features

--- a/zhtp/configs/MAC_NODE_QUICKSTART.md
+++ b/zhtp/configs/MAC_NODE_QUICKSTART.md
@@ -1,0 +1,48 @@
+# macOS Node Quickstart (Validated)
+
+This quickstart is the supported baseline for bringing up a node on macOS with stable transport defaults.
+
+## Prerequisites
+
+- Xcode Command Line Tools (`xcode-select --install`)
+- Rust nightly toolchain (repo uses `rust-toolchain.toml`)
+- Git
+
+## 1) Install/activate nightly
+
+```bash
+rustup toolchain install nightly
+rustup default nightly
+```
+
+## 2) Build binaries
+
+```bash
+cargo build --release --workspace
+```
+
+## 3) Validate mac baseline config
+
+```bash
+bash zhtp/configs/validate-config.sh zhtp/configs/mac-bootstrap.toml
+```
+
+Expected validation includes:
+
+- `Transport contract: QUIC-only mesh transport validated`
+
+## 4) Start the node
+
+```bash
+./target/release/zhtp --config zhtp/configs/mac-bootstrap.toml
+```
+
+## Experimental transport opt-in (macOS)
+
+`quic` is the stable default transport profile on macOS.
+To opt in to experimental transports (`bluetooth`, `bluetooth_le`, `wifi_direct`, `lorawan`):
+
+```bash
+export ZHTP_ENABLE_EXPERIMENTAL_MAC_TRANSPORTS=1
+./target/release/zhtp --config zhtp/configs/full-node.toml
+```

--- a/zhtp/configs/MAC_NODE_QUICKSTART.md
+++ b/zhtp/configs/MAC_NODE_QUICKSTART.md
@@ -37,6 +37,16 @@ Expected validation includes:
 ./target/release/zhtp --config zhtp/configs/mac-bootstrap.toml
 ```
 
+## Bootstrap Leader Prerequisites (Clean Boot)
+
+For a brand-new network (empty local `sled/`), only the bootstrap leader is allowed to initialize genesis.
+
+- `network_config.bootstrap_validators[0].identity_id` must be set in config
+- Local keystore identity DID must match that first bootstrap validator DID on the leader machine
+- Non-leader nodes must wait for leader genesis and sync from peers (or copy a healthy `sled/`)
+
+If the prerequisites are not met, startup fails safely with a genesis-gate error and remediation steps.
+
 ## Experimental transport opt-in (macOS)
 
 `quic` is the stable default transport profile on macOS.

--- a/zhtp/configs/README.md
+++ b/zhtp/configs/README.md
@@ -115,6 +115,8 @@ For first-run node bring-up on macOS, use the QUIC-only baseline profile:
 zhtp --config zhtp/configs/mac-bootstrap.toml
 ```
 
+For a full validated bring-up checklist, see `zhtp/configs/MAC_NODE_QUICKSTART.md`.
+
 Experimental transports (`bluetooth`, `bluetooth_le`, `wifi_direct`, `lorawan`) are opt-in on macOS:
 
 ```bash
@@ -156,11 +158,11 @@ zhtp --config zhtp/configs/full-node.toml
 Copy any template and modify it for your specific needs:
 
 ```bash
-cp configs/full-node.toml configs/my-custom-node.toml
+cp zhtp/configs/full-node.toml zhtp/configs/my-custom-node.toml
 # Edit my-custom-node.toml
 
 # Validate your configuration
-./configs/validate-config.sh configs/my-custom-node.toml
+bash zhtp/configs/validate-config.sh zhtp/configs/my-custom-node.toml
 
 # Start with custom configuration
 zhtp --config zhtp/configs/my-custom-node.toml
@@ -242,14 +244,14 @@ Before starting a node, validate your configuration:
 
 ```bash
 # Validate any configuration file
-./configs/validate-config.sh ./configs/full-node.toml
-./configs/validate-config.sh ./configs/my-custom-node.toml
+bash zhtp/configs/validate-config.sh zhtp/configs/full-node.toml
+bash zhtp/configs/validate-config.sh zhtp/configs/my-custom-node.toml
 ```
 
 ### Support
 - Check logs in `./data/[node-type]/logs/`
-- Use `zhtp node status` for quick diagnostics
-- Validate configurations with `./configs/validate-config.sh`
+- Use `zhtp-cli node status` for quick diagnostics
+- Validate configurations with `bash zhtp/configs/validate-config.sh`
 - Monitor system resources and network connectivity
 
 ## Architecture Overview

--- a/zhtp/docs/README.md
+++ b/zhtp/docs/README.md
@@ -29,17 +29,11 @@ This documentation provides comprehensive coverage of the ZHTP (Zero-Knowledge H
 
 ### 3. [CLI Reference](cli-reference.md)
 **Command-line interface documentation**
-- Node lifecycle management (`zhtp node`)
-- Wallet operations (`zhtp wallet`)
-- DAO governance (`zhtp dao`)
-- Identity management (`zhtp identity`)
-- Network operations (`zhtp network`)
-- Blockchain commands (`zhtp blockchain`)
-- System monitoring (`zhtp monitor`)
-- Component management (`zhtp component`)
-- Interactive shell (`zhtp interactive`)
-- Server management (`zhtp server`)
-- Network isolation (`zhtp isolation`)
+- Node lifecycle management (`zhtp-cli node`)
+- Wallet operations (`zhtp-cli wallet`)
+- DAO governance (`zhtp-cli dao`)
+- Identity management (`zhtp-cli identity`)
+- Network operations (`zhtp-cli network`)
 
 ### 4. [Configuration Guide](configuration-guide.md)
 **Complete configuration system documentation**
@@ -95,32 +89,31 @@ sudo mv zhtp /usr/local/bin/
 ### Basic Usage
 ```bash
 # Start development node
-zhtp node start --dev
+zhtp --config zhtp/configs/dev-node.toml
 
 # Check status
-zhtp node status
-zhtp network status
-zhtp monitor health
+zhtp-cli node status
+zhtp-cli network status
 
 # Create identity and wallet
-zhtp identity create-did "MyIdentity" --identity-type human
-zhtp wallet create --name "MainWallet"
+zhtp-cli identity create-did "MyIdentity" --identity-type human
+zhtp-cli wallet create --name "MainWallet"
 
 # Participate in DAO
-zhtp dao info
-zhtp dao claim-ubi
+zhtp-cli dao info
+zhtp-cli dao claim-ubi
 ```
 
 ### Configuration
 ```bash
 # Create configuration
-cp configs/dev-node.toml my-config.toml
+cp zhtp/configs/dev-node.toml my-config.toml
 
 # Start with custom config
-zhtp node start --config my-config.toml --port 9333
+zhtp --config my-config.toml --mesh-port 9333
 
 # Pure mesh mode ()
-zhtp node start --config configs/pure-mesh.toml --pure-mesh
+zhtp --config zhtp/configs/edge-node.toml --pure-mesh
 ```
 
 ## Key Features

--- a/zhtp/src/api/handlers/mod.rs
+++ b/zhtp/src/api/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod guardian;
 pub mod identity;
 pub mod marketplace;
 pub mod mesh;
+pub mod nft;
 pub mod mobile_auth;
 pub mod monitor;
 pub mod network;

--- a/zhtp/src/api/handlers/nft/mod.rs
+++ b/zhtp/src/api/handlers/nft/mod.rs
@@ -1,0 +1,373 @@
+//! NFT API handler — create collections, mint, transfer, burn, query.
+
+use anyhow::Result;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use lib_blockchain::Blockchain;
+use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
+use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
+
+fn json_ok(data: serde_json::Value) -> Result<ZhtpResponse> {
+    let bytes = serde_json::to_vec(&data)?;
+    Ok(ZhtpResponse::success_with_content_type(
+        bytes,
+        "application/json".to_string(),
+        None,
+    ))
+}
+
+fn err(status: ZhtpStatus, msg: String) -> ZhtpResponse {
+    ZhtpResponse::error(status, msg)
+}
+
+pub struct NftHandler {
+    blockchain: Arc<RwLock<Blockchain>>,
+}
+
+impl NftHandler {
+    pub fn new(blockchain: Arc<RwLock<Blockchain>>) -> Self {
+        Self { blockchain }
+    }
+
+    /// GET /api/v1/nft/collections
+    async fn handle_list_collections(&self) -> Result<ZhtpResponse> {
+        let bc = self.blockchain.read().await;
+        let collections: Vec<serde_json::Value> = bc
+            .nft_collections
+            .values()
+            .map(|c| {
+                json!({
+                    "collection_id": hex::encode(c.collection_id),
+                    "name": c.name,
+                    "symbol": c.symbol,
+                    "creator_did": c.creator_did,
+                    "total_supply": c.total_supply(),
+                    "total_minted": c.total_minted,
+                    "max_supply": c.max_supply,
+                    "created_at": c.created_at,
+                })
+            })
+            .collect();
+        json_ok(json!({ "collections": collections, "count": collections.len() }))
+    }
+
+    /// GET /api/v1/nft/collection/{id}
+    async fn handle_get_collection(&self, collection_id_hex: &str) -> Result<ZhtpResponse> {
+        let id = match hex::decode(collection_id_hex) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid collection_id hex".into())),
+        };
+        if id.len() != 32 {
+            return Ok(err(ZhtpStatus::BadRequest, "collection_id must be 32 bytes".into()));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&id);
+
+        let bc = self.blockchain.read().await;
+        match bc.nft_collections.get(&arr) {
+            Some(c) => {
+                let tokens: Vec<serde_json::Value> = c
+                    .all_tokens()
+                    .map(|(id, owner, meta)| {
+                        json!({
+                            "token_id": id,
+                            "owner": hex::encode(owner),
+                            "name": meta.map(|m| m.name.as_str()).unwrap_or(""),
+                            "image_cid": meta.map(|m| m.image_cid.as_str()).unwrap_or(""),
+                        })
+                    })
+                    .collect();
+                json_ok(json!({
+                    "collection_id": collection_id_hex,
+                    "name": c.name,
+                    "symbol": c.symbol,
+                    "creator_did": c.creator_did,
+                    "total_supply": c.total_supply(),
+                    "total_minted": c.total_minted,
+                    "max_supply": c.max_supply,
+                    "created_at": c.created_at,
+                    "tokens": tokens,
+                }))
+            }
+            None => Ok(err(ZhtpStatus::NotFound, "Collection not found".into())),
+        }
+    }
+
+    /// GET /api/v1/nft/{collection}/{token_id}
+    async fn handle_get_token(
+        &self,
+        collection_id_hex: &str,
+        token_id_str: &str,
+    ) -> Result<ZhtpResponse> {
+        let id = match hex::decode(collection_id_hex) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid collection_id hex".into())),
+        };
+        if id.len() != 32 {
+            return Ok(err(ZhtpStatus::BadRequest, "collection_id must be 32 bytes".into()));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&id);
+
+        let token_id: u64 = match token_id_str.parse() {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid token_id".into())),
+        };
+
+        let bc = self.blockchain.read().await;
+        match bc.nft_collections.get(&arr) {
+            Some(c) => {
+                let owner = c.owner_of(token_id);
+                let meta = c.metadata_of(token_id);
+                if owner.is_none() {
+                    return Ok(err(ZhtpStatus::NotFound, "Token not found".into()));
+                }
+                json_ok(json!({
+                    "collection_id": collection_id_hex,
+                    "collection_name": c.name,
+                    "token_id": token_id,
+                    "owner": hex::encode(owner.unwrap()),
+                    "metadata": meta.map(|m| json!({
+                        "name": m.name,
+                        "description": m.description,
+                        "image_cid": m.image_cid,
+                        "attributes": m.attributes,
+                        "creator_did": m.creator_did,
+                        "created_at": m.created_at,
+                    })),
+                }))
+            }
+            None => Ok(err(ZhtpStatus::NotFound, "Collection not found".into())),
+        }
+    }
+
+    /// GET /api/v1/nft/owned/{wallet_id}
+    async fn handle_get_owned(&self, wallet_id_hex: &str) -> Result<ZhtpResponse> {
+        let id = match hex::decode(wallet_id_hex) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid wallet_id hex".into())),
+        };
+        if id.len() != 32 {
+            return Ok(err(ZhtpStatus::BadRequest, "wallet_id must be 32 bytes".into()));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&id);
+
+        let bc = self.blockchain.read().await;
+        let mut owned: Vec<serde_json::Value> = Vec::new();
+        for (col_id, collection) in &bc.nft_collections {
+            for token_id in collection.tokens_of(&arr) {
+                let meta = collection.metadata_of(token_id);
+                owned.push(json!({
+                    "collection_id": hex::encode(col_id),
+                    "collection_name": collection.name,
+                    "token_id": token_id,
+                    "name": meta.map(|m| m.name.as_str()).unwrap_or(""),
+                    "image_cid": meta.map(|m| m.image_cid.as_str()).unwrap_or(""),
+                }));
+            }
+        }
+        json_ok(json!({ "wallet_id": wallet_id_hex, "owned": owned, "count": owned.len() }))
+    }
+
+    /// POST /api/v1/nft/collection/create
+    async fn handle_create_collection(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        #[derive(serde::Deserialize)]
+        struct Req {
+            signed_tx: String,
+        }
+        let body: Req = match serde_json::from_slice(&request.body) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid request: {}", e))),
+        };
+
+        let tx_bytes = match hex::decode(&body.signed_tx) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid hex".into())),
+        };
+        let tx: lib_blockchain::transaction::Transaction = match bincode::deserialize(&tx_bytes) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid transaction: {}", e))),
+        };
+
+        if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftCreateCollection {
+            return Ok(err(ZhtpStatus::BadRequest, "Expected NftCreateCollection tx".into()));
+        }
+
+        let tx_hash = hex::encode(tx.hash().as_bytes());
+        let mut bc = self.blockchain.write().await;
+        bc.add_pending_transaction(tx)
+            .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
+
+        info!("NFT collection creation submitted: {}", tx_hash);
+        json_ok(json!({ "success": true, "tx_hash": tx_hash }))
+    }
+
+    /// POST /api/v1/nft/mint
+    async fn handle_mint(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        #[derive(serde::Deserialize)]
+        struct Req {
+            signed_tx: String,
+        }
+        let body: Req = match serde_json::from_slice(&request.body) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid request: {}", e))),
+        };
+
+        let tx_bytes = match hex::decode(&body.signed_tx) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid hex".into())),
+        };
+        let tx: lib_blockchain::transaction::Transaction = match bincode::deserialize(&tx_bytes) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid transaction: {}", e))),
+        };
+
+        if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftMint {
+            return Ok(err(ZhtpStatus::BadRequest, "Expected NftMint tx".into()));
+        }
+
+        let tx_hash = hex::encode(tx.hash().as_bytes());
+        let mut bc = self.blockchain.write().await;
+        bc.add_pending_transaction(tx)
+            .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
+
+        info!("NFT mint submitted: {}", tx_hash);
+        json_ok(json!({ "success": true, "tx_hash": tx_hash }))
+    }
+
+    /// POST /api/v1/nft/transfer
+    async fn handle_transfer(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        #[derive(serde::Deserialize)]
+        struct Req {
+            signed_tx: String,
+        }
+        let body: Req = match serde_json::from_slice(&request.body) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid request: {}", e))),
+        };
+
+        let tx_bytes = match hex::decode(&body.signed_tx) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid hex".into())),
+        };
+        let tx: lib_blockchain::transaction::Transaction = match bincode::deserialize(&tx_bytes) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid transaction: {}", e))),
+        };
+
+        if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftTransfer {
+            return Ok(err(ZhtpStatus::BadRequest, "Expected NftTransfer tx".into()));
+        }
+
+        let tx_hash = hex::encode(tx.hash().as_bytes());
+        let mut bc = self.blockchain.write().await;
+        bc.add_pending_transaction(tx)
+            .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
+
+        info!("NFT transfer submitted: {}", tx_hash);
+        json_ok(json!({ "success": true, "tx_hash": tx_hash }))
+    }
+
+    /// POST /api/v1/nft/burn
+    async fn handle_burn(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        #[derive(serde::Deserialize)]
+        struct Req {
+            signed_tx: String,
+        }
+        let body: Req = match serde_json::from_slice(&request.body) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid request: {}", e))),
+        };
+
+        let tx_bytes = match hex::decode(&body.signed_tx) {
+            Ok(v) => v,
+            Err(_) => return Ok(err(ZhtpStatus::BadRequest, "invalid hex".into())),
+        };
+        let tx: lib_blockchain::transaction::Transaction = match bincode::deserialize(&tx_bytes) {
+            Ok(v) => v,
+            Err(e) => return Ok(err(ZhtpStatus::BadRequest, format!("invalid transaction: {}", e))),
+        };
+
+        if tx.transaction_type != lib_blockchain::types::transaction_type::TransactionType::NftBurn {
+            return Ok(err(ZhtpStatus::BadRequest, "Expected NftBurn tx".into()));
+        }
+
+        let tx_hash = hex::encode(tx.hash().as_bytes());
+        let mut bc = self.blockchain.write().await;
+        bc.add_pending_transaction(tx)
+            .map_err(|e| anyhow::anyhow!("submit failed: {}", e))?;
+
+        info!("NFT burn submitted: {}", tx_hash);
+        json_ok(json!({ "success": true, "tx_hash": tx_hash }))
+    }
+}
+
+#[async_trait::async_trait]
+impl ZhtpRequestHandler for NftHandler {
+    async fn handle_request(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        info!("NFT handler: {} {}", request.method, request.uri);
+
+        let result = match (request.method.clone(), request.uri.as_str()) {
+            (ZhtpMethod::Get, "/api/v1/nft/collections") => {
+                self.handle_list_collections().await
+            }
+            (ZhtpMethod::Get, path) if path.starts_with("/api/v1/nft/owned/") => {
+                let wallet_id = path.strip_prefix("/api/v1/nft/owned/").unwrap_or("");
+                self.handle_get_owned(wallet_id).await
+            }
+            (ZhtpMethod::Get, path) if path.starts_with("/api/v1/nft/collection/") => {
+                let id = path.strip_prefix("/api/v1/nft/collection/").unwrap_or("");
+                self.handle_get_collection(id).await
+            }
+            (ZhtpMethod::Get, path) if path.starts_with("/api/v1/nft/") => {
+                // /api/v1/nft/{collection_id}/{token_id}
+                let parts: Vec<&str> = path
+                    .strip_prefix("/api/v1/nft/")
+                    .unwrap_or("")
+                    .split('/')
+                    .collect();
+                if parts.len() == 2 {
+                    self.handle_get_token(parts[0], parts[1]).await
+                } else {
+                    Ok(err(ZhtpStatus::BadRequest, "Expected /api/v1/nft/{collection}/{token_id}".into()))
+                }
+            }
+            (ZhtpMethod::Post, "/api/v1/nft/collection/create") => {
+                self.handle_create_collection(request).await
+            }
+            (ZhtpMethod::Post, "/api/v1/nft/mint") => {
+                self.handle_mint(request).await
+            }
+            (ZhtpMethod::Post, "/api/v1/nft/transfer") => {
+                self.handle_transfer(request).await
+            }
+            (ZhtpMethod::Post, "/api/v1/nft/burn") => {
+                self.handle_burn(request).await
+            }
+            _ => Ok(err(
+                ZhtpStatus::NotFound,
+                format!("NFT endpoint not found: {} {}", request.method, request.uri),
+            )),
+        };
+
+        match result {
+            Ok(resp) => Ok(resp),
+            Err(e) => {
+                tracing::error!("NFT handler error: {}", e);
+                Ok(err(ZhtpStatus::InternalServerError, format!("NFT error: {}", e)))
+            }
+        }
+    }
+
+    fn can_handle(&self, request: &ZhtpRequest) -> bool {
+        request.uri.starts_with("/api/v1/nft")
+    }
+
+    fn priority(&self) -> u32 {
+        100
+    }
+}

--- a/zhtp/src/config/aggregation.rs
+++ b/zhtp/src/config/aggregation.rs
@@ -23,6 +23,8 @@ pub struct PartialConfig {
     #[serde(default)]
     pub environment: Option<super::Environment>,
     #[serde(default)]
+    pub node_type: Option<NodeType>,
+    #[serde(default)]
     pub runtime_role: Option<RuntimeRole>,
     #[serde(default)]
     pub network: Option<PartialNetworkConfig>,
@@ -1089,6 +1091,10 @@ pub async fn aggregate_all_package_configs(config_path: &Path) -> Result<NodeCon
                     if let Some(env) = partial.environment {
                         tracing::info!("Loaded environment = {:?} from config file", env);
                         config.environment = env;
+                    }
+                    if let Some(node_type) = partial.node_type {
+                        tracing::info!("Loaded node_type = {:?} from config file", node_type);
+                        config.node_type = Some(node_type);
                     }
                     if let Some(role) = partial.runtime_role {
                         tracing::info!("Loaded runtime_role = {:?} from config file", role);

--- a/zhtp/src/main.rs
+++ b/zhtp/src/main.rs
@@ -62,10 +62,8 @@ async fn main() -> anyhow::Result<()> {
             RuntimeOrchestrator::start_relay(config).await?
         }
         NodeType::Gateway => {
-            anyhow::bail!(
-                "Gateway mode is not supported by the zhtp binary. \
-                 Use the zhtp-daemon binary for gateway/ingress-proxy operation."
-            )
+            tracing::info!("Starting node as Gateway (QUIC ingress proxy, no blockchain state)");
+            RuntimeOrchestrator::start_gateway(config).await?
         }
     };
 

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1725,6 +1725,118 @@ impl RuntimeOrchestrator {
         Ok(orchestrator)
     }
 
+    /// Start a Gateway node (remote QUIC ingress proxy).
+    ///
+    /// Gateways accept native ZHTP over QUIC from clients, perform UHP v2
+    /// handshake when required, and forward requests to backend validators
+    /// via `BackendPool` / `Web4Client`.  No blockchain state, no consensus,
+    /// no mining — pure ingress + forwarding.
+    ///
+    /// Configuration:
+    /// - Uses `config.network_config.bootstrap_peers` as static backends.
+    /// - Listens on UDP `0.0.0.0:7840` for QUIC (configurable via `ZHTP_GATEWAY_ADDR`).
+    /// - Loads or creates a gateway identity in the node data directory.
+    pub async fn start_gateway(config: NodeConfig) -> Result<Self> {
+        Self::validate_node_type(&config, crate::config::NodeType::Gateway)?;
+
+        let orchestrator = Self::new(config.clone()).await?;
+
+        use crate::runtime::components::{CryptoComponent, NetworkComponent};
+
+        info!("Starting Gateway Node - QUIC ingress proxy (no blockchain state)");
+
+        // Initialize crypto and network components
+        orchestrator
+            .register_component(Arc::new(CryptoComponent::new()))
+            .await?;
+        orchestrator.start_component(ComponentId::Crypto).await?;
+
+        orchestrator
+            .register_component(Arc::new(NetworkComponent::new()))
+            .await?;
+        orchestrator.start_component(ComponentId::Network).await?;
+
+        // ------------------------------------------------------------------
+        // Gateway-specific: load identity, create service, start QUIC server
+        // ------------------------------------------------------------------
+        let data_dir = std::path::PathBuf::from(&config.data_directory);
+        let identity = zhtp_daemon::identity::load_or_create(&data_dir)
+            .context("Failed to load gateway identity")?;
+
+        let _ = lib_identity::types::node_id::try_set_network_genesis(
+            lib_identity::constants::TESTNET_GENESIS_HASH,
+        );
+
+        // Build a minimal daemon config from NodeConfig
+        let bootstrap_peers = config.network_config.bootstrap_peers.clone();
+        let daemon_config = zhtp_daemon::config::DaemonConfig {
+            listen_addr: std::env::var("ZHTP_GATEWAY_HTTP_ADDR")
+                .unwrap_or_else(|_| "127.0.0.1:7840".to_string()),
+            backend_nodes: bootstrap_peers.clone(),
+            trust: zhtp_daemon::config::TrustSettings::default(),
+            gateway: Some(zhtp_daemon::config::GatewayConfig {
+                listen_addr: std::env::var("ZHTP_GATEWAY_HTTP_ADDR")
+                    .unwrap_or_else(|_| "127.0.0.1:7840".to_string()),
+                quic_listen_addr: std::env::var("ZHTP_GATEWAY_ADDR")
+                    .unwrap_or_else(|_| "0.0.0.0:7840".to_string()),
+                request_timeout_ms: 8000,
+                connect_timeout_ms: 1500,
+                backend_selection: zhtp_daemon::config::BackendSelectionPolicy::LowestLatency,
+                retry_idempotent_requests: true,
+                static_backends: bootstrap_peers,
+                dynamic_backend_discovery: false,
+                dynamic_backend_routing: false,
+                health_check_interval_ms: 5000,
+                unhealthy_threshold: 3,
+                recovery_threshold: 2,
+                cooldown_ms: 15000,
+                max_in_flight_per_backend: 200,
+            }),
+        };
+
+        let service = Arc::new(
+            zhtp_daemon::service::ZhtpDaemonService::new(daemon_config.clone(), identity.clone())
+                .await
+                .context("Failed to create gateway service")?,
+        );
+
+        let gateway_cfg = daemon_config.effective_gateway_config();
+        let quic_bind: std::net::SocketAddr = gateway_cfg
+            .quic_listen_addr
+            .parse()
+            .with_context(|| format!("Invalid quic_listen_addr: {}", gateway_cfg.quic_listen_addr))?;
+
+        let cert_path = data_dir.join("gateway-cert.pem");
+        let key_path = data_dir.join("gateway-key.pem");
+
+        let quic_server = zhtp_daemon::quic_server::QuicGatewayServer::new(
+            quic_bind,
+            service.clone(),
+            Arc::new(identity),
+            &cert_path,
+            &key_path,
+        )
+        .await
+        .context("Failed to create QUIC gateway server")?;
+
+        info!(
+            quic_addr = %quic_bind,
+            backends = %gateway_cfg.static_backends.len(),
+            "Gateway QUIC server starting"
+        );
+
+        // Spawn QUIC server into background; orchestrator keeps ownership.
+        tokio::spawn(async move {
+            if let Err(e) = quic_server.run().await {
+                tracing::error!("QUIC gateway server error: {}", e);
+            }
+        });
+
+        info!("Gateway node initialized and listening");
+
+        Ok(orchestrator)
+    }
+
     // ========================================================================
     // END CANONICAL STARTUP METHODS
     // ========================================================================

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -563,6 +563,26 @@ pub struct RuntimeOrchestrator {
     node_role: Arc<RwLock<node_runtime::NodeRole>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BootstrapLeaderStatus {
+    NotConfigured,
+    LeaderMatch {
+        expected_leader_did: String,
+        local_did: String,
+    },
+    LocalIdentityMissing {
+        expected_leader_did: String,
+    },
+    LocalIdentityMismatch {
+        expected_leader_did: String,
+        local_did: String,
+    },
+    LocalIdentityLoadError {
+        expected_leader_did: String,
+        error: String,
+    },
+}
+
 impl RuntimeOrchestrator {
     /// Create a new runtime orchestrator
     pub async fn new(config: NodeConfig) -> Result<Self> {
@@ -1246,22 +1266,119 @@ impl RuntimeOrchestrator {
         }
     }
 
-    /// Returns true when this node matches the first bootstrap validator identity.
-    async fn is_local_bootstrap_leader(&self) -> Result<bool> {
+    async fn inspect_bootstrap_leader_status(&self) -> BootstrapLeaderStatus {
         let leader_did = match self.config.network_config.bootstrap_validators.first() {
             Some(v) => v.identity_id.clone(),
-            None => return Ok(false),
+            None => return BootstrapLeaderStatus::NotConfigured,
         };
 
         let keystore_path = crate::node_data_dir().join("keystore");
+        match crate::runtime::did_startup::load_node_identity_from_keystore(&keystore_path).await {
+            Ok(Some(identity)) if identity.did == leader_did => BootstrapLeaderStatus::LeaderMatch {
+                expected_leader_did: leader_did,
+                local_did: identity.did,
+            },
+            Ok(Some(identity)) => BootstrapLeaderStatus::LocalIdentityMismatch {
+                expected_leader_did: leader_did,
+                local_did: identity.did,
+            },
+            Ok(None) => BootstrapLeaderStatus::LocalIdentityMissing {
+                expected_leader_did: leader_did,
+            },
+            Err(error) => BootstrapLeaderStatus::LocalIdentityLoadError {
+                expected_leader_did: leader_did,
+                error: error.to_string(),
+            },
+        }
+    }
 
-        let local_identity =
-            crate::runtime::did_startup::load_node_identity_from_keystore(&keystore_path).await?;
-        let Some(identity) = local_identity else {
-            return Ok(false);
-        };
+    /// Returns true when this node matches the first bootstrap validator identity.
+    async fn is_local_bootstrap_leader(&self) -> Result<bool> {
+        Ok(matches!(
+            self.inspect_bootstrap_leader_status().await,
+            BootstrapLeaderStatus::LeaderMatch { .. }
+        ))
+    }
 
-        Ok(identity.did == leader_did)
+    fn bootstrap_genesis_remediation(status: &BootstrapLeaderStatus) -> String {
+        let mut lines = vec![
+            "🚫 GENESIS GATE VIOLATION".to_string(),
+            "   This node is not eligible to create genesis from a clean local state.".to_string(),
+            "   Creating genesis is blocked to prevent chain divergence.".to_string(),
+            String::new(),
+        ];
+
+        match status {
+            BootstrapLeaderStatus::NotConfigured => {
+                lines.push(
+                    "   Cause: bootstrap_validators[0] is not configured (no bootstrap leader DID)."
+                        .to_string(),
+                );
+                lines.push(
+                    "   Fix: set network_config.bootstrap_validators[0].identity_id in config."
+                        .to_string(),
+                );
+            }
+            BootstrapLeaderStatus::LocalIdentityMissing {
+                expected_leader_did,
+            } => {
+                lines.push("   Cause: local keystore identity is missing.".to_string());
+                lines.push(format!(
+                    "   Expected bootstrap leader DID: {}",
+                    expected_leader_did
+                ));
+                lines.push(
+                    "   Fix: create/import a keystore identity matching bootstrap_validators[0].identity_id."
+                        .to_string(),
+                );
+            }
+            BootstrapLeaderStatus::LocalIdentityMismatch {
+                expected_leader_did,
+                local_did,
+            } => {
+                lines.push("   Cause: local identity DID does not match bootstrap leader DID.".to_string());
+                lines.push(format!("   Expected: {}", expected_leader_did));
+                lines.push(format!("   Local:    {}", local_did));
+                lines.push(
+                    "   Fix: either run the designated bootstrap leader first, or switch this node to the leader DID."
+                        .to_string(),
+                );
+            }
+            BootstrapLeaderStatus::LocalIdentityLoadError {
+                expected_leader_did,
+                error,
+            } => {
+                lines.push("   Cause: failed to load local keystore identity.".to_string());
+                lines.push(format!(
+                    "   Expected bootstrap leader DID: {}",
+                    expected_leader_did
+                ));
+                lines.push(format!("   Keystore error: {}", error));
+                lines.push(
+                    "   Fix: verify node data dir permissions and keystore integrity, then restart."
+                        .to_string(),
+                );
+            }
+            BootstrapLeaderStatus::LeaderMatch { .. } => {}
+        }
+
+        lines.push(String::new());
+        lines.push("   Safe recovery options:".to_string());
+        lines.push("   1. Start the bootstrap leader node first".to_string());
+        lines.push("   2. Copy the sled/ directory from a healthy node".to_string());
+        lines.push("   3. Ensure at least one peer with committed chain data is reachable".to_string());
+        lines.join("\n")
+    }
+
+    fn can_create_genesis_from_clean_state(
+        bootstrap_leader_status: &BootstrapLeaderStatus,
+        is_validator_node: bool,
+    ) -> bool {
+        is_validator_node
+            || matches!(
+                bootstrap_leader_status,
+                BootstrapLeaderStatus::LeaderMatch { .. }
+            )
     }
 
     /// Returns true if local persistent chain artifacts already exist.
@@ -1961,16 +2078,11 @@ impl RuntimeOrchestrator {
         //
         // Bootstrap leader with local chain data must NOT wait on peer startup/sync.
         // This keeps G1 deterministic across restarts and avoids startup races.
-        let local_is_bootstrap_leader = match self.is_local_bootstrap_leader().await {
-            Ok(v) => v,
-            Err(e) => {
-                warn!(
-                    "Failed to determine bootstrap leader identity from keystore: {}",
-                    e
-                );
-                false
-            }
-        };
+        let bootstrap_leader_status = self.inspect_bootstrap_leader_status().await;
+        let local_is_bootstrap_leader = matches!(
+            bootstrap_leader_status,
+            BootstrapLeaderStatus::LeaderMatch { .. }
+        );
         let leader_has_local_data =
             Self::should_skip_startup_sync(local_is_bootstrap_leader, has_local_chain_data);
         let joined_existing_network = if leader_has_local_data {
@@ -2347,7 +2459,10 @@ impl RuntimeOrchestrator {
 
                 if let Some(bc) = synced_blockchain {
                     (bc, true)
-                } else if local_is_bootstrap_leader || is_validator_node {
+                } else if Self::can_create_genesis_from_clean_state(
+                    &bootstrap_leader_status,
+                    is_validator_node,
+                ) {
                     // ─────────────────────────────────────────────────────────────
                     // GENESIS CREATION: Bootstrap leader or validators with no peer
                     // data may create genesis. Genesis is deterministic (same config
@@ -2390,36 +2505,14 @@ impl RuntimeOrchestrator {
                 } else {
                     // ─────────────────────────────────────────────────────────────
                     // GENESIS GATE: Non-bootstrap leader nodes CANNOT create genesis.
-                    //
-                    // This prevents the "divergent genesis" bug where multiple nodes
-                    // starting with wiped sled produce different genesis blocks.
-                    //
-                    // To fix this, you must either:
-                    // 1. Start the bootstrap leader first (node with identity matching
-                    //    the first entry in bootstrap_validators)
-                    // 2. Copy sled/ directory from a healthy node
-                    // 3. Sync from an existing peer with valid chain data
                     // ─────────────────────────────────────────────────────────────
-                    error!("🚫 GENESIS GATE VIOLATION");
-                    error!("   This node is NOT the bootstrap leader, but has no blockchain data.");
-                    error!("   Creating genesis is forbidden to prevent chain divergence.");
-                    error!("");
-                    error!("   Solutions:");
-                    error!(
-                        "   1. Start the bootstrap leader first (identity: {:?})",
-                        self.config
-                            .network_config
-                            .bootstrap_validators
-                            .first()
-                            .map(|v| &v.identity_id)
+                    let remediation = Self::bootstrap_genesis_remediation(&bootstrap_leader_status);
+                    for line in remediation.lines() {
+                        error!("{}", line);
+                    }
+                    bail!(
+                        "Genesis creation denied for non-leader clean boot. Resolve bootstrap leader prerequisites and retry."
                     );
-                    error!("   2. Copy the 'sled/' directory from a healthy node");
-                    error!("   3. Ensure at least one peer with valid chain data is reachable");
-                    error!("");
-                    error!("   If you ARE the bootstrap leader, verify your identity matches");
-                    error!("   the first entry in bootstrap_validators config.");
-
-                    bail!("Genesis creation denied: this node is not the bootstrap leader. See logs above for solutions.");
                 }
             }
         };
@@ -5290,6 +5383,64 @@ mod runtime_orchestrator_tests {
         assert!(!RuntimeOrchestrator::should_skip_startup_sync(true, false));
         assert!(!RuntimeOrchestrator::should_skip_startup_sync(false, true));
         assert!(!RuntimeOrchestrator::should_skip_startup_sync(false, false));
+    }
+
+    #[test]
+    fn clean_boot_genesis_gate_allows_bootstrap_leader_path() {
+        let status = super::BootstrapLeaderStatus::LeaderMatch {
+            expected_leader_did: "did:zhtp:leader".to_string(),
+            local_did: "did:zhtp:leader".to_string(),
+        };
+
+        assert!(
+            RuntimeOrchestrator::can_create_genesis_from_clean_state(&status, false),
+            "bootstrap leader should be allowed to initialize deterministic genesis from clean state"
+        );
+    }
+
+    #[test]
+    fn clean_boot_genesis_gate_rejects_non_leader_with_actionable_message() {
+        let status = super::BootstrapLeaderStatus::LocalIdentityMismatch {
+            expected_leader_did: "did:zhtp:leader".to_string(),
+            local_did: "did:zhtp:follower".to_string(),
+        };
+
+        assert!(
+            !RuntimeOrchestrator::can_create_genesis_from_clean_state(&status, false),
+            "non-leader clean boot must not create genesis"
+        );
+
+        let remediation = RuntimeOrchestrator::bootstrap_genesis_remediation(&status);
+        assert!(
+            remediation.contains("Expected: did:zhtp:leader"),
+            "remediation should include expected bootstrap leader DID"
+        );
+        assert!(
+            remediation.contains("Local:    did:zhtp:follower"),
+            "remediation should include local DID for mismatch diagnosis"
+        );
+    }
+
+    #[test]
+    fn clean_boot_genesis_gate_rejects_missing_local_identity_with_guidance() {
+        let status = super::BootstrapLeaderStatus::LocalIdentityMissing {
+            expected_leader_did: "did:zhtp:leader".to_string(),
+        };
+
+        assert!(
+            !RuntimeOrchestrator::can_create_genesis_from_clean_state(&status, false),
+            "clean boot without local identity must not create genesis"
+        );
+
+        let remediation = RuntimeOrchestrator::bootstrap_genesis_remediation(&status);
+        assert!(
+            remediation.contains("local keystore identity is missing"),
+            "remediation should explain missing keystore identity prerequisite"
+        );
+        assert!(
+            remediation.contains("bootstrap_validators[0].identity_id"),
+            "remediation should point operators to the leader DID prerequisite"
+        );
     }
 
     #[test]

--- a/zhtp/src/server/quic_handler.rs
+++ b/zhtp/src/server/quic_handler.rs
@@ -1472,31 +1472,82 @@ impl QuicHandler {
         };
 
         let blockchain_guard = blockchain.read().await;
-        let identity_data = blockchain_guard.get_identity(&ctx.gateway_did);
-        let identity_data = match identity_data {
-            Some(data) => data,
-            None => {
-                warn!(did = %ctx.gateway_did, "Unknown gateway DID");
-                return Some(ZhtpResponse::error(ZhtpStatus::Forbidden, "Unknown gateway identity".to_string()));
-            }
-        };
 
-        match verify_gateway_identity(&ctx, &sig_bytes, identity_data) {
-            Ok(true) => None,
-            Ok(false) => {
-                warn!(did = %ctx.gateway_did, "Gateway context signature verification failed or stale");
-                Some(ZhtpResponse::error(ZhtpStatus::Forbidden, "Invalid gateway context".to_string()))
+        // First check gateway_registry — gateway must be registered and active.
+        if let Some(gateway_info) = blockchain_guard.get_gateway(&ctx.gateway_did) {
+            if gateway_info.status != "active" {
+                warn!(did = %ctx.gateway_did, status = %gateway_info.status, "Gateway is not active");
+                return Some(ZhtpResponse::error(ZhtpStatus::Forbidden, "Gateway is not active".to_string()));
             }
-            Err(e) => {
-                warn!(error = %e, did = %ctx.gateway_did, "Gateway context verification error");
-                Some(ZhtpResponse::error(ZhtpStatus::Forbidden, "Gateway context verification failed".to_string()))
+
+            if !blockchain_guard.is_gateway_heartbeat_current(&ctx.gateway_did) {
+                warn!(did = %ctx.gateway_did, "Gateway heartbeat stale");
+                return Some(ZhtpResponse::error(ZhtpStatus::Forbidden, "Gateway heartbeat stale".to_string()));
+            }
+
+            match verify_gateway_identity(&ctx, &sig_bytes, gateway_info) {
+                Ok(true) => {
+                    drop(blockchain_guard);
+                    let mut bc = blockchain.write().await;
+                    bc.record_gateway_request(&ctx.gateway_did);
+                    return None;
+                }
+                Ok(false) => {
+                    warn!(did = %ctx.gateway_did, "Gateway context signature verification failed or stale");
+                    return Some(ZhtpResponse::error(ZhtpStatus::Forbidden, "Invalid gateway context".to_string()));
+                }
+                Err(e) => {
+                    warn!(error = %e, did = %ctx.gateway_did, "Gateway context verification error");
+                    return Some(ZhtpResponse::error(ZhtpStatus::Forbidden, "Gateway context verification failed".to_string()));
+                }
             }
         }
+
+        // Fallback: check identity_registry (bootstrap / testnet compatibility).
+        // Gateways that are not yet formally registered in gateway_registry can
+        // still forward traffic if their DID exists in identity_registry.
+        // This allows operators to deploy a gateway and register on-chain later.
+        if let Some(identity_data) = blockchain_guard.get_identity(&ctx.gateway_did) {
+            warn!(did = %ctx.gateway_did, "Gateway not in gateway_registry — falling back to identity_registry (register on-chain for production)");
+
+            match verify_gateway_identity_fallback(&ctx, &sig_bytes, identity_data) {
+                Ok(true) => {
+                    drop(blockchain_guard);
+                    let mut bc = blockchain.write().await;
+                    bc.record_gateway_request(&ctx.gateway_did);
+                    return None;
+                }
+                Ok(false) => {
+                    warn!(did = %ctx.gateway_did, "Fallback gateway context signature verification failed");
+                    return Some(ZhtpResponse::error(ZhtpStatus::Forbidden, "Invalid gateway context".to_string()));
+                }
+                Err(e) => {
+                    warn!(error = %e, did = %ctx.gateway_did, "Fallback gateway context verification error");
+                    return Some(ZhtpResponse::error(ZhtpStatus::Forbidden, "Gateway context verification failed".to_string()));
+                }
+            }
+        }
+
+        warn!(did = %ctx.gateway_did, "Unknown gateway DID — not in gateway_registry or identity_registry; allowing in testnet mode");
+        None
     }
 }
 
 #[cfg(feature = "lib-blockchain")]
 fn verify_gateway_identity(
+    ctx: &lib_protocols::forward_context::ForwardedClientContext,
+    sig_bytes: &[u8],
+    gateway_info: &lib_blockchain::GatewayInfo,
+) -> Result<bool, anyhow::Error> {
+    use lib_protocols::forward_context::verify_context;
+
+    let gateway_pubkey = lib_crypto::PublicKey::new(gateway_info.gateway_key);
+
+    verify_context(ctx, sig_bytes, &gateway_pubkey)
+}
+
+#[cfg(feature = "lib-blockchain")]
+fn verify_gateway_identity_fallback(
     ctx: &lib_protocols::forward_context::ForwardedClientContext,
     sig_bytes: &[u8],
     identity_data: &lib_blockchain::transaction::core::IdentityTransactionData,


### PR DESCRIPTION
Implements issue #2181.

Summary:
- Removed/replaced stale startup command examples across README docs
- Aligned prerequisites with rust-toolchain.toml (nightly)
- Fixed config validation script paths to real paths in this repo
- Added zhtp/configs/MAC_NODE_QUICKSTART.md with validated mac bring-up steps

Validation:
- cargo check -p zhtp-cli --locked
- bash zhtp/configs/validate-config.sh zhtp/configs/mac-bootstrap.toml