### PR TITLE
[SYNC-WIRE] Introduce /api/v2/blockchain/blocks envelope wire format

### DIFF
--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -252,6 +252,9 @@ impl ZhtpRequestHandler for BlockchainHandler {
             (ZhtpMethod::Get, path) if path.starts_with("/api/v1/blockchain/blocks/") => {
                 self.handle_get_block_range(request).await
             }
+            (ZhtpMethod::Get, path) if path.starts_with("/api/v2/blockchain/blocks/") => {
+                self.handle_get_block_range_v2(request).await
+            }
             // Edge node stats endpoint
             (ZhtpMethod::Get, "/api/v1/blockchain/edge-stats") => {
                 self.handle_edge_stats(request).await
@@ -2809,6 +2812,88 @@ impl BlockchainHandler {
         Ok(ZhtpResponse::success_with_content_type(
             serialized_blocks,
             "application/octet-stream".to_string(),
+            None,
+        ))
+    }
+
+    /// Get block range in v2 envelope format for negotiated sync.
+    async fn handle_get_block_range_v2(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        // Parse start/end from URI: /api/v2/blockchain/blocks/{start}/{end}
+        let parts: Vec<&str> = request.uri.split('/').collect();
+        if parts.len() < 7 {
+            return Ok(ZhtpResponse::error(
+                ZhtpStatus::BadRequest,
+                "Invalid block range format. Use: /api/v2/blockchain/blocks/{start}/{end}"
+                    .to_string(),
+            ));
+        }
+
+        let start: u64 = parts[5]
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid start block number"))?;
+        let end: u64 = parts[6]
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid end block number"))?;
+
+        if end < start {
+            return Ok(ZhtpResponse::error(
+                ZhtpStatus::BadRequest,
+                "End block must be >= start block".to_string(),
+            ));
+        }
+
+        if end - start > 1000 {
+            return Ok(ZhtpResponse::error(
+                ZhtpStatus::BadRequest,
+                "Block range too large (max 1000 blocks per request)".to_string(),
+            ));
+        }
+
+        let blockchain_arc = self
+            .get_blockchain()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get blockchain: {}", e))?;
+        let blockchain = blockchain_arc.read().await;
+
+        if start as usize >= blockchain.blocks.len() {
+            return Ok(ZhtpResponse::error(
+                ZhtpStatus::NotFound,
+                format!(
+                    "Start block {} beyond chain height {}",
+                    start, blockchain.height
+                ),
+            ));
+        }
+
+        let actual_end = std::cmp::min(end as usize, blockchain.blocks.len() - 1);
+        let blocks_slice = &blockchain.blocks[start as usize..=actual_end];
+
+        let payload = bincode::serialize(blocks_slice)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize block payload: {}", e))?;
+        let envelope = crate::sync_wire::BlockPageEnvelopeV2 {
+            wire_version: crate::sync_wire::BLOCK_PAGE_WIRE_V2_CBORENVELOPE.to_string(),
+            block_encoding: crate::sync_wire::BLOCK_PAGE_V2_ENCODING_BINCODE.to_string(),
+            tx_encoding: crate::sync_wire::BLOCK_PAGE_V2_TX_ENCODING_V8.to_string(),
+            start,
+            end: actual_end as u64,
+            count: blocks_slice.len(),
+            payload,
+        };
+        let mut encoded = Vec::new();
+        ciborium::ser::into_writer(&envelope, &mut encoded)
+            .map_err(|e| anyhow::anyhow!("Failed to encode v2 block envelope: {}", e))?;
+
+        tracing::info!(
+            " Serving v2 blocks {}-{} ({} blocks, {} bytes)",
+            start,
+            actual_end,
+            blocks_slice.len(),
+            encoded.len()
+        );
+
+        Ok(ZhtpResponse::success_with_content_type(
+            encoded,
+            "application/cbor".to_string(),
             None,
         ))
     }

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -2744,68 +2744,103 @@ impl BlockchainHandler {
         ))
     }
 
-    /// Get block range for incremental sync (e.g., /blocks/10/20 returns blocks 10-20)
-    async fn handle_get_block_range(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
-        // Parse start/end from URI: /api/v1/blockchain/blocks/{start}/{end}
-        let parts: Vec<&str> = request.uri.split('/').collect();
+    fn parse_block_range_params(
+        uri: &str,
+        usage_hint: &str,
+    ) -> Result<(u64, u64), ZhtpResponse> {
+        let parts: Vec<&str> = uri.split('/').collect();
         if parts.len() < 7 {
-            return Ok(ZhtpResponse::error(
+            return Err(ZhtpResponse::error(
                 ZhtpStatus::BadRequest,
-                "Invalid block range format. Use: /api/v1/blockchain/blocks/{start}/{end}"
-                    .to_string(),
+                usage_hint.to_string(),
             ));
         }
 
-        let start: u64 = parts[5]
-            .parse()
-            .map_err(|_| anyhow::anyhow!("Invalid start block number"))?;
-        let end: u64 = parts[6]
-            .parse()
-            .map_err(|_| anyhow::anyhow!("Invalid end block number"))?;
+        let start: u64 = match parts[5].parse() {
+            Ok(v) => v,
+            Err(_) => {
+                return Err(ZhtpResponse::error(
+                    ZhtpStatus::BadRequest,
+                    "Invalid start block number".to_string(),
+                ))
+            }
+        };
+        let end: u64 = match parts[6].parse() {
+            Ok(v) => v,
+            Err(_) => {
+                return Err(ZhtpResponse::error(
+                    ZhtpStatus::BadRequest,
+                    "Invalid end block number".to_string(),
+                ))
+            }
+        };
 
         if end < start {
-            return Ok(ZhtpResponse::error(
+            return Err(ZhtpResponse::error(
                 ZhtpStatus::BadRequest,
                 "End block must be >= start block".to_string(),
             ));
         }
 
         if end - start > 1000 {
-            return Ok(ZhtpResponse::error(
+            return Err(ZhtpResponse::error(
                 ZhtpStatus::BadRequest,
                 "Block range too large (max 1000 blocks per request)".to_string(),
             ));
         }
 
+        Ok((start, end))
+    }
+
+    async fn load_block_range(
+        &self,
+        start: u64,
+        end: u64,
+    ) -> ZhtpResult<Result<(u64, Vec<lib_blockchain::Block>), ZhtpResponse>> {
         let blockchain_arc = self
             .get_blockchain()
             .await
             .map_err(|e| anyhow::anyhow!("Failed to get blockchain: {}", e))?;
         let blockchain = blockchain_arc.read().await;
 
-        // Validate range is within chain
         if start as usize >= blockchain.blocks.len() {
-            return Ok(ZhtpResponse::error(
+            return Ok(Err(ZhtpResponse::error(
                 ZhtpStatus::NotFound,
                 format!(
                     "Start block {} beyond chain height {}",
                     start, blockchain.height
                 ),
-            ));
+            )));
         }
 
         let actual_end = std::cmp::min(end as usize, blockchain.blocks.len() - 1);
-        let blocks_slice = &blockchain.blocks[start as usize..=actual_end];
+        let blocks = blockchain.blocks[start as usize..=actual_end].to_vec();
+        Ok(Ok((actual_end as u64, blocks)))
+    }
+
+    /// Get block range for incremental sync (e.g., /blocks/10/20 returns blocks 10-20)
+    async fn handle_get_block_range(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        let (start, end) = match Self::parse_block_range_params(
+            &request.uri,
+            "Invalid block range format. Use: /api/v1/blockchain/blocks/{start}/{end}",
+        ) {
+            Ok(v) => v,
+            Err(resp) => return Ok(resp),
+        };
+        let (actual_end, blocks) = match self.load_block_range(start, end).await? {
+            Ok(v) => v,
+            Err(resp) => return Ok(resp),
+        };
 
         // Serialize blocks
-        let serialized_blocks = bincode::serialize(blocks_slice)
+        let serialized_blocks = bincode::serialize(&blocks)
             .map_err(|e| anyhow::anyhow!("Failed to serialize blocks: {}", e))?;
 
         tracing::info!(
             " Serving blocks {}-{} ({} blocks, {} bytes)",
             start,
             actual_end,
-            blocks_slice.len(),
+            blocks.len(),
             serialized_blocks.len()
         );
 
@@ -2818,65 +2853,27 @@ impl BlockchainHandler {
 
     /// Get block range in v2 envelope format for negotiated sync.
     async fn handle_get_block_range_v2(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
-        // Parse start/end from URI: /api/v2/blockchain/blocks/{start}/{end}
-        let parts: Vec<&str> = request.uri.split('/').collect();
-        if parts.len() < 7 {
-            return Ok(ZhtpResponse::error(
-                ZhtpStatus::BadRequest,
-                "Invalid block range format. Use: /api/v2/blockchain/blocks/{start}/{end}"
-                    .to_string(),
-            ));
-        }
+        let (start, end) = match Self::parse_block_range_params(
+            &request.uri,
+            "Invalid block range format. Use: /api/v2/blockchain/blocks/{start}/{end}",
+        ) {
+            Ok(v) => v,
+            Err(resp) => return Ok(resp),
+        };
+        let (actual_end, blocks) = match self.load_block_range(start, end).await? {
+            Ok(v) => v,
+            Err(resp) => return Ok(resp),
+        };
 
-        let start: u64 = parts[5]
-            .parse()
-            .map_err(|_| anyhow::anyhow!("Invalid start block number"))?;
-        let end: u64 = parts[6]
-            .parse()
-            .map_err(|_| anyhow::anyhow!("Invalid end block number"))?;
-
-        if end < start {
-            return Ok(ZhtpResponse::error(
-                ZhtpStatus::BadRequest,
-                "End block must be >= start block".to_string(),
-            ));
-        }
-
-        if end - start > 1000 {
-            return Ok(ZhtpResponse::error(
-                ZhtpStatus::BadRequest,
-                "Block range too large (max 1000 blocks per request)".to_string(),
-            ));
-        }
-
-        let blockchain_arc = self
-            .get_blockchain()
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get blockchain: {}", e))?;
-        let blockchain = blockchain_arc.read().await;
-
-        if start as usize >= blockchain.blocks.len() {
-            return Ok(ZhtpResponse::error(
-                ZhtpStatus::NotFound,
-                format!(
-                    "Start block {} beyond chain height {}",
-                    start, blockchain.height
-                ),
-            ));
-        }
-
-        let actual_end = std::cmp::min(end as usize, blockchain.blocks.len() - 1);
-        let blocks_slice = &blockchain.blocks[start as usize..=actual_end];
-
-        let payload = bincode::serialize(blocks_slice)
+        let payload = bincode::serialize(&blocks)
             .map_err(|e| anyhow::anyhow!("Failed to serialize block payload: {}", e))?;
         let envelope = crate::sync_wire::BlockPageEnvelopeV2 {
             wire_version: crate::sync_wire::BLOCK_PAGE_WIRE_V2_CBORENVELOPE.to_string(),
             block_encoding: crate::sync_wire::BLOCK_PAGE_V2_ENCODING_BINCODE.to_string(),
             tx_encoding: crate::sync_wire::BLOCK_PAGE_V2_TX_ENCODING_V8.to_string(),
             start,
-            end: actual_end as u64,
-            count: blocks_slice.len(),
+            end: actual_end,
+            count: blocks.len(),
             payload,
         };
         let mut encoded = Vec::new();
@@ -2887,7 +2884,7 @@ impl BlockchainHandler {
             " Serving v2 blocks {}-{} ({} blocks, {} bytes)",
             start,
             actual_end,
-            blocks_slice.len(),
+            blocks.len(),
             encoded.len()
         );
 

--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -484,14 +484,21 @@ impl BlockchainComponent {
                         break 'batches;
                     }
 
-                    let blocks: Vec<lib_blockchain::Block> =
-                        match bincode::deserialize(&blocks_resp.body) {
-                            Ok(b) => b,
-                            Err(e) => {
-                                warn!("observer_sync: failed to deserialize blocks: {}", e);
-                                break 'batches;
-                            }
-                        };
+                    let blocks: Vec<lib_blockchain::Block> = match crate::runtime::decode_block_page_for_wire(
+                        &block_page_wire,
+                        &blocks_resp.body,
+                        from,
+                        to,
+                    ) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            warn!(
+                                "observer_sync: failed to decode block page {}-{} (wire={}): {}",
+                                from, to, block_page_wire, e
+                            );
+                            break 'batches;
+                        }
+                    };
 
                     if blocks.is_empty() {
                         warn!(

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -110,11 +110,66 @@ pub(crate) fn block_range_path_for_wire(
     end: u64,
 ) -> anyhow::Result<String> {
     match wire_version {
+        crate::sync_wire::BLOCK_PAGE_WIRE_V2_CBORENVELOPE => {
+            Ok(format!("/api/v2/blockchain/blocks/{}/{}", start, end))
+        }
         crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW => {
             Ok(format!("/api/v1/blockchain/blocks/{}/{}", start, end))
         }
         _ => Err(anyhow::anyhow!(
             "unsupported block page wire version: {}",
+            wire_version
+        )),
+    }
+}
+
+pub(crate) fn decode_block_page_for_wire(
+    wire_version: &str,
+    body: &[u8],
+    expected_start: u64,
+    expected_end: u64,
+) -> anyhow::Result<Vec<lib_blockchain::Block>> {
+    match wire_version {
+        crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW => bincode::deserialize(body)
+            .with_context(|| {
+                format!(
+                    "PayloadDecodeFailed: wire={} range={}..{}",
+                    wire_version, expected_start, expected_end
+                )
+            }),
+        crate::sync_wire::BLOCK_PAGE_WIRE_V2_CBORENVELOPE => {
+            let envelope: crate::sync_wire::BlockPageEnvelopeV2 =
+                ciborium::de::from_reader(body).with_context(|| {
+                    format!(
+                        "BlockPageEnvelopeMalformed: failed cbor decode wire={} range={}..{}",
+                        wire_version, expected_start, expected_end
+                    )
+                })?;
+            crate::sync_wire::validate_block_page_envelope_v2(
+                &envelope,
+                expected_start,
+                expected_end,
+            )?;
+            let blocks: Vec<lib_blockchain::Block> = bincode::deserialize(&envelope.payload)
+                .with_context(|| {
+                    format!(
+                        "PayloadDecodeFailed: wire={} range={}..{}",
+                        wire_version, expected_start, expected_end
+                    )
+                })?;
+            if blocks.len() != envelope.count {
+                return Err(anyhow::anyhow!(
+                    "BlockPageEnvelopeMalformed: count={} payload_blocks={} range={}..{}",
+                    envelope.count,
+                    blocks.len(),
+                    expected_start,
+                    expected_end
+                ));
+            }
+            Ok(blocks)
+        }
+        _ => Err(anyhow::anyhow!(
+            "UnsupportedPeerWireVersion: unsupported local wire decode {}",
             wire_version
         )),
     }
@@ -416,17 +471,19 @@ async fn try_initial_sync_from_peer(
                 break;
             }
 
-            let blocks: Vec<lib_blockchain::Block> = match bincode::deserialize(&blocks_resp.body) {
-                Ok(b) => b,
-                Err(e) => {
-                    warn!(
-                        "⚠️  Failed to deserialize blocks {}-{} from {}: {}",
-                        start, end, peer_addr, e
-                    );
-                    page_error = true;
-                    break;
-                }
-            };
+            let blocks: Vec<lib_blockchain::Block> =
+                match decode_block_page_for_wire(&block_page_wire, &blocks_resp.body, start, end)
+                {
+                    Ok(b) => b,
+                    Err(e) => {
+                        warn!(
+                            "⚠️  Failed to decode block page {}-{} from {} (wire={}): {}",
+                            start, end, peer_addr, block_page_wire, e
+                        );
+                        page_error = true;
+                        break;
+                    }
+                };
 
             if blocks.is_empty() {
                 break;

--- a/zhtp/src/runtime/services/bootstrap_service.rs
+++ b/zhtp/src/runtime/services/bootstrap_service.rs
@@ -248,9 +248,14 @@ impl BootstrapService {
             end - start + 1
         );
 
-        // Deserialize blocks
-        let new_blocks: Vec<lib_blockchain::block::Block> =
-            bincode::deserialize(&blocks_data).context("Failed to deserialize blocks")?;
+        // Decode blocks according to negotiated page wire version.
+        let new_blocks: Vec<lib_blockchain::block::Block> = crate::runtime::decode_block_page_for_wire(
+            &block_page_wire,
+            &blocks_data,
+            start,
+            end,
+        )
+        .context("Failed to decode block page")?;
 
         info!("Appending {} new blocks to local chain", new_blocks.len());
 

--- a/zhtp/src/sync_wire.rs
+++ b/zhtp/src/sync_wire.rs
@@ -3,13 +3,22 @@ use serde::{Deserialize, Serialize};
 /// Legacy block page wire format: raw bincode(Vec<Block>) at
 /// `/api/v1/blockchain/blocks/{start}/{end}`.
 pub const BLOCK_PAGE_WIRE_V1_BINCODERAW: &str = "v1-bincode-raw";
+/// Versioned block page wire format: CBOR envelope + encoded payload at
+/// `/api/v2/blockchain/blocks/{start}/{end}`.
+pub const BLOCK_PAGE_WIRE_V2_CBORENVELOPE: &str = "v2-cbor-envelope";
+
+pub const BLOCK_PAGE_V2_ENCODING_BINCODE: &str = "bincode";
+pub const BLOCK_PAGE_V2_TX_ENCODING_V8: &str = "v8-payload";
 
 /// Current transaction wire bounds supported by this node binary.
 pub const TX_WIRE_MIN_VERSION: u32 = 8;
 pub const TX_WIRE_MAX_VERSION: u32 = 8;
 
 /// Local preference order for block page wire versions.
-pub const LOCAL_BLOCK_PAGE_WIRE_PREFERENCE: [&str; 1] = [BLOCK_PAGE_WIRE_V1_BINCODERAW];
+pub const LOCAL_BLOCK_PAGE_WIRE_PREFERENCE: [&str; 2] = [
+    BLOCK_PAGE_WIRE_V2_CBORENVELOPE,
+    BLOCK_PAGE_WIRE_V1_BINCODERAW,
+];
 
 /// Response shape for `GET /api/v1/blockchain/sync-capabilities`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,6 +27,56 @@ pub struct SyncCapabilities {
     pub tx_wire_min_version: u32,
     pub tx_wire_max_version: u32,
     pub node_software_version: String,
+}
+
+/// Wire envelope for v2 block page responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockPageEnvelopeV2 {
+    pub wire_version: String,
+    pub block_encoding: String,
+    pub tx_encoding: String,
+    pub start: u64,
+    pub end: u64,
+    pub count: usize,
+    pub payload: Vec<u8>,
+}
+
+pub fn validate_block_page_envelope_v2(
+    envelope: &BlockPageEnvelopeV2,
+    expected_start: u64,
+    expected_end: u64,
+) -> anyhow::Result<()> {
+    if envelope.wire_version != BLOCK_PAGE_WIRE_V2_CBORENVELOPE {
+        return Err(anyhow::anyhow!(
+            "BlockPageEnvelopeMalformed: wire_version={}, expected={}",
+            envelope.wire_version,
+            BLOCK_PAGE_WIRE_V2_CBORENVELOPE
+        ));
+    }
+    if envelope.block_encoding != BLOCK_PAGE_V2_ENCODING_BINCODE {
+        return Err(anyhow::anyhow!(
+            "BlockPageEnvelopeMalformed: block_encoding={}, expected={}",
+            envelope.block_encoding,
+            BLOCK_PAGE_V2_ENCODING_BINCODE
+        ));
+    }
+    if envelope.tx_encoding != BLOCK_PAGE_V2_TX_ENCODING_V8 {
+        return Err(anyhow::anyhow!(
+            "BlockPageEnvelopeMalformed: tx_encoding={}, expected={}",
+            envelope.tx_encoding,
+            BLOCK_PAGE_V2_TX_ENCODING_V8
+        ));
+    }
+    if envelope.start != expected_start || envelope.end != expected_end {
+        return Err(anyhow::anyhow!(
+            "BlockPageEnvelopeMalformed: range={}..{} expected={}..{}",
+            envelope.start,
+            envelope.end,
+            expected_start,
+            expected_end
+        ));
+    }
+    Ok(())
 }
 
 impl SyncCapabilities {
@@ -64,5 +123,33 @@ mod tests {
         let peer = vec!["v3-unknown".to_string()];
         let selected = select_preferred_block_page_wire(&local, &peer);
         assert!(selected.is_none());
+    }
+
+    #[test]
+    fn validates_v2_envelope_metadata() {
+        let envelope = BlockPageEnvelopeV2 {
+            wire_version: BLOCK_PAGE_WIRE_V2_CBORENVELOPE.to_string(),
+            block_encoding: BLOCK_PAGE_V2_ENCODING_BINCODE.to_string(),
+            tx_encoding: BLOCK_PAGE_V2_TX_ENCODING_V8.to_string(),
+            start: 10,
+            end: 20,
+            count: 0,
+            payload: Vec::new(),
+        };
+        assert!(validate_block_page_envelope_v2(&envelope, 10, 20).is_ok());
+    }
+
+    #[test]
+    fn rejects_v2_envelope_with_wrong_range() {
+        let envelope = BlockPageEnvelopeV2 {
+            wire_version: BLOCK_PAGE_WIRE_V2_CBORENVELOPE.to_string(),
+            block_encoding: BLOCK_PAGE_V2_ENCODING_BINCODE.to_string(),
+            tx_encoding: BLOCK_PAGE_V2_TX_ENCODING_V8.to_string(),
+            start: 11,
+            end: 20,
+            count: 0,
+            payload: Vec::new(),
+        };
+        assert!(validate_block_page_envelope_v2(&envelope, 10, 20).is_err());
     }
 }


### PR DESCRIPTION
## Summary
Implements issue #2220 by adding a versioned v2 block-page wire endpoint and decode path with explicit envelope metadata validation.

## Changes
- add /api/v2/blockchain/blocks/{start}/{end} returning application/cbor envelope
- add BlockPageEnvelopeV2 wire contract plus metadata validator
- add runtime decode helper that supports both v1 raw bincode and v2 envelope
- route negotiated wire version through initial sync, observer sync, and bootstrap sync decode paths
- add unit tests for v2 envelope metadata validation

## Validation
- cargo check -p zhtp

## Notes
- PR is intentionally stacked on top of #2225 (feature/2219-sync-capabilities-negotiation).