### PR TITLE
[SYNC-WIRE] Capabilities endpoint and wire-version negotiation (#2219)

### DIFF
--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -242,6 +242,9 @@ impl ZhtpRequestHandler for BlockchainHandler {
                 self.handle_import_chain(request).await
             }
             // New incremental sync endpoints
+            (ZhtpMethod::Get, "/api/v1/blockchain/sync-capabilities") => {
+                self.handle_get_sync_capabilities(request).await
+            }
             (ZhtpMethod::Get, "/api/v1/blockchain/tip") => self.handle_get_chain_tip(request).await,
             (ZhtpMethod::Get, path) if path.starts_with("/api/v1/blockchain/quorum-proof/") => {
                 self.handle_get_quorum_proof(request).await
@@ -2717,6 +2720,20 @@ impl BlockchainHandler {
             tip_info.validator_count
         );
 
+        Ok(ZhtpResponse::success_with_content_type(
+            json_response,
+            "application/json".to_string(),
+            None,
+        ))
+    }
+
+    /// Get node sync wire capabilities for block page negotiation.
+    async fn handle_get_sync_capabilities(
+        &self,
+        _request: ZhtpRequest,
+    ) -> ZhtpResult<ZhtpResponse> {
+        let caps = crate::sync_wire::SyncCapabilities::local();
+        let json_response = serde_json::to_vec(&caps)?;
         Ok(ZhtpResponse::success_with_content_type(
             json_response,
             "application/json".to_string(),

--- a/zhtp/src/lib.rs
+++ b/zhtp/src/lib.rs
@@ -45,6 +45,7 @@ pub mod security;
 pub mod server;
 pub mod session_manager;
 pub mod storage_network_integration;
+pub mod sync_wire;
 pub mod unified_server;
 pub mod utils;
 pub mod web4_manifest;

--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -410,12 +410,29 @@ impl BlockchainComponent {
                     continue;
                 }
 
+                let block_page_wire = match crate::runtime::negotiate_block_page_wire_version(
+                    &client,
+                    &peer_quic_addr,
+                )
+                .await
+                {
+                    Ok(wire) => wire,
+                    Err(e) => {
+                        warn!(
+                            "observer_sync: failed wire negotiation with {}: {}",
+                            peer_quic_addr, e
+                        );
+                        continue;
+                    }
+                };
+
                 info!(
-                    "📥 Observer gap-fill: peer {} height={}, local={}, fetching {} block(s)",
+                    "📥 Observer gap-fill: peer {} height={}, local={}, fetching {} block(s) (wire={})",
                     peer_quic_addr,
                     peer_tip.height,
                     local_height_before_peer,
-                    peer_tip.height - local_height_before_peer
+                    peer_tip.height - local_height_before_peer,
+                    block_page_wire
                 );
 
                 // Fetch and apply missing blocks in batches of 100.
@@ -430,7 +447,18 @@ impl BlockchainComponent {
                     let from = current + 1;
                     let to = std::cmp::min(from + 99, target);
 
-                    let path = format!("/api/v1/blockchain/blocks/{}/{}", from, to);
+                    let path =
+                        match crate::runtime::block_range_path_for_wire(&block_page_wire, from, to)
+                        {
+                            Ok(path) => path,
+                            Err(e) => {
+                                warn!(
+                                    "observer_sync: invalid wire {} for {}: {}",
+                                    block_page_wire, peer_quic_addr, e
+                                );
+                                break 'batches;
+                            }
+                        };
                     let blocks_resp = match tokio::time::timeout(
                         Duration::from_secs(30),
                         client.get(&path),

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -102,6 +102,94 @@ pub use node_runtime_orchestrator::NodeRuntimeOrchestrator;
 pub use shared_blockchain::*;
 pub use shared_dht::*;
 
+const SYNC_CAPABILITIES_ENDPOINT: &str = "/api/v1/blockchain/sync-capabilities";
+
+pub(crate) fn block_range_path_for_wire(
+    wire_version: &str,
+    start: u64,
+    end: u64,
+) -> anyhow::Result<String> {
+    match wire_version {
+        crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW => {
+            Ok(format!("/api/v1/blockchain/blocks/{}/{}", start, end))
+        }
+        _ => Err(anyhow::anyhow!(
+            "unsupported block page wire version: {}",
+            wire_version
+        )),
+    }
+}
+
+pub(crate) async fn negotiate_block_page_wire_version(
+    client: &lib_network::client::ZhtpClient,
+    peer_addr: &str,
+) -> anyhow::Result<String> {
+    let local_supported = crate::sync_wire::LOCAL_BLOCK_PAGE_WIRE_PREFERENCE
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+
+    let caps_resp = match tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        client.get(SYNC_CAPABILITIES_ENDPOINT),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => resp,
+        Ok(Err(e)) => {
+            warn!(
+                "⚠️  sync-capabilities request failed for {}: {}; falling back to {}",
+                peer_addr,
+                e,
+                crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW
+            );
+            return Ok(crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW.to_string());
+        }
+        Err(_) => {
+            warn!(
+                "⚠️  sync-capabilities request timed out for {}; falling back to {}",
+                peer_addr,
+                crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW
+            );
+            return Ok(crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW.to_string());
+        }
+    };
+
+    if !caps_resp.is_success() {
+        warn!(
+            "⚠️  peer {} does not expose sync capabilities (status={}): falling back to {}",
+            peer_addr,
+            caps_resp.status_message,
+            crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW
+        );
+        return Ok(crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW.to_string());
+    }
+
+    let peer_caps: crate::sync_wire::SyncCapabilities = serde_json::from_slice(&caps_resp.body)
+        .with_context(|| format!("failed to parse sync capabilities from {}", peer_addr))?;
+
+    let selected = crate::sync_wire::select_preferred_block_page_wire(
+        &crate::sync_wire::LOCAL_BLOCK_PAGE_WIRE_PREFERENCE,
+        &peer_caps.block_page_wire_versions,
+    );
+
+    match selected {
+        Some(wire) => {
+            info!(
+                "🔁 Sync wire negotiated with {}: {} (peer_supported={:?}, local_supported={:?})",
+                peer_addr, wire, peer_caps.block_page_wire_versions, local_supported
+            );
+            Ok(wire)
+        }
+        None => Err(anyhow::anyhow!(
+            "UnsupportedPeerWireVersion: peer={} peer_supported={:?} local_supported={:?}",
+            peer_addr,
+            peer_caps.block_page_wire_versions,
+            local_supported
+        )),
+    }
+}
+
 /// Try to sync blockchain from bootstrap peers using paginated block-range QUIC requests.
 ///
 /// Uses the same `/api/v1/blockchain/blocks/{start}/{end}` endpoint as the catch-up
@@ -255,12 +343,20 @@ async fn try_initial_sync_from_peer(
         }
 
         highest_peer_height = highest_peer_height.max(tip.height);
+        let block_page_wire = match negotiate_block_page_wire_version(&client, peer).await {
+            Ok(wire) => wire,
+            Err(e) => {
+                warn!("⚠️  Failed sync wire negotiation with {}: {}", peer_addr, e);
+                continue;
+            }
+        };
         info!(
-            "📥 Peer {} at height {} — fetching blocks {}-{}",
+            "📥 Peer {} at height {} — fetching blocks {}-{} (wire={})",
             peer_addr,
             tip.height,
             local_height + 1,
-            tip.height
+            tip.height,
+            block_page_wire
         );
 
         // Paginated import: 200 blocks per request, same as consensus catch-up.
@@ -276,7 +372,17 @@ async fn try_initial_sync_from_peer(
             }
             let start = next_start;
             let end = tip.height.min(start + BLOCKS_PER_PAGE - 1);
-            let url = format!("/api/v1/blockchain/blocks/{}/{}", start, end);
+            let url = match block_range_path_for_wire(&block_page_wire, start, end) {
+                Ok(path) => path,
+                Err(e) => {
+                    warn!(
+                        "⚠️  Invalid sync wire {} for {}: {}",
+                        block_page_wire, peer_addr, e
+                    );
+                    page_error = true;
+                    break;
+                }
+            };
 
             let blocks_resp =
                 match tokio::time::timeout(std::time::Duration::from_secs(60), client.get(&url))

--- a/zhtp/src/runtime/services/bootstrap_service.rs
+++ b/zhtp/src/runtime/services/bootstrap_service.rs
@@ -213,10 +213,20 @@ impl BootstrapService {
         // Fetch missing blocks incrementally
         let start = local_height + 1;
         let end = peer_tip.height;
-        let blocks_path = format!("/api/v1/blockchain/blocks/{}/{}", start, end);
+        let block_page_wire = crate::runtime::negotiate_block_page_wire_version(client, peer_label)
+            .await
+            .context("Failed sync wire negotiation")?;
+        let blocks_path =
+            crate::runtime::block_range_path_for_wire(&block_page_wire, start, end)
+                .context("Failed to build block-range path for negotiated wire version")?;
 
         let blocks_response = timeout(Duration::from_secs(30), async {
-            info!("GET {} ({} blocks)", blocks_path, end - start + 1);
+            info!(
+                "GET {} ({} blocks, wire={})",
+                blocks_path,
+                end - start + 1,
+                block_page_wire
+            );
             client.get(&blocks_path).await
         })
         .await

--- a/zhtp/src/sync_wire.rs
+++ b/zhtp/src/sync_wire.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+
+/// Legacy block page wire format: raw bincode(Vec<Block>) at
+/// `/api/v1/blockchain/blocks/{start}/{end}`.
+pub const BLOCK_PAGE_WIRE_V1_BINCODERAW: &str = "v1-bincode-raw";
+
+/// Current transaction wire bounds supported by this node binary.
+pub const TX_WIRE_MIN_VERSION: u32 = 8;
+pub const TX_WIRE_MAX_VERSION: u32 = 8;
+
+/// Local preference order for block page wire versions.
+pub const LOCAL_BLOCK_PAGE_WIRE_PREFERENCE: [&str; 1] = [BLOCK_PAGE_WIRE_V1_BINCODERAW];
+
+/// Response shape for `GET /api/v1/blockchain/sync-capabilities`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncCapabilities {
+    pub block_page_wire_versions: Vec<String>,
+    pub tx_wire_min_version: u32,
+    pub tx_wire_max_version: u32,
+    pub node_software_version: String,
+}
+
+impl SyncCapabilities {
+    pub fn local() -> Self {
+        Self {
+            block_page_wire_versions: LOCAL_BLOCK_PAGE_WIRE_PREFERENCE
+                .iter()
+                .map(|v| (*v).to_string())
+                .collect(),
+            tx_wire_min_version: TX_WIRE_MIN_VERSION,
+            tx_wire_max_version: TX_WIRE_MAX_VERSION,
+            node_software_version: crate::VERSION.to_string(),
+        }
+    }
+}
+
+/// Select the highest mutually supported block page wire version according to
+/// local preference ordering. Returns `None` when there is no overlap.
+pub fn select_preferred_block_page_wire(
+    local_preference: &[&str],
+    peer_supported: &[String],
+) -> Option<String> {
+    local_preference
+        .iter()
+        .find(|local| peer_supported.iter().any(|peer| peer == *local))
+        .map(|selected| (*selected).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_highest_mutual_by_local_preference() {
+        let local = ["v2-cbor-envelope", "v1-bincode-raw"];
+        let peer = vec!["v1-bincode-raw".to_string()];
+        let selected = select_preferred_block_page_wire(&local, &peer);
+        assert_eq!(selected.as_deref(), Some("v1-bincode-raw"));
+    }
+
+    #[test]
+    fn returns_none_when_no_wire_overlap() {
+        let local = ["v2-cbor-envelope", "v1-bincode-raw"];
+        let peer = vec!["v3-unknown".to_string()];
+        let selected = select_preferred_block_page_wire(&local, &peer);
+        assert!(selected.is_none());
+    }
+}


### PR DESCRIPTION
## Summary
Implements issue #2219 by adding explicit block-sync capability discovery and wire-version negotiation for observer/bootstrap sync paths.

## Changes
- Added new endpoint:
  - `GET /api/v1/blockchain/sync-capabilities`
- Added shared sync wire module:
  - `zhtp/src/sync_wire.rs`
  - local supported block-page wire versions
  - tx wire min/max metadata
  - deterministic local capability payload
  - pure selection logic with unit tests
- Added runtime negotiation helpers:
  - `negotiate_block_page_wire_version(...)`
  - `block_range_path_for_wire(...)`
- Wired negotiation into:
  - initial bootstrap sync (`runtime/mod.rs`)
  - observer gap-fill loop (`runtime/components/blockchain.rs`)
  - bootstrap service incremental sync (`runtime/services/bootstrap_service.rs`)
- Added actionable no-overlap error path:
  - `UnsupportedPeerWireVersion: ... peer_supported ... local_supported`

## Behavior
- If peer exposes capabilities and overlap exists, selected wire version is logged per peer.
- If peer does not expose endpoint (legacy peer), runtime falls back to `v1-bincode-raw` with warning.
- If endpoint exists but no overlap, sync fails for that peer with explicit incompatibility diagnostics.

## Validation
- `cargo check -p zhtp` passes.
- `cargo test -p zhtp sync_wire --lib` is currently blocked by existing unrelated lib-test compile failures in this branch (pre-existing `quic_handler` test typing errors).

Closes #2219
