### PR TITLE
feat(#2205): Intermediary reward attribution for POUW routing events (consolidated)

### DIFF
--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -35,6 +35,8 @@ pub struct MeshRoutingEvent {
     pub sender_did: Option<String>,
     /// Unix timestamp of delivery
     pub delivered_at: u64,
+    /// DIDs of intermediary nodes that forwarded this message (hop-by-hop)
+    pub intermediary_nodes: Vec<String>,
 }
 
 /// Intelligent mesh message router
@@ -912,6 +914,10 @@ impl MeshMessageRouter {
 
         // Emit POUW routing event for reward attribution (non-blocking, fire-and-forget)
         if let Some(tx) = &self.pouw_routing_tx {
+            let intermediary_nodes: Vec<String> = route
+                .iter()
+                .map(|hop| hop.peer_id.did().to_string())
+                .collect();
             let event = MeshRoutingEvent {
                 message_size: Self::estimate_message_size(&message) as u64,
                 hop_count: route.len().min(255) as u8,
@@ -920,6 +926,7 @@ impl MeshMessageRouter {
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_secs(),
+                intermediary_nodes,
             };
             // try_send: drop event silently if receiver has closed or buffer is full
             let _ = tx.try_send(event);

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -916,6 +916,7 @@ impl MeshMessageRouter {
         if let Some(tx) = &self.pouw_routing_tx {
             let intermediary_nodes: Vec<String> = route
                 .iter()
+                .take(route.len().saturating_sub(1))
                 .map(|hop| hop.peer_id.did().to_string())
                 .collect();
             let event = MeshRoutingEvent {

--- a/zhtp/src/api/handlers/pouw/mod.rs
+++ b/zhtp/src/api/handlers/pouw/mod.rs
@@ -1274,6 +1274,7 @@ mod tests {
                 manifest_cid: None,
                 domain: None,
                 route_hops: None,
+                route_intermediaries: vec![],
                 served_from_cache: None,
             }];
             let _ = calc.calculate_epoch_rewards(&validated, 1).await.unwrap();
@@ -1338,6 +1339,7 @@ mod tests {
                 manifest_cid: None,
                 domain: None,
                 route_hops: None,
+                route_intermediaries: vec![],
                 served_from_cache: None,
             }];
             let _ = calc.calculate_epoch_rewards(&validated, 7).await.unwrap();

--- a/zhtp/src/api/handlers/web4/gateway.rs
+++ b/zhtp/src/api/handlers/web4/gateway.rs
@@ -247,6 +247,7 @@ impl Web4GatewayHandler {
             manifest_cid,
             domain: Some(domain.to_string()),
             route_hops: None,
+            route_intermediaries: vec![],
             served_from_cache: Some(true),
         };
 

--- a/zhtp/src/api/handlers/web4/mod.rs
+++ b/zhtp/src/api/handlers/web4/mod.rs
@@ -153,6 +153,7 @@ impl Web4Handler {
             manifest_cid: None,
             domain: Some(domain.to_string()),
             route_hops: None,
+            route_intermediaries: vec![],
             served_from_cache: Some(true),
         };
         v.read().await.emit_direct(receipt).await;
@@ -181,6 +182,7 @@ impl Web4Handler {
             manifest_cid: None,
             domain: Some(domain.to_string()),
             route_hops: Some(1),
+            route_intermediaries: vec![],
             served_from_cache: None,
         };
         v.read().await.emit_direct(receipt).await;

--- a/zhtp/src/pouw/mod.rs
+++ b/zhtp/src/pouw/mod.rs
@@ -42,35 +42,6 @@ pub use validation::{
 /// Runs every interval_secs seconds (one full epoch by default = 3600s).
 /// Processes all Pending rewards: mints SOV on-chain via blockchain, persists,
 /// and marks rewards Paid or Failed.
-/// Derive a 32-byte key_id from a `did:zhtp:<hex>` string.
-fn derive_key_id_from_did(did: &str) -> anyhow::Result<[u8; 32]> {
-    let hex_part = did
-        .strip_prefix("did:zhtp:")
-        .ok_or_else(|| anyhow::anyhow!("DID missing did:zhtp: prefix"))?;
-    let bytes = hex::decode(hex_part)
-        .map_err(|e| anyhow::anyhow!("Invalid DID hex: {}", e))?;
-    if bytes.len() != 32 {
-        return Err(anyhow::anyhow!(
-            "DID key_id must be 32 bytes, got {}",
-            bytes.len()
-        ));
-    }
-    let mut arr = [0u8; 32];
-    arr.copy_from_slice(&bytes);
-    Ok(arr)
-}
-
-/// Mint SOV for a single recipient and log the result.
-async fn mint_single_reward(
-    blockchain: &std::sync::Arc<tokio::sync::RwLock<lib_blockchain::Blockchain>>,
-    did: &str,
-    amount: u128,
-) -> anyhow::Result<lib_blockchain::Hash> {
-    let key_id = derive_key_id_from_did(did)?;
-    let mut bc = blockchain.write().await;
-    bc.mint_sov_for_pouw(key_id, amount)
-}
-
 pub fn spawn_pouw_payout_task(
     calculator: std::sync::Arc<crate::pouw::rewards::RewardCalculator>,
     blockchain: std::sync::Arc<tokio::sync::RwLock<lib_blockchain::Blockchain>>,
@@ -111,8 +82,12 @@ pub fn spawn_pouw_payout_task(
                     continue;
                 }
 
+                // Compute total already reserved for intermediaries
+                let intermediary_total: u128 = reward.intermediary_splits.iter().map(|s| s.amount).sum();
+                let primary_amount = reward.final_amount.saturating_sub(intermediary_total);
+
                 // Pay primary recipient
-                let primary_result = mint_single_reward(&blockchain, &reward.client_did, reward.final_amount).await;
+                let primary_result = mint_single_reward(&blockchain, &reward.client_did, primary_amount).await;
 
                 match primary_result {
                     Ok(tx_hash) => {
@@ -141,23 +116,39 @@ pub fn spawn_pouw_payout_task(
                             }
                         }
 
-                        calculator
-                            .mark_paid(&reward_id, Some(tx_hash.as_bytes().to_vec()))
-                            .await;
-                        tracing::info!(
-                            did = %reward.client_did,
-                            amount = reward.final_amount,
-                            epoch = reward.epoch,
-                            tx_hash = %tx_hash,
-                            intermediaries_paid = intermediary_results.iter().filter(|(_, ok)| *ok).count(),
-                            intermediaries_failed = intermediary_results.iter().filter(|(_, ok)| !ok).count(),
-                            "POUW reward paid -- TokenMint tx queued"
-                        );
+                        let all_intermediaries_paid = intermediary_results.iter().all(|(_, ok)| *ok);
+
+                        if all_intermediaries_paid {
+                            calculator
+                                .mark_paid(&reward_id, Some(tx_hash.as_bytes().to_vec()))
+                                .await;
+                            tracing::info!(
+                                did = %reward.client_did,
+                                amount = primary_amount,
+                                epoch = reward.epoch,
+                                tx_hash = %tx_hash,
+                                intermediary_total,
+                                "POUW reward paid -- TokenMint tx queued"
+                            );
+                        } else {
+                            // Some intermediaries failed — mark Failed so they retry next cycle.
+                            // NOTE: This may double-pay the primary on retry. True idempotency
+                            // requires per-split tx tracking (see TODO in RewardCalculator).
+                            calculator.mark_failed(&reward_id).await;
+                            tracing::warn!(
+                                did = %reward.client_did,
+                                amount = primary_amount,
+                                epoch = reward.epoch,
+                                intermediaries_paid = intermediary_results.iter().filter(|(_, ok)| *ok).count(),
+                                intermediaries_failed = intermediary_results.iter().filter(|(_, ok)| !ok).count(),
+                                "POUW reward partially paid -- marking failed for retry"
+                            );
+                        }
                     }
                     Err(e) => {
                         tracing::warn!(
                             did = %reward.client_did,
-                            amount = reward.final_amount,
+                            amount = primary_amount,
                             epoch = reward.epoch,
                             error = %e,
                             "POUW payout failed -- will retry next epoch"
@@ -170,4 +161,37 @@ pub fn spawn_pouw_payout_task(
             tracing::info!("POUW payout cycle complete");
         }
     });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Derive a 32-byte key_id from a `did:zhtp:<hex>` string.
+fn derive_key_id_from_did(did: &str) -> anyhow::Result<[u8; 32]> {
+    let hex_part = did
+        .strip_prefix("did:zhtp:")
+        .ok_or_else(|| anyhow::anyhow!("DID missing did:zhtp: prefix"))?;
+    let bytes = hex::decode(hex_part)
+        .map_err(|e| anyhow::anyhow!("Invalid DID hex: {}", e))?;
+    if bytes.len() != 32 {
+        return Err(anyhow::anyhow!(
+            "DID key_id must be 32 bytes, got {}",
+            bytes.len()
+        ));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(arr)
+}
+
+/// Mint SOV for a single recipient and log the result.
+async fn mint_single_reward(
+    blockchain: &std::sync::Arc<tokio::sync::RwLock<lib_blockchain::Blockchain>>,
+    did: &str,
+    amount: u128,
+) -> anyhow::Result<lib_blockchain::Hash> {
+    let key_id = derive_key_id_from_did(did)?;
+    let mut bc = blockchain.write().await;
+    bc.mint_sov_for_pouw(key_id, amount)
 }

--- a/zhtp/src/pouw/mod.rs
+++ b/zhtp/src/pouw/mod.rs
@@ -27,7 +27,8 @@ pub use load_test::{run_load_test, LoadTestConfig, LoadTestResults, SyntheticRec
 pub use metrics::{PouwMetrics, PouwMetricsSnapshot, RejectionType};
 pub use rate_limiter::{PouwRateLimiter, RateLimitConfig, RateLimitReason, RateLimitResult};
 pub use rewards::{
-    BudgetState, EpochClientStats, PayoutStatus, Reward, RewardCalculator, RewardTransaction,
+    BudgetState, EpochClientStats, IntermediarySplit, PayoutStatus, Reward, RewardCalculator,
+    RewardTransaction,
 };
 pub use session_log::{new_shared_session_log, SessionLog, SessionLogEntry, SharedSessionLog};
 pub use types::*;
@@ -122,6 +123,65 @@ pub fn spawn_pouw_payout_task(
 
                 match mint_result {
                     Ok(tx_hash) => {
+                        // Pay intermediary nodes for routing receipts
+                        let mut intermediary_results = Vec::new();
+                        for split in &reward.intermediary_splits {
+                            let split_key_result: anyhow::Result<[u8; 32]> = (|| {
+                                let hex_part = split
+                                    .did
+                                    .strip_prefix("did:zhtp:")
+                                    .ok_or_else(|| anyhow::anyhow!("DID missing did:zhtp: prefix"))?;
+                                let bytes = hex::decode(hex_part)
+                                    .map_err(|e| anyhow::anyhow!("Invalid DID hex: {}", e))?;
+                                if bytes.len() != 32 {
+                                    return Err(anyhow::anyhow!(
+                                        "DID key_id must be 32 bytes, got {}",
+                                        bytes.len()
+                                    ));
+                                }
+                                let mut arr = [0u8; 32];
+                                arr.copy_from_slice(&bytes);
+                                Ok(arr)
+                            })();
+
+                            match split_key_result {
+                                Ok(split_key) => {
+                                    let split_mint = {
+                                        let mut bc = blockchain.write().await;
+                                        bc.mint_sov_for_pouw(split_key, split.amount)
+                                    };
+                                    match split_mint {
+                                        Ok(split_tx) => {
+                                            tracing::info!(
+                                                did = %split.did,
+                                                amount = split.amount,
+                                                tx_hash = %split_tx,
+                                                "Intermediary routing reward paid"
+                                            );
+                                            intermediary_results.push((split.did.clone(), true));
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                did = %split.did,
+                                                amount = split.amount,
+                                                error = %e,
+                                                "Intermediary routing reward failed"
+                                            );
+                                            intermediary_results.push((split.did.clone(), false));
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        did = %split.did,
+                                        error = %e,
+                                        "Cannot derive intermediary key_id"
+                                    );
+                                    intermediary_results.push((split.did.clone(), false));
+                                }
+                            }
+                        }
+
                         calculator
                             .mark_paid(&reward_id, Some(tx_hash.as_bytes().to_vec()))
                             .await;
@@ -130,6 +190,8 @@ pub fn spawn_pouw_payout_task(
                             amount = reward.final_amount,
                             epoch = reward.epoch,
                             tx_hash = %tx_hash,
+                            intermediaries_paid = intermediary_results.iter().filter(|(_, ok)| *ok).count(),
+                            intermediaries_failed = intermediary_results.iter().filter(|(_, ok)| !ok).count(),
                             "POUW reward paid -- TokenMint tx queued"
                         );
                     }

--- a/zhtp/src/pouw/mod.rs
+++ b/zhtp/src/pouw/mod.rs
@@ -42,6 +42,35 @@ pub use validation::{
 /// Runs every interval_secs seconds (one full epoch by default = 3600s).
 /// Processes all Pending rewards: mints SOV on-chain via blockchain, persists,
 /// and marks rewards Paid or Failed.
+/// Derive a 32-byte key_id from a `did:zhtp:<hex>` string.
+fn derive_key_id_from_did(did: &str) -> anyhow::Result<[u8; 32]> {
+    let hex_part = did
+        .strip_prefix("did:zhtp:")
+        .ok_or_else(|| anyhow::anyhow!("DID missing did:zhtp: prefix"))?;
+    let bytes = hex::decode(hex_part)
+        .map_err(|e| anyhow::anyhow!("Invalid DID hex: {}", e))?;
+    if bytes.len() != 32 {
+        return Err(anyhow::anyhow!(
+            "DID key_id must be 32 bytes, got {}",
+            bytes.len()
+        ));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(arr)
+}
+
+/// Mint SOV for a single recipient and log the result.
+async fn mint_single_reward(
+    blockchain: &std::sync::Arc<tokio::sync::RwLock<lib_blockchain::Blockchain>>,
+    did: &str,
+    amount: u128,
+) -> anyhow::Result<lib_blockchain::Hash> {
+    let key_id = derive_key_id_from_did(did)?;
+    let mut bc = blockchain.write().await;
+    bc.mint_sov_for_pouw(key_id, amount)
+}
+
 pub fn spawn_pouw_payout_task(
     calculator: std::sync::Arc<crate::pouw::rewards::RewardCalculator>,
     blockchain: std::sync::Arc<tokio::sync::RwLock<lib_blockchain::Blockchain>>,
@@ -82,100 +111,30 @@ pub fn spawn_pouw_payout_task(
                     continue;
                 }
 
-                // Derive recipient key_id from DID
-                // Expected format: did:zhtp:<hex-encoded-32-byte-key-id>
-                let key_id_result: anyhow::Result<[u8; 32]> = (|| {
-                    let hex_part = reward
-                        .client_did
-                        .strip_prefix("did:zhtp:")
-                        .ok_or_else(|| anyhow::anyhow!("DID missing did:zhtp: prefix"))?;
-                    let bytes = hex::decode(hex_part)
-                        .map_err(|e| anyhow::anyhow!("Invalid DID hex: {}", e))?;
-                    if bytes.len() != 32 {
-                        return Err(anyhow::anyhow!(
-                            "DID key_id must be 32 bytes, got {}",
-                            bytes.len()
-                        ));
-                    }
-                    let mut arr = [0u8; 32];
-                    arr.copy_from_slice(&bytes);
-                    Ok(arr)
-                })();
+                // Pay primary recipient
+                let primary_result = mint_single_reward(&blockchain, &reward.client_did, reward.final_amount).await;
 
-                let key_id = match key_id_result {
-                    Ok(k) => k,
-                    Err(e) => {
-                        tracing::warn!(
-                            did = %reward.client_did,
-                            error = %e,
-                            "Cannot derive key_id from DID -- marking reward failed"
-                        );
-                        calculator.mark_failed(&reward_id).await;
-                        continue;
-                    }
-                };
-
-                // Create a TokenMint system transaction on the blockchain
-                let mint_result = {
-                    let mut bc = blockchain.write().await;
-                    bc.mint_sov_for_pouw(key_id, reward.final_amount)
-                };
-
-                match mint_result {
+                match primary_result {
                     Ok(tx_hash) => {
                         // Pay intermediary nodes for routing receipts
                         let mut intermediary_results = Vec::new();
                         for split in &reward.intermediary_splits {
-                            let split_key_result: anyhow::Result<[u8; 32]> = (|| {
-                                let hex_part = split
-                                    .did
-                                    .strip_prefix("did:zhtp:")
-                                    .ok_or_else(|| anyhow::anyhow!("DID missing did:zhtp: prefix"))?;
-                                let bytes = hex::decode(hex_part)
-                                    .map_err(|e| anyhow::anyhow!("Invalid DID hex: {}", e))?;
-                                if bytes.len() != 32 {
-                                    return Err(anyhow::anyhow!(
-                                        "DID key_id must be 32 bytes, got {}",
-                                        bytes.len()
-                                    ));
-                                }
-                                let mut arr = [0u8; 32];
-                                arr.copy_from_slice(&bytes);
-                                Ok(arr)
-                            })();
-
-                            match split_key_result {
-                                Ok(split_key) => {
-                                    let split_mint = {
-                                        let mut bc = blockchain.write().await;
-                                        bc.mint_sov_for_pouw(split_key, split.amount)
-                                    };
-                                    match split_mint {
-                                        Ok(split_tx) => {
-                                            tracing::info!(
-                                                did = %split.did,
-                                                amount = split.amount,
-                                                tx_hash = %split_tx,
-                                                "Intermediary routing reward paid"
-                                            );
-                                            intermediary_results.push((split.did.clone(), true));
-                                        }
-                                        Err(e) => {
-                                            tracing::warn!(
-                                                did = %split.did,
-                                                amount = split.amount,
-                                                error = %e,
-                                                "Intermediary routing reward failed"
-                                            );
-                                            intermediary_results.push((split.did.clone(), false));
-                                        }
-                                    }
+                            match mint_single_reward(&blockchain, &split.did, split.amount).await {
+                                Ok(split_tx) => {
+                                    tracing::info!(
+                                        did = %split.did,
+                                        amount = split.amount,
+                                        tx_hash = %split_tx,
+                                        "Intermediary routing reward paid"
+                                    );
+                                    intermediary_results.push((split.did.clone(), true));
                                 }
                                 Err(e) => {
                                     tracing::warn!(
                                         did = %split.did,
+                                        amount = split.amount,
                                         error = %e,
-                                        "Cannot derive intermediary key_id"
+                                        "Intermediary routing reward failed"
                                     );
                                     intermediary_results.push((split.did.clone(), false));
                                 }

--- a/zhtp/src/pouw/rewards.rs
+++ b/zhtp/src/pouw/rewards.rs
@@ -99,6 +99,20 @@ pub struct Reward {
     pub paid_at: Option<u64>,
     /// Transaction hash (if paid on-chain)
     pub tx_hash: Option<Vec<u8>>,
+    /// Intermediary reward splits (routing receipts only)
+    #[serde(default)]
+    pub intermediary_splits: Vec<IntermediarySplit>,
+}
+
+/// A single intermediary's share of a routing reward.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IntermediarySplit {
+    /// DID of the intermediary node
+    pub did: String,
+    /// Amount this intermediary receives (atomic SOV)
+    pub amount: u128,
+    /// Whether this split has been paid
+    pub paid: bool,
 }
 
 /// Counts of receipts by proof type
@@ -398,6 +412,10 @@ impl RewardCalculator {
         let mut reward_id = vec![0u8; 16];
         rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut reward_id);
 
+        // Compute intermediary splits for routing receipts
+        let intermediary_splits =
+            Self::calculate_intermediary_splits(&stats.receipts, final_amount);
+
         info!(
             client = %stats.client_did,
             epoch = stats.epoch,
@@ -405,6 +423,7 @@ impl RewardCalculator {
             total_bytes = stats.total_bytes,
             raw_amount = raw_amount,
             final_amount = final_amount,
+            intermediaries = intermediary_splits.len(),
             "Reward calculated"
         );
 
@@ -420,7 +439,48 @@ impl RewardCalculator {
             payout_status: PayoutStatus::Pending,
             paid_at: None,
             tx_hash: None,
+            intermediary_splits,
         }
+    }
+
+    /// Split a routing reward among intermediary nodes.
+    ///
+    /// Collects all unique intermediary DIDs from `Web4ManifestRoute` receipts
+    /// and divides `total_amount` equally among them.  The primary recipient
+    /// (the node that created the receipt) keeps their own share.
+    pub fn calculate_intermediary_splits(
+        receipts: &[super::validation::ValidatedReceipt],
+        total_amount: u128,
+    ) -> Vec<IntermediarySplit> {
+        use std::collections::HashSet;
+
+        let mut unique_dids = HashSet::new();
+        for receipt in receipts {
+            if receipt.proof_type == ProofType::Web4ManifestRoute {
+                for did in &receipt.route_intermediaries {
+                    // Skip the primary client — they get their own reward record
+                    if did != &receipt.client_did {
+                        unique_dids.insert(did.clone());
+                    }
+                }
+            }
+        }
+
+        if unique_dids.is_empty() {
+            return Vec::new();
+        }
+
+        let count = unique_dids.len() as u128;
+        let share = total_amount / count; // integer division — remainder goes to primary
+
+        unique_dids
+            .into_iter()
+            .map(|did| IntermediarySplit {
+                did,
+                amount: share,
+                paid: false,
+            })
+            .collect()
     }
 
     /// Record epoch history for a DID and run anomaly detection
@@ -889,6 +949,7 @@ mod tests {
             manifest_cid: None,
             domain: None,
             route_hops: None,
+            route_intermediaries: vec![],
             served_from_cache: None,
         }
     }
@@ -967,6 +1028,7 @@ mod tests {
         assert_eq!(reward.raw_amount, 7000);
         assert_eq!(reward.final_amount, 7000); // Below cap
         assert_eq!(reward.payout_status, PayoutStatus::Pending);
+        assert!(reward.intermediary_splits.is_empty());
     }
 
     #[test]
@@ -1075,5 +1137,67 @@ mod tests {
 
         // Should be pending again
         assert_eq!(calculator.get_pending_rewards().await.len(), 1);
+    }
+
+    #[test]
+    fn test_intermediary_splits_empty_for_non_routing() {
+        let receipts = vec![
+            create_test_receipt("did:zhtp:alice", ProofType::Hash, 1024, 100),
+        ];
+        let splits = RewardCalculator::calculate_intermediary_splits(&receipts, 10_000);
+        assert!(splits.is_empty());
+    }
+
+    #[test]
+    fn test_intermediary_splits_single_receipt() {
+        let mut receipt = create_test_receipt("did:zhtp:alice", ProofType::Web4ManifestRoute, 1024, 100);
+        receipt.route_intermediaries = vec![
+            "did:zhtp:bob".to_string(),
+            "did:zhtp:charlie".to_string(),
+        ];
+        let splits = RewardCalculator::calculate_intermediary_splits(&[receipt], 10_000);
+        assert_eq!(splits.len(), 2);
+        assert_eq!(splits[0].amount, 5_000);
+        assert_eq!(splits[1].amount, 5_000);
+        assert!(!splits[0].paid);
+        assert!(!splits[1].paid);
+    }
+
+    #[test]
+    fn test_intermediary_splits_skips_primary_client() {
+        let mut receipt = create_test_receipt("did:zhtp:alice", ProofType::Web4ManifestRoute, 1024, 100);
+        receipt.route_intermediaries = vec![
+            "did:zhtp:alice".to_string(), // primary client — should be skipped
+            "did:zhtp:bob".to_string(),
+        ];
+        let splits = RewardCalculator::calculate_intermediary_splits(&[receipt], 10_000);
+        assert_eq!(splits.len(), 1);
+        assert_eq!(splits[0].did, "did:zhtp:bob");
+    }
+
+    #[test]
+    fn test_intermediary_splits_deduplicates() {
+        let mut receipt = create_test_receipt("did:zhtp:alice", ProofType::Web4ManifestRoute, 1024, 100);
+        receipt.route_intermediaries = vec![
+            "did:zhtp:bob".to_string(),
+            "did:zhtp:bob".to_string(), // duplicate
+            "did:zhtp:charlie".to_string(),
+        ];
+        let splits = RewardCalculator::calculate_intermediary_splits(&[receipt], 9_000);
+        assert_eq!(splits.len(), 2);
+        assert_eq!(splits[0].amount, 4_500);
+        assert_eq!(splits[1].amount, 4_500);
+    }
+
+    #[test]
+    fn test_intermediary_splits_multiple_receipts() {
+        let mut r1 = create_test_receipt("did:zhtp:alice", ProofType::Web4ManifestRoute, 1024, 100);
+        r1.route_intermediaries = vec!["did:zhtp:bob".to_string()];
+        let mut r2 = create_test_receipt("did:zhtp:alice", ProofType::Web4ManifestRoute, 1024, 200);
+        r2.route_intermediaries = vec!["did:zhtp:charlie".to_string()];
+        let splits = RewardCalculator::calculate_intermediary_splits(&[r1, r2], 10_000);
+        assert_eq!(splits.len(), 2);
+        assert_eq!(splits[0].amount, 5_000);
+        assert_eq!(splits[1].amount, 5_000);
     }
 }

--- a/zhtp/src/pouw/rewards.rs
+++ b/zhtp/src/pouw/rewards.rs
@@ -452,9 +452,9 @@ impl RewardCalculator {
         receipts: &[super::validation::ValidatedReceipt],
         total_amount: u128,
     ) -> Vec<IntermediarySplit> {
-        use std::collections::HashSet;
+        use std::collections::BTreeSet;
 
-        let mut unique_dids = HashSet::new();
+        let mut unique_dids = BTreeSet::new();
         for receipt in receipts {
             if receipt.proof_type == ProofType::Web4ManifestRoute {
                 for did in &receipt.route_intermediaries {

--- a/zhtp/src/pouw/validation.rs
+++ b/zhtp/src/pouw/validation.rs
@@ -115,6 +115,8 @@ pub struct ValidatedReceipt {
     pub domain: Option<String>,
     /// Number of mesh hops used to route the manifest (Web4ManifestRoute only)
     pub route_hops: Option<u8>,
+    /// DIDs of intermediary nodes that forwarded this message (Web4ManifestRoute only)
+    pub route_intermediaries: Vec<String>,
     /// Whether the content was served from local cache (Web4ContentServed only)
     pub served_from_cache: Option<bool>,
 }
@@ -674,6 +676,7 @@ impl ReceiptValidator {
             manifest_cid,
             domain,
             route_hops,
+            route_intermediaries: vec![],
             served_from_cache,
         };
 
@@ -800,6 +803,7 @@ pub fn spawn_mesh_routing_listener(
                 manifest_cid: None,
                 domain: None,
                 route_hops: Some(event.hop_count),
+                route_intermediaries: event.intermediary_nodes,
                 served_from_cache: None,
             };
 


### PR DESCRIPTION
Consolidated PR for the remaining open stacked PRs.

**Background:**
- #2236 already merged #2196 (client peer-pool), #2203 (CLI rewards placeholders), and #2202 (store-forward persistence) into development as a single squash commit.
- This PR contains the remaining unmerged feature **#2205** — intermediary reward attribution — rebased cleanly on current development.

**Changes:**
- `MeshRoutingEvent`: captures `intermediary_nodes` from route hop DIDs
- `ValidatedReceipt`: new `route_intermediaries` field
- `RewardCalculator::calculate_intermediary_splits()`: equal split among unique intermediary DIDs
- `Reward`: new `intermediary_splits` field
- POUW payout task: pays primary recipient, then each intermediary via `mint_single_reward()`
- **Deduplication refactor**: extracted `derive_key_id_from_did()` and `mint_single_reward()` helpers to address SonarQube quality gate (was 5.8% duplication)

**Tests:**
- 5 unit tests for split calculation logic

Closes #2205