### PR TITLE
[SYNC-WIRE] Migration plan: dual-stack default, strict mode, and v1 deprecation

### DIFF
--- a/docs/specs/block-sync-wire-compat-v1.md
+++ b/docs/specs/block-sync-wire-compat-v1.md
@@ -1,0 +1,80 @@
+# Block Sync Wire Compatibility and Migration Plan (v1)
+
+## Purpose
+This document defines the staged migration from implicit v1 raw block pages to explicit negotiated sync wire versions.
+
+Current implementation status:
+- v2 envelope wire is implemented and preferred
+- explicit negotiation is implemented (`/api/v1/blockchain/sync-capabilities`)
+- v1 fallback remains enabled by default
+- strict mode is available via runtime flag
+
+## Wire Versions
+- `v1-bincode-raw`: legacy raw `Vec<Block>` payload (`/api/v1/blockchain/blocks/{start}/{end}`)
+- `v2-cbor-envelope`: self-describing envelope (`/api/v2/blockchain/blocks/{start}/{end}`)
+
+## Rollout Phases
+1. Phase 1 (current): Dual-stack default
+- Default behavior: prefer v2, fallback to v1 when capabilities are missing/unavailable.
+- Goal: keep mixed fleets syncable while rolling out v2 servers.
+
+2. Phase 2: Strict mode default
+- Default behavior: require successful capability negotiation; disable implicit v1 fallback.
+- v1 fallback available only via explicit opt-in.
+
+3. Phase 3: v1 deprecation/removal
+- Remove v1 fallback code paths once bootstrap fleet readiness is confirmed.
+- Keep explicit failure diagnostics for incompatible peers.
+
+## Operator Flags
+- `ZHTP_SYNC_WIRE_STRICT=1`
+  - Enables strict mode.
+  - Disables fallback when sync-capabilities endpoint is unavailable or fails.
+  - Negotiation failures return `UnsupportedPeerWireVersion`.
+
+Examples:
+```bash
+# Dual-stack default (Phase 1)
+zhtp --testnet --config ~/.zhtp/config.toml --data-dir ~/.zhtp
+
+# Strict mode (Phase 2 behavior)
+ZHTP_SYNC_WIRE_STRICT=1 zhtp --testnet --config ~/.zhtp/config.toml --data-dir ~/.zhtp
+```
+
+## Failure Classes and Operations Signals
+Observer/bootstrap sync decode paths classify errors as:
+- `UnsupportedPeerWireVersion`
+- `LegacyTxVariantUnsupported`
+- `BlockPageEnvelopeMalformed`
+- `PayloadDecodeFailed`
+
+Every decode failure log includes:
+- peer
+- endpoint/path
+- selected wire version
+- requested range
+- payload prefix (first bytes)
+- payload hash
+
+Counters are recorded per peer/wire:
+- wire selection usage
+- decode failure counts by error class
+
+## Field Verification Checklist (Mac Observer)
+Use this checklist after deployment to confirm observer sync progression beyond previous stall points.
+
+1. Build and run observer node in dev profile.
+2. Confirm negotiation logs show v2 selection against upgraded peers.
+3. Confirm no repeated opaque decode loops; failures must emit structured class + context.
+4. If strict mode is enabled, verify peers without sync-capabilities fail with explicit `UnsupportedPeerWireVersion`.
+5. Confirm observer height advances beyond prior stall height and remains stable after restart.
+6. Capture logs for one full bootstrap session and archive with:
+- selected wire per peer
+- any decode failures and class counts
+- final synced height
+
+## Deprecation Gate (Phase 3 Entry Criteria)
+Do not remove v1 support until all are true:
+- bootstrap peers serving current testnet expose sync-capabilities
+- no production observers depend on v1 fallback for at least one full release cycle
+- strict mode validation completed on macOS observer nodes under real bootstrap traffic

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -106,6 +106,16 @@ pub use shared_dht::*;
 
 const SYNC_CAPABILITIES_ENDPOINT: &str = "/api/v1/blockchain/sync-capabilities";
 
+fn strict_sync_wire_mode_enabled() -> bool {
+    std::env::var("ZHTP_SYNC_WIRE_STRICT")
+        .ok()
+        .map(|v| {
+            let normalized = v.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
+}
+
 pub(crate) fn block_range_path_for_wire(
     wire_version: &str,
     start: u64,
@@ -193,6 +203,7 @@ pub(crate) async fn negotiate_block_page_wire_version(
     client: &lib_network::client::ZhtpClient,
     peer_addr: &str,
 ) -> anyhow::Result<String> {
+    let strict_mode = strict_sync_wire_mode_enabled();
     let local_supported = crate::sync_wire::LOCAL_BLOCK_PAGE_WIRE_PREFERENCE
         .iter()
         .map(|s| s.to_string())
@@ -206,6 +217,13 @@ pub(crate) async fn negotiate_block_page_wire_version(
     {
         Ok(Ok(resp)) => resp,
         Ok(Err(e)) => {
+            if strict_mode {
+                return Err(anyhow::anyhow!(
+                    "UnsupportedPeerWireVersion: peer={} strict_mode=true fallback_disabled reason=sync_capabilities_request_failed error={}",
+                    peer_addr,
+                    e
+                ));
+            }
             warn!(
                 "⚠️  sync-capabilities request failed for {}: {}; falling back to {}",
                 peer_addr,
@@ -217,6 +235,12 @@ pub(crate) async fn negotiate_block_page_wire_version(
             return Ok(selected);
         }
         Err(_) => {
+            if strict_mode {
+                return Err(anyhow::anyhow!(
+                    "UnsupportedPeerWireVersion: peer={} strict_mode=true fallback_disabled reason=sync_capabilities_timeout",
+                    peer_addr
+                ));
+            }
             warn!(
                 "⚠️  sync-capabilities request timed out for {}; falling back to {}",
                 peer_addr,
@@ -229,6 +253,13 @@ pub(crate) async fn negotiate_block_page_wire_version(
     };
 
     if !caps_resp.is_success() {
+        if strict_mode {
+            return Err(anyhow::anyhow!(
+                "UnsupportedPeerWireVersion: peer={} strict_mode=true fallback_disabled reason=sync_capabilities_status status={}",
+                peer_addr,
+                caps_resp.status_message
+            ));
+        }
         warn!(
             "⚠️  peer {} does not expose sync capabilities (status={}): falling back to {}",
             peer_addr,


### PR DESCRIPTION
## Summary
Implements issue #2223 with explicit fallback policy control and operator migration documentation.

## Changes
- add runtime strict-mode policy flag: ZHTP_SYNC_WIRE_STRICT=1
- strict mode disables implicit v1 fallback when sync-capabilities is unavailable/failing
- strict-mode negotiation failures emit explicit UnsupportedPeerWireVersion errors
- add migration spec doc with:
  - phase rollout plan (dual-stack, strict default, v1 deprecation)
  - operator flags and examples
  - failure classes and diagnostics expectations
  - field verification checklist for mac observer sync progression

## Validation
- cargo check -p zhtp

## Notes
- PR is stacked on top of #2228 (feature/2222-sync-decode-errors-metrics).