### PR TITLE
Welfare DAO sector tokens + stake/unstake + V9 tx decode

### DIFF
--- a/docs/testnet/REPLAY_PROCEDURE.md
+++ b/docs/testnet/REPLAY_PROCEDURE.md
@@ -99,7 +99,7 @@ All wallets from the snapshot are in `genesis.toml` and get created at node star
 
 ### Run from local machine
 
-The CLI connects over QUIC to g1. Do NOT run from g1 itself — the keystore on g1 has a broken handshake.
+Run provisioning from the local machine (QUIC to g1). Payroll also runs locally with `--keystore /tmp/council_keystore` pointing at the council member keystore.
 
 ---
 

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -666,35 +666,7 @@ impl Blockchain {
         blockchain.initialize_cbe_genesis();
 
         // Initialize Treasury Kernel if not already present.
-        if blockchain.treasury_kernel.is_none() {
-            let kernel_init: Option<(lib_crypto::PublicKey, String)> = blockchain
-                .council_members
-                .first()
-                .and_then(|cm| {
-                    let did = cm.identity_id.clone();
-                    blockchain.identity_registry.get(&did).and_then(|id| {
-                        match id.public_key.as_slice().try_into() {
-                            Ok(pk_bytes) => Some((lib_crypto::PublicKey::new(pk_bytes), did)),
-                            Err(_) => {
-                                warn!(
-                                    "Treasury Kernel skip: council {} has invalid pk length {}",
-                                    &did[..40.min(did.len())], id.public_key.len()
-                                );
-                                None
-                            }
-                        }
-                    })
-                });
-            if let Some((authority_pk, authority_did)) = kernel_init {
-                blockchain.initialize_treasury_kernel(authority_pk);
-                info!(
-                    "🏛️ Treasury Kernel initialized (authority: {})",
-                    &authority_did[..40.min(authority_did.len())]
-                );
-            }
-        } else {
-            info!("🏛️ Treasury Kernel restored from persistence");
-        }
+        blockchain.init_treasury_kernel_if_missing();
 
         // Welfare DAO tokens are initialized after kernel init in the component
         // startup path (council_members not yet loaded at this point).

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -10,10 +10,52 @@ impl Blockchain {
         }
     }
 
+    /// Initialize the Treasury Kernel from the first council member's identity
+    /// if not already loaded from persistence. No-op if kernel is present or
+    /// if council data is unavailable.
+    pub fn init_treasury_kernel_if_missing(&mut self) {
+        if self.treasury_kernel.is_some() {
+            info!("🏛️ Treasury Kernel restored from persistence");
+            return;
+        }
+
+        let kernel_init_data: Option<(lib_crypto::PublicKey, String)> = self
+            .council_members
+            .first()
+            .and_then(|cm| {
+                let did = cm.identity_id.clone();
+                self.identity_registry.get(&did).and_then(|id| {
+                    match id.public_key.as_slice().try_into() {
+                        Ok(pk_bytes) => Some((lib_crypto::PublicKey::new(pk_bytes), did)),
+                        Err(_) => {
+                            warn!(
+                                "Treasury Kernel skip: council pk length {}",
+                                id.public_key.len()
+                            );
+                            None
+                        }
+                    }
+                })
+            });
+
+        if let Some((authority_pk, authority_did)) = kernel_init_data {
+            self.initialize_treasury_kernel(authority_pk);
+            info!(
+                "🏛️ Treasury Kernel initialized with council authority {}",
+                &authority_did[..40.min(authority_did.len())]
+            );
+        } else if self.council_members.is_empty() {
+            warn!("Treasury Kernel not initialized: no council members configured");
+        } else {
+            warn!("Treasury Kernel not initialized: council member not in identity registry");
+        }
+    }
+
     /// Initialize the 5 welfare DAO sector tokens if not already present.
     /// Each token is kernel-controlled (mint/burn only via Treasury Kernel),
-    /// 1:1 SOV-backed, and uses the corresponding sector DAO key_id as its
-    /// reserve wallet address.
+    /// 1:1 SOV-backed, and identified by a deterministic token_id derived from
+    /// (name, symbol). The DAO key_id is used by the executor during
+    /// stake/unstake operations, not by the token itself.
     pub fn ensure_welfare_dao_tokens(&mut self) {
         use crate::contracts::economics::fee_router::{
             DAO_HEALTHCARE_KEY_ID, DAO_EDUCATION_KEY_ID, DAO_ENERGY_KEY_ID,

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -9,6 +9,7 @@ use crate::transaction::oracle_governance::{
     OracleConfigUpdateData,
 };
 use crate::types::{transaction_type::TransactionType, Hash};
+use bincode::Options;
 use serde::{Deserialize, Serialize};
 
 /// Zero-knowledge transaction with identity support
@@ -54,8 +55,14 @@ struct TransactionV9Wire {
 }
 
 impl TransactionV9Wire {
-    fn into_transaction(self) -> Transaction {
-        Transaction {
+    fn into_transaction(self) -> Result<Transaction, String> {
+        if self.fee > u64::MAX as u128 {
+            return Err(format!(
+                "V9 fee {} exceeds u64::MAX, cannot convert to on-chain format",
+                self.fee
+            ));
+        }
+        Ok(Transaction {
             version: self.version,
             chain_id: self.chain_id,
             transaction_type: self.transaction_type,
@@ -65,7 +72,7 @@ impl TransactionV9Wire {
             signature: self.signature,
             memo: self.memo,
             payload: self.payload,
-        }
+        })
     }
 }
 
@@ -83,12 +90,18 @@ pub fn decode_client_transaction(bytes: &[u8]) -> Result<Transaction, String> {
     }
     let version = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
 
+    // Use size-limited deserialization to prevent allocator abuse.
+    // Must match legacy bincode encoding (fixint, allow trailing bytes).
+    let opts = bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .allow_trailing_bytes()
+        .with_limit(bytes.len() as u64);
     if version >= TX_VERSION_V9 {
-        bincode::deserialize::<TransactionV9Wire>(bytes)
-            .map(|w| w.into_transaction())
+        opts.deserialize::<TransactionV9Wire>(bytes)
             .map_err(|e| format!("V9 decode failed: {}", e))
+            .and_then(|w| w.into_transaction())
     } else {
-        bincode::deserialize::<Transaction>(bytes)
+        opts.deserialize::<Transaction>(bytes)
             .map_err(|e| format!("V8 decode failed: {}", e))
     }
 }

--- a/scripts/replay-chain.sh
+++ b/scripts/replay-chain.sh
@@ -168,11 +168,11 @@ errors=0
 grep "^PROVISION" /tmp/replay_commands.txt | while IFS='|' read -r _ wid owner wtype bonus pk; do
     count=$((count + 1))
     # Build command
-    cmd="/opt/zhtp/zhtp-cli -s 127.0.0.1:9334 wallet provision --wallet-id $wid --owner $owner --wallet-type $wtype"
+    cmd="$CLI -s $SERVER wallet provision --wallet-id $wid --owner $owner --wallet-type $wtype"
     [ -n "$bonus" ] && cmd="$cmd $bonus"
     [ -n "$pk" ] && cmd="$cmd $pk"
 
-    result=$(ssh zhtp-g1 "$cmd" 2>&1) || {
+    result=$($cmd 2>&1) || {
         err "[$count/$PROVISION_TOTAL] Failed: $wid ($wtype) - $result"
         errors=$((errors + 1))
         continue
@@ -213,7 +213,7 @@ grep "^PAYROLL" /tmp/replay_commands.txt | while IFS='|' read -r _ to amount; do
 
     cmd="$CLI -s $SERVER cbe payroll --contract-id $contract_id --amount-cbe $amount --collaborator $to --deliverable-hash $deliverable_hash --keystore /tmp/council_keystore"
 
-    result=$(ssh zhtp-g1 "$cmd" 2>&1) || {
+    result=$($cmd 2>&1) || {
         err "[$count/$PAYROLL_TOTAL] Failed payroll to $to amount=$amount - $result"
         errors=$((errors + 1))
         continue
@@ -230,7 +230,7 @@ log "Payroll replay complete: $count allocations, $errors errors"
 # ============================================================================
 log ""
 log "=== STEP 4: Verification ==="
-ssh zhtp-g1 "/opt/zhtp/zhtp-cli -s 127.0.0.1:9334 blockchain status" 2>&1 || log "Could not get blockchain status"
+$CLI -s $SERVER blockchain status 2>&1 || log "Could not get blockchain status"
 
 log ""
 log "=== CHAIN REPLAY COMPLETE ==="

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -489,7 +489,7 @@ pub enum DaoAction {
         #[arg(long)]
         amount: u128,
         /// Lock period in blocks (minimum 100, ~100 seconds)
-        #[arg(long, default_value = "1000")]
+        #[arg(long, default_value = "1000", value_parser = clap::value_parser!(u64).range(100..))]
         lock_blocks: u64,
     },
     /// Unstake SOV from a sector DAO. Burns welfare tokens and returns SOV.

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -1545,6 +1545,10 @@ impl WalletHandler {
             /// from the on-chain identity registry.
             #[serde(default)]
             public_key: Option<String>,
+            /// Optional created_at timestamp (unix seconds). For chain replay: backdate
+            /// identity registration so PoUW maturity is immediate. If omitted, uses now.
+            #[serde(default)]
+            created_at: Option<u64>,
         }
 
         let req: ProvisionRequest = serde_json::from_slice(&request.body)

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -1545,10 +1545,6 @@ impl WalletHandler {
             /// from the on-chain identity registry.
             #[serde(default)]
             public_key: Option<String>,
-            /// Optional created_at timestamp (unix seconds). For chain replay: backdate
-            /// identity registration so PoUW maturity is immediate. If omitted, uses now.
-            #[serde(default)]
-            created_at: Option<u64>,
         }
 
         let req: ProvisionRequest = serde_json::from_slice(&request.body)

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -916,13 +916,16 @@ impl Web4Handler {
             ));
         }
 
-        // Debit sender, credit treasury (direct balance manipulation)
+        // TODO: Known limitation — direct balance manipulation outside consensus diverges state
+        // across nodes. The fee debit must be moved into block-level processing (like
+        // WalletRegistration initial_balance). The DomainRegistration transaction should carry the
+        // fee amount, and `process_domain_transactions` should debit/credit during block execution.
         let sender_balance = u128::from(token.balance_of(&sender_key));
         let treasury_balance = u128::from(token.balance_of(&treasury_key));
         token.set_balance(&sender_key, sender_balance - fee_sov);
         token.set_balance(&treasury_key, treasury_balance + fee_sov);
 
-        // Generate a deterministic hash for the receipt (not a real tx hash, just audit ID)
+        // Audit receipt ID (non-deterministic — uses wall-clock timestamp)
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -938,8 +941,9 @@ impl Web4Handler {
         );
 
         info!(
-            "Domain fee: {} SOV debited from {} → treasury (receipt: {})",
+            "Domain fee: {} atoms ({} SOV) debited from {} → treasury (receipt: {})",
             fee_sov,
+            fee_sov / 1_000_000_000_000_000_000,
             hex::encode(&from_wallet_id[..8]),
             &receipt_hash[..16]
         );
@@ -2153,6 +2157,7 @@ mod tests {
         [u8; 32],
         [u8; 32],
         lib_crypto::PrivateKey,
+        Arc<RwLock<lib_blockchain::Blockchain>>,
     )> {
         let storage: Arc<dyn UnifiedStorage> = Arc::new(TestStorage::default());
         let registry = Arc::new(DomainRegistry::new(storage.clone()).await?);
@@ -2210,7 +2215,7 @@ mod tests {
             .clone()
             .expect("test identity should include private key");
         let handler =
-            Web4Handler::new_with_registry(registry, publisher, identity_manager, blockchain)
+            Web4Handler::new_with_registry(registry, publisher, identity_manager, blockchain.clone())
                 .await?;
 
         Ok((
@@ -2219,6 +2224,7 @@ mod tests {
             owner_wallet_id,
             treasury_wallet_id,
             owner_private,
+            blockchain,
         ))
     }
 
@@ -2266,7 +2272,7 @@ mod tests {
 
     #[tokio::test]
     async fn register_domain_without_fee_payment_tx_creates_system_tx() -> anyhow::Result<()> {
-        let (handler, owner_identity, _owner_wallet_id, _treasury_wallet_id, _owner_private) =
+        let (handler, owner_identity, owner_wallet_id, treasury_wallet_id, _owner_private, blockchain) =
             setup_handler().await?;
         let request =
             simple_registration_request(&owner_identity, "system-fee.zhtp", "<html>ok</html>")?;
@@ -2282,6 +2288,68 @@ mod tests {
         assert_eq!(response.status, ZhtpStatus::Ok);
         let body: serde_json::Value = serde_json::from_slice(&response.body)?;
         assert_eq!(body["success"], serde_json::Value::Bool(true));
+
+        // Assert balances changed: sender debited, treasury credited
+        let bc = blockchain.read().await;
+        let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
+        let token = bc.token_contracts.get(&sov_token_id).unwrap();
+
+        let sender_key = BcPublicKey {
+            dilithium_pk: [0u8; 2592],
+            kyber_pk: [0u8; 1568],
+            key_id: owner_wallet_id,
+        };
+        let treasury_key = BcPublicKey {
+            dilithium_pk: [0u8; 2592],
+            kyber_pk: [0u8; 1568],
+            key_id: treasury_wallet_id,
+        };
+        // Owner started with 100, fee is 10 → 90 remaining
+        assert_eq!(token.balance_of(&sender_key), 90);
+        // Treasury started with 0, received 10
+        assert_eq!(token.balance_of(&treasury_key), 10);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn register_domain_insufficient_balance_fails() -> anyhow::Result<()> {
+        let (handler, owner_identity, owner_wallet_id, _treasury_wallet_id, _owner_private, blockchain) =
+            setup_handler().await?;
+
+        // Drain the owner balance so fee cannot be paid
+        {
+            let mut bc = blockchain.write().await;
+            let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
+            let token = bc.token_contracts.get_mut(&sov_token_id).unwrap();
+            let sender_key = BcPublicKey {
+                dilithium_pk: [0u8; 2592],
+                kyber_pk: [0u8; 1568],
+                key_id: owner_wallet_id,
+            };
+            token.set_balance(&sender_key, 0);
+        }
+
+        let request =
+            simple_registration_request(&owner_identity, "broke.zhtp", "<html>no</html>")?;
+
+        let principal = SecurityPrincipal::new(
+            owner_identity.did.clone(),
+            Role::Citizen,
+            NodeType::FullNode,
+        );
+        let response = handler
+            .register_domain_simple(serde_json::to_vec(&request)?, &principal)
+            .await?;
+        // Should fail due to insufficient balance
+        assert_ne!(response.status, ZhtpStatus::Ok);
+        let body: serde_json::Value = serde_json::from_slice(&response.body)?;
+        let error_msg = body["error"].as_str().unwrap_or("");
+        assert!(
+            error_msg.contains("Insufficient SOV balance"),
+            "Expected insufficient balance error, got: {}",
+            error_msg
+        );
 
         Ok(())
     }

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -852,16 +852,18 @@ impl Web4Handler {
     }
 
 
-    /// Debit domain registration fee from owner's Primary wallet and credit to
-    /// DAO treasury. Operates directly on the in-memory SOV token contract —
-    /// no Transaction object needed. The DomainRegistration transaction (which IS
-    /// included in the block) serves as the on-chain audit record of the fee payment.
+    /// Create a system TokenTransfer for the domain registration fee.
+    /// The node builds the transaction server-side using the authenticated user's
+    /// identity, eliminating the need for the app to construct bincode transactions.
     async fn create_domain_fee_system_tx(
         &self,
         owner_identity: &ZhtpIdentity,
         fee_sov: u128,
     ) -> anyhow::Result<String> {
-        let mut blockchain = self.blockchain.write().await;
+        let blockchain_arc = crate::runtime::blockchain_provider::get_global_blockchain()
+            .await
+            .map_err(|e| anyhow!("blockchain unavailable: {}", e))?;
+        let mut blockchain = blockchain_arc.write().await;
 
         let owner_hash = lib_blockchain::Hash::from_slice(&owner_identity.id.0);
 
@@ -875,12 +877,12 @@ impl Web4Handler {
             })
             .ok_or_else(|| anyhow!("Primary wallet not found for identity"))?;
         let from_wallet_id = owner_wallet.wallet_id.as_array();
+        let from_public_key = owner_wallet.public_key.clone();
 
         // Find treasury wallet
         let treasury_wallet_id_hex = blockchain
             .get_dao_treasury_wallet_id()
-            .ok_or_else(|| anyhow!("DAO treasury wallet is not configured"))?
-            .clone();
+            .ok_or_else(|| anyhow!("DAO treasury wallet is not configured"))?;
         let treasury_bytes = hex::decode(&treasury_wallet_id_hex)
             .map_err(|_| anyhow!("DAO treasury wallet id is malformed"))?;
         if treasury_bytes.len() != 32 {
@@ -889,25 +891,18 @@ impl Web4Handler {
         let mut to_wallet = [0u8; 32];
         to_wallet.copy_from_slice(&treasury_bytes);
 
-        // Direct balance transfer via the in-memory SOV token contract.
+        // Check SOV balance
         let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
         let sender_key = lib_blockchain::integration::crypto_integration::PublicKey {
             dilithium_pk: [0u8; 2592],
             kyber_pk: [0u8; 1568],
             key_id: from_wallet_id,
         };
-        let treasury_key = lib_blockchain::integration::crypto_integration::PublicKey {
-            dilithium_pk: [0u8; 2592],
-            kyber_pk: [0u8; 1568],
-            key_id: to_wallet,
-        };
-
-        let token = blockchain
+        let balance = blockchain
             .token_contracts
-            .get_mut(&sov_token_id)
-            .ok_or_else(|| anyhow!("SOV token contract not initialized"))?;
-
-        let balance = u128::from(token.balance_of(&sender_key));
+            .get(&sov_token_id)
+            .map(|t| u128::from(t.balance_of(&sender_key)))
+            .unwrap_or(0);
         if balance < fee_sov {
             return Err(anyhow!(
                 "Insufficient SOV balance: have {} atoms, need {} atoms",
@@ -916,35 +911,61 @@ impl Web4Handler {
             ));
         }
 
-        // Debit sender, credit treasury (direct balance manipulation)
-        let sender_balance = u128::from(token.balance_of(&sender_key));
-        let treasury_balance = u128::from(token.balance_of(&treasury_key));
-        token.set_balance(&sender_key, sender_balance - fee_sov);
-        token.set_balance(&treasury_key, treasury_balance + fee_sov);
-
-        // Generate a deterministic hash for the receipt (not a real tx hash, just audit ID)
+        // Build system TokenTransfer transaction
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        let receipt_preimage = format!(
-            "domain_fee:{}:{}:{}",
-            hex::encode(&from_wallet_id[..8]),
-            fee_sov,
-            now
-        );
-        let receipt_hash = hex::encode(
-            lib_blockchain::types::hash::blake3_hash(receipt_preimage.as_bytes()).as_bytes(),
-        );
 
+        let transfer_data = lib_blockchain::transaction::TokenTransferData {
+            token_id: sov_token_id,
+            from: from_wallet_id,
+            to: to_wallet,
+            amount: fee_sov,
+            nonce: 0,
+        };
+
+        let dilithium_pk: [u8; 2592] = from_public_key
+            .as_slice()
+            .try_into()
+            .unwrap_or([0u8; 2592]);
+
+        let memo = format!("domain_registration_fee:{}", now);
+
+        let tx = lib_blockchain::transaction::Transaction {
+            version: lib_blockchain::transaction::TX_VERSION_V8,
+            chain_id: 0x03,
+            transaction_type: lib_blockchain::TransactionType::TokenTransfer,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: lib_blockchain::integration::crypto_integration::Signature {
+                signature: Vec::new(),
+                public_key:
+                    lib_blockchain::integration::crypto_integration::PublicKey::new(dilithium_pk),
+                algorithm:
+                    lib_blockchain::integration::crypto_integration::SignatureAlgorithm::DEFAULT,
+                timestamp: now,
+            },
+            memo: memo.into_bytes(),
+            payload: lib_blockchain::transaction::TransactionPayload::TokenTransfer(
+                transfer_data,
+            ),
+        };
+
+        let tx_hash = hex::encode(tx.hash().as_bytes());
         info!(
-            "Domain fee: {} SOV debited from {} → treasury (receipt: {})",
+            "Domain fee system tx: {} SOV from {} to treasury ({})",
             fee_sov,
             hex::encode(&from_wallet_id[..8]),
-            &receipt_hash[..16]
+            &tx_hash[..16]
         );
 
-        Ok(receipt_hash)
+        blockchain
+            .add_system_transaction(tx)
+            .map_err(|e| anyhow!("Failed to submit domain fee tx: {}", e))?;
+
+        Ok(tx_hash)
     }
 
     /// Register a new Web4 domain

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -852,18 +852,16 @@ impl Web4Handler {
     }
 
 
-    /// Create a system TokenTransfer for the domain registration fee.
-    /// The node builds the transaction server-side using the authenticated user's
-    /// identity, eliminating the need for the app to construct bincode transactions.
+    /// Debit domain registration fee from owner's Primary wallet and credit to
+    /// DAO treasury. Operates directly on the in-memory SOV token contract —
+    /// no Transaction object needed. The DomainRegistration transaction (which IS
+    /// included in the block) serves as the on-chain audit record of the fee payment.
     async fn create_domain_fee_system_tx(
         &self,
         owner_identity: &ZhtpIdentity,
         fee_sov: u128,
     ) -> anyhow::Result<String> {
-        let blockchain_arc = crate::runtime::blockchain_provider::get_global_blockchain()
-            .await
-            .map_err(|e| anyhow!("blockchain unavailable: {}", e))?;
-        let mut blockchain = blockchain_arc.write().await;
+        let mut blockchain = self.blockchain.write().await;
 
         let owner_hash = lib_blockchain::Hash::from_slice(&owner_identity.id.0);
 
@@ -877,12 +875,12 @@ impl Web4Handler {
             })
             .ok_or_else(|| anyhow!("Primary wallet not found for identity"))?;
         let from_wallet_id = owner_wallet.wallet_id.as_array();
-        let from_public_key = owner_wallet.public_key.clone();
 
         // Find treasury wallet
         let treasury_wallet_id_hex = blockchain
             .get_dao_treasury_wallet_id()
-            .ok_or_else(|| anyhow!("DAO treasury wallet is not configured"))?;
+            .ok_or_else(|| anyhow!("DAO treasury wallet is not configured"))?
+            .clone();
         let treasury_bytes = hex::decode(&treasury_wallet_id_hex)
             .map_err(|_| anyhow!("DAO treasury wallet id is malformed"))?;
         if treasury_bytes.len() != 32 {
@@ -891,18 +889,25 @@ impl Web4Handler {
         let mut to_wallet = [0u8; 32];
         to_wallet.copy_from_slice(&treasury_bytes);
 
-        // Check SOV balance
+        // Direct balance transfer via the in-memory SOV token contract.
         let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
         let sender_key = lib_blockchain::integration::crypto_integration::PublicKey {
             dilithium_pk: [0u8; 2592],
             kyber_pk: [0u8; 1568],
             key_id: from_wallet_id,
         };
-        let balance = blockchain
+        let treasury_key = lib_blockchain::integration::crypto_integration::PublicKey {
+            dilithium_pk: [0u8; 2592],
+            kyber_pk: [0u8; 1568],
+            key_id: to_wallet,
+        };
+
+        let token = blockchain
             .token_contracts
-            .get(&sov_token_id)
-            .map(|t| u128::from(t.balance_of(&sender_key)))
-            .unwrap_or(0);
+            .get_mut(&sov_token_id)
+            .ok_or_else(|| anyhow!("SOV token contract not initialized"))?;
+
+        let balance = u128::from(token.balance_of(&sender_key));
         if balance < fee_sov {
             return Err(anyhow!(
                 "Insufficient SOV balance: have {} atoms, need {} atoms",
@@ -911,61 +916,35 @@ impl Web4Handler {
             ));
         }
 
-        // Build system TokenTransfer transaction
+        // Debit sender, credit treasury (direct balance manipulation)
+        let sender_balance = u128::from(token.balance_of(&sender_key));
+        let treasury_balance = u128::from(token.balance_of(&treasury_key));
+        token.set_balance(&sender_key, sender_balance - fee_sov);
+        token.set_balance(&treasury_key, treasury_balance + fee_sov);
+
+        // Generate a deterministic hash for the receipt (not a real tx hash, just audit ID)
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-
-        let transfer_data = lib_blockchain::transaction::TokenTransferData {
-            token_id: sov_token_id,
-            from: from_wallet_id,
-            to: to_wallet,
-            amount: fee_sov,
-            nonce: 0,
-        };
-
-        let dilithium_pk: [u8; 2592] = from_public_key
-            .as_slice()
-            .try_into()
-            .unwrap_or([0u8; 2592]);
-
-        let memo = format!("domain_registration_fee:{}", now);
-
-        let tx = lib_blockchain::transaction::Transaction {
-            version: lib_blockchain::transaction::TX_VERSION_V8,
-            chain_id: 0x03,
-            transaction_type: lib_blockchain::TransactionType::TokenTransfer,
-            inputs: vec![],
-            outputs: vec![],
-            fee: 0,
-            signature: lib_blockchain::integration::crypto_integration::Signature {
-                signature: Vec::new(),
-                public_key:
-                    lib_blockchain::integration::crypto_integration::PublicKey::new(dilithium_pk),
-                algorithm:
-                    lib_blockchain::integration::crypto_integration::SignatureAlgorithm::DEFAULT,
-                timestamp: now,
-            },
-            memo: memo.into_bytes(),
-            payload: lib_blockchain::transaction::TransactionPayload::TokenTransfer(
-                transfer_data,
-            ),
-        };
-
-        let tx_hash = hex::encode(tx.hash().as_bytes());
-        info!(
-            "Domain fee system tx: {} SOV from {} to treasury ({})",
-            fee_sov,
+        let receipt_preimage = format!(
+            "domain_fee:{}:{}:{}",
             hex::encode(&from_wallet_id[..8]),
-            &tx_hash[..16]
+            fee_sov,
+            now
+        );
+        let receipt_hash = hex::encode(
+            lib_blockchain::types::hash::blake3_hash(receipt_preimage.as_bytes()).as_bytes(),
         );
 
-        blockchain
-            .add_system_transaction(tx)
-            .map_err(|e| anyhow!("Failed to submit domain fee tx: {}", e))?;
+        info!(
+            "Domain fee: {} SOV debited from {} → treasury (receipt: {})",
+            fee_sov,
+            hex::encode(&from_wallet_id[..8]),
+            &receipt_hash[..16]
+        );
 
-        Ok(tx_hash)
+        Ok(receipt_hash)
     }
 
     /// Register a new Web4 domain

--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -619,31 +619,7 @@ impl Component for BlockchainComponent {
                 // Initialize Treasury Kernel if not restored from persistence.
                 {
                     let mut bc = shared_blockchain.write().await;
-                    if bc.treasury_kernel.is_none() {
-                        let kernel_init: Option<(lib_crypto::PublicKey, String)> = bc
-                            .council_members
-                            .first()
-                            .and_then(|cm| {
-                                let did = cm.identity_id.clone();
-                                bc.identity_registry.get(&did).and_then(|id| {
-                                    match id.public_key.as_slice().try_into() {
-                                        Ok(pk_bytes) => Some((lib_crypto::PublicKey::new(pk_bytes), did)),
-                                        Err(_) => {
-                                            warn!("Treasury Kernel skip: council pk length {}", id.public_key.len());
-                                            None
-                                        }
-                                    }
-                                })
-                            });
-                        if let Some((authority_pk, authority_did)) = kernel_init {
-                            bc.initialize_treasury_kernel(authority_pk);
-                            info!("🏛️ Treasury Kernel initialized (authority: {})", &authority_did[..40.min(authority_did.len())]);
-                        } else {
-                            warn!("Treasury Kernel not initialized: no council member in registry");
-                        }
-                    } else {
-                        info!("🏛️ Treasury Kernel restored from persistence");
-                    }
+                    bc.init_treasury_kernel_if_missing();
                     // Initialize welfare DAO sector tokens (idempotent, requires kernel).
                     bc.ensure_welfare_dao_tokens();
                 }

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1457,36 +1457,7 @@ impl RuntimeOrchestrator {
                 }
             }
             // Initialize Treasury Kernel if not already loaded from persistence.
-            if blockchain.treasury_kernel.is_none() {
-                let kernel_init_data: Option<(lib_crypto::PublicKey, String)> = blockchain
-                    .council_members
-                    .first()
-                    .and_then(|cm| {
-                        let did = cm.identity_id.clone();
-                        blockchain
-                            .identity_registry
-                            .get(&did)
-                            .and_then(|id| {
-                                match id.public_key.as_slice().try_into() {
-                                    Ok(pk_bytes) => Some((lib_crypto::PublicKey::new(pk_bytes), did)),
-                                    Err(_) => {
-                                        warn!("Treasury Kernel skip: council pk length {}", id.public_key.len());
-                                        None
-                                    }
-                                }
-                            })
-                    });
-                if let Some((authority_pk, authority_did)) = kernel_init_data {
-                    blockchain.initialize_treasury_kernel(authority_pk);
-                    info!("🏛️ Treasury Kernel initialized with council authority {}", &authority_did[..40.min(authority_did.len())]);
-                } else if blockchain.council_members.is_empty() {
-                    warn!("Treasury Kernel not initialized: no council members configured");
-                } else {
-                    warn!("Treasury Kernel not initialized: council member not in identity registry");
-                }
-            } else {
-                info!("🏛️ Treasury Kernel restored from persistence");
-            }
+            blockchain.init_treasury_kernel_if_missing();
             blockchain.ensure_welfare_dao_tokens();
         } // Release write lock
 
@@ -4405,31 +4376,7 @@ impl RuntimeOrchestrator {
                     // Initialize Treasury Kernel if not restored from persistence.
                     {
                         let mut bc = blockchain_arc.write().await;
-                        if bc.treasury_kernel.is_none() {
-                            let kernel_init: Option<(lib_crypto::PublicKey, String)> = bc
-                                .council_members
-                                .first()
-                                .and_then(|cm| {
-                                    let did = cm.identity_id.clone();
-                                    bc.identity_registry.get(&did).and_then(|id| {
-                                        match id.public_key.as_slice().try_into() {
-                                            Ok(pk_bytes) => Some((lib_crypto::PublicKey::new(pk_bytes), did)),
-                                            Err(_) => {
-                                                warn!("Treasury Kernel skip: council pk length {}", id.public_key.len());
-                                                None
-                                            }
-                                        }
-                                    })
-                                });
-                            if let Some((authority_pk, authority_did)) = kernel_init {
-                                bc.initialize_treasury_kernel(authority_pk);
-                                info!("🏛️ Treasury Kernel initialized with council authority {}", &authority_did[..40.min(authority_did.len())]);
-                            } else {
-                                warn!("Treasury Kernel not initialized: no council member in registry");
-                            }
-                        } else {
-                            info!("🏛️ Treasury Kernel restored from persistence");
-                        }
+                        bc.init_treasury_kernel_if_missing();
                     }
 
                     info!("Shared blockchain service initialized");


### PR DESCRIPTION
## Summary

- **5 welfare DAO sector tokens** (HEAL, EDU, ENRG, HOME, FOOD) — kernel-controlled, 1:1 SOV-backed, elastic supply
- **Stake→mint**: citizen stakes SOV into sector DAO → receives welfare token 1:1
- **Unstake→burn**: citizen returns welfare token after lock period → gets SOV back
- **CLI**: `zhtp-cli dao stake --sector healthcare --amount 100 --lock-blocks 1000`
- **V9 version-gated tx decode**: nodes accept both u64 fee (V8) and u128 fee (V9) from clients
- **All PR #2214 review fixes** included (direct balance debit for domain fees, no system tx hack, explicit pk validation)

## Token addresses (deterministic)

| Token | Symbol | token_id |
|-------|--------|----------|
| HealthToken | HEAL | `3fcaf4ee0d54d5c136ed6165f1ea98f0429e88540e577956d2a2b8fa5a60f8b7` |
| EduToken | EDU | `97743bb8df6d441dbfcc10540627330186084e54c73c458a34e9608ed9e2a912` |
| EnergyToken | ENRG | `e043aca01bc700d49d31976f258db9c64217b4e09bf5998c3de9d76e67665b18` |
| HousingToken | HOME | `44e4b6b99b10f2a9a06399688d79a743410b5a1674c85d323331f9f7abf1ce90` |
| FoodToken | FOOD | `c5f7418e4cf9dd65d945a6026ad95645a6873099366b168a459dc7bd60a9438b` |

## Test plan

- [x] Tokens created at startup (verified on all 3 validators)
- [x] Treasury Kernel initialized and persists
- [x] Build clean (zhtp + zhtp-cli)
- [ ] Stake tx from app (blocked on app DaoStake FFI — separate issue)
- [ ] Unstake after lock expires