### PR TITLE
[SYNC-WIRE] Add structured sync decode errors, metrics, and diagnostics

### DIFF
--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -492,9 +492,14 @@ impl BlockchainComponent {
                     ) {
                         Ok(b) => b,
                         Err(e) => {
-                            warn!(
-                                "observer_sync: failed to decode block page {}-{} (wire={}): {}",
-                                from, to, block_page_wire, e
+                            crate::runtime::log_sync_decode_failure(
+                                &peer_quic_addr,
+                                &path,
+                                &block_page_wire,
+                                from,
+                                to,
+                                &blocks_resp.body,
+                                &e,
                             );
                             break 'batches;
                         }

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -78,6 +78,7 @@ pub mod shared_blockchain;
 pub mod shared_dht;
 pub mod storage_provider; // Global access to storage for component sharing
 pub mod storage_rewards;
+pub mod sync_diagnostics;
 #[cfg(test)]
 pub mod test_api_integration;
 pub mod token_utils;
@@ -211,7 +212,9 @@ pub(crate) async fn negotiate_block_page_wire_version(
                 e,
                 crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW
             );
-            return Ok(crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW.to_string());
+            let selected = crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW.to_string();
+            crate::runtime::sync_diagnostics::record_wire_selection(peer_addr, &selected);
+            return Ok(selected);
         }
         Err(_) => {
             warn!(
@@ -219,7 +222,9 @@ pub(crate) async fn negotiate_block_page_wire_version(
                 peer_addr,
                 crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW
             );
-            return Ok(crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW.to_string());
+            let selected = crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW.to_string();
+            crate::runtime::sync_diagnostics::record_wire_selection(peer_addr, &selected);
+            return Ok(selected);
         }
     };
 
@@ -230,7 +235,9 @@ pub(crate) async fn negotiate_block_page_wire_version(
             caps_resp.status_message,
             crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW
         );
-        return Ok(crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW.to_string());
+        let selected = crate::sync_wire::BLOCK_PAGE_WIRE_V1_BINCODERAW.to_string();
+        crate::runtime::sync_diagnostics::record_wire_selection(peer_addr, &selected);
+        return Ok(selected);
     }
 
     let peer_caps: crate::sync_wire::SyncCapabilities = serde_json::from_slice(&caps_resp.body)
@@ -247,6 +254,7 @@ pub(crate) async fn negotiate_block_page_wire_version(
                 "🔁 Sync wire negotiated with {}: {} (peer_supported={:?}, local_supported={:?})",
                 peer_addr, wire, peer_caps.block_page_wire_versions, local_supported
             );
+            crate::runtime::sync_diagnostics::record_wire_selection(peer_addr, &wire);
             Ok(wire)
         }
         None => Err(anyhow::anyhow!(
@@ -256,6 +264,36 @@ pub(crate) async fn negotiate_block_page_wire_version(
             local_supported
         )),
     }
+}
+
+pub(crate) fn log_sync_decode_failure(
+    peer: &str,
+    endpoint: &str,
+    wire_version: &str,
+    start: u64,
+    end: u64,
+    payload: &[u8],
+    err: &anyhow::Error,
+) {
+    let class = crate::runtime::sync_diagnostics::classify_sync_decode_error(err);
+    crate::runtime::sync_diagnostics::record_decode_failure(peer, wire_version, class);
+
+    let prefix_len = std::cmp::min(payload.len(), 16);
+    let payload_prefix = hex::encode(&payload[..prefix_len]);
+    let payload_hash = hex::encode(blake3::hash(payload).as_bytes());
+
+    warn!(
+        "sync_decode_failure class={} peer={} endpoint={} wire={} range={}..{} payload_prefix={} payload_hash={} err={}",
+        class.as_str(),
+        peer,
+        endpoint,
+        wire_version,
+        start,
+        end,
+        payload_prefix,
+        payload_hash,
+        err
+    );
 }
 
 /// Try to sync blockchain from bootstrap peers using paginated block-range QUIC requests.
@@ -489,9 +527,14 @@ async fn try_initial_sync_from_peer(
                 {
                     Ok(b) => b,
                     Err(e) => {
-                        warn!(
-                            "⚠️  Failed to decode block page {}-{} from {} (wire={}): {}",
-                            start, end, peer_addr, block_page_wire, e
+                        log_sync_decode_failure(
+                            &peer_addr.to_string(),
+                            &url,
+                            &block_page_wire,
+                            start,
+                            end,
+                            &blocks_resp.body,
+                            &e,
                         );
                         page_error = true;
                         break;

--- a/zhtp/src/runtime/services/bootstrap_service.rs
+++ b/zhtp/src/runtime/services/bootstrap_service.rs
@@ -255,7 +255,18 @@ impl BootstrapService {
             start,
             end,
         )
-        .context("Failed to decode block page")?;
+        .map_err(|e| {
+            crate::runtime::log_sync_decode_failure(
+                peer_label,
+                &blocks_path,
+                &block_page_wire,
+                start,
+                end,
+                &blocks_data,
+                &e,
+            );
+            anyhow::anyhow!("Failed to decode block page: {}", e)
+        })?;
 
         info!("Appending {} new blocks to local chain", new_blocks.len());
 

--- a/zhtp/src/runtime/sync_diagnostics.rs
+++ b/zhtp/src/runtime/sync_diagnostics.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum SyncDecodeErrorClass {
+    UnsupportedPeerWireVersion,
+    LegacyTxVariantUnsupported,
+    BlockPageEnvelopeMalformed,
+    PayloadDecodeFailed,
+}
+
+impl SyncDecodeErrorClass {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::UnsupportedPeerWireVersion => "UnsupportedPeerWireVersion",
+            Self::LegacyTxVariantUnsupported => "LegacyTxVariantUnsupported",
+            Self::BlockPageEnvelopeMalformed => "BlockPageEnvelopeMalformed",
+            Self::PayloadDecodeFailed => "PayloadDecodeFailed",
+        }
+    }
+}
+
+#[derive(Default)]
+struct SyncDecodeMetrics {
+    // key: (peer, wire_version)
+    wire_selection_counts: HashMap<(String, String), u64>,
+    // key: (peer, wire_version, error_class)
+    decode_failure_counts: HashMap<(String, String, &'static str), u64>,
+}
+
+fn metrics() -> &'static Mutex<SyncDecodeMetrics> {
+    static METRICS: OnceLock<Mutex<SyncDecodeMetrics>> = OnceLock::new();
+    METRICS.get_or_init(|| Mutex::new(SyncDecodeMetrics::default()))
+}
+
+pub(crate) fn classify_sync_decode_error(err: &anyhow::Error) -> SyncDecodeErrorClass {
+    let s = err.to_string();
+    if s.contains("UnsupportedPeerWireVersion") {
+        SyncDecodeErrorClass::UnsupportedPeerWireVersion
+    } else if s.contains("IncompatibleLegacyTx") || s.contains("unsupported legacy transaction type") {
+        SyncDecodeErrorClass::LegacyTxVariantUnsupported
+    } else if s.contains("BlockPageEnvelopeMalformed") {
+        SyncDecodeErrorClass::BlockPageEnvelopeMalformed
+    } else {
+        SyncDecodeErrorClass::PayloadDecodeFailed
+    }
+}
+
+pub(crate) fn record_wire_selection(peer: &str, wire_version: &str) {
+    let mut guard = metrics()
+        .lock()
+        .expect("sync diagnostics mutex poisoned while recording wire selection");
+    let key = (peer.to_string(), wire_version.to_string());
+    *guard.wire_selection_counts.entry(key).or_insert(0) += 1;
+}
+
+pub(crate) fn record_decode_failure(peer: &str, wire_version: &str, class: SyncDecodeErrorClass) {
+    let mut guard = metrics()
+        .lock()
+        .expect("sync diagnostics mutex poisoned while recording decode failure");
+    let key = (
+        peer.to_string(),
+        wire_version.to_string(),
+        class.as_str(),
+    );
+    *guard.decode_failure_counts.entry(key).or_insert(0) += 1;
+}


### PR DESCRIPTION
## Summary
Implements issue #2222 by standardizing sync decode diagnostics and adding per-peer/per-wire counters.

## Changes
- add runtime sync_diagnostics module with structured error classes:
  - UnsupportedPeerWireVersion
  - LegacyTxVariantUnsupported
  - BlockPageEnvelopeMalformed
  - PayloadDecodeFailed
- add in-memory counters for wire selection usage and decode failures (peer + wire + class)
- add unified sync decode failure logger with required context:
  - peer, endpoint, selected wire version, range, payload prefix, payload hash
- wire diagnostics into observer sync, bootstrap sync, and initial sync decode failure paths
- wire version usage is recorded during negotiation (including v1 fallback paths)

## Validation
- cargo check -p zhtp

## Notes
- PR is stacked on top of #2227 (feature/2221-observer-legacy-decode-adapter).