### PR TITLE
[EPIC-MESH-RELAY-READINESS] Wire multi-hop routing algorithm library into MeshMessageRouter (#2209)

### DIFF
--- a/lib-network/src/mesh/server.rs
+++ b/lib-network/src/mesh/server.rs
@@ -1534,12 +1534,16 @@ impl ZhtpMeshServer {
         );
         let identity_store = Arc::new(RwLock::new(identity_store));
 
-        // Create message router (Ticket #149: using peer_registry)
+        // Create message router (Ticket #149: using peer_registry, #2209: with multi-hop)
+        let multi_hop_router = Arc::new(RwLock::new(
+            crate::routing::multi_hop::MultiHopRouter::new(),
+        ));
         let message_router = Arc::new(RwLock::new(
             crate::routing::message_routing::MeshMessageRouter::new(
                 self.peer_registry.clone(),
                 self.long_range_relays.clone(),
-            ),
+            )
+            .with_multi_hop_router(multi_hop_router),
         ));
 
         // Set mesh server reference in router for reward tracking

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -15,6 +15,7 @@ use crate::identity::unified_peer::UnifiedPeerId;
 use crate::mesh::connection::MeshConnection;
 use crate::protocols::NetworkProtocol;
 use crate::relays::LongRangeRelay;
+use crate::routing::multi_hop::MultiHopRouter;
 use crate::transport::TransportManager;
 use crate::types::mesh_message::{MeshMessageEnvelope, ZhtpMeshMessage};
 use lib_identity::NodeId;
@@ -67,6 +68,8 @@ pub struct MeshMessageRouter {
     pub transport_manager: Option<TransportManager>,
     /// Optional event sink for POUW receipt generation on successful message delivery
     pub pouw_routing_tx: Option<tokio::sync::mpsc::Sender<MeshRoutingEvent>>,
+    /// Multi-hop routing engine with advanced pathfinding algorithms
+    pub multi_hop_router: Option<Arc<RwLock<MultiHopRouter>>>,
 }
 
 /// Routing table for mesh network
@@ -231,6 +234,7 @@ impl MeshMessageRouter {
             mesh_server: None, // Can be set later with set_mesh_server()
             transport_manager: None,
             pouw_routing_tx: None,
+            multi_hop_router: None,
         }
     }
 
@@ -240,6 +244,12 @@ impl MeshMessageRouter {
     /// convert routing events into `Web4ManifestRoute` receipts.
     pub fn with_pouw_routing_tx(mut self, tx: tokio::sync::mpsc::Sender<MeshRoutingEvent>) -> Self {
         self.pouw_routing_tx = Some(tx);
+        self
+    }
+
+    /// Attach a multi-hop routing engine for advanced pathfinding.
+    pub fn with_multi_hop_router(mut self, router: Arc<RwLock<MultiHopRouter>>) -> Self {
+        self.multi_hop_router = Some(router);
         self
     }
 
@@ -586,9 +596,32 @@ impl MeshMessageRouter {
         Err(anyhow!("No route found to destination"))
     }
 
+    /// Sync PeerRegistry topology into the MultiHopRouter graph
+    async fn sync_multi_hop_topology(&self) -> Result<()> {
+        let registry = self.peer_registry.read().await;
+
+        // Build MeshConnection map from registry entries
+        let mut connections: HashMap<PublicKey, MeshConnection> = HashMap::new();
+        for entry in registry.all_peers() {
+            if let Some(conn) = Self::peer_entry_to_mesh_connection(entry) {
+                connections.insert(entry.peer_id.public_key().clone(), conn);
+            }
+        }
+
+        drop(registry);
+
+        if let Some(ref mhr) = self.multi_hop_router {
+            let router = mhr.read().await;
+            router.update_topology(&connections).await?;
+        }
+
+        Ok(())
+    }
+
     /// Find multi-hop route through mesh network
     ///
     /// **MIGRATION (Ticket #146):** Updated to use UnifiedPeerId for routing
+    /// **MIGRATION (#2209):** Delegates to MultiHopRouter when available for advanced algorithms
     async fn find_mesh_route(
         &self,
         destination: &UnifiedPeerId,
@@ -596,7 +629,31 @@ impl MeshMessageRouter {
     ) -> Result<Vec<RouteHop>> {
         debug!("Searching mesh network for route");
 
-        // Ticket #149: Use peer_registry instead of mesh_connections
+        // Try MultiHopRouter first if configured (#2209)
+        if let Some(ref mhr) = self.multi_hop_router {
+            if let Err(e) = self.sync_multi_hop_topology().await {
+                warn!("Failed to sync multi-hop topology: {}", e);
+            }
+
+            let source_pk = sender.public_key().clone();
+            let dest_pk = destination.public_key().clone();
+
+            let router = mhr.read().await;
+            match router.find_multi_hop_path(&source_pk, &dest_pk, 1024).await {
+                Ok(hops) => {
+                    info!(
+                        "MultiHopRouter found route ({} hops, algorithm-selected)",
+                        hops.len()
+                    );
+                    return Ok(hops);
+                }
+                Err(e) => {
+                    debug!("MultiHopRouter could not find path: {}, falling back", e);
+                }
+            }
+        }
+
+        // Fallback: legacy Dijkstra over PeerRegistry + TopologyMap
         let registry = self.peer_registry.read().await;
         let routing_table = self.routing_table.read().await;
 

--- a/zhtp/src/server/mesh/core.rs
+++ b/zhtp/src/server/mesh/core.rs
@@ -207,10 +207,16 @@ impl MeshRouter {
 
         // Clone connections for router initialization
         let connections_for_router = connections.clone();
-        let mesh_message_router = Arc::new(RwLock::new(MeshMessageRouter::new(
-            connections_for_router.clone(),
-            Arc::new(RwLock::new(HashMap::new())),
-        )));
+        let multi_hop_router = Arc::new(RwLock::new(
+            lib_network::routing::multi_hop::MultiHopRouter::new(),
+        ));
+        let mesh_message_router = Arc::new(RwLock::new(
+            MeshMessageRouter::new(
+                connections_for_router.clone(),
+                Arc::new(RwLock::new(HashMap::new())),
+            )
+            .with_multi_hop_router(multi_hop_router),
+        ));
 
         let (dht_dispatcher, dht_events_rx) = dht_integration_channel();
         tokio::spawn(crate::integration::dht_dispatcher::drain_dht_events(


### PR DESCRIPTION
## Summary
Wires the existing `MultiHopRouter` (5 algorithms: Dijkstra, A*, BFS, LoadAware, Adaptive) into the active `MeshMessageRouter`.

## Problem
The `MultiHopRouter` library in `lib-network/src/routing/multi_hop.rs` (1,008 lines, 5 complete pathfinding algorithms) was not integrated into `MeshMessageRouter::find_mesh_route`. The active router used its own simpler Dijkstra over `TopologyMap::peer_connections`, leaving advanced routing capabilities unused.

## Changes
- `MeshMessageRouter`: new `multi_hop_router` field + `with_multi_hop_router()` builder
- `MeshMessageRouter::sync_multi_hop_topology()`: converts `PeerRegistry` entries into `MeshConnection`s via the existing `peer_entry_to_mesh_connection` helper, then populates `MultiHopRouter::TopologyGraph`
- `MeshMessageRouter::find_mesh_route()`: delegates to `MultiHopRouter::find_multi_hop_path` first; falls back to legacy Dijkstra on failure
- `zhtp/src/server/mesh/core.rs`: wires `MultiHopRouter::new()` into `MeshRouter` construction
- `lib-network/src/mesh/server.rs`: wires `MultiHopRouter::new()` into `ZhtpMeshServer` construction

## Verification
- `cargo check -p lib-network` ✅
- `cargo check -p zhtp` ✅

Closes #2209
