### PR TITLE
EPIC-ZDNS: Health-aware DNS + runtime wiring (#2245)

### DIFF
--- a/docs/specs/client-bootstrap-v1.md
+++ b/docs/specs/client-bootstrap-v1.md
@@ -1,0 +1,167 @@
+# Client Bootstrap Specification v1
+
+## Overview
+
+How clients discover and connect to the ZHTP network without hardcoded validator lists.
+
+## Bootstrap Flow
+
+```
+1. App starts
+2. Try ZDNS: query network.sov via UDP 53 to bootstrap IPs
+3. Get validator IP list (multiple A records)
+4. Optionally: GET /api/v1/network/directory for rich metadata
+5. Latency probe: QUIC ping to top 3 candidates
+6. Connect to fastest validator via QUIC + UHP v2
+```
+
+## Step 1: Hardcoded Bootstrap
+
+App ships with 3 bootstrap IPs (current validators):
+
+```
+77.42.37.161    (g1 — Helsinki)
+77.42.74.80     (g2 — Helsinki)
+178.105.9.247   (g3 — Zurich)
+```
+
+These are ZDNS server addresses (port 53) AND validator addresses (port 9334).
+
+## Step 2: ZDNS Query
+
+Query `network.sov` via standard DNS (UDP port 53):
+
+```
+DNS Query:
+  Type: A
+  Name: network.sov
+  Server: <any bootstrap IP>:53
+```
+
+Response:
+```
+;; ANSWER SECTION:
+network.sov.    3600    IN    A    77.42.37.161
+network.sov.    3600    IN    A    77.42.74.80
+network.sov.    3600    IN    A    178.105.9.247
+```
+
+Multiple A records — all active validators. Round-robin ordered.
+
+### DNS query format
+
+Standard RFC 1035 DNS over UDP. Any DNS client library works (iOS: `dnssd`, Android: `DnsResolver`, React Native: native module wrapping system DNS).
+
+### Reserved domains
+
+| Domain | Returns |
+|--------|---------|
+| `network.sov` | All active validator IPs |
+| `directory.sov` | All ZDNS server IPs (for bootstrap refresh) |
+| `*.sov` | Gateway IP for Web4 content (existing) |
+
+## Step 3: Rich Directory (Optional)
+
+For more metadata than DNS provides:
+
+```
+GET /api/v1/network/directory
+Host: <any validator IP>:9334
+Transport: QUIC (public mode, no auth required)
+```
+
+Response:
+```json
+{
+  "validators": [
+    {
+      "did": "did:zhtp:59e07e17...",
+      "endpoint": "77.42.37.161:9334",
+      "stake": 1000,
+      "status": "active",
+      "last_activity": 28046,
+      "healthy": true
+    },
+    {
+      "did": "did:zhtp:f37a3077...",
+      "endpoint": "77.42.74.80:9334",
+      "stake": 1000,
+      "status": "active",
+      "last_activity": 28045,
+      "healthy": true
+    },
+    {
+      "did": "did:zhtp:bf409db9...",
+      "endpoint": "178.105.9.247:9334",
+      "stake": 1000,
+      "status": "active",
+      "last_activity": 28046,
+      "healthy": true
+    }
+  ],
+  "zdns_servers": [
+    "77.42.37.161:53",
+    "77.42.74.80:53",
+    "178.105.9.247:53"
+  ],
+  "network_id": "development",
+  "chain_height": 28046,
+  "validator_count": 3
+}
+```
+
+Use this for intelligent routing: pick lowest latency, highest stake, most recent block.
+
+## Step 4: Latency Probe
+
+QUIC connect + close to top 3 candidates. Measure RTT. Pick fastest.
+
+```pseudocode
+candidates = dns_response.addresses  // or directory.validators
+for each candidate in candidates[0..3]:
+    start = now()
+    quic_connect(candidate, port=9334, timeout=2s)
+    quic_close()
+    candidate.latency = now() - start
+
+best = candidates.sort_by(latency).first()
+```
+
+## Step 5: Connect
+
+Standard QUIC connection to the selected validator:
+
+```
+Transport: QUIC (port 9334)
+ALPN: zhtp-uhp/2 (authenticated) or zhtp-public/1 (read-only)
+Auth: UHP v2 handshake (Dilithium5 + Kyber1024)
+```
+
+## Fallback
+
+If ZDNS fails (port 53 blocked by network):
+
+1. Try the directory API directly on port 9334 (QUIC, public mode)
+2. If that also fails, connect to bootstrap IPs directly (hardcoded list)
+
+## Bootstrap Refresh
+
+After connecting, periodically query `directory.sov` to update the bootstrap list. Cache locally so the app doesn't depend on hardcoded IPs after first successful connection.
+
+## Config
+
+The app's network config:
+
+```typescript
+const BOOTSTRAP_IPS = [
+  "77.42.37.161",
+  "77.42.74.80",
+  "178.105.9.247",
+];
+
+const ZDNS_PORT = 53;
+const QUIC_PORT = 9334;
+const NETWORK_DOMAIN = "network.sov";
+const DIRECTORY_DOMAIN = "directory.sov";
+const DIRECTORY_API = "/api/v1/network/directory";
+```

--- a/lib-network/src/lib.rs
+++ b/lib-network/src/lib.rs
@@ -308,6 +308,7 @@ pub mod validator_discovery_transport; // Mesh-based validator discovery gossip 
     feature = "full"
 ))]
 pub mod web4;
+pub mod zdns;
 #[cfg(any(
     feature = "quic",
     feature = "mdns",

--- a/lib-network/src/lib.rs
+++ b/lib-network/src/lib.rs
@@ -308,6 +308,12 @@ pub mod validator_discovery_transport; // Mesh-based validator discovery gossip 
     feature = "full"
 ))]
 pub mod web4;
+#[cfg(any(
+    feature = "quic",
+    feature = "mdns",
+    feature = "lorawan",
+    feature = "full"
+))]
 pub mod zdns;
 #[cfg(any(
     feature = "quic",

--- a/lib-network/src/zdns/mod.rs
+++ b/lib-network/src/zdns/mod.rs
@@ -29,28 +29,14 @@
 //! resolver.invalidate("myapp.zhtp");
 //! ```
 
-// ZDNS runtime was moved to zhtp; enabling storage-integration here is blocked until relocation is finished.
-#[cfg(feature = "storage-integration")]
-compile_error!("lib-network no longer ships ZDNS runtime. Use zhtp stubs/relocated module (Phase 4 relocation pass).");
-
-#[cfg(feature = "storage-integration")]
 pub mod resolver;
-#[cfg(feature = "storage-integration")]
 pub mod config;
-#[cfg(feature = "storage-integration")]
 pub mod error;
-#[cfg(feature = "storage-integration")]
 pub mod packet;
-#[cfg(feature = "storage-integration")]
 pub mod transport;
 
-#[cfg(feature = "storage-integration")]
 pub use resolver::{ZdnsResolver, Web4Record, CachedRecord, ResolverMetrics};
-#[cfg(feature = "storage-integration")]
 pub use config::ZdnsConfig;
-#[cfg(feature = "storage-integration")]
 pub use error::ZdnsError;
-#[cfg(feature = "storage-integration")]
 pub use packet::{DnsPacket, DnsQuestion, DnsAnswer, MAX_UDP_SIZE};
-#[cfg(feature = "storage-integration")]
 pub use transport::{ZdnsTransportServer, ZdnsServerConfig, TransportStats, DNS_PORT};

--- a/lib-network/src/zdns/packet.rs
+++ b/lib-network/src/zdns/packet.rs
@@ -218,7 +218,7 @@ impl DnsPacket {
         }
     }
 
-    /// Create a DNS response with multiple A records (round-robin).
+    /// Create a DNS response with multiple A records.
     /// Used for `network.sov` to return all validator IPs.
     pub fn a_records(query: &DnsPacket, ips: &[Ipv4Addr], ttl: u32) -> Self {
         let question = query.question.clone();

--- a/lib-network/src/zdns/packet.rs
+++ b/lib-network/src/zdns/packet.rs
@@ -218,6 +218,32 @@ impl DnsPacket {
         }
     }
 
+    /// Create a DNS response with multiple A records (round-robin).
+    /// Used for `network.sov` to return all validator IPs.
+    pub fn a_records(query: &DnsPacket, ips: &[Ipv4Addr], ttl: u32) -> Self {
+        let question = query.question.clone();
+        let name = question.as_ref().map(|q| q.name.clone()).unwrap_or_default();
+
+        let answers = ips
+            .iter()
+            .map(|ip| DnsAnswer {
+                name: name.clone(),
+                rtype: TYPE_A,
+                rclass: CLASS_IN,
+                ttl,
+                rdata: ip.octets().to_vec(),
+            })
+            .collect();
+
+        DnsPacket {
+            id: query.id,
+            is_response: true,
+            question,
+            answers,
+            rcode: 0,
+        }
+    }
+
     /// Create an NXDOMAIN response
     pub fn nxdomain(query: &DnsPacket) -> Self {
         DnsPacket {

--- a/lib-network/src/zdns/packet.rs
+++ b/lib-network/src/zdns/packet.rs
@@ -448,4 +448,59 @@ mod tests {
         assert_eq!(packet.query_name(), Some("test.zhtp"));
         assert!(packet.is_a_query());
     }
+
+    #[test]
+    fn test_serialize_multi_a_records() {
+        let query = DnsPacket {
+            id: 0x1234,
+            is_response: false,
+            question: Some(DnsQuestion {
+                name: "network.sov".to_string(),
+                qtype: TYPE_A,
+                qclass: CLASS_IN,
+            }),
+            answers: vec![],
+            rcode: 0,
+        };
+
+        let ips = vec![
+            Ipv4Addr::new(77, 42, 37, 161),
+            Ipv4Addr::new(77, 42, 74, 80),
+            Ipv4Addr::new(178, 105, 9, 247),
+        ];
+
+        let response = DnsPacket::a_records(&query, &ips, 300);
+        assert_eq!(response.answers.len(), 3);
+        assert_eq!(response.answers[0].rdata, vec![77, 42, 37, 161]);
+        assert_eq!(response.answers[1].rdata, vec![77, 42, 74, 80]);
+        assert_eq!(response.answers[2].rdata, vec![178, 105, 9, 247]);
+
+        // Round-trip: serialize and parse back
+        let bytes = response.serialize();
+        let parsed = DnsPacket::parse(&bytes).unwrap();
+        assert_eq!(parsed.id, 0x1234);
+        assert!(parsed.is_response);
+        assert_eq!(parsed.answers.len(), 3);
+        assert_eq!(parsed.answers[0].rdata, vec![77, 42, 37, 161]);
+        assert_eq!(parsed.answers[2].rdata, vec![178, 105, 9, 247]);
+        assert_eq!(parsed.answers[0].ttl, 300);
+    }
+
+    #[test]
+    fn test_a_records_empty() {
+        let query = DnsPacket {
+            id: 0xAAAA,
+            is_response: false,
+            question: Some(DnsQuestion {
+                name: "network.sov".to_string(),
+                qtype: TYPE_A,
+                qclass: CLASS_IN,
+            }),
+            answers: vec![],
+            rcode: 0,
+        };
+
+        let response = DnsPacket::a_records(&query, &[], 60);
+        assert_eq!(response.answers.len(), 0);
+    }
 }

--- a/lib-network/src/zdns/transport.rs
+++ b/lib-network/src/zdns/transport.rs
@@ -49,8 +49,12 @@ const RATE_LIMIT_WINDOW_SECS: u64 = 10;
 /// Maximum TCP message size (RFC 1035 limit)
 const MAX_TCP_MESSAGE_SIZE: usize = 65535;
 
+/// Provider for dynamic network endpoint resolution.
+/// Called when ZDNS receives a query for `network.sov` or `directory.sov`.
+/// Returns a list of validator IPv4 addresses from the on-chain registry.
+pub type NetworkEndpointProvider = Arc<dyn Fn() -> Vec<Ipv4Addr> + Send + Sync>;
+
 /// ZDNS Server configuration
-#[derive(Debug, Clone)]
 pub struct ZdnsServerConfig {
     /// Port to listen on (default: 53)
     pub port: u16,
@@ -66,6 +70,36 @@ pub struct ZdnsServerConfig {
     pub enable_rate_limit: bool,
     /// Allowed capabilities for gateway routing (None = all allowed)
     pub allowed_capabilities: Option<Vec<Web4Capability>>,
+    /// Dynamic endpoint provider for `network.sov` queries.
+    /// When set, `network.sov` returns all validator IPs from the on-chain registry
+    /// instead of the single hardcoded gateway_ip.
+    pub network_endpoint_provider: Option<NetworkEndpointProvider>,
+}
+
+impl Clone for ZdnsServerConfig {
+    fn clone(&self) -> Self {
+        Self {
+            port: self.port,
+            gateway_ip: self.gateway_ip,
+            default_ttl: self.default_ttl,
+            enable_tcp: self.enable_tcp,
+            bind_addr: self.bind_addr,
+            enable_rate_limit: self.enable_rate_limit,
+            allowed_capabilities: self.allowed_capabilities.clone(),
+            network_endpoint_provider: self.network_endpoint_provider.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for ZdnsServerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZdnsServerConfig")
+            .field("port", &self.port)
+            .field("gateway_ip", &self.gateway_ip)
+            .field("bind_addr", &self.bind_addr)
+            .field("network_endpoint_provider", &self.network_endpoint_provider.is_some())
+            .finish()
+    }
 }
 
 impl Default for ZdnsServerConfig {
@@ -80,6 +114,7 @@ impl Default for ZdnsServerConfig {
             enable_rate_limit: true,
             // By default, only allow HttpServe and SpaServe (not DownloadOnly)
             allowed_capabilities: Some(vec![Web4Capability::HttpServe, Web4Capability::SpaServe]),
+            network_endpoint_provider: None,
         }
     }
 }
@@ -95,6 +130,7 @@ impl ZdnsServerConfig {
             bind_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             enable_rate_limit: false, // Disabled for local testing
             allowed_capabilities: None, // Allow all for testing
+            network_endpoint_provider: None,
         }
     }
 
@@ -110,6 +146,7 @@ impl ZdnsServerConfig {
             bind_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             enable_rate_limit: true,
             allowed_capabilities: Some(vec![Web4Capability::HttpServe, Web4Capability::SpaServe]),
+            network_endpoint_provider: None,
         }
     }
 
@@ -530,6 +567,27 @@ impl ZdnsTransportServer {
             debug!(domain = %domain_lower, "Non-A query, returning NOTIMP");
             stats.write().await.errors += 1;
             return Some(DnsPacket::notimp(&query));
+        }
+
+        // Special handling for network.sov — return all validator IPs
+        if (domain_lower == "network.sov" || domain_lower == "directory.sov")
+            && config.network_endpoint_provider.is_some()
+        {
+            let provider = config.network_endpoint_provider.as_ref().unwrap();
+            let endpoints = provider();
+            if endpoints.is_empty() {
+                debug!(domain = %domain_lower, "No network endpoints available");
+                stats.write().await.nxdomain += 1;
+                return Some(DnsPacket::nxdomain(&query));
+            }
+            // Return all validator IPs as multiple A records (round-robin)
+            debug!(
+                domain = %domain_lower,
+                count = endpoints.len(),
+                "Returning network directory A records"
+            );
+            stats.write().await.resolved += 1;
+            return Some(DnsPacket::a_records(&query, &endpoints, config.default_ttl));
         }
 
         // Resolve domain using ZDNS resolver (with caching)

--- a/lib-network/src/zdns/transport.rs
+++ b/lib-network/src/zdns/transport.rs
@@ -576,11 +576,11 @@ impl ZdnsTransportServer {
             let provider = config.network_endpoint_provider.as_ref().unwrap();
             let endpoints = provider();
             if endpoints.is_empty() {
-                debug!(domain = %domain_lower, "No network endpoints available");
-                stats.write().await.nxdomain += 1;
-                return Some(DnsPacket::nxdomain(&query));
+                debug!(domain = %domain_lower, "No network endpoints available (temporary)");
+                stats.write().await.errors += 1;
+                return Some(DnsPacket::servfail(&query));
             }
-            // Return all validator IPs as multiple A records (round-robin)
+            // Return all validator IPs as multiple A records
             debug!(
                 domain = %domain_lower,
                 count = endpoints.len(),

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -195,6 +195,7 @@ impl ZhtpRequestHandler for BlockchainHandler {
                 self.handle_blockchain_status(request).await
             }
             (ZhtpMethod::Get, "/api/v1/chain/info") => self.handle_chain_info(request).await,
+            (ZhtpMethod::Get, "/api/v1/network/directory") => self.handle_network_directory(request).await,
             (ZhtpMethod::Get, "/api/v1/blockchain/latest") => {
                 self.handle_latest_block(request).await
             }
@@ -1010,6 +1011,50 @@ impl BlockchainHandler {
         };
 
         Ok(ZhtpResponse::json(&response_data, None)?)
+    }
+
+    /// Network directory: returns validators, relays, and ZDNS servers for client routing.
+    /// Public endpoint — no authentication required.
+    async fn handle_network_directory(&self, _request: ZhtpRequest) -> Result<ZhtpResponse> {
+        let blockchain_arc = self.get_blockchain().await?;
+        let blockchain = blockchain_arc.read().await;
+
+        let validators: Vec<serde_json::Value> = blockchain
+            .validator_registry
+            .iter()
+            .map(|(_, v)| {
+                serde_json::json!({
+                    "did": v.identity_id,
+                    "endpoint": v.network_address,
+                    "stake": v.stake,
+                    "status": v.status,
+                    "last_activity": v.last_activity,
+                    "healthy": v.status == "active",
+                })
+            })
+            .collect();
+
+        let zdns_servers: Vec<String> = blockchain
+            .validator_registry
+            .values()
+            .filter(|v| v.status == "active")
+            .filter_map(|v| {
+                // Extract IP from endpoint (format: "host:port")
+                let host = v.network_address.split(':').next()?;
+                Some(format!("{}:53", host))
+            })
+            .collect();
+
+        let response = serde_json::json!({
+            "validators": validators,
+            "relays": [],
+            "zdns_servers": zdns_servers,
+            "network_id": self.environment.to_string().to_ascii_lowercase(),
+            "chain_height": blockchain.height,
+            "validator_count": validators.len(),
+        });
+
+        Ok(ZhtpResponse::json(&response, None)?)
     }
 
     /// Handle latest block request

--- a/zhtp/src/config/aggregation.rs
+++ b/zhtp/src/config/aggregation.rs
@@ -38,6 +38,43 @@ pub struct PartialConfig {
     pub storage_config: Option<PartialStorageConfig>,
     #[serde(default)]
     pub validator_config: Option<PartialValidatorConfig>,
+    #[serde(default)]
+    pub zdns: Option<PartialZdnsConfig>,
+}
+
+/// Partial ZDNS configuration
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PartialZdnsConfig {
+    /// Enable ZDNS server (default: false — opt-in)
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// Bind address (default: 0.0.0.0)
+    #[serde(default)]
+    pub bind: Option<String>,
+    /// Port (default: 53)
+    #[serde(default)]
+    pub port: Option<u16>,
+}
+
+/// ZDNS server configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZdnsNodeConfig {
+    /// Enable ZDNS DNS server
+    pub enabled: bool,
+    /// Bind address (default: 0.0.0.0 for public access)
+    pub bind: String,
+    /// DNS port (default: 53)
+    pub port: u16,
+}
+
+impl Default for ZdnsNodeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind: "0.0.0.0".to_string(),
+            port: 53,
+        }
+    }
 }
 
 /// Partial network configuration (matches user-friendly [network_config] section)
@@ -210,6 +247,10 @@ pub struct NodeConfig {
     pub economics_config: EconomicsConfig,
     pub protocols_config: ProtocolsConfig,
     pub rewards_config: RewardsConfig,
+
+    /// ZDNS configuration (network directory DNS server)
+    #[serde(default)]
+    pub zdns_config: ZdnsNodeConfig,
 
     // Validator configuration (Gap 5)
     #[serde(default)]
@@ -813,6 +854,8 @@ impl Default for NodeConfig {
 
             rewards_config: RewardsConfig::default(),
 
+            zdns_config: ZdnsNodeConfig::default(),
+
             validator_config: None, // Gap 5: Disabled by default
 
             port_assignments: HashMap::new(),
@@ -1270,6 +1313,20 @@ pub async fn aggregate_all_package_configs(config_path: &Path) -> Result<NodeCon
                                 config.consensus_config.validator_enabled = true;
                                 tracing::info!("  validator_config.enabled = true implies consensus_config.validator_enabled = true");
                             }
+                        }
+                    }
+
+                    // Merge [zdns] section
+                    if let Some(zdns) = partial.zdns {
+                        if zdns.enabled.unwrap_or(false) {
+                            config.zdns_config.enabled = true;
+                            tracing::info!("Loaded [zdns] section: enabled");
+                        }
+                        if let Some(bind) = zdns.bind {
+                            config.zdns_config.bind = bind;
+                        }
+                        if let Some(port) = zdns.port {
+                            config.zdns_config.port = port;
                         }
                     }
                 } else {

--- a/zhtp/src/config/aggregation.rs
+++ b/zhtp/src/config/aggregation.rs
@@ -48,7 +48,7 @@ pub struct PartialZdnsConfig {
     /// Enable ZDNS server (default: false — opt-in)
     #[serde(default)]
     pub enabled: Option<bool>,
-    /// Bind address (default: 0.0.0.0)
+    /// Bind address (default: 127.0.0.1)
     #[serde(default)]
     pub bind: Option<String>,
     /// Port (default: 53)
@@ -61,7 +61,7 @@ pub struct PartialZdnsConfig {
 pub struct ZdnsNodeConfig {
     /// Enable ZDNS DNS server
     pub enabled: bool,
-    /// Bind address (default: 0.0.0.0 for public access)
+    /// Bind address (default: 127.0.0.1 — set to "0.0.0.0" to expose publicly)
     pub bind: String,
     /// DNS port (default: 53)
     pub port: u16,
@@ -71,7 +71,7 @@ impl Default for ZdnsNodeConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            bind: "0.0.0.0".to_string(),
+            bind: "127.0.0.1".to_string(),
             port: 53,
         }
     }
@@ -249,7 +249,7 @@ pub struct NodeConfig {
     pub rewards_config: RewardsConfig,
 
     /// ZDNS configuration (network directory DNS server)
-    #[serde(default)]
+    #[serde(default, alias = "zdns")]
     pub zdns_config: ZdnsNodeConfig,
 
     // Validator configuration (Gap 5)
@@ -1318,8 +1318,8 @@ pub async fn aggregate_all_package_configs(config_path: &Path) -> Result<NodeCon
 
                     // Merge [zdns] section
                     if let Some(zdns) = partial.zdns {
-                        if zdns.enabled.unwrap_or(false) {
-                            config.zdns_config.enabled = true;
+                        config.zdns_config.enabled = zdns.enabled.unwrap_or(config.zdns_config.enabled);
+                        if config.zdns_config.enabled {
                             tracing::info!("Loaded [zdns] section: enabled");
                         }
                         if let Some(bind) = zdns.bind {

--- a/zhtp/src/runtime/components/protocols.rs
+++ b/zhtp/src/runtime/components/protocols.rs
@@ -430,9 +430,31 @@ impl Component for ProtocolsComponent {
         // Start ZDNS transport server if enabled (UDP/TCP DNS on port 53)
         if self.enable_zdns_transport {
             info!(" Starting ZDNS transport server (DNS on port 53)...");
-            // SECURITY: Use builder pattern with explicit bind address
-            let transport_config = ZdnsServerConfig::production(self.zdns_gateway_ip)
+            let mut transport_config = ZdnsServerConfig::production(self.zdns_gateway_ip)
                 .with_bind_addr(self.zdns_bind_addr);
+
+            // Wire dynamic endpoint provider: reads active validator IPs from on-chain registry.
+            // Health filtering: only returns validators with status == "active".
+            if let Ok(blockchain_arc) = crate::runtime::blockchain_provider::get_global_blockchain().await {
+                let bc_ref = blockchain_arc.clone();
+                transport_config.network_endpoint_provider = Some(std::sync::Arc::new(move || {
+                    // Synchronous closure — use try_read to avoid blocking.
+                    // If the lock is held, return empty (DNS will retry on next query).
+                    let bc = match bc_ref.try_read() {
+                        Ok(bc) => bc,
+                        Err(_) => return vec![],
+                    };
+                    bc.validator_registry
+                        .values()
+                        .filter(|v| v.status == "active")
+                        .filter_map(|v| {
+                            let host = v.network_address.split(':').next()?;
+                            host.parse::<std::net::Ipv4Addr>().ok()
+                        })
+                        .collect()
+                }));
+                info!(" ✓ ZDNS network endpoint provider wired to validator registry");
+            }
             let transport_server = Arc::new(ZdnsTransportServer::new(
                 zdns_resolver.clone(),
                 transport_config,

--- a/zhtp/src/runtime/components/protocols.rs
+++ b/zhtp/src/runtime/components/protocols.rs
@@ -446,8 +446,11 @@ impl Component for ProtocolsComponent {
             if let Ok(blockchain_arc) = crate::runtime::blockchain_provider::get_global_blockchain().await {
                 let bc_ref = blockchain_arc.clone();
                 transport_config.network_endpoint_provider = Some(std::sync::Arc::new(move || {
-                    // Synchronous closure — use try_read to avoid blocking.
-                    // If the lock is held, return empty (DNS will retry on next query).
+                    // Synchronous closure called from DNS handler thread — MUST NOT block
+                    // on the async RwLock (would deadlock the tokio runtime). try_read()
+                    // returns immediately; on contention, empty vec → SERVFAIL → client
+                    // retries on next query (typically <1s). DNS TTL caching prevents
+                    // SERVFAIL from being sticky.
                     let bc = match bc_ref.try_read() {
                         Ok(bc) => bc,
                         Err(_) => return vec![],

--- a/zhtp/src/runtime/components/protocols.rs
+++ b/zhtp/src/runtime/components/protocols.rs
@@ -43,11 +43,13 @@ pub struct ProtocolsComponent {
     discovery_port: u16,
     is_edge_node: bool,
     /// Enable ZDNS transport server (UDP/TCP DNS on port 53)
-    pub enable_zdns_transport: bool,
+    pub(crate) enable_zdns_transport: bool,
     /// Gateway IP for ZDNS transport responses
-    pub zdns_gateway_ip: std::net::Ipv4Addr,
+    pub(crate) zdns_gateway_ip: std::net::Ipv4Addr,
     /// Bind address for ZDNS transport (defaults to localhost for safety)
-    pub zdns_bind_addr: std::net::IpAddr,
+    pub(crate) zdns_bind_addr: std::net::IpAddr,
+    /// ZDNS DNS port (default: 53)
+    pub(crate) zdns_port: u16,
     /// Enable HTTPS gateway for browser-based Web4 access
     enable_https_gateway: bool,
     /// HTTPS gateway configuration
@@ -93,6 +95,7 @@ impl ProtocolsComponent {
             enable_zdns_transport: false, // Disabled by default (requires root for port 53)
             zdns_gateway_ip: std::net::Ipv4Addr::new(127, 0, 0, 1),
             zdns_bind_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+            zdns_port: 53,
             enable_https_gateway: false, // Disabled by default
             https_gateway_config: None,
             https_gateway: Arc::new(RwLock::new(None)),
@@ -130,6 +133,7 @@ impl ProtocolsComponent {
             enable_zdns_transport: false, // Disabled by default
             zdns_gateway_ip: std::net::Ipv4Addr::new(127, 0, 0, 1),
             zdns_bind_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+            zdns_port: 53,
             enable_https_gateway: false,
             https_gateway_config: None,
             https_gateway: Arc::new(RwLock::new(None)),
@@ -160,6 +164,7 @@ impl ProtocolsComponent {
             zdns_gateway_ip: gateway_ip,
             // SECURITY: Default to localhost even when enabled
             zdns_bind_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+            zdns_port: 53,
             enable_https_gateway: false,
             https_gateway_config: None,
             https_gateway: Arc::new(RwLock::new(None)),
@@ -189,6 +194,7 @@ impl ProtocolsComponent {
             enable_zdns_transport: false,
             zdns_gateway_ip: std::net::Ipv4Addr::new(127, 0, 0, 1),
             zdns_bind_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+            zdns_port: 53,
             enable_https_gateway: true,
             https_gateway_config: Some(gateway_config),
             https_gateway: Arc::new(RwLock::new(None)),
@@ -218,6 +224,7 @@ impl ProtocolsComponent {
             enable_zdns_transport: true,
             zdns_gateway_ip: gateway_ip,
             zdns_bind_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+            zdns_port: 53,
             enable_https_gateway: true,
             https_gateway_config: Some(https_config),
             https_gateway: Arc::new(RwLock::new(None)),
@@ -427,11 +434,12 @@ impl Component for ProtocolsComponent {
         *self.zdns_resolver.write().await = Some(zdns_resolver.clone());
         info!(" ✓ ZDNS resolver initialized with LRU cache (size: 10000, TTL: up to 1hr)");
 
-        // Start ZDNS transport server if enabled (UDP/TCP DNS on port 53)
+        // Start ZDNS transport server if enabled
         if self.enable_zdns_transport {
-            info!(" Starting ZDNS transport server (DNS on port 53)...");
+            info!(" Starting ZDNS transport server (DNS on port {})...", self.zdns_port);
             let mut transport_config = ZdnsServerConfig::production(self.zdns_gateway_ip)
                 .with_bind_addr(self.zdns_bind_addr);
+            transport_config.port = self.zdns_port;
 
             // Wire dynamic endpoint provider: reads active validator IPs from on-chain registry.
             // Health filtering: only returns validators with status == "active".

--- a/zhtp/src/runtime/components/protocols.rs
+++ b/zhtp/src/runtime/components/protocols.rs
@@ -43,11 +43,11 @@ pub struct ProtocolsComponent {
     discovery_port: u16,
     is_edge_node: bool,
     /// Enable ZDNS transport server (UDP/TCP DNS on port 53)
-    enable_zdns_transport: bool,
+    pub enable_zdns_transport: bool,
     /// Gateway IP for ZDNS transport responses
-    zdns_gateway_ip: std::net::Ipv4Addr,
+    pub zdns_gateway_ip: std::net::Ipv4Addr,
     /// Bind address for ZDNS transport (defaults to localhost for safety)
-    zdns_bind_addr: std::net::IpAddr,
+    pub zdns_bind_addr: std::net::IpAddr,
     /// Enable HTTPS gateway for browser-based Web4 access
     enable_https_gateway: bool,
     /// HTTPS gateway configuration

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1138,19 +1138,57 @@ impl RuntimeOrchestrator {
 
             // Wire ZDNS config from [zdns] TOML section
             if self.config.zdns_config.enabled {
-                let bind: std::net::IpAddr = self.config.zdns_config.bind.parse()
-                    .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
-                let gateway_ip = local_ip_address::local_ip()
-                    .ok()
-                    .and_then(|ip| match ip {
-                        std::net::IpAddr::V4(v4) => Some(v4),
-                        _ => None,
-                    })
-                    .unwrap_or(std::net::Ipv4Addr::new(127, 0, 0, 1));
-                protocols.enable_zdns_transport = true;
-                protocols.zdns_gateway_ip = gateway_ip;
-                protocols.zdns_bind_addr = bind;
-                info!("🌐 ZDNS enabled: bind={}:{} gateway_ip={}", bind, self.config.zdns_config.port, gateway_ip);
+                match self.config.zdns_config.bind.parse::<std::net::IpAddr>() {
+                    Err(e) => {
+                        tracing::error!(
+                            "Invalid zdns bind address '{}': {} — skipping ZDNS init",
+                            self.config.zdns_config.bind, e
+                        );
+                    }
+                    Ok(bind) => {
+                        // Determine gateway IP: try bootstrap_validators config first,
+                        // then fall back to local_ip with a warning.
+                        let gateway_ip = {
+                            let mut found: Option<std::net::Ipv4Addr> = None;
+                            // Check our own bootstrap_validators config for an endpoint we can parse
+                            for bv in &self.config.network_config.bootstrap_validators {
+                                for ep in &bv.endpoints {
+                                    let host = ep.split(':').next().unwrap_or("");
+                                    if let Ok(ip) = host.parse::<std::net::Ipv4Addr>() {
+                                        if !ip.is_loopback() && !ip.is_unspecified() {
+                                            found = Some(ip);
+                                            break;
+                                        }
+                                    }
+                                }
+                                if found.is_some() { break; }
+                            }
+                            match found {
+                                Some(ip) => ip,
+                                None => {
+                                    let fallback = local_ip_address::local_ip()
+                                        .ok()
+                                        .and_then(|ip| match ip {
+                                            std::net::IpAddr::V4(v4) => Some(v4),
+                                            _ => None,
+                                        })
+                                        .unwrap_or(std::net::Ipv4Addr::new(127, 0, 0, 1));
+                                    warn!(
+                                        "ZDNS gateway_ip: no public endpoint in bootstrap_validators config, \
+                                         using local IP {} (may be a private address)",
+                                        fallback
+                                    );
+                                    fallback
+                                }
+                            }
+                        };
+                        protocols.enable_zdns_transport = true;
+                        protocols.zdns_gateway_ip = gateway_ip;
+                        protocols.zdns_bind_addr = bind;
+                        protocols.zdns_port = self.config.zdns_config.port;
+                        info!("ZDNS enabled: bind={}:{} gateway_ip={}", bind, self.config.zdns_config.port, gateway_ip);
+                    }
+                }
             }
 
             self.register_component(Arc::new(protocols))

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1128,13 +1128,32 @@ impl RuntimeOrchestrator {
             let quic_port = self.config.protocols_config.quic_port;
             let discovery_port = self.config.protocols_config.discovery_port;
             let is_edge_node = *self.is_edge_node.read().await;
-            self.register_component(Arc::new(ProtocolsComponent::new_with_node_type_and_ports(
+            let mut protocols = ProtocolsComponent::new_with_node_type_and_ports(
                 environment,
                 api_port,
                 quic_port,
                 discovery_port,
                 is_edge_node,
-            )))
+            );
+
+            // Wire ZDNS config from [zdns] TOML section
+            if self.config.zdns_config.enabled {
+                let bind: std::net::IpAddr = self.config.zdns_config.bind.parse()
+                    .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+                let gateway_ip = local_ip_address::local_ip()
+                    .ok()
+                    .and_then(|ip| match ip {
+                        std::net::IpAddr::V4(v4) => Some(v4),
+                        _ => None,
+                    })
+                    .unwrap_or(std::net::Ipv4Addr::new(127, 0, 0, 1));
+                protocols.enable_zdns_transport = true;
+                protocols.zdns_gateway_ip = gateway_ip;
+                protocols.zdns_bind_addr = bind;
+                info!("🌐 ZDNS enabled: bind={}:{} gateway_ip={}", bind, self.config.zdns_config.port, gateway_ip);
+            }
+
+            self.register_component(Arc::new(protocols))
             .await?;
         }
 

--- a/zhtp/src/web4_stub.rs
+++ b/zhtp/src/web4_stub.rs
@@ -234,12 +234,23 @@ impl ZhtpRelayProtocol {
 #[derive(Debug, Clone, Default)]
 pub struct ZdnsTransportServer;
 
-#[derive(Debug, Clone, Default)]
-pub struct ZdnsServerConfig;
+/// Network endpoint provider for ZDNS directory queries.
+pub type NetworkEndpointProvider = std::sync::Arc<dyn Fn() -> Vec<std::net::Ipv4Addr> + Send + Sync>;
+
+#[derive(Clone, Default)]
+pub struct ZdnsServerConfig {
+    pub network_endpoint_provider: Option<NetworkEndpointProvider>,
+}
+
+impl std::fmt::Debug for ZdnsServerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZdnsServerConfig").finish()
+    }
+}
 
 impl ZdnsServerConfig {
     pub fn production(_gateway_ip: std::net::Ipv4Addr) -> Self {
-        Self
+        Self { network_endpoint_provider: None }
     }
 
     pub fn with_bind_addr(self, _addr: std::net::IpAddr) -> Self {

--- a/zhtp/src/web4_stub.rs
+++ b/zhtp/src/web4_stub.rs
@@ -239,6 +239,7 @@ pub type NetworkEndpointProvider = std::sync::Arc<dyn Fn() -> Vec<std::net::Ipv4
 
 #[derive(Clone, Default)]
 pub struct ZdnsServerConfig {
+    pub port: u16,
     pub network_endpoint_provider: Option<NetworkEndpointProvider>,
 }
 
@@ -250,7 +251,7 @@ impl std::fmt::Debug for ZdnsServerConfig {
 
 impl ZdnsServerConfig {
     pub fn production(_gateway_ip: std::net::Ipv4Addr) -> Self {
-        Self { network_endpoint_provider: None }
+        Self { port: 53, network_endpoint_provider: None }
     }
 
     pub fn with_bind_addr(self, _addr: std::net::IpAddr) -> Self {


### PR DESCRIPTION
Parent epic: #2242
Depends on: #2250

## Summary

Wires the `NetworkEndpointProvider` into the runtime so ZDNS returns only healthy validator IPs. The provider reads from the on-chain validator registry and filters by `status == "active"`.

## Changes

- `zhtp/src/runtime/components/protocols.rs`: Inject provider closure that reads `blockchain.validator_registry`, filters active validators, extracts IPv4 addresses
- `zhtp/src/web4_stub.rs`: Add `network_endpoint_provider` field to stub config for compatibility

## Test plan

- [x] Build clean
- [ ] Stop a validator → verify its IP disappears from `dig network.sov`
- [ ] Restart it → verify it reappears