### PR TITLE
EPIC-ZDNS: Enable ZDNS transport server (#2243)

### DIFF
--- a/lib-network/src/lib.rs
+++ b/lib-network/src/lib.rs
@@ -308,6 +308,7 @@ pub mod validator_discovery_transport; // Mesh-based validator discovery gossip 
     feature = "full"
 ))]
 pub mod web4;
+pub mod zdns;
 #[cfg(any(
     feature = "quic",
     feature = "mdns",

--- a/lib-network/src/zdns/mod.rs
+++ b/lib-network/src/zdns/mod.rs
@@ -29,28 +29,14 @@
 //! resolver.invalidate("myapp.zhtp");
 //! ```
 
-// ZDNS runtime was moved to zhtp; enabling storage-integration here is blocked until relocation is finished.
-#[cfg(feature = "storage-integration")]
-compile_error!("lib-network no longer ships ZDNS runtime. Use zhtp stubs/relocated module (Phase 4 relocation pass).");
-
-#[cfg(feature = "storage-integration")]
 pub mod resolver;
-#[cfg(feature = "storage-integration")]
 pub mod config;
-#[cfg(feature = "storage-integration")]
 pub mod error;
-#[cfg(feature = "storage-integration")]
 pub mod packet;
-#[cfg(feature = "storage-integration")]
 pub mod transport;
 
-#[cfg(feature = "storage-integration")]
 pub use resolver::{ZdnsResolver, Web4Record, CachedRecord, ResolverMetrics};
-#[cfg(feature = "storage-integration")]
 pub use config::ZdnsConfig;
-#[cfg(feature = "storage-integration")]
 pub use error::ZdnsError;
-#[cfg(feature = "storage-integration")]
 pub use packet::{DnsPacket, DnsQuestion, DnsAnswer, MAX_UDP_SIZE};
-#[cfg(feature = "storage-integration")]
 pub use transport::{ZdnsTransportServer, ZdnsServerConfig, TransportStats, DNS_PORT};

--- a/zhtp/src/config/aggregation.rs
+++ b/zhtp/src/config/aggregation.rs
@@ -38,6 +38,43 @@ pub struct PartialConfig {
     pub storage_config: Option<PartialStorageConfig>,
     #[serde(default)]
     pub validator_config: Option<PartialValidatorConfig>,
+    #[serde(default)]
+    pub zdns: Option<PartialZdnsConfig>,
+}
+
+/// Partial ZDNS configuration
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PartialZdnsConfig {
+    /// Enable ZDNS server (default: false — opt-in)
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// Bind address (default: 0.0.0.0)
+    #[serde(default)]
+    pub bind: Option<String>,
+    /// Port (default: 53)
+    #[serde(default)]
+    pub port: Option<u16>,
+}
+
+/// ZDNS server configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZdnsNodeConfig {
+    /// Enable ZDNS DNS server
+    pub enabled: bool,
+    /// Bind address (default: 0.0.0.0 for public access)
+    pub bind: String,
+    /// DNS port (default: 53)
+    pub port: u16,
+}
+
+impl Default for ZdnsNodeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind: "0.0.0.0".to_string(),
+            port: 53,
+        }
+    }
 }
 
 /// Partial network configuration (matches user-friendly [network_config] section)
@@ -210,6 +247,10 @@ pub struct NodeConfig {
     pub economics_config: EconomicsConfig,
     pub protocols_config: ProtocolsConfig,
     pub rewards_config: RewardsConfig,
+
+    /// ZDNS configuration (network directory DNS server)
+    #[serde(default)]
+    pub zdns_config: ZdnsNodeConfig,
 
     // Validator configuration (Gap 5)
     #[serde(default)]
@@ -813,6 +854,8 @@ impl Default for NodeConfig {
 
             rewards_config: RewardsConfig::default(),
 
+            zdns_config: ZdnsNodeConfig::default(),
+
             validator_config: None, // Gap 5: Disabled by default
 
             port_assignments: HashMap::new(),
@@ -1270,6 +1313,20 @@ pub async fn aggregate_all_package_configs(config_path: &Path) -> Result<NodeCon
                                 config.consensus_config.validator_enabled = true;
                                 tracing::info!("  validator_config.enabled = true implies consensus_config.validator_enabled = true");
                             }
+                        }
+                    }
+
+                    // Merge [zdns] section
+                    if let Some(zdns) = partial.zdns {
+                        if zdns.enabled.unwrap_or(false) {
+                            config.zdns_config.enabled = true;
+                            tracing::info!("Loaded [zdns] section: enabled");
+                        }
+                        if let Some(bind) = zdns.bind {
+                            config.zdns_config.bind = bind;
+                        }
+                        if let Some(port) = zdns.port {
+                            config.zdns_config.port = port;
                         }
                     }
                 } else {

--- a/zhtp/src/runtime/components/protocols.rs
+++ b/zhtp/src/runtime/components/protocols.rs
@@ -43,11 +43,11 @@ pub struct ProtocolsComponent {
     discovery_port: u16,
     is_edge_node: bool,
     /// Enable ZDNS transport server (UDP/TCP DNS on port 53)
-    enable_zdns_transport: bool,
+    pub enable_zdns_transport: bool,
     /// Gateway IP for ZDNS transport responses
-    zdns_gateway_ip: std::net::Ipv4Addr,
+    pub zdns_gateway_ip: std::net::Ipv4Addr,
     /// Bind address for ZDNS transport (defaults to localhost for safety)
-    zdns_bind_addr: std::net::IpAddr,
+    pub zdns_bind_addr: std::net::IpAddr,
     /// Enable HTTPS gateway for browser-based Web4 access
     enable_https_gateway: bool,
     /// HTTPS gateway configuration

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1128,13 +1128,32 @@ impl RuntimeOrchestrator {
             let quic_port = self.config.protocols_config.quic_port;
             let discovery_port = self.config.protocols_config.discovery_port;
             let is_edge_node = *self.is_edge_node.read().await;
-            self.register_component(Arc::new(ProtocolsComponent::new_with_node_type_and_ports(
+            let mut protocols = ProtocolsComponent::new_with_node_type_and_ports(
                 environment,
                 api_port,
                 quic_port,
                 discovery_port,
                 is_edge_node,
-            )))
+            );
+
+            // Wire ZDNS config from [zdns] TOML section
+            if self.config.zdns_config.enabled {
+                let bind: std::net::IpAddr = self.config.zdns_config.bind.parse()
+                    .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+                let gateway_ip = local_ip_address::local_ip()
+                    .ok()
+                    .and_then(|ip| match ip {
+                        std::net::IpAddr::V4(v4) => Some(v4),
+                        _ => None,
+                    })
+                    .unwrap_or(std::net::Ipv4Addr::new(127, 0, 0, 1));
+                protocols.enable_zdns_transport = true;
+                protocols.zdns_gateway_ip = gateway_ip;
+                protocols.zdns_bind_addr = bind;
+                info!("🌐 ZDNS enabled: bind={}:{} gateway_ip={}", bind, self.config.zdns_config.port, gateway_ip);
+            }
+
+            self.register_component(Arc::new(protocols))
             .await?;
         }
 


### PR DESCRIPTION
Parent epic: #2242

## Summary

Enables the ZDNS DNS server that was fully implemented but disabled behind a feature gate. Validators can now serve DNS queries on port 53 for `.sov` and `.zhtp` domains.

## Changes

- Remove `storage-integration` compile_error gate from `lib-network/src/zdns/mod.rs`
- Export `zdns` module from `lib-network/src/lib.rs`
- Add `[zdns]` config section with `enabled`, `bind`, `port` fields
- Wire config into `ProtocolsComponent` at runtime startup
- Auto-detect node's public IP for DNS responses via `local_ip_address`

## Config

```toml
[zdns]
enabled = true
# bind = "0.0.0.0"  # default
# port = 53          # default
```

## Test plan

- [x] Build clean (lib-network + zhtp)
- [ ] Deploy with `[zdns] enabled = true` → verify `dig @<ip> test.sov` returns A record
- [ ] Verify port 53 is accessible from external host