### PR TITLE
[EPIC-MESH-RELAY-READINESS] Fix reward counter partial reset bug (#2208)

### DIFF
--- a/lib-network/src/mesh/server.rs
+++ b/lib-network/src/mesh/server.rs
@@ -2411,6 +2411,24 @@ impl ZhtpMeshServer {
         }
     }
 
+    /// Subtract claimed amount from the theoretical tokens counter (partial reset)
+    ///
+    /// This preserves unclaimed accumulated tokens when a claim is capped
+    /// at `max_batch_size`, preventing operator token loss.
+    pub async fn subtract_reward_counter(&self, amount: u64) {
+        let mut stats = self.routing_stats.write().await;
+        let previous = stats.theoretical_tokens_earned;
+        stats.theoretical_tokens_earned = stats.theoretical_tokens_earned.saturating_sub(amount);
+
+        if previous > 0 {
+            info!(
+                " Routing reward counter partial reset: {} SOV claimed, {} SOV remaining",
+                amount,
+                stats.theoretical_tokens_earned
+            );
+        }
+    }
+
     /// Get complete routing statistics snapshot
     ///
     /// Returns a complete snapshot of current routing statistics including:
@@ -2498,6 +2516,24 @@ impl ZhtpMeshServer {
 
         if previous > 0 {
             info!(" Storage reward counter reset: {} SOV claimed", previous);
+        }
+    }
+
+    /// Subtract claimed amount from the storage theoretical tokens counter (partial reset)
+    ///
+    /// This preserves unclaimed accumulated tokens when a claim is capped
+    /// at `max_batch_size`, preventing operator token loss.
+    pub async fn subtract_storage_reward_counter(&self, amount: u64) {
+        let mut stats = self.storage_stats.write().await;
+        let previous = stats.theoretical_tokens_earned;
+        stats.theoretical_tokens_earned = stats.theoretical_tokens_earned.saturating_sub(amount);
+
+        if previous > 0 {
+            info!(
+                " Storage reward counter partial reset: {} SOV claimed, {} SOV remaining",
+                amount,
+                stats.theoretical_tokens_earned
+            );
         }
     }
 

--- a/zhtp/src/runtime/components/network.rs
+++ b/zhtp/src/runtime/components/network.rs
@@ -80,6 +80,18 @@ impl NetworkComponent {
         }
     }
 
+    pub async fn subtract_routing_rewards(&self, amount: u64) -> Result<()> {
+        if let Some(ref server) = *self.mesh_server.read().await {
+            server.subtract_reward_counter(amount).await;
+            info!(" Routing rewards partially reset: {} SOV subtracted", amount);
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "Cannot subtract routing rewards: mesh server not initialized"
+            ))
+        }
+    }
+
     pub async fn get_node_id(&self) -> Option<[u8; 32]> {
         if let Some(ref server) = *self.mesh_server.read().await {
             Some(server.get_node_id())
@@ -119,6 +131,18 @@ impl NetworkComponent {
         } else {
             Err(anyhow::anyhow!(
                 "Cannot reset storage rewards: mesh server not initialized"
+            ))
+        }
+    }
+
+    pub async fn subtract_storage_rewards(&self, amount: u64) -> Result<()> {
+        if let Some(ref server) = *self.mesh_server.read().await {
+            server.subtract_storage_reward_counter(amount).await;
+            info!(" Storage rewards partially reset: {} SOV subtracted", amount);
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "Cannot subtract storage rewards: mesh server not initialized"
             ))
         }
     }

--- a/zhtp/src/runtime/routing_rewards.rs
+++ b/zhtp/src/runtime/routing_rewards.rs
@@ -228,13 +228,14 @@ impl RoutingRewardProcessor {
 
         info!("    Transaction added to pending pool");
 
-        // Reset counter (only reset claimed amount if capped)
+        // Reset counter: use partial reset when capped, full reset when exact match
         if claim_amount < stats.theoretical_tokens_earned {
-            // TODO: Partial reset - need to add this to mesh server
-            warn!("     Partial reset not yet implemented - resetting all");
+            self.network_component
+                .subtract_routing_rewards(claim_amount)
+                .await?;
+        } else {
+            self.network_component.reset_routing_rewards().await?;
         }
-
-        self.network_component.reset_routing_rewards().await?;
 
         info!("    Reward counter reset");
         info!("═══════════════════════════════════════════════════════");

--- a/zhtp/src/runtime/storage_rewards.rs
+++ b/zhtp/src/runtime/storage_rewards.rs
@@ -228,13 +228,14 @@ impl StorageRewardProcessor {
 
         info!("    Transaction added to pending pool");
 
-        // Reset counter (only reset claimed amount if capped)
+        // Reset counter: use partial reset when capped, full reset when exact match
         if claim_amount < stats.theoretical_tokens_earned {
-            // TODO: Partial reset - need to add this to mesh server
-            warn!("     Partial reset not yet implemented - resetting all");
+            self.network_component
+                .subtract_storage_rewards(claim_amount)
+                .await?;
+        } else {
+            self.network_component.reset_storage_rewards().await?;
         }
-
-        self.network_component.reset_storage_rewards().await?;
 
         info!("    Reward counter reset");
         info!("═══════════════════════════════════════════════════════");


### PR DESCRIPTION
## Summary
Implements partial reset for routing and storage reward counters when claims are capped at `max_batch_size`.

## Problem
When `claim_amount < theoretical_tokens_earned`, the processor logged a warning and then reset the **entire** counter, causing operators to lose unclaimed tokens.

## Changes
- **lib-network**: Add `subtract_reward_counter()` and `subtract_storage_reward_counter()` to `ZhtpMeshServer`
- **zhtp/runtime/components**: Add `subtract_routing_rewards()` and `subtract_storage_rewards()` bridge methods on `NetworkComponent`
- **zhtp/runtime/routing_rewards**: Use partial reset when capped, full reset when exact match
- **zhtp/runtime/storage_rewards**: Same partial reset logic

## Verification
- `cargo check -p lib-network` ✅
- `cargo check -p zhtp` ✅

Closes #2208