### PR TITLE
[SYNC-WIRE] Implement observer-only legacy block decode adapter

### DIFF
--- a/zhtp/src/runtime/legacy_block_adapter.rs
+++ b/zhtp/src/runtime/legacy_block_adapter.rs
@@ -1,0 +1,327 @@
+use anyhow::{anyhow, Result};
+use lib_blockchain::transaction::{
+    BondingCurveBuyData, BondingCurveDeployData, BondingCurveGraduateData, BondingCurveSellData,
+    CancelOracleUpdateData, DaoExecutionData, DaoProposalData, DaoVoteData,
+    GovernanceConfigUpdateData, IdentityTransactionData, InitEntityRegistryData, TokenMintData,
+    TokenTransferData, Transaction, TransactionInput, TransactionOutput, TransactionPayload,
+    UbiClaimData, ValidatorTransactionData, WalletTransactionData,
+};
+use lib_blockchain::types::transaction_type::TransactionType;
+use serde::{Deserialize, Deserializer};
+
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyBlock {
+    header: lib_blockchain::block::BlockHeader,
+    transactions: Vec<LegacyTransaction>,
+}
+
+#[derive(Debug, Clone)]
+struct LegacyTransaction {
+    version: u32,
+    chain_id: u8,
+    transaction_type: TransactionType,
+    inputs: Vec<TransactionInput>,
+    outputs: Vec<TransactionOutput>,
+    fee: u64,
+    signature: lib_blockchain::integration::crypto_integration::Signature,
+    memo: Vec<u8>,
+    identity_data: Option<IdentityTransactionData>,
+    wallet_data: Option<WalletTransactionData>,
+    validator_data: Option<ValidatorTransactionData>,
+    dao_proposal_data: Option<DaoProposalData>,
+    dao_vote_data: Option<DaoVoteData>,
+    dao_execution_data: Option<DaoExecutionData>,
+    ubi_claim_data: Option<UbiClaimData>,
+    profit_declaration_data: Option<lib_blockchain::transaction::ProfitDeclarationData>,
+    token_transfer_data: Option<TokenTransferData>,
+    token_mint_data: Option<TokenMintData>,
+    governance_config_data: Option<GovernanceConfigUpdateData>,
+    bonding_curve_deploy_data: Option<BondingCurveDeployData>,
+    bonding_curve_buy_data: Option<BondingCurveBuyData>,
+    bonding_curve_sell_data: Option<BondingCurveSellData>,
+    bonding_curve_graduate_data: Option<BondingCurveGraduateData>,
+    oracle_committee_update_data: Option<lib_blockchain::transaction::OracleCommitteeUpdateData>,
+    oracle_config_update_data: Option<lib_blockchain::transaction::OracleConfigUpdateData>,
+    oracle_attestation_data: Option<lib_blockchain::transaction::OracleAttestationData>,
+    cancel_oracle_update_data: Option<CancelOracleUpdateData>,
+    init_entity_registry_data: Option<InitEntityRegistryData>,
+}
+
+impl<'de> Deserialize<'de> for LegacyTransaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct TxVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for TxVisitor {
+            type Value = LegacyTransaction;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("legacy transaction tuple (v1..v7)")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                use serde::de::Error;
+
+                macro_rules! next {
+                    ($name:literal) => {
+                        seq.next_element()?
+                            .ok_or_else(|| A::Error::missing_field($name))?
+                    };
+                }
+
+                let version: u32 = next!("version");
+                let chain_id: u8 = next!("chain_id");
+                let transaction_type: TransactionType = next!("transaction_type");
+                let inputs: Vec<TransactionInput> = next!("inputs");
+                let outputs: Vec<TransactionOutput> = next!("outputs");
+                let fee: u64 = next!("fee");
+                let signature: lib_blockchain::integration::crypto_integration::Signature =
+                    next!("signature");
+                let memo: Vec<u8> = next!("memo");
+                let identity_data: Option<IdentityTransactionData> = next!("identity_data");
+                let wallet_data: Option<WalletTransactionData> = next!("wallet_data");
+                let validator_data: Option<ValidatorTransactionData> = next!("validator_data");
+                let dao_proposal_data: Option<DaoProposalData> = next!("dao_proposal_data");
+                let dao_vote_data: Option<DaoVoteData> = next!("dao_vote_data");
+                let dao_execution_data: Option<DaoExecutionData> = next!("dao_execution_data");
+                let ubi_claim_data: Option<UbiClaimData> = next!("ubi_claim_data");
+                let profit_declaration_data: Option<lib_blockchain::transaction::ProfitDeclarationData> =
+                    next!("profit_declaration_data");
+                let token_transfer_data: Option<TokenTransferData> = next!("token_transfer_data");
+
+                let token_mint_data: Option<TokenMintData> = if version >= 2 {
+                    next!("token_mint_data")
+                } else {
+                    None
+                };
+
+                let governance_config_data: Option<GovernanceConfigUpdateData> =
+                    next!("governance_config_data");
+
+                let (
+                    bonding_curve_deploy_data,
+                    bonding_curve_buy_data,
+                    bonding_curve_sell_data,
+                    bonding_curve_graduate_data,
+                ) = if version >= 3 {
+                    (
+                        next!("bonding_curve_deploy_data"),
+                        next!("bonding_curve_buy_data"),
+                        next!("bonding_curve_sell_data"),
+                        next!("bonding_curve_graduate_data"),
+                    )
+                } else {
+                    (None, None, None, None)
+                };
+
+                let (oracle_committee_update_data, oracle_config_update_data) = if version >= 4 {
+                    (
+                        next!("oracle_committee_update_data"),
+                        next!("oracle_config_update_data"),
+                    )
+                } else {
+                    (None, None)
+                };
+
+                let oracle_attestation_data: Option<lib_blockchain::transaction::OracleAttestationData> =
+                    if version >= 5 {
+                        next!("oracle_attestation_data")
+                    } else {
+                        None
+                    };
+
+                let cancel_oracle_update_data: Option<CancelOracleUpdateData> =
+                    if version >= 6 {
+                        next!("cancel_oracle_update_data")
+                    } else {
+                        None
+                    };
+
+                let init_entity_registry_data: Option<InitEntityRegistryData> = if version >= 7 {
+                    next!("init_entity_registry_data")
+                } else {
+                    None
+                };
+
+                Ok(LegacyTransaction {
+                    version,
+                    chain_id,
+                    transaction_type,
+                    inputs,
+                    outputs,
+                    fee,
+                    signature,
+                    memo,
+                    identity_data,
+                    wallet_data,
+                    validator_data,
+                    dao_proposal_data,
+                    dao_vote_data,
+                    dao_execution_data,
+                    ubi_claim_data,
+                    profit_declaration_data,
+                    token_transfer_data,
+                    token_mint_data,
+                    governance_config_data,
+                    bonding_curve_deploy_data,
+                    bonding_curve_buy_data,
+                    bonding_curve_sell_data,
+                    bonding_curve_graduate_data,
+                    oracle_committee_update_data,
+                    oracle_config_update_data,
+                    oracle_attestation_data,
+                    cancel_oracle_update_data,
+                    init_entity_registry_data,
+                })
+            }
+        }
+
+        deserializer.deserialize_tuple(28, TxVisitor)
+    }
+}
+
+pub(crate) fn decode_legacy_block_page(body: &[u8]) -> Result<Vec<lib_blockchain::Block>> {
+    let legacy_blocks: Vec<LegacyBlock> = bincode::deserialize(body)
+        .map_err(|e| anyhow!("LegacyBlockDecodeFailed: {}", e))?;
+    let mut converted = Vec::with_capacity(legacy_blocks.len());
+    for (block_idx, block) in legacy_blocks.into_iter().enumerate() {
+        let block_height = block.header.height;
+        let mut txs = Vec::with_capacity(block.transactions.len());
+        for (tx_idx, tx) in block.transactions.into_iter().enumerate() {
+            let tx_type = tx.transaction_type;
+            let tx_current = convert_legacy_transaction(tx).map_err(|e| {
+                anyhow!(
+                    "IncompatibleLegacyTx: block_height={} block_index={} tx_index={} tx_type={:?}: {}",
+                    block_height,
+                    block_idx,
+                    tx_idx,
+                    tx_type,
+                    e
+                )
+            })?;
+            txs.push(tx_current);
+        }
+        converted.push(lib_blockchain::Block::new(block.header, txs));
+    }
+    Ok(converted)
+}
+
+fn convert_legacy_transaction(tx: LegacyTransaction) -> Result<Transaction> {
+    let payload = match tx.transaction_type {
+        TransactionType::IdentityRegistration
+        | TransactionType::IdentityUpdate
+        | TransactionType::IdentityRevocation => TransactionPayload::Identity(
+            tx.identity_data
+                .ok_or_else(|| anyhow!("missing legacy identity_data"))?,
+        ),
+        TransactionType::WalletRegistration | TransactionType::WalletUpdate => {
+            TransactionPayload::Wallet(
+                tx.wallet_data
+                    .ok_or_else(|| anyhow!("missing legacy wallet_data"))?,
+            )
+        }
+        TransactionType::ValidatorRegistration
+        | TransactionType::ValidatorUpdate
+        | TransactionType::ValidatorUnregister => TransactionPayload::Validator(
+            tx.validator_data
+                .ok_or_else(|| anyhow!("missing legacy validator_data"))?,
+        ),
+        TransactionType::DaoProposal => TransactionPayload::DaoProposal(
+            tx.dao_proposal_data
+                .ok_or_else(|| anyhow!("missing legacy dao_proposal_data"))?,
+        ),
+        TransactionType::DaoVote => TransactionPayload::DaoVote(
+            tx.dao_vote_data
+                .ok_or_else(|| anyhow!("missing legacy dao_vote_data"))?,
+        ),
+        TransactionType::DaoExecution => TransactionPayload::DaoExecution(
+            tx.dao_execution_data
+                .ok_or_else(|| anyhow!("missing legacy dao_execution_data"))?,
+        ),
+        TransactionType::UBIClaim => TransactionPayload::UbiClaim(
+            tx.ubi_claim_data
+                .ok_or_else(|| anyhow!("missing legacy ubi_claim_data"))?,
+        ),
+        TransactionType::ProfitDeclaration => TransactionPayload::ProfitDeclaration(
+            tx.profit_declaration_data
+                .ok_or_else(|| anyhow!("missing legacy profit_declaration_data"))?,
+        ),
+        TransactionType::TokenTransfer => TransactionPayload::TokenTransfer(
+            tx.token_transfer_data
+                .ok_or_else(|| anyhow!("missing legacy token_transfer_data"))?,
+        ),
+        TransactionType::TokenMint => TransactionPayload::TokenMint(
+            tx.token_mint_data
+                .ok_or_else(|| anyhow!("missing legacy token_mint_data"))?,
+        ),
+        TransactionType::GovernanceConfigUpdate => TransactionPayload::GovernanceConfigUpdate(
+            tx.governance_config_data
+                .ok_or_else(|| anyhow!("missing legacy governance_config_data"))?,
+        ),
+        TransactionType::BondingCurveDeploy => TransactionPayload::BondingCurveDeploy(
+            tx.bonding_curve_deploy_data
+                .ok_or_else(|| anyhow!("missing legacy bonding_curve_deploy_data"))?,
+        ),
+        TransactionType::BondingCurveBuy => TransactionPayload::BondingCurveBuy(
+            tx.bonding_curve_buy_data
+                .ok_or_else(|| anyhow!("missing legacy bonding_curve_buy_data"))?,
+        ),
+        TransactionType::BondingCurveSell => TransactionPayload::BondingCurveSell(
+            tx.bonding_curve_sell_data
+                .ok_or_else(|| anyhow!("missing legacy bonding_curve_sell_data"))?,
+        ),
+        TransactionType::BondingCurveGraduate => TransactionPayload::BondingCurveGraduate(
+            tx.bonding_curve_graduate_data
+                .ok_or_else(|| anyhow!("missing legacy bonding_curve_graduate_data"))?,
+        ),
+        TransactionType::UpdateOracleCommittee => TransactionPayload::OracleCommitteeUpdate(
+            tx.oracle_committee_update_data
+                .ok_or_else(|| anyhow!("missing legacy oracle_committee_update_data"))?,
+        ),
+        TransactionType::UpdateOracleConfig => TransactionPayload::OracleConfigUpdate(
+            tx.oracle_config_update_data
+                .ok_or_else(|| anyhow!("missing legacy oracle_config_update_data"))?,
+        ),
+        TransactionType::OracleAttestation => TransactionPayload::OracleAttestation(
+            tx.oracle_attestation_data
+                .ok_or_else(|| anyhow!("missing legacy oracle_attestation_data"))?,
+        ),
+        TransactionType::CancelOracleUpdate => TransactionPayload::CancelOracleUpdate(
+            tx.cancel_oracle_update_data
+                .ok_or_else(|| anyhow!("missing legacy cancel_oracle_update_data"))?,
+        ),
+        TransactionType::InitEntityRegistry => TransactionPayload::InitEntityRegistry(
+            tx.init_entity_registry_data
+                .ok_or_else(|| anyhow!("missing legacy init_entity_registry_data"))?,
+        ),
+        TransactionType::Transfer
+        | TransactionType::Coinbase
+        | TransactionType::ContractDeployment
+        | TransactionType::ContractExecution
+        | TransactionType::SessionCreation
+        | TransactionType::SessionTermination
+        | TransactionType::ContentUpload
+        | TransactionType::UbiDistribution
+        | TransactionType::DifficultyUpdate => TransactionPayload::None,
+        _ => {
+            return Err(anyhow!(
+                "unsupported legacy transaction type {:?}",
+                tx.transaction_type
+            ))
+        }
+    };
+
+    Ok(Transaction {
+        version: tx.version,
+        chain_id: tx.chain_id,
+        transaction_type: tx.transaction_type,
+        inputs: tx.inputs,
+        outputs: tx.outputs,
+        fee: tx.fee,
+        signature: tx.signature,
+        memo: tx.memo,
+        payload,
+    })
+}

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -63,6 +63,7 @@ pub mod dht_indexing;
 pub mod did_startup;
 pub mod edge_state_provider; // Global access to edge node state for header-only sync
 pub mod identity_manager_provider;
+pub mod legacy_block_adapter;
 pub mod mesh_router_provider;
 pub mod network_blockchain_event_receiver;
 pub mod network_blockchain_provider;
@@ -130,13 +131,25 @@ pub(crate) fn decode_block_page_for_wire(
     expected_end: u64,
 ) -> anyhow::Result<Vec<lib_blockchain::Block>> {
     match wire_version {
-        crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW => bincode::deserialize(body)
-            .with_context(|| {
+        crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW => {
+            match bincode::deserialize(body).with_context(|| {
                 format!(
                     "PayloadDecodeFailed: wire={} range={}..{}",
                     wire_version, expected_start, expected_end
                 )
-            }),
+            }) {
+                Ok(blocks) => Ok(blocks),
+                Err(primary_err) => crate::runtime::legacy_block_adapter::decode_legacy_block_page(
+                    body,
+                )
+                .with_context(|| {
+                    format!(
+                        "PayloadDecodeFailed: wire={} range={}..{} primary={} fallback_legacy_decode=true",
+                        wire_version, expected_start, expected_end, primary_err
+                    )
+                }),
+            }
+        }
         crate::sync_wire::BLOCK_PAGE_WIRE_V2_CBORENVELOPE => {
             let envelope: crate::sync_wire::BlockPageEnvelopeV2 =
                 ciborium::de::from_reader(body).with_context(|| {


### PR DESCRIPTION
## Summary
Implements issue #2221 by adding a scoped legacy block-page decode adapter for sync paths.

## Changes
- add runtime legacy_block_adapter module with v1..v7 legacy transaction tuple decoder
- add conversion from legacy transaction shape to current Transaction payload model
- fail closed with deterministic IncompatibleLegacyTx diagnostics (block height/index + tx index + tx type)
- wire adapter as fallback only when v1 raw block page decode fails in sync decode path

## Guardrails
- no changes to validator consensus commit/apply execution paths
- unknown legacy transaction variants are rejected (no silent drop)

## Validation
- cargo check -p zhtp

## Notes
- PR is stacked on top of #2226 (feature/2220-v2-block-page-envelope).