### PR TITLE
feat(network): relay admission policy and eligibility state machine (#2201)

### DIFF
--- a/lib-network/src/peer_registry/mod.rs
+++ b/lib-network/src/peer_registry/mod.rs
@@ -17,6 +17,8 @@
 //! - **Comprehensive Metadata**: All connection, routing, and capability data in one place
 // Synchronization module (Ticket #151)
 pub mod sync;
+// Relay admission state machine (#2201)
+pub mod relay_admission;
 
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
@@ -323,6 +325,10 @@ pub struct PeerEntry {
     /// Trust score (0.0 - 1.0)
     pub trust_score: f64,
 
+    // === Relay Admission (#2201) ===
+    /// Relay admission status (None = not yet evaluated)
+    pub relay_admission: Option<relay_admission::RelayAdmissionStatus>,
+
     // === Statistics (use atomic counters for lock-free updates) ===
     /// Total data transferred (atomic for lock-free updates)
     #[serde(skip)]
@@ -391,6 +397,8 @@ impl PeerEntry {
             last_seen,
             tier,
             trust_score,
+            // Initialize relay admission as unevaluated
+            relay_admission: None,
             // Initialize atomic counters
             data_transferred: Arc::new(AtomicU64::new(0)),
             tokens_earned: Arc::new(AtomicU64::new(0)),
@@ -1212,6 +1220,62 @@ impl PeerRegistry {
         }
     }
 
+    // ========== RELAY ADMISSION (#2201) ==========
+
+    /// Evaluate and set relay admission status for a peer.
+    pub fn evaluate_and_set_relay_admission(&mut self, peer_id: &UnifiedPeerId) -> Result<relay_admission::RelayAdmissionStatus> {
+        let entry = self.peers.get(peer_id).ok_or_else(|| anyhow!("Peer not found"))?;
+        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        let status = relay_admission::evaluate_relay_admission(
+            entry.authenticated,
+            entry.quantum_secure,
+            entry.trust_score,
+            &entry.tier,
+            entry.connection_metrics.stability_score,
+            entry.connection_metrics.latency_ms,
+            entry.capabilities.routing_capacity,
+            entry.last_seen,
+            now,
+            entry.relay_admission.as_ref(),
+        );
+        let entry = self.peers.get_mut(peer_id).ok_or_else(|| anyhow!("Peer not found"))?;
+        entry.relay_admission = Some(status.clone());
+        Ok(status)
+    }
+
+    /// Set relay admission status manually (e.g., by operator or governance).
+    pub fn set_relay_admission(&mut self, peer_id: &UnifiedPeerId, status: relay_admission::RelayAdmissionStatus) -> Result<()> {
+        let entry = self.peers.get_mut(peer_id).ok_or_else(|| anyhow!("Peer not found"))?;
+        entry.relay_admission = Some(status);
+        Ok(())
+    }
+
+    /// Get relay admission status for a peer.
+    pub fn relay_admission_status(&self, peer_id: &UnifiedPeerId) -> Option<relay_admission::RelayAdmissionStatus> {
+        self.peers.get(peer_id)?.relay_admission.clone()
+    }
+
+    /// Iterate over peers whose relay admission state is `Eligible`.
+    pub fn eligible_relays(&self) -> impl Iterator<Item = &PeerEntry> {
+        self.peers.values().filter(|e| {
+            e.relay_admission.as_ref().map_or(false, |a| a.state == relay_admission::RelayAdmissionState::Eligible)
+        })
+    }
+
+    /// Summary of relay admission states across all peers.
+    pub fn relay_admission_summary(&self) -> relay_admission::RelayAdmissionSummary {
+        let mut summary = relay_admission::RelayAdmissionSummary::default();
+        for entry in self.peers.values() {
+            match entry.relay_admission.as_ref().map(|a| &a.state) {
+                Some(relay_admission::RelayAdmissionState::Eligible) => summary.eligible += 1,
+                Some(relay_admission::RelayAdmissionState::Probation) => summary.probation += 1,
+                Some(relay_admission::RelayAdmissionState::Blocked) => summary.blocked += 1,
+                None => summary.unevaluated += 1,
+            }
+        }
+        summary
+    }
+
     // ========== UNIFIED ADDRESS RESOLUTION METHODS ==========
     //
     // These methods integrate the unified AddressResolver with the PeerRegistry
@@ -1678,10 +1742,11 @@ mod tests {
             },
             location: None,
             reliability_score: 0.92,
+            relay_admission: None,
             dht_info: None,
             discovery_method: DiscoveryMethod::MeshScan,
             first_seen: 0,
-            last_seen: 0,
+            last_seen: std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
             tier: PeerTier::Tier3,
             trust_score: 0.8,
             // Atomic counters
@@ -2235,5 +2300,129 @@ mod tests {
         // Cleanup should keep recent entries
         limiter.cleanup_old_entries();
         assert_eq!(limiter.per_peer_counts.len(), 2);
+    }
+
+    // ========== RELAY ADMISSION TESTS (#2201) ==========
+
+    #[test]
+    fn test_relay_admission_eligible_peer() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.8, &PeerTier::Tier2, 0.9, 50, 100, now, now, None,
+        );
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Eligible);
+    }
+
+    #[test]
+    fn test_relay_admission_probation_peer() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        // Low stability but otherwise OK -> Probation
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.6, &PeerTier::Tier2, 0.4, 50, 100, now, now, None,
+        );
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Probation);
+    }
+
+    #[test]
+    fn test_relay_admission_blocked_low_trust() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.2, &PeerTier::Tier2, 0.9, 50, 100, now, now, None,
+        );
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Blocked);
+    }
+
+    #[test]
+    fn test_relay_admission_blocked_untrusted_tier() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.8, &PeerTier::Untrusted, 0.9, 50, 100, now, now, None,
+        );
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Blocked);
+    }
+
+    #[test]
+    fn test_relay_admission_blocked_not_authenticated() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let status = relay_admission::evaluate_relay_admission(
+            false, true, 0.8, &PeerTier::Tier2, 0.9, 50, 100, now, now, None,
+        );
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Blocked);
+    }
+
+    #[test]
+    fn test_relay_admission_block_expiration() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let existing = relay_admission::RelayAdmissionStatus::blocked("test", now - 100, Some(now - 10));
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.8, &PeerTier::Tier2, 0.9, 50, 100, now, now, Some(&existing),
+        );
+        // Block expired -> re-evaluated to Eligible
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Eligible);
+    }
+
+    #[test]
+    fn test_relay_admission_block_persists() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let existing = relay_admission::RelayAdmissionStatus::blocked("test", now - 100, Some(now + 1000));
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.8, &PeerTier::Tier2, 0.9, 50, 100, now, now, Some(&existing),
+        );
+        // Block still active
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Blocked);
+    }
+
+    #[test]
+    fn test_relay_admission_registry_methods() {
+        let mut registry = PeerRegistry::new();
+        let peer_id = create_test_peer_id();
+        let entry = create_test_entry(peer_id.clone());
+        upsert_blocking(&mut registry, entry).expect("Failed to upsert");
+
+        // Initially unevaluated
+        assert!(registry.relay_admission_status(&peer_id).is_none());
+
+        // Evaluate
+        let status = registry.evaluate_and_set_relay_admission(&peer_id).unwrap();
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Eligible);
+        assert!(registry.relay_admission_status(&peer_id).is_some());
+
+        // Eligible relays count
+        assert_eq!(registry.eligible_relays().count(), 1);
+
+        // Summary
+        let summary = registry.relay_admission_summary();
+        assert_eq!(summary.eligible, 1);
+        assert_eq!(summary.unevaluated, 0);
+    }
+
+    #[test]
+    fn test_relay_admission_summary_counts() {
+        let mut registry = PeerRegistry::new();
+
+        let p1 = create_test_peer_id();
+        let mut e1 = create_test_entry(p1.clone());
+        e1.relay_admission = Some(relay_admission::RelayAdmissionStatus::eligible("", 0));
+        upsert_blocking(&mut registry, e1).unwrap();
+
+        let p2 = create_test_peer_id();
+        let mut e2 = create_test_entry(p2.clone());
+        e2.relay_admission = Some(relay_admission::RelayAdmissionStatus::probation("", 0, 100));
+        upsert_blocking(&mut registry, e2).unwrap();
+
+        let p3 = create_test_peer_id();
+        let mut e3 = create_test_entry(p3.clone());
+        e3.relay_admission = Some(relay_admission::RelayAdmissionStatus::blocked("", 0, None));
+        upsert_blocking(&mut registry, e3).unwrap();
+
+        let p4 = create_test_peer_id();
+        let e4 = create_test_entry(p4.clone());
+        upsert_blocking(&mut registry, e4).unwrap();
+
+        let summary = registry.relay_admission_summary();
+        assert_eq!(summary.eligible, 1);
+        assert_eq!(summary.probation, 1);
+        assert_eq!(summary.blocked, 1);
+        assert_eq!(summary.unevaluated, 1);
     }
 }

--- a/lib-network/src/peer_registry/relay_admission.rs
+++ b/lib-network/src/peer_registry/relay_admission.rs
@@ -1,0 +1,212 @@
+//! Relay Admission Policy and Eligibility State Machine (#2201)
+//!
+//! Defines and enforces relay admission states (eligible, probation, blocked)
+//! based on identity/trust/health criteria.
+
+use serde::{Deserialize, Serialize};
+
+/// Relay admission state for a peer.
+///
+/// Governs whether a peer may participate in message routing for others.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RelayAdmissionState {
+    /// New or under-evaluation peer; may route but with penalty.
+    Probation,
+    /// Fully approved for relay/routing duties.
+    Eligible,
+    /// Explicitly barred from routing (abuse, health, trust failure).
+    Blocked,
+}
+
+/// Detailed relay admission status for a peer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayAdmissionStatus {
+    /// Current admission state.
+    pub state: RelayAdmissionState,
+    /// Human-readable reason for the current state.
+    pub reason: String,
+    /// Unix timestamp of last evaluation.
+    pub evaluated_at: u64,
+    /// DID of evaluator, or "auto" for heuristic evaluation.
+    pub evaluated_by: Option<String>,
+    /// If Probation, when the probation period expires.
+    pub probation_end: Option<u64>,
+    /// If Blocked, when the block expires (None = permanent).
+    pub block_expires: Option<u64>,
+}
+
+impl RelayAdmissionStatus {
+    /// Create a new `Eligible` status.
+    pub fn eligible(reason: impl Into<String>, evaluated_at: u64) -> Self {
+        Self {
+            state: RelayAdmissionState::Eligible,
+            reason: reason.into(),
+            evaluated_at,
+            evaluated_by: Some("auto".to_string()),
+            probation_end: None,
+            block_expires: None,
+        }
+    }
+
+    /// Create a new `Probation` status.
+    pub fn probation(reason: impl Into<String>, evaluated_at: u64, end: u64) -> Self {
+        Self {
+            state: RelayAdmissionState::Probation,
+            reason: reason.into(),
+            evaluated_at,
+            evaluated_by: Some("auto".to_string()),
+            probation_end: Some(end),
+            block_expires: None,
+        }
+    }
+
+    /// Create a new `Blocked` status.
+    pub fn blocked(reason: impl Into<String>, evaluated_at: u64, expires: Option<u64>) -> Self {
+        Self {
+            state: RelayAdmissionState::Blocked,
+            reason: reason.into(),
+            evaluated_at,
+            evaluated_by: Some("auto".to_string()),
+            probation_end: None,
+            block_expires: expires,
+        }
+    }
+
+    /// Returns true if a `Blocked` status has expired and should be re-evaluated.
+    pub fn is_block_expired(&self, now: u64) -> bool {
+        self.state == RelayAdmissionState::Blocked
+            && self.block_expires.map_or(false, |exp| now >= exp)
+    }
+
+    /// Returns true if a `Probation` status has expired.
+    pub fn is_probation_expired(&self, now: u64) -> bool {
+        self.state == RelayAdmissionState::Probation
+            && self.probation_end.map_or(false, |exp| now >= exp)
+    }
+}
+
+/// Summary of relay admission counts across the registry.
+#[derive(Debug, Clone, Default)]
+pub struct RelayAdmissionSummary {
+    pub eligible: usize,
+    pub probation: usize,
+    pub blocked: usize,
+    pub unevaluated: usize,
+}
+
+/// Evaluate relay admission for a peer based on heuristics.
+///
+/// # Criteria for `Eligible`
+/// - `authenticated` + `quantum_secure` both true
+/// - `trust_score` >= 0.5
+/// - `tier` >= Tier2
+/// - `connection_metrics.stability_score` >= 0.6
+/// - `connection_metrics.latency_ms` <= 500
+/// - `capabilities.routing_capacity` >= 10
+/// - `last_seen` within the last hour
+///
+/// # Criteria for `Probation`
+/// - Missing 1–2 eligible criteria
+/// - `trust_score` >= 0.3
+/// - `authenticated` is true
+///
+/// # Criteria for `Blocked`
+/// - `trust_score` < 0.3, or
+/// - `tier` == Untrusted, or
+/// - `authenticated` is false
+pub fn evaluate_relay_admission(
+    authenticated: bool,
+    quantum_secure: bool,
+    trust_score: f64,
+    tier: &super::PeerTier,
+    stability_score: f64,
+    latency_ms: u32,
+    routing_capacity: u32,
+    last_seen: u64,
+    now: u64,
+    existing: Option<&RelayAdmissionStatus>,
+) -> RelayAdmissionStatus {
+    // Preserve existing block unless expired
+    if let Some(existing) = existing {
+        if existing.state == RelayAdmissionState::Blocked && !existing.is_block_expired(now) {
+            return RelayAdmissionStatus {
+                state: RelayAdmissionState::Blocked,
+                reason: format!("Block still active: {}", existing.reason),
+                evaluated_at: now,
+                evaluated_by: existing.evaluated_by.clone(),
+                probation_end: None,
+                block_expires: existing.block_expires,
+            };
+        }
+    }
+
+    // Hard block conditions
+    if !authenticated {
+        return RelayAdmissionStatus::blocked(
+            "Peer is not authenticated",
+            now,
+            None,
+        );
+    }
+    if trust_score < 0.3 {
+        return RelayAdmissionStatus::blocked(
+            format!("Trust score {:.2} below minimum threshold 0.3", trust_score),
+            now,
+            None,
+        );
+    }
+    if *tier == super::PeerTier::Untrusted {
+        return RelayAdmissionStatus::blocked(
+            "Peer tier is Untrusted",
+            now,
+            None,
+        );
+    }
+
+    // Score eligible criteria
+    let mut eligible_criteria = 0;
+    let total_criteria = 7;
+
+    if quantum_secure { eligible_criteria += 1; }
+    if trust_score >= 0.5 { eligible_criteria += 1; }
+    if *tier >= super::PeerTier::Tier2 { eligible_criteria += 1; }
+    if stability_score >= 0.6 { eligible_criteria += 1; }
+    if latency_ms <= 500 { eligible_criteria += 1; }
+    if routing_capacity >= 10 { eligible_criteria += 1; }
+    if now.saturating_sub(last_seen) <= 3600 { eligible_criteria += 1; }
+
+    if eligible_criteria == total_criteria {
+        RelayAdmissionStatus::eligible("All admission criteria met", now)
+    } else if eligible_criteria >= total_criteria - 2 {
+        let reason = format!(
+            "Partial criteria met ({}/{}): quantum={}, trust={:.2}, tier={:?}, stability={:.2}, latency={}ms, capacity={}, fresh={}",
+            eligible_criteria,
+            total_criteria,
+            quantum_secure,
+            trust_score,
+            tier,
+            stability_score,
+            latency_ms,
+            routing_capacity,
+            now.saturating_sub(last_seen) <= 3600,
+        );
+        RelayAdmissionStatus::probation(reason, now, now + 3600)
+    } else {
+        RelayAdmissionStatus::blocked(
+            format!(
+                "Insufficient criteria ({}/{}): quantum={}, trust={:.2}, tier={:?}, stability={:.2}, latency={}ms, capacity={}, fresh={}",
+                eligible_criteria,
+                total_criteria,
+                quantum_secure,
+                trust_score,
+                tier,
+                stability_score,
+                latency_ms,
+                routing_capacity,
+                now.saturating_sub(last_seen) <= 3600,
+            ),
+            now,
+            Some(now + 86400), // 24h temporary block
+        )
+    }
+}

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -514,6 +514,20 @@ impl MeshMessageRouter {
         .await
     }
 
+    /// Determine if a peer is routable based on admission state, trust, auth, and tier.
+    fn is_peer_routable(entry: &crate::peer_registry::PeerEntry) -> bool {
+        use crate::peer_registry::relay_admission::RelayAdmissionState;
+        if let Some(ref admission) = entry.relay_admission {
+            if admission.state == RelayAdmissionState::Blocked {
+                return false;
+            }
+        }
+        entry.authenticated
+            && entry.quantum_secure
+            && entry.trust_score >= 0.3
+            && entry.tier != crate::peer_registry::PeerTier::Untrusted
+    }
+
     /// Find optimal route to destination
     pub async fn find_optimal_route(
         &self,
@@ -543,12 +557,23 @@ impl MeshMessageRouter {
             .get(destination)
             .or_else(|| registry.find_by_public_key(&destination.public_key()));
         if let Some(peer_entry) = peer_entry_opt {
-            // Enforce secure routing only: authenticated + quantum secure
-            if !peer_entry.authenticated || !peer_entry.quantum_secure {
+            if !Self::is_peer_routable(peer_entry) {
                 return Err(anyhow::anyhow!(
-                    "Direct route rejected: insecure transport for peer {}",
-                    destination.to_compact_string()
+                    "Direct route rejected: peer {} is not routable (admission={:?}, trust={:.2}, tier={:?})",
+                    destination.to_compact_string(),
+                    peer_entry.relay_admission.as_ref().map(|a| &a.state),
+                    peer_entry.trust_score,
+                    peer_entry.tier,
                 ));
+            }
+
+            if peer_entry.relay_admission.as_ref().map_or(false, |a| {
+                a.state == crate::peer_registry::relay_admission::RelayAdmissionState::Probation
+            }) {
+                warn!(
+                    peer = %destination.to_compact_string(),
+                    "Direct route to peer on probation — routing with penalty"
+                );
             }
 
             info!("Direct connection available to destination");
@@ -672,20 +697,36 @@ impl MeshMessageRouter {
     /// Calculate edge weight for routing algorithm
     ///
     /// **MIGRATION (Ticket #149):** Updated to use PeerRegistry
+    /// **#2201:** Enforces relay admission policy in edge weighting.
     async fn calculate_edge_weight(
         &self,
         _from: &UnifiedPeerId,
         to: &UnifiedPeerId,
         registry: &crate::peer_registry::PeerRegistry,
     ) -> f64 {
-        // Weight based on latency, stability, and bandwidth
         if let Some(peer_entry) = registry.get(to) {
+            // #2201: Blocked or otherwise non-routable peers are unreachable
+            if !Self::is_peer_routable(peer_entry) {
+                return f64::INFINITY;
+            }
+
             let latency_weight = peer_entry.connection_metrics.latency_ms as f64 / 1000.0; // Convert to seconds
             let stability_weight = 1.0 - peer_entry.connection_metrics.stability_score; // Lower stability = higher weight
             let bandwidth_weight =
                 1.0 / (peer_entry.connection_metrics.bandwidth_capacity as f64 / 1_000_000.0); // Favor higher bandwidth
 
-            latency_weight + stability_weight + bandwidth_weight
+            let base_weight = latency_weight + stability_weight + bandwidth_weight;
+
+            // #2201: Probation peers incur a routing penalty
+            let probation_penalty = if peer_entry.relay_admission.as_ref().map_or(false, |a| {
+                a.state == crate::peer_registry::relay_admission::RelayAdmissionState::Probation
+            }) {
+                1.5
+            } else {
+                1.0
+            };
+
+            base_weight * probation_penalty
         } else {
             f64::INFINITY // No connection
         }
@@ -694,6 +735,7 @@ impl MeshMessageRouter {
     /// Construct route from pathfinding result
     ///
     /// **MIGRATION (Ticket #149):** Updated to use PeerRegistry
+    /// **#2201:** Defensively skips non-routable peers in constructed paths.
     async fn construct_route_from_path(
         &self,
         previous: &HashMap<UnifiedPeerId, Option<UnifiedPeerId>>,
@@ -706,6 +748,15 @@ impl MeshMessageRouter {
         // Trace back from destination to source
         while let Some(Some(prev)) = previous.get(&current) {
             if let Some(peer_entry) = registry.get(&current) {
+                // #2201: Skip non-routable peers defensively (Dijkstra should already exclude them)
+                if !Self::is_peer_routable(peer_entry) {
+                    warn!(
+                        peer = %current.to_compact_string(),
+                        "Skipping non-routable peer in constructed route"
+                    );
+                    current = prev.clone();
+                    continue;
+                }
                 let endpoint = peer_entry
                     .endpoints
                     .first()
@@ -1102,6 +1153,30 @@ impl MeshMessageRouter {
     pub async fn get_delivery_status(&self, message_id: u64) -> Option<DeliveryStatus> {
         let tracking = self.delivery_tracking.read().await;
         tracking.get(&message_id).cloned()
+    }
+
+    // ==================== RELAY ADMISSION (#2201) ====================
+
+    /// Evaluate relay admission for all peers in the registry.
+    pub async fn update_relay_admissions(&self) -> crate::peer_registry::relay_admission::RelayAdmissionSummary {
+        let mut registry = self.peer_registry.write().await;
+        let peer_ids: Vec<_> = registry.all_peers().map(|e| e.peer_id.clone()).collect();
+        for peer_id in peer_ids {
+            let _ = registry.evaluate_and_set_relay_admission(&peer_id);
+        }
+        registry.relay_admission_summary()
+    }
+
+    /// Count of peers currently eligible for relay duties.
+    pub async fn eligible_relay_count(&self) -> usize {
+        let registry = self.peer_registry.read().await;
+        registry.eligible_relays().count()
+    }
+
+    /// Summary of relay admission states across all peers.
+    pub async fn relay_admission_summary(&self) -> crate::peer_registry::relay_admission::RelayAdmissionSummary {
+        let registry = self.peer_registry.read().await;
+        registry.relay_admission_summary()
     }
 
     /// Update routing table with topology information


### PR DESCRIPTION
## Summary

Implements the relay admission policy and eligibility state machine requested in #2201. Peers now carry an explicit `RelayAdmissionStatus` that gates their participation in message routing for others.

## Changes

### New module: `lib-network/src/peer_registry/relay_admission.rs`
- `RelayAdmissionState` enum: `Probation`, `Eligible`, `Blocked`
- `RelayAdmissionStatus` with `reason`, `evaluated_at`, `evaluated_by`, `probation_end`, `block_expires`
- `evaluate_relay_admission()` heuristic:
  | Criterion | Threshold |
  |-----------|-----------|
  | authenticated + quantum_secure | both true |
  | trust_score | >= 0.5 |
  | tier | >= Tier2 |
  | stability_score | >= 0.6 |
  | latency_ms | <= 500 |
  | routing_capacity | >= 10 |
  | last_seen | within 1h |
  - All met -> `Eligible`
  - Missing 1-2 but trust >= 0.3 -> `Probation`
  - Otherwise -> `Blocked` (24h expiry unless permanent)
  - Existing `Blocked` state persists until `block_expires`

### `PeerEntry` + `PeerRegistry`
- New field: `relay_admission: Option<RelayAdmissionStatus>`
- New methods: `evaluate_and_set_relay_admission()`, `set_relay_admission()`, `relay_admission_status()`, `eligible_relays()`, `relay_admission_summary()`

### `MeshMessageRouter` routing integration
- `is_peer_routable()` — rejects `Blocked`, unauthenticated, insecure, low-trust, or `Untrusted` tier peers
- `find_optimal_route()` — direct routes gated on `is_peer_routable()`
- `calculate_edge_weight()` — returns `INFINITY` for non-routable; `1.5x` penalty for `Probation`
- `construct_route_from_path()` — defensively skips non-routable peers
- New APIs: `update_relay_admissions()`, `eligible_relay_count()`, `relay_admission_summary()`

## Build & Test
- `cargo check -p lib-network` :white_check_mark:
- `cargo check --workspace` :white_check_mark:
- `cargo test -p lib-network --lib peer_registry` — 47 passed :white_check_mark:
- `cargo test -p lib-network --lib routing` — 9 passed :white_check_mark:

## Acceptance Criteria
- [x] Relay admission state machine documented and implemented
- [x] Client/gateway selection honors admission state (via `is_peer_routable` + edge weights)
- [x] APIs expose admission reason/status (`relay_admission_status`, `relay_admission_summary`)
- [x] Negative tests for unregistered or non-compliant peers

Refs #2201
