### PR TITLE
EPIC-ZDNS: App bootstrap integration spec (#2248)

### DIFF
--- a/docs/specs/client-bootstrap-v1.md
+++ b/docs/specs/client-bootstrap-v1.md
@@ -1,0 +1,167 @@
+# Client Bootstrap Specification v1
+
+## Overview
+
+How clients discover and connect to the ZHTP network without hardcoded validator lists.
+
+## Bootstrap Flow
+
+```
+1. App starts
+2. Try ZDNS: query network.sov via UDP 53 to bootstrap IPs
+3. Get validator IP list (multiple A records)
+4. Optionally: GET /api/v1/network/directory for rich metadata
+5. Latency probe: QUIC ping to top 3 candidates
+6. Connect to fastest validator via QUIC + UHP v2
+```
+
+## Step 1: Hardcoded Bootstrap
+
+App ships with 3 bootstrap IPs (current validators):
+
+```
+77.42.37.161    (g1 — Helsinki)
+77.42.74.80     (g2 — Helsinki)
+178.105.9.247   (g3 — Zurich)
+```
+
+These are ZDNS server addresses (port 53) AND validator addresses (port 9334).
+
+## Step 2: ZDNS Query
+
+Query `network.sov` via standard DNS (UDP port 53):
+
+```
+DNS Query:
+  Type: A
+  Name: network.sov
+  Server: <any bootstrap IP>:53
+```
+
+Response:
+```
+;; ANSWER SECTION:
+network.sov.    3600    IN    A    77.42.37.161
+network.sov.    3600    IN    A    77.42.74.80
+network.sov.    3600    IN    A    178.105.9.247
+```
+
+Multiple A records — all active validators. Round-robin ordered.
+
+### DNS query format
+
+Standard RFC 1035 DNS over UDP. Any DNS client library works (iOS: `dnssd`, Android: `DnsResolver`, React Native: native module wrapping system DNS).
+
+### Reserved domains
+
+| Domain | Returns |
+|--------|---------|
+| `network.sov` | All active validator IPs |
+| `directory.sov` | All ZDNS server IPs (for bootstrap refresh) |
+| `*.sov` | Gateway IP for Web4 content (existing) |
+
+## Step 3: Rich Directory (Optional)
+
+For more metadata than DNS provides:
+
+```
+GET /api/v1/network/directory
+Host: <any validator IP>:9334
+Transport: QUIC (public mode, no auth required)
+```
+
+Response:
+```json
+{
+  "validators": [
+    {
+      "did": "did:zhtp:59e07e17...",
+      "endpoint": "77.42.37.161:9334",
+      "stake": 1000,
+      "status": "active",
+      "last_activity": 28046,
+      "healthy": true
+    },
+    {
+      "did": "did:zhtp:f37a3077...",
+      "endpoint": "77.42.74.80:9334",
+      "stake": 1000,
+      "status": "active",
+      "last_activity": 28045,
+      "healthy": true
+    },
+    {
+      "did": "did:zhtp:bf409db9...",
+      "endpoint": "178.105.9.247:9334",
+      "stake": 1000,
+      "status": "active",
+      "last_activity": 28046,
+      "healthy": true
+    }
+  ],
+  "zdns_servers": [
+    "77.42.37.161:53",
+    "77.42.74.80:53",
+    "178.105.9.247:53"
+  ],
+  "network_id": "development",
+  "chain_height": 28046,
+  "validator_count": 3
+}
+```
+
+Use this for intelligent routing: pick lowest latency, highest stake, most recent block.
+
+## Step 4: Latency Probe
+
+QUIC connect + close to top 3 candidates. Measure RTT. Pick fastest.
+
+```pseudocode
+candidates = dns_response.addresses  // or directory.validators
+for each candidate in candidates[0..3]:
+    start = now()
+    quic_connect(candidate, port=9334, timeout=2s)
+    quic_close()
+    candidate.latency = now() - start
+
+best = candidates.sort_by(latency).first()
+```
+
+## Step 5: Connect
+
+Standard QUIC connection to the selected validator:
+
+```
+Transport: QUIC (port 9334)
+ALPN: zhtp-uhp/2 (authenticated) or zhtp-public/1 (read-only)
+Auth: UHP v2 handshake (Dilithium5 + Kyber1024)
+```
+
+## Fallback
+
+If ZDNS fails (port 53 blocked by network):
+
+1. Try the directory API directly on port 9334 (QUIC, public mode)
+2. If that also fails, connect to bootstrap IPs directly (hardcoded list)
+
+## Bootstrap Refresh
+
+After connecting, periodically query `directory.sov` to update the bootstrap list. Cache locally so the app doesn't depend on hardcoded IPs after first successful connection.
+
+## Config
+
+The app's network config:
+
+```typescript
+const BOOTSTRAP_IPS = [
+  "77.42.37.161",
+  "77.42.74.80",
+  "178.105.9.247",
+];
+
+const ZDNS_PORT = 53;
+const QUIC_PORT = 9334;
+const NETWORK_DOMAIN = "network.sov";
+const DIRECTORY_DOMAIN = "directory.sov";
+const DIRECTORY_API = "/api/v1/network/directory";
+```

--- a/lib-network/src/lib.rs
+++ b/lib-network/src/lib.rs
@@ -308,6 +308,7 @@ pub mod validator_discovery_transport; // Mesh-based validator discovery gossip 
     feature = "full"
 ))]
 pub mod web4;
+pub mod zdns;
 #[cfg(any(
     feature = "quic",
     feature = "mdns",

--- a/lib-network/src/zdns/mod.rs
+++ b/lib-network/src/zdns/mod.rs
@@ -29,28 +29,14 @@
 //! resolver.invalidate("myapp.zhtp");
 //! ```
 
-// ZDNS runtime was moved to zhtp; enabling storage-integration here is blocked until relocation is finished.
-#[cfg(feature = "storage-integration")]
-compile_error!("lib-network no longer ships ZDNS runtime. Use zhtp stubs/relocated module (Phase 4 relocation pass).");
-
-#[cfg(feature = "storage-integration")]
 pub mod resolver;
-#[cfg(feature = "storage-integration")]
 pub mod config;
-#[cfg(feature = "storage-integration")]
 pub mod error;
-#[cfg(feature = "storage-integration")]
 pub mod packet;
-#[cfg(feature = "storage-integration")]
 pub mod transport;
 
-#[cfg(feature = "storage-integration")]
 pub use resolver::{ZdnsResolver, Web4Record, CachedRecord, ResolverMetrics};
-#[cfg(feature = "storage-integration")]
 pub use config::ZdnsConfig;
-#[cfg(feature = "storage-integration")]
 pub use error::ZdnsError;
-#[cfg(feature = "storage-integration")]
 pub use packet::{DnsPacket, DnsQuestion, DnsAnswer, MAX_UDP_SIZE};
-#[cfg(feature = "storage-integration")]
 pub use transport::{ZdnsTransportServer, ZdnsServerConfig, TransportStats, DNS_PORT};

--- a/zhtp/src/config/aggregation.rs
+++ b/zhtp/src/config/aggregation.rs
@@ -38,6 +38,43 @@ pub struct PartialConfig {
     pub storage_config: Option<PartialStorageConfig>,
     #[serde(default)]
     pub validator_config: Option<PartialValidatorConfig>,
+    #[serde(default)]
+    pub zdns: Option<PartialZdnsConfig>,
+}
+
+/// Partial ZDNS configuration
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PartialZdnsConfig {
+    /// Enable ZDNS server (default: false — opt-in)
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// Bind address (default: 0.0.0.0)
+    #[serde(default)]
+    pub bind: Option<String>,
+    /// Port (default: 53)
+    #[serde(default)]
+    pub port: Option<u16>,
+}
+
+/// ZDNS server configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZdnsNodeConfig {
+    /// Enable ZDNS DNS server
+    pub enabled: bool,
+    /// Bind address (default: 0.0.0.0 for public access)
+    pub bind: String,
+    /// DNS port (default: 53)
+    pub port: u16,
+}
+
+impl Default for ZdnsNodeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind: "0.0.0.0".to_string(),
+            port: 53,
+        }
+    }
 }
 
 /// Partial network configuration (matches user-friendly [network_config] section)
@@ -210,6 +247,10 @@ pub struct NodeConfig {
     pub economics_config: EconomicsConfig,
     pub protocols_config: ProtocolsConfig,
     pub rewards_config: RewardsConfig,
+
+    /// ZDNS configuration (network directory DNS server)
+    #[serde(default)]
+    pub zdns_config: ZdnsNodeConfig,
 
     // Validator configuration (Gap 5)
     #[serde(default)]
@@ -813,6 +854,8 @@ impl Default for NodeConfig {
 
             rewards_config: RewardsConfig::default(),
 
+            zdns_config: ZdnsNodeConfig::default(),
+
             validator_config: None, // Gap 5: Disabled by default
 
             port_assignments: HashMap::new(),
@@ -1270,6 +1313,20 @@ pub async fn aggregate_all_package_configs(config_path: &Path) -> Result<NodeCon
                                 config.consensus_config.validator_enabled = true;
                                 tracing::info!("  validator_config.enabled = true implies consensus_config.validator_enabled = true");
                             }
+                        }
+                    }
+
+                    // Merge [zdns] section
+                    if let Some(zdns) = partial.zdns {
+                        if zdns.enabled.unwrap_or(false) {
+                            config.zdns_config.enabled = true;
+                            tracing::info!("Loaded [zdns] section: enabled");
+                        }
+                        if let Some(bind) = zdns.bind {
+                            config.zdns_config.bind = bind;
+                        }
+                        if let Some(port) = zdns.port {
+                            config.zdns_config.port = port;
                         }
                     }
                 } else {

--- a/zhtp/src/runtime/components/protocols.rs
+++ b/zhtp/src/runtime/components/protocols.rs
@@ -43,11 +43,11 @@ pub struct ProtocolsComponent {
     discovery_port: u16,
     is_edge_node: bool,
     /// Enable ZDNS transport server (UDP/TCP DNS on port 53)
-    enable_zdns_transport: bool,
+    pub enable_zdns_transport: bool,
     /// Gateway IP for ZDNS transport responses
-    zdns_gateway_ip: std::net::Ipv4Addr,
+    pub zdns_gateway_ip: std::net::Ipv4Addr,
     /// Bind address for ZDNS transport (defaults to localhost for safety)
-    zdns_bind_addr: std::net::IpAddr,
+    pub zdns_bind_addr: std::net::IpAddr,
     /// Enable HTTPS gateway for browser-based Web4 access
     enable_https_gateway: bool,
     /// HTTPS gateway configuration

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1128,13 +1128,32 @@ impl RuntimeOrchestrator {
             let quic_port = self.config.protocols_config.quic_port;
             let discovery_port = self.config.protocols_config.discovery_port;
             let is_edge_node = *self.is_edge_node.read().await;
-            self.register_component(Arc::new(ProtocolsComponent::new_with_node_type_and_ports(
+            let mut protocols = ProtocolsComponent::new_with_node_type_and_ports(
                 environment,
                 api_port,
                 quic_port,
                 discovery_port,
                 is_edge_node,
-            )))
+            );
+
+            // Wire ZDNS config from [zdns] TOML section
+            if self.config.zdns_config.enabled {
+                let bind: std::net::IpAddr = self.config.zdns_config.bind.parse()
+                    .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+                let gateway_ip = local_ip_address::local_ip()
+                    .ok()
+                    .and_then(|ip| match ip {
+                        std::net::IpAddr::V4(v4) => Some(v4),
+                        _ => None,
+                    })
+                    .unwrap_or(std::net::Ipv4Addr::new(127, 0, 0, 1));
+                protocols.enable_zdns_transport = true;
+                protocols.zdns_gateway_ip = gateway_ip;
+                protocols.zdns_bind_addr = bind;
+                info!("🌐 ZDNS enabled: bind={}:{} gateway_ip={}", bind, self.config.zdns_config.port, gateway_ip);
+            }
+
+            self.register_component(Arc::new(protocols))
             .await?;
         }
 


### PR DESCRIPTION
Parent epic: #2242

## Summary

Client-side bootstrap specification for the app dev. Documents the exact flow from app startup to connected validator, including ZDNS queries, directory API, latency probing, and fallback logic.

## File

`docs/specs/client-bootstrap-v1.md`

## Key decisions

- 3 hardcoded bootstrap IPs (current validators)
- ZDNS on port 53 for DNS-based discovery (`network.sov`)
- Rich directory API on port 9334 for metadata routing
- Fallback: QUIC directory if port 53 blocked, then hardcoded IPs
- Bootstrap refresh after first connection via `directory.sov`