### PR TITLE
feat(network): implement route probe/response control-plane (#2198)

### DIFF
--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -225,6 +225,157 @@ impl MeshMessageHandler {
         }
     }
 
+    /// Handle route discovery probe
+    ///
+    /// If this node is the target, sends a RouteResponse back to the originator.
+    /// Otherwise, decrements TTL and forwards toward the target.
+    async fn handle_route_probe(
+        &self,
+        probe_id: u64,
+        target: PublicKey,
+        originator: PublicKey,
+        ttl: u8,
+        _sender: PublicKey,
+    ) -> Result<()> {
+        if ttl == 0 {
+            debug!("Route probe {} TTL expired, dropping", probe_id);
+            return Ok(());
+        }
+
+        // Check if we are the target
+        if let Some(node_id) = &self.node_id {
+            if node_id == &target {
+                let registry = self.peer_registry.read().await;
+                let quality = registry
+                    .find_by_public_key(node_id)
+                    .map(|e| e.route_quality)
+                    .unwrap_or(0.5);
+                let latency = registry
+                    .find_by_public_key(node_id)
+                    .map(|e| e.connection_metrics.latency_ms)
+                    .unwrap_or(0);
+                drop(registry);
+
+                let response = ZhtpMeshMessage::RouteResponse {
+                    probe_id,
+                    route_quality: quality,
+                    latency_ms: latency,
+                    originator: originator.clone(),
+                    ttl: 5,
+                };
+
+                if let Some(router) = &self.message_router {
+                    router
+                        .read()
+                        .await
+                        .route_message(response, originator, node_id.clone())
+                        .await?;
+                    info!("Sent RouteResponse for probe {} (we are target)", probe_id);
+                }
+                return Ok(());
+            }
+        }
+
+        // Forward toward target
+        let new_ttl = ttl.saturating_sub(1);
+        let forward = ZhtpMeshMessage::RouteProbe {
+            probe_id,
+            target: target.clone(),
+            originator: originator.clone(),
+            ttl: new_ttl,
+        };
+
+        if let Some(router) = &self.message_router {
+            router
+                .read()
+                .await
+                .route_message(forward, target, originator)
+                .await?;
+            debug!("Forwarded RouteProbe {} toward target (ttl={})", probe_id, new_ttl);
+        }
+
+        Ok(())
+    }
+
+    /// Handle route discovery response
+    ///
+    /// If this node is the originator, updates the peer registry with the
+    /// measured route quality and latency for the target.
+    /// Otherwise, decrements TTL and forwards toward the originator.
+    async fn handle_route_response(
+        &self,
+        probe_id: u64,
+        route_quality: f64,
+        latency_ms: u32,
+        originator: PublicKey,
+        ttl: u8,
+        sender: PublicKey,
+    ) -> Result<()> {
+        if ttl == 0 {
+            debug!("Route response {} TTL expired, dropping", probe_id);
+            return Ok(());
+        }
+
+        // Check if we are the originator
+        if let Some(node_id) = &self.node_id {
+            if node_id == &originator {
+                // Update peer registry for the target (the node that sent the response)
+                let mut registry = self.peer_registry.write().await;
+                let updated = registry.update_by_public_key(&sender, |entry| {
+                    entry.route_quality = route_quality;
+                    entry.connection_metrics.latency_ms = latency_ms;
+                    entry.last_seen = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                });
+                drop(registry);
+
+                if updated {
+                    info!(
+                        "Route probe {} completed: target {} quality={:.2} latency={}ms",
+                        probe_id,
+                        hex::encode(&sender.key_id[..8]),
+                        route_quality,
+                        latency_ms
+                    );
+                } else {
+                    warn!(
+                        "Route probe {} response from unknown peer {}",
+                        probe_id,
+                        hex::encode(&sender.key_id[..8])
+                    );
+                }
+                return Ok(());
+            }
+        }
+
+        // Forward toward originator
+        let new_ttl = ttl.saturating_sub(1);
+        let forward = ZhtpMeshMessage::RouteResponse {
+            probe_id,
+            route_quality,
+            latency_ms,
+            originator: originator.clone(),
+            ttl: new_ttl,
+        };
+
+        if let Some(router) = &self.message_router {
+            router
+                .read()
+                .await
+                .route_message(forward, originator, sender)
+                .await?;
+            debug!(
+                "Forwarded RouteResponse {} toward originator (ttl={})",
+                probe_id,
+                new_ttl
+            );
+        }
+
+        Ok(())
+    }
+
     /// Handle incoming mesh message
     pub async fn handle_mesh_message(
         &self,
@@ -424,22 +575,31 @@ impl MeshMessageHandler {
                 self.handle_new_transaction(transaction, sender, tx_hash, fee)
                     .await?;
             }
-            ZhtpMeshMessage::RouteProbe { probe_id, target } => {
-                // TODO: Implement route probe handling
-                tracing::info!("Received route probe {} for target {:?}", probe_id, target);
+            ZhtpMeshMessage::RouteProbe {
+                probe_id,
+                target,
+                originator,
+                ttl,
+            } => {
+                self.handle_route_probe(probe_id, target, originator, ttl, sender)
+                    .await?;
             }
             ZhtpMeshMessage::RouteResponse {
                 probe_id,
                 route_quality,
                 latency_ms,
+                originator,
+                ttl,
             } => {
-                // TODO: Implement route response handling
-                tracing::info!(
-                    "Received route response for probe {} with quality {} and latency {}ms",
+                self.handle_route_response(
                     probe_id,
                     route_quality,
-                    latency_ms
-                );
+                    latency_ms,
+                    originator,
+                    ttl,
+                    sender,
+                )
+                .await?;
             }
             ZhtpMeshMessage::BootstrapProofRequest {
                 requester,

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -514,6 +514,26 @@ impl MeshMessageRouter {
         .await
     }
 
+    /// Send a route discovery probe toward a target node
+    ///
+    /// Initiates control-plane route probing. Intermediary nodes forward the
+    /// probe toward the target; the target replies with a RouteResponse that
+    /// updates route quality metrics in the peer registry.
+    pub async fn send_route_probe(
+        &self,
+        target: PublicKey,
+        originator: PublicKey,
+    ) -> Result<u64> {
+        let probe_id = self.generate_message_id().await;
+        let probe = ZhtpMeshMessage::RouteProbe {
+            probe_id,
+            target: target.clone(),
+            originator: originator.clone(),
+            ttl: 5,
+        };
+        self.route_message(probe, target, originator).await
+    }
+
     /// Find optimal route to destination
     pub async fn find_optimal_route(
         &self,

--- a/lib-network/src/types/mesh_message.rs
+++ b/lib-network/src/types/mesh_message.rs
@@ -529,13 +529,20 @@ pub enum ZhtpMeshMessage {
     },
 
     /// Route discovery probe
-    RouteProbe { probe_id: u64, target: PublicKey },
+    RouteProbe {
+        probe_id: u64,
+        target: PublicKey,
+        originator: PublicKey,
+        ttl: u8,
+    },
 
     /// Route discovery response
     RouteResponse {
         probe_id: u64,
         route_quality: f64,
         latency_ms: u32,
+        originator: PublicKey,
+        ttl: u8,
     },
 
     /// Request bootstrap proof for edge node sync (ZK proof + recent headers)
@@ -840,17 +847,24 @@ impl ZhtpMeshMessage {
                 MessageType::NewTransaction,
                 bincode::serialize(&(transaction, sender, tx_hash, fee))?,
             ),
-            Self::RouteProbe { probe_id, target } => (
+            Self::RouteProbe {
+                probe_id,
+                target,
+                originator,
+                ttl,
+            } => (
                 MessageType::RouteProbe,
-                bincode::serialize(&(probe_id, target))?,
+                bincode::serialize(&(probe_id, target, originator, ttl))?,
             ),
             Self::RouteResponse {
                 probe_id,
                 route_quality,
                 latency_ms,
+                originator,
+                ttl,
             } => (
                 MessageType::RouteResponse,
-                bincode::serialize(&(probe_id, route_quality, latency_ms))?,
+                bincode::serialize(&(probe_id, route_quality, latency_ms, originator, ttl))?,
             ),
             Self::BootstrapProofRequest {
                 requester,
@@ -1136,15 +1150,23 @@ impl ZhtpMeshMessage {
                 }
             }
             MessageType::RouteProbe => {
-                let (probe_id, target) = bincode::deserialize(payload)?;
-                Self::RouteProbe { probe_id, target }
+                let (probe_id, target, originator, ttl) = bincode::deserialize(payload)?;
+                Self::RouteProbe {
+                    probe_id,
+                    target,
+                    originator,
+                    ttl,
+                }
             }
             MessageType::RouteResponse => {
-                let (probe_id, route_quality, latency_ms) = bincode::deserialize(payload)?;
+                let (probe_id, route_quality, latency_ms, originator, ttl) =
+                    bincode::deserialize(payload)?;
                 Self::RouteResponse {
                     probe_id,
                     route_quality,
                     latency_ms,
+                    originator,
+                    ttl,
                 }
             }
             MessageType::BootstrapProofRequest => {


### PR DESCRIPTION
## Summary

Completes the control-plane implementation for route discovery probes and responses, replacing the TODO stubs in `message_handler.rs`.

## Changes

- **RouteProbe handler** (`handle_route_probe`):
  - Validates TTL; drops expired probes
  - If this node is the target: reads own route quality/latency from peer registry, sends `RouteResponse` back to originator
  - Otherwise: decrements TTL and forwards toward target via message router

- **RouteResponse handler** (`handle_route_response`):
  - Validates TTL; drops expired responses
  - If this node is the originator: updates peer registry with `route_quality`, `latency_ms`, and `last_seen` for the target peer
  - Otherwise: decrements TTL and forwards toward originator via message router

- **MeshMessageRouter**: adds `send_route_probe()` for initiating control-plane probes

- **ZhtpMeshMessage variants**: `RouteProbe` and `RouteResponse` extended with `originator` and `ttl` fields to support multi-hop forwarding semantics

## Checklist

- [x] Code compiles (`cargo check -p lib-network`)
- [x] Replaces TODO stubs at lines 427 and 436
- [x] Updates peer registry quality metrics
- [x] Updates routing table topology (via registry route quality)

Refs #2198