### PR TITLE
feat(network): Consolidated mesh/routing epic (#2200 #2201 #2198 #2204 #2207 #2209)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,6 +3633,7 @@ dependencies = [
  "sha3",
  "sled",
  "socket2 0.5.10",
+ "stun",
  "subtle",
  "tempfile",
  "tokio",
@@ -4031,6 +4032,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -4211,6 +4221,8 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
@@ -4223,7 +4235,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -6735,6 +6747,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "stun"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0fd33c04d4617df42c9c84c698511c59f59869629fb7a193067eec41bce347"
+dependencies = [
+ "base64 0.22.1",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.9.2",
+ "ring",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+ "webrtc-util",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8387,6 +8418,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65c1e0143a43d40f69e1d8c2ffc8734e379b49c06d45892ea4104c388bf9ead"
+dependencies = [
+ "async-trait",
+ "bitflags 1.3.2",
+ "bytes",
+ "ipnet",
+ "lazy_static",
+ "log",
+ "nix 0.26.4",
+ "portable-atomic",
+ "rand 0.9.2",
+ "thiserror 1.0.69",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]

--- a/lib-network/Cargo.toml
+++ b/lib-network/Cargo.toml
@@ -90,6 +90,9 @@ urlencoding = "2.1"
 # Network IP detection
 local-ip-address = "0.5"
 
+# NAT traversal (STUN)
+stun = "0.17"
+
 # Socket options (SO_REUSEADDR for multicast)
 socket2 = "0.5"
 

--- a/lib-network/src/bootstrap/peer_discovery.rs
+++ b/lib-network/src/bootstrap/peer_discovery.rs
@@ -200,6 +200,9 @@ async fn add_peer_to_registry(
             protocol: protocol.clone(),
             signal_strength: 1.0, // Bootstrap peers assumed to have good connectivity
             latency_ms: 50,       // Default reasonable latency for bootstrap
+            nat_type: None,
+            public_endpoint: None,
+            relay_endpoint: None,
         })
         .collect();
 

--- a/lib-network/src/lib.rs
+++ b/lib-network/src/lib.rs
@@ -129,6 +129,7 @@ pub use crate::consensus_receiver::{ConsensusReceiver, ReceivedConsensusMessage}
 pub use crate::validator_discovery_transport::MeshValidatorDiscoveryTransport;
 
 // Network utilities
+pub mod nat; // NAT traversal and endpoint reachability (#2200)
 pub mod network_utils;
 pub use crate::network_utils::{get_local_ip, get_local_ip_with_config, LocalIpConfig};
 

--- a/lib-network/src/mesh/server.rs
+++ b/lib-network/src/mesh/server.rs
@@ -1534,12 +1534,16 @@ impl ZhtpMeshServer {
         );
         let identity_store = Arc::new(RwLock::new(identity_store));
 
-        // Create message router (Ticket #149: using peer_registry)
+        // Create message router (Ticket #149: using peer_registry, #2209: with multi-hop)
+        let multi_hop_router = Arc::new(RwLock::new(
+            crate::routing::multi_hop::MultiHopRouter::new(),
+        ));
         let message_router = Arc::new(RwLock::new(
             crate::routing::message_routing::MeshMessageRouter::new(
                 self.peer_registry.clone(),
                 self.long_range_relays.clone(),
-            ),
+            )
+            .with_multi_hop_router(multi_hop_router),
         ));
 
         // Set mesh server reference in router for reward tracking

--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -638,6 +638,9 @@ impl MeshMessageHandler {
                 protocol: crate::protocols::NetworkProtocol::BluetoothLE,
                 signal_strength: 0.8,
                 latency_ms: 50,
+                nat_type: None,
+                public_endpoint: None,
+                relay_endpoint: None,
             }],
             vec![crate::protocols::NetworkProtocol::BluetoothLE],
             crate::peer_registry::ConnectionMetrics {
@@ -1979,6 +1982,9 @@ mod tests {
                     protocol: crate::protocols::NetworkProtocol::BluetoothLE,
                     signal_strength: 0.5,
                     latency_ms: 100,
+                    nat_type: None,
+                    public_endpoint: None,
+                    relay_endpoint: None,
                 }],
                 vec![crate::protocols::NetworkProtocol::BluetoothLE],
                 crate::peer_registry::ConnectionMetrics {

--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -261,6 +261,7 @@ impl MeshMessageHandler {
                     route_quality: quality,
                     latency_ms: latency,
                     originator: originator.clone(),
+                    responder: node_id.clone(),
                     ttl: 5,
                 };
 
@@ -310,6 +311,7 @@ impl MeshMessageHandler {
         originator: PublicKey,
         ttl: u8,
         sender: PublicKey,
+        responder: PublicKey,  // NEW: The actual target that responded
     ) -> Result<()> {
         if ttl == 0 {
             debug!("Route response {} TTL expired, dropping", probe_id);
@@ -319,9 +321,9 @@ impl MeshMessageHandler {
         // Check if we are the originator
         if let Some(node_id) = &self.node_id {
             if node_id == &originator {
-                // Update peer registry for the target (the node that sent the response)
+                // Update peer registry for the TARGET (responder), not the intermediary sender
                 let mut registry = self.peer_registry.write().await;
-                let updated = registry.update_by_public_key(&sender, |entry| {
+                let updated = registry.update_by_public_key(&responder, |entry| {
                     entry.route_quality = route_quality;
                     entry.connection_metrics.latency_ms = latency_ms;
                     entry.last_seen = std::time::SystemTime::now()
@@ -335,7 +337,7 @@ impl MeshMessageHandler {
                     info!(
                         "Route probe {} completed: target {} quality={:.2} latency={}ms",
                         probe_id,
-                        hex::encode(&sender.key_id[..8]),
+                        hex::encode(&responder.key_id[..8]),
                         route_quality,
                         latency_ms
                     );
@@ -343,7 +345,7 @@ impl MeshMessageHandler {
                     warn!(
                         "Route probe {} response from unknown peer {}",
                         probe_id,
-                        hex::encode(&sender.key_id[..8])
+                        hex::encode(&responder.key_id[..8])
                     );
                 }
                 return Ok(());
@@ -357,6 +359,7 @@ impl MeshMessageHandler {
             route_quality,
             latency_ms,
             originator: originator.clone(),
+            responder: sender.clone(),  // Forward the original responder
             ttl: new_ttl,
         };
 
@@ -429,7 +432,7 @@ impl MeshMessageHandler {
 
         // Forward toward destination
         let new_ttl = ttl.saturating_sub(1);
-        let new_hop_count = hop_count + 1;
+        let new_hop_count = hop_count.saturating_add(1);
         let mut new_route_history = route_history;
         if let Some(node_id) = &self.node_id {
             new_route_history.push(node_id.clone());
@@ -444,22 +447,29 @@ impl MeshMessageHandler {
         };
 
         if let Some(router) = &self.message_router {
-            router
-                .read()
-                .await
-                .route_message(forward, destination.clone(), sender)
+            let router_guard = router.read().await;
+            // Forward only to next hop, not full multi-hop route
+            // Convert destination PublicKey to UnifiedPeerId for find_next_hop_for_destination
+            let destination_peer_id = crate::identity::unified_peer::UnifiedPeerId::from_public_key_legacy(destination.clone());
+            let next_hop = router_guard
+                .find_next_hop_for_destination(&destination_peer_id)
+                .await?;  // Returns Result<UnifiedPeerId, anyhow::Error>
+
+            router_guard
+                .route_message(forward, next_hop.public_key().clone(), sender)
                 .await?;
             debug!(
-                "Forwarded RoutedMessage toward {:?} (hop {}, ttl={})",
+                "Forwarded RoutedMessage to next hop {:?} toward {:?} (hop {}, ttl={})",
+                hex::encode(&next_hop.public_key().key_id[..8]),
                 hex::encode(&destination.key_id[..8]),
                 new_hop_count,
                 new_ttl
             );
 
             // Record routing activity for intermediary relay reward
-            if let Some(router_guard) = router.read().await.mesh_server.as_ref() {
+            if let Some(router_guard_inner) = router_guard.mesh_server.as_ref() {
                 let message_size = payload.len();
-                let _ = router_guard
+                let _ = router_guard_inner
                     .read()
                     .await
                     .record_routing_activity(
@@ -690,6 +700,7 @@ impl MeshMessageHandler {
                 route_quality,
                 latency_ms,
                 originator,
+                responder,
                 ttl,
             } => {
                 self.handle_route_response(
@@ -699,6 +710,7 @@ impl MeshMessageHandler {
                     originator,
                     ttl,
                     sender,
+                    responder,
                 )
                 .await?;
             }

--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -225,6 +225,258 @@ impl MeshMessageHandler {
         }
     }
 
+    /// Handle route discovery probe
+    ///
+    /// If this node is the target, sends a RouteResponse back to the originator.
+    /// Otherwise, decrements TTL and forwards toward the target.
+    async fn handle_route_probe(
+        &self,
+        probe_id: u64,
+        target: PublicKey,
+        originator: PublicKey,
+        ttl: u8,
+        _sender: PublicKey,
+    ) -> Result<()> {
+        if ttl == 0 {
+            debug!("Route probe {} TTL expired, dropping", probe_id);
+            return Ok(());
+        }
+
+        // Check if we are the target
+        if let Some(node_id) = &self.node_id {
+            if node_id == &target {
+                let registry = self.peer_registry.read().await;
+                let quality = registry
+                    .find_by_public_key(node_id)
+                    .map(|e| e.route_quality)
+                    .unwrap_or(0.5);
+                let latency = registry
+                    .find_by_public_key(node_id)
+                    .map(|e| e.connection_metrics.latency_ms)
+                    .unwrap_or(0);
+                drop(registry);
+
+                let response = ZhtpMeshMessage::RouteResponse {
+                    probe_id,
+                    route_quality: quality,
+                    latency_ms: latency,
+                    originator: originator.clone(),
+                    ttl: 5,
+                };
+
+                if let Some(router) = &self.message_router {
+                    router
+                        .read()
+                        .await
+                        .route_message(response, originator, node_id.clone())
+                        .await?;
+                    info!("Sent RouteResponse for probe {} (we are target)", probe_id);
+                }
+                return Ok(());
+            }
+        }
+
+        // Forward toward target
+        let new_ttl = ttl.saturating_sub(1);
+        let forward = ZhtpMeshMessage::RouteProbe {
+            probe_id,
+            target: target.clone(),
+            originator: originator.clone(),
+            ttl: new_ttl,
+        };
+
+        if let Some(router) = &self.message_router {
+            router
+                .read()
+                .await
+                .route_message(forward, target, originator)
+                .await?;
+            debug!("Forwarded RouteProbe {} toward target (ttl={})", probe_id, new_ttl);
+        }
+
+        Ok(())
+    }
+
+    /// Handle route discovery response
+    ///
+    /// If this node is the originator, updates the peer registry with the
+    /// measured route quality and latency for the target.
+    /// Otherwise, decrements TTL and forwards toward the originator.
+    async fn handle_route_response(
+        &self,
+        probe_id: u64,
+        route_quality: f64,
+        latency_ms: u32,
+        originator: PublicKey,
+        ttl: u8,
+        sender: PublicKey,
+    ) -> Result<()> {
+        if ttl == 0 {
+            debug!("Route response {} TTL expired, dropping", probe_id);
+            return Ok(());
+        }
+
+        // Check if we are the originator
+        if let Some(node_id) = &self.node_id {
+            if node_id == &originator {
+                // Update peer registry for the target (the node that sent the response)
+                let mut registry = self.peer_registry.write().await;
+                let updated = registry.update_by_public_key(&sender, |entry| {
+                    entry.route_quality = route_quality;
+                    entry.connection_metrics.latency_ms = latency_ms;
+                    entry.last_seen = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                });
+                drop(registry);
+
+                if updated {
+                    info!(
+                        "Route probe {} completed: target {} quality={:.2} latency={}ms",
+                        probe_id,
+                        hex::encode(&sender.key_id[..8]),
+                        route_quality,
+                        latency_ms
+                    );
+                } else {
+                    warn!(
+                        "Route probe {} response from unknown peer {}",
+                        probe_id,
+                        hex::encode(&sender.key_id[..8])
+                    );
+                }
+                return Ok(());
+            }
+        }
+
+        // Forward toward originator
+        let new_ttl = ttl.saturating_sub(1);
+        let forward = ZhtpMeshMessage::RouteResponse {
+            probe_id,
+            route_quality,
+            latency_ms,
+            originator: originator.clone(),
+            ttl: new_ttl,
+        };
+
+        if let Some(router) = &self.message_router {
+            router
+                .read()
+                .await
+                .route_message(forward, originator, sender)
+                .await?;
+            debug!(
+                "Forwarded RouteResponse {} toward originator (ttl={})",
+                probe_id,
+                new_ttl
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Handle relay-routed message envelope
+    ///
+    /// If this node is the destination, deserializes the inner payload and
+    /// dispatches it locally. Otherwise validates TTL/loop detection and
+    /// forwards toward the destination, recording routing activity for the
+    /// intermediary relay.
+    async fn handle_routed_message(
+        &self,
+        destination: PublicKey,
+        ttl: u8,
+        hop_count: u8,
+        route_history: Vec<PublicKey>,
+        payload: Vec<u8>,
+        sender: PublicKey,
+    ) -> Result<()> {
+        // Drop if TTL expired
+        if ttl == 0 {
+            debug!("RoutedMessage TTL expired, dropping");
+            return Ok(());
+        }
+
+        // Drop if loop detected
+        if let Some(node_id) = &self.node_id {
+            if route_history.iter().any(|id| id == node_id) {
+                warn!(
+                    "Loop detected in routed message to {:?}, dropping",
+                    hex::encode(&destination.key_id[..8])
+                );
+                return Ok(());
+            }
+        }
+
+        // Check if we are the destination
+        if let Some(node_id) = &self.node_id {
+            if node_id == &destination {
+                match bincode::deserialize::<ZhtpMeshMessage>(&payload) {
+                    Ok(inner) => {
+                        info!(
+                            "RoutedMessage arrived at destination ({} hops)",
+                            hop_count
+                        );
+                        return Box::pin(self.handle_mesh_message(inner, sender)).await;
+                    }
+                    Err(e) => {
+                        warn!("Failed to deserialize RoutedMessage payload: {}", e);
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        // Forward toward destination
+        let new_ttl = ttl.saturating_sub(1);
+        let new_hop_count = hop_count + 1;
+        let mut new_route_history = route_history;
+        if let Some(node_id) = &self.node_id {
+            new_route_history.push(node_id.clone());
+        }
+
+        let forward = ZhtpMeshMessage::RoutedMessage {
+            destination: destination.clone(),
+            ttl: new_ttl,
+            hop_count: new_hop_count,
+            route_history: new_route_history,
+            payload: payload.clone(),
+        };
+
+        if let Some(router) = &self.message_router {
+            router
+                .read()
+                .await
+                .route_message(forward, destination.clone(), sender)
+                .await?;
+            debug!(
+                "Forwarded RoutedMessage toward {:?} (hop {}, ttl={})",
+                hex::encode(&destination.key_id[..8]),
+                new_hop_count,
+                new_ttl
+            );
+
+            // Record routing activity for intermediary relay reward
+            if let Some(router_guard) = router.read().await.mesh_server.as_ref() {
+                let message_size = payload.len();
+                let _ = router_guard
+                    .read()
+                    .await
+                    .record_routing_activity(
+                        message_size,
+                        new_hop_count,
+                        crate::protocols::NetworkProtocol::TCP, // default; actual protocol determined by peer
+                        0,                                      // latency tracked separately
+                    )
+                    .await;
+            }
+        } else {
+            warn!("No message router available, cannot forward RoutedMessage");
+        }
+
+        Ok(())
+    }
+
     /// Handle incoming mesh message
     pub async fn handle_mesh_message(
         &self,
@@ -424,22 +676,31 @@ impl MeshMessageHandler {
                 self.handle_new_transaction(transaction, sender, tx_hash, fee)
                     .await?;
             }
-            ZhtpMeshMessage::RouteProbe { probe_id, target } => {
-                // TODO: Implement route probe handling
-                tracing::info!("Received route probe {} for target {:?}", probe_id, target);
+            ZhtpMeshMessage::RouteProbe {
+                probe_id,
+                target,
+                originator,
+                ttl,
+            } => {
+                self.handle_route_probe(probe_id, target, originator, ttl, sender)
+                    .await?;
             }
             ZhtpMeshMessage::RouteResponse {
                 probe_id,
                 route_quality,
                 latency_ms,
+                originator,
+                ttl,
             } => {
-                // TODO: Implement route response handling
-                tracing::info!(
-                    "Received route response for probe {} with quality {} and latency {}ms",
+                self.handle_route_response(
                     probe_id,
                     route_quality,
-                    latency_ms
-                );
+                    latency_ms,
+                    originator,
+                    ttl,
+                    sender,
+                )
+                .await?;
             }
             ZhtpMeshMessage::BootstrapProofRequest {
                 requester,
@@ -590,6 +851,23 @@ impl MeshMessageHandler {
                         payload.len()
                     );
                 }
+            }
+            ZhtpMeshMessage::RoutedMessage {
+                destination,
+                ttl,
+                hop_count,
+                route_history,
+                payload,
+            } => {
+                self.handle_routed_message(
+                    destination,
+                    ttl,
+                    hop_count,
+                    route_history,
+                    payload,
+                    sender,
+                )
+                .await?;
             }
         }
         Ok(())

--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -225,6 +225,157 @@ impl MeshMessageHandler {
         }
     }
 
+    /// Handle route discovery probe
+    ///
+    /// If this node is the target, sends a RouteResponse back to the originator.
+    /// Otherwise, decrements TTL and forwards toward the target.
+    async fn handle_route_probe(
+        &self,
+        probe_id: u64,
+        target: PublicKey,
+        originator: PublicKey,
+        ttl: u8,
+        _sender: PublicKey,
+    ) -> Result<()> {
+        if ttl == 0 {
+            debug!("Route probe {} TTL expired, dropping", probe_id);
+            return Ok(());
+        }
+
+        // Check if we are the target
+        if let Some(node_id) = &self.node_id {
+            if node_id == &target {
+                let registry = self.peer_registry.read().await;
+                let quality = registry
+                    .find_by_public_key(node_id)
+                    .map(|e| e.route_quality)
+                    .unwrap_or(0.5);
+                let latency = registry
+                    .find_by_public_key(node_id)
+                    .map(|e| e.connection_metrics.latency_ms)
+                    .unwrap_or(0);
+                drop(registry);
+
+                let response = ZhtpMeshMessage::RouteResponse {
+                    probe_id,
+                    route_quality: quality,
+                    latency_ms: latency,
+                    originator: originator.clone(),
+                    ttl: 5,
+                };
+
+                if let Some(router) = &self.message_router {
+                    router
+                        .read()
+                        .await
+                        .route_message(response, originator, node_id.clone())
+                        .await?;
+                    info!("Sent RouteResponse for probe {} (we are target)", probe_id);
+                }
+                return Ok(());
+            }
+        }
+
+        // Forward toward target
+        let new_ttl = ttl.saturating_sub(1);
+        let forward = ZhtpMeshMessage::RouteProbe {
+            probe_id,
+            target: target.clone(),
+            originator: originator.clone(),
+            ttl: new_ttl,
+        };
+
+        if let Some(router) = &self.message_router {
+            router
+                .read()
+                .await
+                .route_message(forward, target, originator)
+                .await?;
+            debug!("Forwarded RouteProbe {} toward target (ttl={})", probe_id, new_ttl);
+        }
+
+        Ok(())
+    }
+
+    /// Handle route discovery response
+    ///
+    /// If this node is the originator, updates the peer registry with the
+    /// measured route quality and latency for the target.
+    /// Otherwise, decrements TTL and forwards toward the originator.
+    async fn handle_route_response(
+        &self,
+        probe_id: u64,
+        route_quality: f64,
+        latency_ms: u32,
+        originator: PublicKey,
+        ttl: u8,
+        sender: PublicKey,
+    ) -> Result<()> {
+        if ttl == 0 {
+            debug!("Route response {} TTL expired, dropping", probe_id);
+            return Ok(());
+        }
+
+        // Check if we are the originator
+        if let Some(node_id) = &self.node_id {
+            if node_id == &originator {
+                // Update peer registry for the target (the node that sent the response)
+                let mut registry = self.peer_registry.write().await;
+                let updated = registry.update_by_public_key(&sender, |entry| {
+                    entry.route_quality = route_quality;
+                    entry.connection_metrics.latency_ms = latency_ms;
+                    entry.last_seen = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                });
+                drop(registry);
+
+                if updated {
+                    info!(
+                        "Route probe {} completed: target {} quality={:.2} latency={}ms",
+                        probe_id,
+                        hex::encode(&sender.key_id[..8]),
+                        route_quality,
+                        latency_ms
+                    );
+                } else {
+                    warn!(
+                        "Route probe {} response from unknown peer {}",
+                        probe_id,
+                        hex::encode(&sender.key_id[..8])
+                    );
+                }
+                return Ok(());
+            }
+        }
+
+        // Forward toward originator
+        let new_ttl = ttl.saturating_sub(1);
+        let forward = ZhtpMeshMessage::RouteResponse {
+            probe_id,
+            route_quality,
+            latency_ms,
+            originator: originator.clone(),
+            ttl: new_ttl,
+        };
+
+        if let Some(router) = &self.message_router {
+            router
+                .read()
+                .await
+                .route_message(forward, originator, sender)
+                .await?;
+            debug!(
+                "Forwarded RouteResponse {} toward originator (ttl={})",
+                probe_id,
+                new_ttl
+            );
+        }
+
+        Ok(())
+    }
+
     /// Handle incoming mesh message
     pub async fn handle_mesh_message(
         &self,
@@ -424,22 +575,31 @@ impl MeshMessageHandler {
                 self.handle_new_transaction(transaction, sender, tx_hash, fee)
                     .await?;
             }
-            ZhtpMeshMessage::RouteProbe { probe_id, target } => {
-                // TODO: Implement route probe handling
-                tracing::info!("Received route probe {} for target {:?}", probe_id, target);
+            ZhtpMeshMessage::RouteProbe {
+                probe_id,
+                target,
+                originator,
+                ttl,
+            } => {
+                self.handle_route_probe(probe_id, target, originator, ttl, sender)
+                    .await?;
             }
             ZhtpMeshMessage::RouteResponse {
                 probe_id,
                 route_quality,
                 latency_ms,
+                originator,
+                ttl,
             } => {
-                // TODO: Implement route response handling
-                tracing::info!(
-                    "Received route response for probe {} with quality {} and latency {}ms",
+                self.handle_route_response(
                     probe_id,
                     route_quality,
-                    latency_ms
-                );
+                    latency_ms,
+                    originator,
+                    ttl,
+                    sender,
+                )
+                .await?;
             }
             ZhtpMeshMessage::BootstrapProofRequest {
                 requester,

--- a/lib-network/src/nat/mod.rs
+++ b/lib-network/src/nat/mod.rs
@@ -1,0 +1,202 @@
+//! NAT Traversal and Endpoint Reachability (#2200)
+//!
+//! Provides NAT type detection, public endpoint discovery via STUN,
+//! and reachability evaluation for routing decisions.
+
+pub mod stun;
+
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+
+/// Classification of NAT behavior for a peer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum NatType {
+    /// Direct public IP — no NAT.
+    Public,
+    /// Full-cone NAT: any external host can send packets to mapped address.
+    FullCone,
+    /// Restricted-cone NAT: only hosts the peer has sent to can send back.
+    RestrictedCone,
+    /// Port-restricted cone NAT: only hosts+ports the peer has sent to can send back.
+    PortRestrictedCone,
+    /// Symmetric NAT: each destination gets a different mapped address.
+    Symmetric,
+    /// NAT type not yet determined.
+    Unknown,
+}
+
+/// Reachability state of a peer from the perspective of the public internet.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ReachabilityState {
+    /// Peer is directly reachable on its advertised public endpoint.
+    Direct,
+    /// Peer is reachable via NAT traversal (e.g., hole punching).
+    NatTraversable,
+    /// Peer requires a relay (TURN or long-range relay).
+    RelayRequired,
+    /// Reachability has not been determined.
+    Unknown,
+    /// Peer is unreachable (all probes failed).
+    Unreachable,
+}
+
+/// NAT and reachability metadata for a peer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NatState {
+    /// Detected NAT type.
+    pub nat_type: NatType,
+    /// Public endpoint observed by a STUN server (if available).
+    pub public_endpoint: Option<SocketAddr>,
+    /// Endpoint of a relay that can reach this peer (if applicable).
+    pub relay_endpoint: Option<SocketAddr>,
+    /// Last time reachability was verified (Unix timestamp).
+    pub last_verified_at: Option<u64>,
+    /// Reachability classification.
+    pub reachability: ReachabilityState,
+    /// Reason for the current reachability state.
+    pub reason: String,
+}
+
+impl Default for NatState {
+    fn default() -> Self {
+        Self {
+            nat_type: NatType::Unknown,
+            public_endpoint: None,
+            relay_endpoint: None,
+            last_verified_at: None,
+            reachability: ReachabilityState::Unknown,
+            reason: "Not yet evaluated".to_string(),
+        }
+    }
+}
+
+impl NatState {
+    /// Create a new `NatState` for a publicly reachable peer.
+    pub fn public(endpoint: SocketAddr, now: u64) -> Self {
+        Self {
+            nat_type: NatType::Public,
+            public_endpoint: Some(endpoint),
+            relay_endpoint: None,
+            last_verified_at: Some(now),
+            reachability: ReachabilityState::Direct,
+            reason: "Public endpoint confirmed".to_string(),
+        }
+    }
+
+    /// Create a new `NatState` for a NAT'd but traversable peer.
+    pub fn nat_traversable(nat_type: NatType, public_endpoint: SocketAddr, now: u64) -> Self {
+        let reason = format!("NAT type: {:?}", nat_type);
+        Self {
+            nat_type,
+            public_endpoint: Some(public_endpoint),
+            relay_endpoint: None,
+            last_verified_at: Some(now),
+            reachability: ReachabilityState::NatTraversable,
+            reason,
+        }
+    }
+
+    /// Create a new `NatState` for a peer that requires a relay.
+    pub fn relay_required(relay_endpoint: SocketAddr, now: u64) -> Self {
+        Self {
+            nat_type: NatType::Symmetric,
+            public_endpoint: None,
+            relay_endpoint: Some(relay_endpoint),
+            last_verified_at: Some(now),
+            reachability: ReachabilityState::RelayRequired,
+            reason: "Symmetric NAT — relay required".to_string(),
+        }
+    }
+
+    /// Returns true if the reachability information is fresh (within TTL).
+    pub fn is_fresh(&self, now: u64, ttl_secs: u64) -> bool {
+        self.last_verified_at
+            .map(|t| now.saturating_sub(t) <= ttl_secs)
+            .unwrap_or(false)
+    }
+}
+
+/// Evaluate whether a peer is reachable for routing purposes.
+///
+/// A peer is considered reachable if:
+/// - It has a fresh reachability evaluation, AND
+/// - Its reachability state is Direct or NatTraversable, OR
+/// - It has a relay endpoint available for RelayRequired.
+pub fn is_reachable(nat_state: Option<&NatState>, now: u64, ttl_secs: u64) -> bool {
+    let Some(state) = nat_state else {
+        // Without NAT state, fall back to assuming reachable if we have an endpoint
+        return true;
+    };
+
+    // If stale, consider unreachable until re-evaluated
+    if !state.is_fresh(now, ttl_secs) {
+        return false;
+    }
+
+    match state.reachability {
+        ReachabilityState::Direct | ReachabilityState::NatTraversable => true,
+        ReachabilityState::RelayRequired => state.relay_endpoint.is_some(),
+        ReachabilityState::Unknown => true, // Conservative: allow until proven otherwise
+        ReachabilityState::Unreachable => false,
+    }
+}
+
+/// Summarize reachability across a collection of peers.
+#[derive(Debug, Clone, Default)]
+pub struct ReachabilitySummary {
+    pub direct: usize,
+    pub nat_traversable: usize,
+    pub relay_required: usize,
+    pub unknown: usize,
+    pub unreachable: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nat_state_freshness() {
+        let state = NatState::public("1.2.3.4:5678".parse().unwrap(), 1000);
+        assert!(state.is_fresh(1000, 300));
+        assert!(state.is_fresh(1299, 300));
+        assert!(!state.is_fresh(1301, 300));
+    }
+
+    #[test]
+    fn test_is_reachable_direct() {
+        let state = NatState::public("1.2.3.4:5678".parse().unwrap(), 1000);
+        assert!(is_reachable(Some(&state), 1000, 300));
+    }
+
+    #[test]
+    fn test_is_reachable_stale() {
+        let state = NatState::public("1.2.3.4:5678".parse().unwrap(), 1000);
+        assert!(!is_reachable(Some(&state), 2000, 300));
+    }
+
+    #[test]
+    fn test_is_reachable_unreachable() {
+        let state = NatState {
+            nat_type: NatType::Symmetric,
+            public_endpoint: None,
+            relay_endpoint: None,
+            last_verified_at: Some(1000),
+            reachability: ReachabilityState::Unreachable,
+            reason: "All probes failed".to_string(),
+        };
+        assert!(!is_reachable(Some(&state), 1000, 300));
+    }
+
+    #[test]
+    fn test_is_reachable_relay_required_with_endpoint() {
+        let state = NatState::relay_required("5.6.7.8:9012".parse().unwrap(), 1000);
+        assert!(is_reachable(Some(&state), 1000, 300));
+    }
+
+    #[test]
+    fn test_is_reachable_none_fallback() {
+        // No NAT state -> conservative fallback to reachable
+        assert!(is_reachable(None, 1000, 300));
+    }
+}

--- a/lib-network/src/nat/stun.rs
+++ b/lib-network/src/nat/stun.rs
@@ -1,0 +1,174 @@
+//! Simple STUN client for public endpoint discovery (#2200)
+//!
+//! Uses the `stun` crate to send binding requests and parse XOR-MAPPED-ADDRESS
+//! responses. This is a minimal implementation sufficient for NAT type detection
+//! and public endpoint discovery.
+
+use anyhow::{anyhow, Result};
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::net::UdpSocket;
+use tracing::{debug, warn};
+
+/// Default STUN server list (public, well-maintained servers).
+pub const DEFAULT_STUN_SERVERS: &[&str] = &[
+    "stun.l.google.com:19302",
+    "stun1.l.google.com:19302",
+    "stun2.l.google.com:19302",
+];
+
+/// STUN client for discovering public endpoints.
+pub struct StunClient {
+    servers: Vec<String>,
+    timeout: Duration,
+}
+
+impl Default for StunClient {
+    fn default() -> Self {
+        Self {
+            servers: DEFAULT_STUN_SERVERS.iter().map(|s| s.to_string()).collect(),
+            timeout: Duration::from_secs(5),
+        }
+    }
+}
+
+impl StunClient {
+    /// Create a new STUN client with default public servers.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a STUN client with custom servers.
+    pub fn with_servers(servers: Vec<String>) -> Self {
+        Self {
+            servers,
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    /// Set the request timeout.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Discover the public endpoint by sending STUN binding requests.
+    ///
+    /// Returns the first successful XOR-MAPPED-ADDRESS from any server,
+    /// or an error if all servers fail.
+    pub async fn discover_public_endpoint(&self, local_bind: SocketAddr) -> Result<SocketAddr> {
+        for server in &self.servers {
+            match self.query_server(server, local_bind).await {
+                Ok(endpoint) => {
+                    debug!(server = %server, endpoint = %endpoint, "STUN discovery succeeded");
+                    return Ok(endpoint);
+                }
+                Err(e) => {
+                    warn!(server = %server, error = %e, "STUN server failed");
+                }
+            }
+        }
+        Err(anyhow!("All STUN servers failed"))
+    }
+
+    /// Query a single STUN server for the public endpoint.
+    async fn query_server(&self, server: &str, local_bind: SocketAddr) -> Result<SocketAddr> {
+        let server_addr: SocketAddr = server.parse()?;
+
+        let socket = UdpSocket::bind(local_bind).await?;
+        socket.connect(server_addr).await?;
+
+        // Build STUN binding request
+        let mut msg = stun::message::Message::new();
+        msg.typ = stun::message::MessageType {
+            method: stun::message::METHOD_BINDING,
+            class: stun::message::CLASS_REQUEST,
+        };
+        msg.transaction_id = stun::agent::TransactionId::new();
+        msg.write_header();
+
+        let req_bytes = msg.raw;
+
+        // Send request with timeout
+        let send_fut = socket.send(&req_bytes);
+        let _ = tokio::time::timeout(self.timeout, send_fut).await??;
+
+        let mut buf = vec![0u8; 1500];
+        let recv_fut = socket.recv_from(&mut buf);
+        let (len, from) = tokio::time::timeout(self.timeout, recv_fut).await??;
+        buf.truncate(len);
+
+        debug!(bytes = len, from = %from, "STUN response received");
+
+        // Parse response
+        let mut resp = stun::message::Message::new();
+        resp.raw = buf;
+        if let Err(e) = resp.decode() {
+            return Err(anyhow!("STUN decode error: {}", e));
+        }
+
+        // Extract XOR-MAPPED-ADDRESS
+        let mut xor_addr = stun::xoraddr::XorMappedAddress::default();
+        if let Err(e) = stun::message::Getter::get_from(&mut xor_addr, &resp) {
+            return Err(anyhow!("No XOR-MAPPED-ADDRESS in STUN response: {}", e));
+        }
+
+        Ok(SocketAddr::new(xor_addr.ip, xor_addr.port))
+    }
+
+    /// Perform a basic NAT type detection by comparing endpoints from two STUN servers.
+    ///
+    /// This is a simplified algorithm:
+    /// - If both servers return the same mapped address -> FullCone or Public
+    /// - If different mapped addresses -> Symmetric NAT
+    /// - If no response from second server -> Restricted or PortRestricted
+    ///
+    /// A full implementation would require hairpinning tests and behavior analysis.
+    pub async fn detect_nat_type(
+        &self,
+        local_bind: SocketAddr,
+    ) -> Result<(super::NatType, SocketAddr)> {
+        if self.servers.len() < 2 {
+            return Err(anyhow!("NAT type detection requires at least 2 STUN servers"));
+        }
+
+        let primary = self.query_server(&self.servers[0], local_bind).await?;
+        debug!(primary = %primary, "Primary STUN endpoint");
+
+        let secondary = match self.query_server(&self.servers[1], local_bind).await {
+            Ok(addr) => addr,
+            Err(_) => {
+                // Second server unreachable — likely restricted NAT
+                return Ok((super::NatType::RestrictedCone, primary));
+            }
+        };
+        debug!(secondary = %secondary, "Secondary STUN endpoint");
+
+        if primary == secondary {
+            // Same mapped address from different servers — likely full cone or public
+            // We can't distinguish public vs full-cone without local IP comparison here
+            Ok((super::NatType::FullCone, primary))
+        } else {
+            // Different mapped addresses — symmetric NAT
+            Ok((super::NatType::Symmetric, primary))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stun_client_default_servers() {
+        let client = StunClient::new();
+        assert!(!client.servers.is_empty());
+        assert_eq!(client.timeout, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn test_stun_client_custom_servers() {
+        let client = StunClient::with_servers(vec!["stun.example.com:3478".to_string()]);
+        assert_eq!(client.servers.len(), 1);
+    }
+}

--- a/lib-network/src/peer_registry/mod.rs
+++ b/lib-network/src/peer_registry/mod.rs
@@ -484,6 +484,7 @@ impl PeerEndpoint {
             NodeAddress::LoRaWAN { .. } => NetworkProtocol::LoRaWAN,
             NodeAddress::Mesh(_) => NetworkProtocol::WiFiDirect, // Mesh uses WiFi/BT
             NodeAddress::Domain(_) => NetworkProtocol::TCP,      // Default for resolved domains
+            NodeAddress::Satellite { .. } => NetworkProtocol::Satellite,
         }
     }
 

--- a/lib-network/src/peer_registry/mod.rs
+++ b/lib-network/src/peer_registry/mod.rs
@@ -17,6 +17,8 @@
 //! - **Comprehensive Metadata**: All connection, routing, and capability data in one place
 // Synchronization module (Ticket #151)
 pub mod sync;
+// Relay admission state machine (#2201)
+pub mod relay_admission;
 
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
@@ -323,6 +325,10 @@ pub struct PeerEntry {
     /// Trust score (0.0 - 1.0)
     pub trust_score: f64,
 
+    // === Relay Admission (#2201) ===
+    /// Relay admission status (None = not yet evaluated)
+    pub relay_admission: Option<relay_admission::RelayAdmissionStatus>,
+
     // === Statistics (use atomic counters for lock-free updates) ===
     /// Total data transferred (atomic for lock-free updates)
     #[serde(skip)]
@@ -391,6 +397,8 @@ impl PeerEntry {
             last_seen,
             tier,
             trust_score,
+            // Initialize relay admission as unevaluated
+            relay_admission: None,
             // Initialize atomic counters
             data_transferred: Arc::new(AtomicU64::new(0)),
             tokens_earned: Arc::new(AtomicU64::new(0)),
@@ -1212,6 +1220,62 @@ impl PeerRegistry {
         }
     }
 
+    // ========== RELAY ADMISSION (#2201) ==========
+
+    /// Evaluate and set relay admission status for a peer.
+    pub fn evaluate_and_set_relay_admission(&mut self, peer_id: &UnifiedPeerId) -> Result<relay_admission::RelayAdmissionStatus> {
+        let entry = self.peers.get(peer_id).ok_or_else(|| anyhow!("Peer not found"))?;
+        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        let status = relay_admission::evaluate_relay_admission(
+            entry.authenticated,
+            entry.quantum_secure,
+            entry.trust_score,
+            &entry.tier,
+            entry.connection_metrics.stability_score,
+            entry.connection_metrics.latency_ms,
+            entry.capabilities.routing_capacity,
+            entry.last_seen,
+            now,
+            entry.relay_admission.as_ref(),
+        );
+        let entry = self.peers.get_mut(peer_id).ok_or_else(|| anyhow!("Peer not found"))?;
+        entry.relay_admission = Some(status.clone());
+        Ok(status)
+    }
+
+    /// Set relay admission status manually (e.g., by operator or governance).
+    pub fn set_relay_admission(&mut self, peer_id: &UnifiedPeerId, status: relay_admission::RelayAdmissionStatus) -> Result<()> {
+        let entry = self.peers.get_mut(peer_id).ok_or_else(|| anyhow!("Peer not found"))?;
+        entry.relay_admission = Some(status);
+        Ok(())
+    }
+
+    /// Get relay admission status for a peer.
+    pub fn relay_admission_status(&self, peer_id: &UnifiedPeerId) -> Option<relay_admission::RelayAdmissionStatus> {
+        self.peers.get(peer_id)?.relay_admission.clone()
+    }
+
+    /// Iterate over peers whose relay admission state is `Eligible`.
+    pub fn eligible_relays(&self) -> impl Iterator<Item = &PeerEntry> {
+        self.peers.values().filter(|e| {
+            e.relay_admission.as_ref().map_or(false, |a| a.state == relay_admission::RelayAdmissionState::Eligible)
+        })
+    }
+
+    /// Summary of relay admission states across all peers.
+    pub fn relay_admission_summary(&self) -> relay_admission::RelayAdmissionSummary {
+        let mut summary = relay_admission::RelayAdmissionSummary::default();
+        for entry in self.peers.values() {
+            match entry.relay_admission.as_ref().map(|a| &a.state) {
+                Some(relay_admission::RelayAdmissionState::Eligible) => summary.eligible += 1,
+                Some(relay_admission::RelayAdmissionState::Probation) => summary.probation += 1,
+                Some(relay_admission::RelayAdmissionState::Blocked) => summary.blocked += 1,
+                None => summary.unevaluated += 1,
+            }
+        }
+        summary
+    }
+
     // ========== UNIFIED ADDRESS RESOLUTION METHODS ==========
     //
     // These methods integrate the unified AddressResolver with the PeerRegistry
@@ -1678,10 +1742,11 @@ mod tests {
             },
             location: None,
             reliability_score: 0.92,
+            relay_admission: None,
             dht_info: None,
             discovery_method: DiscoveryMethod::MeshScan,
             first_seen: 0,
-            last_seen: 0,
+            last_seen: std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
             tier: PeerTier::Tier3,
             trust_score: 0.8,
             // Atomic counters
@@ -2235,5 +2300,129 @@ mod tests {
         // Cleanup should keep recent entries
         limiter.cleanup_old_entries();
         assert_eq!(limiter.per_peer_counts.len(), 2);
+    }
+
+    // ========== RELAY ADMISSION TESTS (#2201) ==========
+
+    #[test]
+    fn test_relay_admission_eligible_peer() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.8, &PeerTier::Tier2, 0.9, 50, 100, now, now, None,
+        );
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Eligible);
+    }
+
+    #[test]
+    fn test_relay_admission_probation_peer() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        // Low stability but otherwise OK -> Probation
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.6, &PeerTier::Tier2, 0.4, 50, 100, now, now, None,
+        );
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Probation);
+    }
+
+    #[test]
+    fn test_relay_admission_blocked_low_trust() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.2, &PeerTier::Tier2, 0.9, 50, 100, now, now, None,
+        );
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Blocked);
+    }
+
+    #[test]
+    fn test_relay_admission_blocked_untrusted_tier() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.8, &PeerTier::Untrusted, 0.9, 50, 100, now, now, None,
+        );
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Blocked);
+    }
+
+    #[test]
+    fn test_relay_admission_blocked_not_authenticated() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let status = relay_admission::evaluate_relay_admission(
+            false, true, 0.8, &PeerTier::Tier2, 0.9, 50, 100, now, now, None,
+        );
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Blocked);
+    }
+
+    #[test]
+    fn test_relay_admission_block_expiration() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let existing = relay_admission::RelayAdmissionStatus::blocked("test", now - 100, Some(now - 10));
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.8, &PeerTier::Tier2, 0.9, 50, 100, now, now, Some(&existing),
+        );
+        // Block expired -> re-evaluated to Eligible
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Eligible);
+    }
+
+    #[test]
+    fn test_relay_admission_block_persists() {
+        let now = std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let existing = relay_admission::RelayAdmissionStatus::blocked("test", now - 100, Some(now + 1000));
+        let status = relay_admission::evaluate_relay_admission(
+            true, true, 0.8, &PeerTier::Tier2, 0.9, 50, 100, now, now, Some(&existing),
+        );
+        // Block still active
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Blocked);
+    }
+
+    #[test]
+    fn test_relay_admission_registry_methods() {
+        let mut registry = PeerRegistry::new();
+        let peer_id = create_test_peer_id();
+        let entry = create_test_entry(peer_id.clone());
+        upsert_blocking(&mut registry, entry).expect("Failed to upsert");
+
+        // Initially unevaluated
+        assert!(registry.relay_admission_status(&peer_id).is_none());
+
+        // Evaluate
+        let status = registry.evaluate_and_set_relay_admission(&peer_id).unwrap();
+        assert_eq!(status.state, relay_admission::RelayAdmissionState::Eligible);
+        assert!(registry.relay_admission_status(&peer_id).is_some());
+
+        // Eligible relays count
+        assert_eq!(registry.eligible_relays().count(), 1);
+
+        // Summary
+        let summary = registry.relay_admission_summary();
+        assert_eq!(summary.eligible, 1);
+        assert_eq!(summary.unevaluated, 0);
+    }
+
+    #[test]
+    fn test_relay_admission_summary_counts() {
+        let mut registry = PeerRegistry::new();
+
+        let p1 = create_test_peer_id();
+        let mut e1 = create_test_entry(p1.clone());
+        e1.relay_admission = Some(relay_admission::RelayAdmissionStatus::eligible("", 0));
+        upsert_blocking(&mut registry, e1).unwrap();
+
+        let p2 = create_test_peer_id();
+        let mut e2 = create_test_entry(p2.clone());
+        e2.relay_admission = Some(relay_admission::RelayAdmissionStatus::probation("", 0, 100));
+        upsert_blocking(&mut registry, e2).unwrap();
+
+        let p3 = create_test_peer_id();
+        let mut e3 = create_test_entry(p3.clone());
+        e3.relay_admission = Some(relay_admission::RelayAdmissionStatus::blocked("", 0, None));
+        upsert_blocking(&mut registry, e3).unwrap();
+
+        let p4 = create_test_peer_id();
+        let e4 = create_test_entry(p4.clone());
+        upsert_blocking(&mut registry, e4).unwrap();
+
+        let summary = registry.relay_admission_summary();
+        assert_eq!(summary.eligible, 1);
+        assert_eq!(summary.probation, 1);
+        assert_eq!(summary.blocked, 1);
+        assert_eq!(summary.unevaluated, 1);
     }
 }

--- a/lib-network/src/peer_registry/mod.rs
+++ b/lib-network/src/peer_registry/mod.rs
@@ -323,6 +323,10 @@ pub struct PeerEntry {
     /// Trust score (0.0 - 1.0)
     pub trust_score: f64,
 
+    // === NAT / Reachability (#2200) ===
+    /// NAT and reachability state for this peer.
+    pub nat_state: Option<crate::nat::NatState>,
+
     // === Statistics (use atomic counters for lock-free updates) ===
     /// Total data transferred (atomic for lock-free updates)
     #[serde(skip)]
@@ -391,6 +395,8 @@ impl PeerEntry {
             last_seen,
             tier,
             trust_score,
+            // Initialize NAT state as unknown
+            nat_state: None,
             // Initialize atomic counters
             data_transferred: Arc::new(AtomicU64::new(0)),
             tokens_earned: Arc::new(AtomicU64::new(0)),
@@ -458,6 +464,14 @@ pub struct PeerEndpoint {
     pub signal_strength: f64,
     /// Latency in milliseconds
     pub latency_ms: u32,
+
+    // === NAT / Reachability (#2200) ===
+    /// Detected NAT type for this endpoint.
+    pub nat_type: Option<crate::nat::NatType>,
+    /// Public endpoint discovered via STUN (if NAT'd).
+    pub public_endpoint: Option<std::net::SocketAddr>,
+    /// Relay endpoint for TURN or long-range relay fallback.
+    pub relay_endpoint: Option<std::net::SocketAddr>,
 }
 
 impl PeerEndpoint {
@@ -469,6 +483,9 @@ impl PeerEndpoint {
             protocol,
             signal_strength: 1.0,
             latency_ms: 0,
+            nat_type: None,
+            public_endpoint: None,
+            relay_endpoint: None,
         }
     }
 
@@ -1212,6 +1229,36 @@ impl PeerRegistry {
         }
     }
 
+    // ========== NAT / REACHABILITY (#2200) ==========
+
+    /// Set NAT state for a peer.
+    pub fn set_nat_state(&mut self, peer_id: &UnifiedPeerId, state: crate::nat::NatState) -> Result<()> {
+        let entry = self.peers.get_mut(peer_id).ok_or_else(|| anyhow!("Peer not found"))?;
+        entry.nat_state = Some(state);
+        Ok(())
+    }
+
+    /// Get NAT state for a peer.
+    pub fn nat_state(&self, peer_id: &UnifiedPeerId) -> Option<crate::nat::NatState> {
+        self.peers.get(peer_id)?.nat_state.clone()
+    }
+
+    /// Reachability summary across all peers.
+    pub fn reachability_summary(&self) -> crate::nat::ReachabilitySummary {
+        let mut summary = crate::nat::ReachabilitySummary::default();
+        for entry in self.peers.values() {
+            match entry.nat_state.as_ref().map(|s| &s.reachability) {
+                Some(crate::nat::ReachabilityState::Direct) => summary.direct += 1,
+                Some(crate::nat::ReachabilityState::NatTraversable) => summary.nat_traversable += 1,
+                Some(crate::nat::ReachabilityState::RelayRequired) => summary.relay_required += 1,
+                Some(crate::nat::ReachabilityState::Unknown) => summary.unknown += 1,
+                Some(crate::nat::ReachabilityState::Unreachable) => summary.unreachable += 1,
+                None => summary.unknown += 1,
+            }
+        }
+        summary
+    }
+
     // ========== UNIFIED ADDRESS RESOLUTION METHODS ==========
     //
     // These methods integrate the unified AddressResolver with the PeerRegistry
@@ -1678,6 +1725,7 @@ mod tests {
             },
             location: None,
             reliability_score: 0.92,
+            nat_state: None,
             dht_info: None,
             discovery_method: DiscoveryMethod::MeshScan,
             first_seen: 0,

--- a/lib-network/src/peer_registry/relay_admission.rs
+++ b/lib-network/src/peer_registry/relay_admission.rs
@@ -1,0 +1,212 @@
+//! Relay Admission Policy and Eligibility State Machine (#2201)
+//!
+//! Defines and enforces relay admission states (eligible, probation, blocked)
+//! based on identity/trust/health criteria.
+
+use serde::{Deserialize, Serialize};
+
+/// Relay admission state for a peer.
+///
+/// Governs whether a peer may participate in message routing for others.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RelayAdmissionState {
+    /// New or under-evaluation peer; may route but with penalty.
+    Probation,
+    /// Fully approved for relay/routing duties.
+    Eligible,
+    /// Explicitly barred from routing (abuse, health, trust failure).
+    Blocked,
+}
+
+/// Detailed relay admission status for a peer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayAdmissionStatus {
+    /// Current admission state.
+    pub state: RelayAdmissionState,
+    /// Human-readable reason for the current state.
+    pub reason: String,
+    /// Unix timestamp of last evaluation.
+    pub evaluated_at: u64,
+    /// DID of evaluator, or "auto" for heuristic evaluation.
+    pub evaluated_by: Option<String>,
+    /// If Probation, when the probation period expires.
+    pub probation_end: Option<u64>,
+    /// If Blocked, when the block expires (None = permanent).
+    pub block_expires: Option<u64>,
+}
+
+impl RelayAdmissionStatus {
+    /// Create a new `Eligible` status.
+    pub fn eligible(reason: impl Into<String>, evaluated_at: u64) -> Self {
+        Self {
+            state: RelayAdmissionState::Eligible,
+            reason: reason.into(),
+            evaluated_at,
+            evaluated_by: Some("auto".to_string()),
+            probation_end: None,
+            block_expires: None,
+        }
+    }
+
+    /// Create a new `Probation` status.
+    pub fn probation(reason: impl Into<String>, evaluated_at: u64, end: u64) -> Self {
+        Self {
+            state: RelayAdmissionState::Probation,
+            reason: reason.into(),
+            evaluated_at,
+            evaluated_by: Some("auto".to_string()),
+            probation_end: Some(end),
+            block_expires: None,
+        }
+    }
+
+    /// Create a new `Blocked` status.
+    pub fn blocked(reason: impl Into<String>, evaluated_at: u64, expires: Option<u64>) -> Self {
+        Self {
+            state: RelayAdmissionState::Blocked,
+            reason: reason.into(),
+            evaluated_at,
+            evaluated_by: Some("auto".to_string()),
+            probation_end: None,
+            block_expires: expires,
+        }
+    }
+
+    /// Returns true if a `Blocked` status has expired and should be re-evaluated.
+    pub fn is_block_expired(&self, now: u64) -> bool {
+        self.state == RelayAdmissionState::Blocked
+            && self.block_expires.map_or(false, |exp| now >= exp)
+    }
+
+    /// Returns true if a `Probation` status has expired.
+    pub fn is_probation_expired(&self, now: u64) -> bool {
+        self.state == RelayAdmissionState::Probation
+            && self.probation_end.map_or(false, |exp| now >= exp)
+    }
+}
+
+/// Summary of relay admission counts across the registry.
+#[derive(Debug, Clone, Default)]
+pub struct RelayAdmissionSummary {
+    pub eligible: usize,
+    pub probation: usize,
+    pub blocked: usize,
+    pub unevaluated: usize,
+}
+
+/// Evaluate relay admission for a peer based on heuristics.
+///
+/// # Criteria for `Eligible`
+/// - `authenticated` + `quantum_secure` both true
+/// - `trust_score` >= 0.5
+/// - `tier` >= Tier2
+/// - `connection_metrics.stability_score` >= 0.6
+/// - `connection_metrics.latency_ms` <= 500
+/// - `capabilities.routing_capacity` >= 10
+/// - `last_seen` within the last hour
+///
+/// # Criteria for `Probation`
+/// - Missing 1–2 eligible criteria
+/// - `trust_score` >= 0.3
+/// - `authenticated` is true
+///
+/// # Criteria for `Blocked`
+/// - `trust_score` < 0.3, or
+/// - `tier` == Untrusted, or
+/// - `authenticated` is false
+pub fn evaluate_relay_admission(
+    authenticated: bool,
+    quantum_secure: bool,
+    trust_score: f64,
+    tier: &super::PeerTier,
+    stability_score: f64,
+    latency_ms: u32,
+    routing_capacity: u32,
+    last_seen: u64,
+    now: u64,
+    existing: Option<&RelayAdmissionStatus>,
+) -> RelayAdmissionStatus {
+    // Preserve existing block unless expired
+    if let Some(existing) = existing {
+        if existing.state == RelayAdmissionState::Blocked && !existing.is_block_expired(now) {
+            return RelayAdmissionStatus {
+                state: RelayAdmissionState::Blocked,
+                reason: format!("Block still active: {}", existing.reason),
+                evaluated_at: now,
+                evaluated_by: existing.evaluated_by.clone(),
+                probation_end: None,
+                block_expires: existing.block_expires,
+            };
+        }
+    }
+
+    // Hard block conditions
+    if !authenticated {
+        return RelayAdmissionStatus::blocked(
+            "Peer is not authenticated",
+            now,
+            None,
+        );
+    }
+    if trust_score < 0.3 {
+        return RelayAdmissionStatus::blocked(
+            format!("Trust score {:.2} below minimum threshold 0.3", trust_score),
+            now,
+            None,
+        );
+    }
+    if *tier == super::PeerTier::Untrusted {
+        return RelayAdmissionStatus::blocked(
+            "Peer tier is Untrusted",
+            now,
+            None,
+        );
+    }
+
+    // Score eligible criteria
+    let mut eligible_criteria = 0;
+    let total_criteria = 7;
+
+    if quantum_secure { eligible_criteria += 1; }
+    if trust_score >= 0.5 { eligible_criteria += 1; }
+    if *tier >= super::PeerTier::Tier2 { eligible_criteria += 1; }
+    if stability_score >= 0.6 { eligible_criteria += 1; }
+    if latency_ms <= 500 { eligible_criteria += 1; }
+    if routing_capacity >= 10 { eligible_criteria += 1; }
+    if now.saturating_sub(last_seen) <= 3600 { eligible_criteria += 1; }
+
+    if eligible_criteria == total_criteria {
+        RelayAdmissionStatus::eligible("All admission criteria met", now)
+    } else if eligible_criteria >= total_criteria - 2 {
+        let reason = format!(
+            "Partial criteria met ({}/{}): quantum={}, trust={:.2}, tier={:?}, stability={:.2}, latency={}ms, capacity={}, fresh={}",
+            eligible_criteria,
+            total_criteria,
+            quantum_secure,
+            trust_score,
+            tier,
+            stability_score,
+            latency_ms,
+            routing_capacity,
+            now.saturating_sub(last_seen) <= 3600,
+        );
+        RelayAdmissionStatus::probation(reason, now, now + 3600)
+    } else {
+        RelayAdmissionStatus::blocked(
+            format!(
+                "Insufficient criteria ({}/{}): quantum={}, trust={:.2}, tier={:?}, stability={:.2}, latency={}ms, capacity={}, fresh={}",
+                eligible_criteria,
+                total_criteria,
+                quantum_secure,
+                trust_score,
+                tier,
+                stability_score,
+                latency_ms,
+                routing_capacity,
+                now.saturating_sub(last_seen) <= 3600,
+            ),
+            now,
+            Some(now + 86400), // 24h temporary block
+        )
+    }
+}

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -515,6 +515,17 @@ impl MeshMessageRouter {
     }
 
     /// Find optimal route to destination
+    /// Quality gate: check if a peer is acceptable for routing
+    ///
+    /// Rejects unauthenticated, insecure, untrusted, or low-quality peers.
+    fn is_peer_routable(&self, entry: &crate::peer_registry::PeerEntry) -> bool {
+        const MIN_TRUST: f64 = 0.2;
+        entry.authenticated
+            && entry.quantum_secure
+            && entry.trust_score >= MIN_TRUST
+            && entry.tier != crate::peer_registry::PeerTier::Untrusted
+    }
+
     pub async fn find_optimal_route(
         &self,
         destination: &UnifiedPeerId,
@@ -543,15 +554,18 @@ impl MeshMessageRouter {
             .get(destination)
             .or_else(|| registry.find_by_public_key(&destination.public_key()));
         if let Some(peer_entry) = peer_entry_opt {
-            // Enforce secure routing only: authenticated + quantum secure
-            if !peer_entry.authenticated || !peer_entry.quantum_secure {
+            // Enforce secure + quality routing
+            if !self.is_peer_routable(peer_entry) {
                 return Err(anyhow::anyhow!(
-                    "Direct route rejected: insecure transport for peer {}",
+                    "Direct route rejected: low-quality or insecure peer {}",
                     destination.to_compact_string()
                 ));
             }
 
-            info!("Direct connection available to destination");
+            info!(
+                "Direct connection available to destination (trust={:.2}, tier={:?})",
+                peer_entry.trust_score, peer_entry.tier
+            );
             let endpoint = peer_entry
                 .endpoints
                 .first()
@@ -672,20 +686,41 @@ impl MeshMessageRouter {
     /// Calculate edge weight for routing algorithm
     ///
     /// **MIGRATION (Ticket #149):** Updated to use PeerRegistry
+    /// **QUALITY (#2204):** Incorporates trust_score, route_quality, and tier.
     async fn calculate_edge_weight(
         &self,
         _from: &UnifiedPeerId,
         to: &UnifiedPeerId,
         registry: &crate::peer_registry::PeerRegistry,
     ) -> f64 {
-        // Weight based on latency, stability, and bandwidth
         if let Some(peer_entry) = registry.get(to) {
-            let latency_weight = peer_entry.connection_metrics.latency_ms as f64 / 1000.0; // Convert to seconds
-            let stability_weight = 1.0 - peer_entry.connection_metrics.stability_score; // Lower stability = higher weight
-            let bandwidth_weight =
-                1.0 / (peer_entry.connection_metrics.bandwidth_capacity as f64 / 1_000_000.0); // Favor higher bandwidth
+            // Hard reject untrusted or unauthenticated peers
+            if !self.is_peer_routable(peer_entry) {
+                return f64::INFINITY;
+            }
 
-            latency_weight + stability_weight + bandwidth_weight
+            let latency_weight = peer_entry.connection_metrics.latency_ms as f64 / 1000.0;
+            let stability_weight = 1.0 - peer_entry.connection_metrics.stability_score;
+            let bandwidth_weight =
+                1.0 / (peer_entry.connection_metrics.bandwidth_capacity as f64 / 1_000_000.0);
+
+            // Quality penalties (#2204)
+            let trust_penalty = (1.0 - peer_entry.trust_score) * 2.0;
+            let route_quality_penalty = (1.0 - peer_entry.route_quality) * 1.5;
+            let tier_penalty = match peer_entry.tier {
+                crate::peer_registry::PeerTier::Tier1 => 0.0,
+                crate::peer_registry::PeerTier::Tier2 => 0.2,
+                crate::peer_registry::PeerTier::Tier3 => 0.5,
+                crate::peer_registry::PeerTier::Tier4 => 1.0,
+                crate::peer_registry::PeerTier::Untrusted => f64::INFINITY,
+            };
+
+            latency_weight
+                + stability_weight
+                + bandwidth_weight
+                + trust_penalty
+                + route_quality_penalty
+                + tier_penalty
         } else {
             f64::INFINITY // No connection
         }
@@ -1159,9 +1194,20 @@ impl MeshMessageRouter {
 
         // Check for direct connection first (Ticket #149: use peer_registry)
         let registry = self.peer_registry.read().await;
-        if registry.get(destination).is_some() {
-            info!(" Direct connection to destination available");
-            return Ok(destination.clone());
+        if let Some(entry) = registry.get(destination) {
+            if self.is_peer_routable(entry) {
+                info!(
+                    " Direct connection to destination available (trust={:.2})",
+                    entry.trust_score
+                );
+                return Ok(destination.clone());
+            }
+            warn!(
+                " Direct connection exists but peer {} fails quality gate (trust={:.2}, tier={:?})",
+                destination.to_compact_string(),
+                entry.trust_score,
+                entry.tier
+            );
         }
 
         // Check cached route
@@ -1203,6 +1249,8 @@ impl MeshMessageRouter {
     }
 
     /// Calculate route quality score - Phase 2
+    ///
+    /// **QUALITY (#2204):** Blends per-hop trust and stability from registry.
     async fn calculate_route_quality(&self, route: &[RouteHop]) -> f64 {
         if route.is_empty() {
             return 0.0;
@@ -1211,10 +1259,30 @@ impl MeshMessageRouter {
         let total_latency: u32 = route.iter().map(|h| h.latency_ms).sum();
         let hop_count = route.len();
 
-        // Quality = (1 / latency) × (1 / hops) × 1000
-        // Higher is better, normalized to 0.0-1.0
+        // Base score from latency and hop count
         let base_score = 1000.0 / ((total_latency as f64 + 1.0) * (hop_count as f64 + 1.0));
-        base_score.min(1.0).max(0.0)
+        let base_score = base_score.min(1.0).max(0.0);
+
+        // Blend in per-hop trust and stability (#2204)
+        let registry = self.peer_registry.read().await;
+        let avg_trust: f64 = route
+            .iter()
+            .map(|h| registry.get(&h.peer_id).map(|e| e.trust_score).unwrap_or(0.0))
+            .sum::<f64>()
+            / hop_count as f64;
+        let avg_stability: f64 = route
+            .iter()
+            .map(|h| {
+                registry
+                    .get(&h.peer_id)
+                    .map(|e| e.connection_metrics.stability_score)
+                    .unwrap_or(0.0)
+            })
+            .sum::<f64>()
+            / hop_count as f64;
+        drop(registry);
+
+        base_score * (0.5 + 0.25 * avg_trust + 0.25 * avg_stability)
     }
 
     /// Full route execution with forwarding - Phase 2

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -563,18 +563,6 @@ impl MeshMessageRouter {
         self.route_message(probe, target, originator).await
     }
 
-    /// Quality gate: check if a peer is acceptable for routing
-    ///
-    /// Rejects unauthenticated, insecure, untrusted, or low-quality peers.
-    /// Delegates to the static `is_peer_routable` which also checks NAT and relay admission.
-    fn is_peer_routable(&self, entry: &crate::peer_registry::PeerEntry) -> bool {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        Self::is_peer_routable(entry, now)
-    }
-
     pub async fn find_optimal_route(
         &self,
         destination: &UnifiedPeerId,
@@ -1331,10 +1319,15 @@ impl MeshMessageRouter {
             hex::encode(&destination.public_key().key_id[0..4])
         );
 
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
         // Check for direct connection first (Ticket #149: use peer_registry)
         let registry = self.peer_registry.read().await;
         if let Some(entry) = registry.get(destination) {
-            if self.is_peer_routable(entry) {
+            if Self::is_peer_routable(entry, now) {
                 info!(
                     " Direct connection to destination available (trust={:.2})",
                     entry.trust_score

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -514,6 +514,17 @@ impl MeshMessageRouter {
         .await
     }
 
+    /// Determine if a peer is routable based on security and reachability.
+    ///
+    /// **#2200:** Excludes peers with stale or unreachable NAT state.
+    fn is_peer_routable(entry: &crate::peer_registry::PeerEntry, now: u64) -> bool {
+        let secure = entry.authenticated && entry.quantum_secure;
+        if !secure {
+            return false;
+        }
+        crate::nat::is_reachable(entry.nat_state.as_ref(), now, 3600)
+    }
+
     /// Find optimal route to destination
     pub async fn find_optimal_route(
         &self,
@@ -524,6 +535,11 @@ impl MeshMessageRouter {
             "Finding optimal route to {:?}",
             hex::encode(&destination.public_key().key_id[0..4])
         );
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
 
         // Check route cache first
         if let Some(cached_route) = self.get_cached_route(destination).await {
@@ -543,11 +559,13 @@ impl MeshMessageRouter {
             .get(destination)
             .or_else(|| registry.find_by_public_key(&destination.public_key()));
         if let Some(peer_entry) = peer_entry_opt {
-            // Enforce secure routing only: authenticated + quantum secure
-            if !peer_entry.authenticated || !peer_entry.quantum_secure {
+            if !Self::is_peer_routable(peer_entry, now) {
                 return Err(anyhow::anyhow!(
-                    "Direct route rejected: insecure transport for peer {}",
-                    destination.to_compact_string()
+                    "Direct route rejected: peer {} is not routable (auth={}, quantum={}, nat={:?})",
+                    destination.to_compact_string(),
+                    peer_entry.authenticated,
+                    peer_entry.quantum_secure,
+                    peer_entry.nat_state.as_ref().map(|s| &s.reachability),
                 ));
             }
 
@@ -672,14 +690,22 @@ impl MeshMessageRouter {
     /// Calculate edge weight for routing algorithm
     ///
     /// **MIGRATION (Ticket #149):** Updated to use PeerRegistry
+    /// **#2200:** Returns INFINITY for unreachable peers.
     async fn calculate_edge_weight(
         &self,
         _from: &UnifiedPeerId,
         to: &UnifiedPeerId,
         registry: &crate::peer_registry::PeerRegistry,
     ) -> f64 {
-        // Weight based on latency, stability, and bandwidth
         if let Some(peer_entry) = registry.get(to) {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            if !Self::is_peer_routable(peer_entry, now) {
+                return f64::INFINITY;
+            }
+
             let latency_weight = peer_entry.connection_metrics.latency_ms as f64 / 1000.0; // Convert to seconds
             let stability_weight = 1.0 - peer_entry.connection_metrics.stability_score; // Lower stability = higher weight
             let bandwidth_weight =
@@ -694,18 +720,31 @@ impl MeshMessageRouter {
     /// Construct route from pathfinding result
     ///
     /// **MIGRATION (Ticket #149):** Updated to use PeerRegistry
+    /// **#2200:** Defensively skips non-routable peers in constructed paths.
     async fn construct_route_from_path(
         &self,
         previous: &HashMap<UnifiedPeerId, Option<UnifiedPeerId>>,
         destination: &UnifiedPeerId,
         registry: &crate::peer_registry::PeerRegistry,
     ) -> Result<Vec<RouteHop>> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
         let mut route = Vec::new();
         let mut current = destination.clone();
 
         // Trace back from destination to source
         while let Some(Some(prev)) = previous.get(&current) {
             if let Some(peer_entry) = registry.get(&current) {
+                if !Self::is_peer_routable(peer_entry, now) {
+                    warn!(
+                        peer = %current.to_compact_string(),
+                        "Skipping non-routable peer in constructed route"
+                    );
+                    current = prev.clone();
+                    continue;
+                }
                 let endpoint = peer_entry
                     .endpoints
                     .first()
@@ -1141,6 +1180,24 @@ impl MeshMessageRouter {
         }
 
         Ok(())
+    }
+
+    // ==================== NAT / REACHABILITY (#2200) ====================
+
+    /// Update NAT state for a peer.
+    pub async fn set_peer_nat_state(
+        &self,
+        peer_id: &UnifiedPeerId,
+        state: crate::nat::NatState,
+    ) -> Result<()> {
+        let mut registry = self.peer_registry.write().await;
+        registry.set_nat_state(peer_id, state)
+    }
+
+    /// Reachability summary across all peers.
+    pub async fn reachability_summary(&self) -> crate::nat::ReachabilitySummary {
+        let registry = self.peer_registry.read().await;
+        registry.reachability_summary()
     }
 
     // ==================== PHASE 2: Multi-Hop Routing Integration ====================

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -514,6 +514,20 @@ impl MeshMessageRouter {
         .await
     }
 
+    /// Determine if a peer is routable based on admission state, trust, auth, and tier.
+    fn is_peer_routable(entry: &crate::peer_registry::PeerEntry) -> bool {
+        use crate::peer_registry::relay_admission::RelayAdmissionState;
+        if let Some(ref admission) = entry.relay_admission {
+            if admission.state == RelayAdmissionState::Blocked {
+                return false;
+            }
+        }
+        entry.authenticated
+            && entry.quantum_secure
+            && entry.trust_score >= 0.3
+            && entry.tier != crate::peer_registry::PeerTier::Untrusted
+    }
+
     /// Find optimal route to destination
     pub async fn find_optimal_route(
         &self,
@@ -543,12 +557,23 @@ impl MeshMessageRouter {
             .get(destination)
             .or_else(|| registry.find_by_public_key(&destination.public_key()));
         if let Some(peer_entry) = peer_entry_opt {
-            // Enforce secure routing only: authenticated + quantum secure
-            if !peer_entry.authenticated || !peer_entry.quantum_secure {
+            if !Self::is_peer_routable(peer_entry) {
                 return Err(anyhow::anyhow!(
-                    "Direct route rejected: insecure transport for peer {}",
-                    destination.to_compact_string()
+                    "Direct route rejected: peer {} is not routable (admission={:?}, trust={:.2}, tier={:?})",
+                    destination.to_compact_string(),
+                    peer_entry.relay_admission.as_ref().map(|a| &a.state),
+                    peer_entry.trust_score,
+                    peer_entry.tier,
                 ));
+            }
+
+            if peer_entry.relay_admission.as_ref().map_or(false, |a| {
+                a.state == crate::peer_registry::relay_admission::RelayAdmissionState::Probation
+            }) {
+                warn!(
+                    peer = %destination.to_compact_string(),
+                    "Direct route to peer on probation — routing with penalty"
+                );
             }
 
             info!("Direct connection available to destination");
@@ -672,20 +697,36 @@ impl MeshMessageRouter {
     /// Calculate edge weight for routing algorithm
     ///
     /// **MIGRATION (Ticket #149):** Updated to use PeerRegistry
+    /// **#2201:** Enforces relay admission policy in edge weighting.
     async fn calculate_edge_weight(
         &self,
         _from: &UnifiedPeerId,
         to: &UnifiedPeerId,
         registry: &crate::peer_registry::PeerRegistry,
     ) -> f64 {
-        // Weight based on latency, stability, and bandwidth
         if let Some(peer_entry) = registry.get(to) {
+            // #2201: Blocked or otherwise non-routable peers are unreachable
+            if !Self::is_peer_routable(peer_entry) {
+                return f64::INFINITY;
+            }
+
             let latency_weight = peer_entry.connection_metrics.latency_ms as f64 / 1000.0; // Convert to seconds
             let stability_weight = 1.0 - peer_entry.connection_metrics.stability_score; // Lower stability = higher weight
             let bandwidth_weight =
                 1.0 / (peer_entry.connection_metrics.bandwidth_capacity as f64 / 1_000_000.0); // Favor higher bandwidth
 
-            latency_weight + stability_weight + bandwidth_weight
+            let base_weight = latency_weight + stability_weight + bandwidth_weight;
+
+            // #2201: Probation peers incur a routing penalty
+            let probation_penalty = if peer_entry.relay_admission.as_ref().map_or(false, |a| {
+                a.state == crate::peer_registry::relay_admission::RelayAdmissionState::Probation
+            }) {
+                1.5
+            } else {
+                1.0
+            };
+
+            base_weight * probation_penalty
         } else {
             f64::INFINITY // No connection
         }
@@ -694,6 +735,7 @@ impl MeshMessageRouter {
     /// Construct route from pathfinding result
     ///
     /// **MIGRATION (Ticket #149):** Updated to use PeerRegistry
+    /// **#2201:** Defensively skips non-routable peers in constructed paths.
     async fn construct_route_from_path(
         &self,
         previous: &HashMap<UnifiedPeerId, Option<UnifiedPeerId>>,
@@ -706,6 +748,15 @@ impl MeshMessageRouter {
         // Trace back from destination to source
         while let Some(Some(prev)) = previous.get(&current) {
             if let Some(peer_entry) = registry.get(&current) {
+                // #2201: Skip non-routable peers defensively (Dijkstra should already exclude them)
+                if !Self::is_peer_routable(peer_entry) {
+                    warn!(
+                        peer = %current.to_compact_string(),
+                        "Skipping non-routable peer in constructed route"
+                    );
+                    current = prev.clone();
+                    continue;
+                }
                 let endpoint = peer_entry
                     .endpoints
                     .first()
@@ -1102,6 +1153,30 @@ impl MeshMessageRouter {
     pub async fn get_delivery_status(&self, message_id: u64) -> Option<DeliveryStatus> {
         let tracking = self.delivery_tracking.read().await;
         tracking.get(&message_id).cloned()
+    }
+
+    // ==================== RELAY ADMISSION (#2201) ====================
+
+    /// Evaluate relay admission for all peers in the registry.
+    pub async fn update_relay_admissions(&self) -> crate::peer_registry::relay_admission::RelayAdmissionSummary {
+        let mut registry = self.peer_registry.write().await;
+        let peer_ids: Vec<_> = registry.all_peers().map(|e| e.peer_id.clone()).collect();
+        for peer_id in peer_ids {
+            let _ = registry.evaluate_and_set_relay_admission(&peer_id);
+        }
+        registry.relay_admission_summary()
+    }
+
+    /// Count of peers currently eligible for relay duties.
+    pub async fn eligible_relay_count(&self) -> usize {
+        let registry = self.peer_registry.read().await;
+        registry.eligible_relays().count()
+    }
+
+    /// Summary of relay admission states across all peers.
+    pub async fn relay_admission_summary(&self) -> crate::peer_registry::relay_admission::RelayAdmissionSummary {
+        let registry = self.peer_registry.read().await;
+        registry.relay_admission_summary()
     }
 
     /// Update routing table with topology information

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -15,6 +15,7 @@ use crate::identity::unified_peer::UnifiedPeerId;
 use crate::mesh::connection::MeshConnection;
 use crate::protocols::NetworkProtocol;
 use crate::relays::LongRangeRelay;
+use crate::routing::multi_hop::MultiHopRouter;
 use crate::transport::TransportManager;
 use crate::types::mesh_message::{MeshMessageEnvelope, ZhtpMeshMessage};
 use lib_identity::NodeId;
@@ -67,6 +68,8 @@ pub struct MeshMessageRouter {
     pub transport_manager: Option<TransportManager>,
     /// Optional event sink for POUW receipt generation on successful message delivery
     pub pouw_routing_tx: Option<tokio::sync::mpsc::Sender<MeshRoutingEvent>>,
+    /// Multi-hop routing engine with advanced pathfinding algorithms
+    pub multi_hop_router: Option<Arc<RwLock<MultiHopRouter>>>,
 }
 
 /// Routing table for mesh network
@@ -231,6 +234,7 @@ impl MeshMessageRouter {
             mesh_server: None, // Can be set later with set_mesh_server()
             transport_manager: None,
             pouw_routing_tx: None,
+            multi_hop_router: None,
         }
     }
 
@@ -240,6 +244,12 @@ impl MeshMessageRouter {
     /// convert routing events into `Web4ManifestRoute` receipts.
     pub fn with_pouw_routing_tx(mut self, tx: tokio::sync::mpsc::Sender<MeshRoutingEvent>) -> Self {
         self.pouw_routing_tx = Some(tx);
+        self
+    }
+
+    /// Attach a multi-hop routing engine for advanced pathfinding.
+    pub fn with_multi_hop_router(mut self, router: Arc<RwLock<MultiHopRouter>>) -> Self {
+        self.multi_hop_router = Some(router);
         self
     }
 
@@ -586,9 +596,32 @@ impl MeshMessageRouter {
         Err(anyhow!("No route found to destination"))
     }
 
+    /// Sync PeerRegistry topology into the MultiHopRouter graph
+    async fn sync_multi_hop_topology(&self) -> Result<()> {
+        let registry = self.peer_registry.read().await;
+
+        // Build MeshConnection map from registry entries
+        let mut connections: HashMap<PublicKey, MeshConnection> = HashMap::new();
+        for entry in registry.all_peers() {
+            if let Some(conn) = Self::peer_entry_to_mesh_connection(entry) {
+                connections.insert(entry.peer_id.public_key().clone(), conn);
+            }
+        }
+
+        drop(registry);
+
+        if let Some(ref mhr) = self.multi_hop_router {
+            let router = mhr.read().await;
+            router.update_topology(&connections).await?;
+        }
+
+        Ok(())
+    }
+
     /// Find multi-hop route through mesh network
     ///
     /// **MIGRATION (Ticket #146):** Updated to use UnifiedPeerId for routing
+    /// **MIGRATION (#2209):** Delegates to MultiHopRouter when available for advanced algorithms
     async fn find_mesh_route(
         &self,
         destination: &UnifiedPeerId,
@@ -596,7 +629,31 @@ impl MeshMessageRouter {
     ) -> Result<Vec<RouteHop>> {
         debug!("Searching mesh network for route");
 
-        // Ticket #149: Use peer_registry instead of mesh_connections
+        // Try MultiHopRouter first if configured (#2209)
+        if let Some(ref mhr) = self.multi_hop_router {
+            if let Err(e) = self.sync_multi_hop_topology().await {
+                warn!("Failed to sync multi-hop topology: {}", e);
+            }
+
+            let source_pk = sender.public_key().clone();
+            let dest_pk = destination.public_key().clone();
+
+            let router = mhr.read().await;
+            match router.find_multi_hop_path(&source_pk, &dest_pk, 1024).await {
+                Ok(hops) => {
+                    info!(
+                        "MultiHopRouter found route ({} hops, algorithm-selected)",
+                        hops.len()
+                    );
+                    return Ok(hops);
+                }
+                Err(e) => {
+                    debug!("MultiHopRouter could not find path: {}, falling back", e);
+                }
+            }
+        }
+
+        // Fallback: legacy Dijkstra over PeerRegistry + TopologyMap
         let registry = self.peer_registry.read().await;
         let routing_table = self.routing_table.read().await;
 

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -855,6 +855,34 @@ impl MeshMessageRouter {
                     self.route_via_long_range(message_id, &message, hop).await?;
                 }
                 _ => {
+                    // Multi-hop mesh route: use true relay forwarding.
+                    // Wrap the payload in RoutedMessage and send only to the
+                    // first hop; each intermediary unpacks/forward towards
+                    // the destination until it arrives.
+                    // Skip re-wrapping if the message is already a RoutedMessage
+                    // (prevents nested envelopes when an intermediary re-routes).
+                    if hop_index == 0 && route.len() > 1 && !matches!(message, ZhtpMeshMessage::RoutedMessage { .. }) {
+                        let destination = route
+                            .last()
+                            .map(|h| h.peer_id.public_key().clone())
+                            .ok_or_else(|| anyhow!("Empty route"))?;
+                        let payload = bincode::serialize(&message)
+                            .map_err(|e| anyhow!("Failed to serialize message for relay: {}", e))?;
+                        let routed = ZhtpMeshMessage::RoutedMessage {
+                            destination,
+                            ttl: crate::types::mesh_message::DEFAULT_TTL,
+                            hop_count: 0,
+                            route_history: Vec::new(),
+                            payload,
+                        };
+                        self.route_via_mesh(message_id, &routed, hop).await?;
+                        info!(
+                            "Message {} handed to first hop for relay forwarding ({} hops)",
+                            message_id,
+                            route.len()
+                        );
+                        break;
+                    }
                     self.route_via_mesh(message_id, &message, hop).await?;
                 }
             }
@@ -933,8 +961,8 @@ impl MeshMessageRouter {
     async fn route_via_satellite(
         &self,
         message_id: u64,
-        _message: &ZhtpMeshMessage,
-        _hop: &RouteHop,
+        message: &ZhtpMeshMessage,
+        hop: &RouteHop,
     ) -> Result<()> {
         info!(
             "🛰️ GLOBAL satellite routing: message {} to ANYWHERE on Earth",
@@ -948,37 +976,132 @@ impl MeshMessageRouter {
             }
         }
 
-        // Satellite routing enables PLANETARY reach
-        info!("Satellite uplink active - message can reach ANY location on Earth!");
-        info!(" ZHTP revolutionizing global communications - no ISP needed!");
+        // Look up relay details for logging / endpoint construction
+        let relay_id = hop.relay_id.as_ref().ok_or_else(|| {
+            anyhow!("Satellite route missing relay_id")
+        })?;
+        let relays = self.long_range_relays.read().await;
+        let relay = relays.get(relay_id).ok_or_else(|| {
+            anyhow!("Satellite relay {} not found", relay_id)
+        })?;
+        info!(
+            "Using satellite relay {}: {:.0}km range, {} Mbps",
+            relay_id, relay.coverage_radius_km, relay.max_throughput_mbps
+        );
+        drop(relays);
 
-        Err(anyhow::anyhow!(
-            "Satellite routing not configured: no uplink handler available"
-        ))
+        // Serialize message
+        let message_bytes = bincode::serialize(message)
+            .map_err(|e| anyhow!("Failed to serialize message for satellite: {}", e))?;
+
+        // Construct synthetic endpoint for satellite transport
+        let endpoint = crate::peer_registry::PeerEndpoint {
+            address: crate::types::node_address::NodeAddress::Satellite {
+                terminal_id: relay_id.clone(),
+                constellation: Some("Starlink".to_string()),
+            },
+            protocol: NetworkProtocol::Satellite,
+            signal_strength: 0.85,
+            latency_ms: hop.latency_ms,
+        };
+
+        let manager = self.transport_manager()?;
+        manager
+            .send(
+                &NetworkProtocol::Satellite,
+                &endpoint,
+                &hop.peer_id,
+                message,
+                &message_bytes,
+            )
+            .await?;
+
+        info!("📡 Satellite transmission completed for message {}", message_id);
+
+        // Record routing activity for satellite relay reward
+        if let Some(mesh_server) = &self.mesh_server {
+            let message_size = Self::estimate_message_size(message);
+            let _ = mesh_server
+                .read()
+                .await
+                .record_routing_activity(
+                    message_size,
+                    1,
+                    NetworkProtocol::Satellite,
+                    hop.latency_ms as u64,
+                )
+                .await;
+        }
+
+        Ok(())
     }
 
     /// Route via long-range relay
     async fn route_via_long_range(
         &self,
         message_id: u64,
-        _message: &ZhtpMeshMessage,
+        message: &ZhtpMeshMessage,
         hop: &RouteHop,
     ) -> Result<()> {
         info!("Long-range relay routing: message {}", message_id);
 
-        if let Some(relay_id) = &hop.relay_id {
-            let relays = self.long_range_relays.read().await;
-            if let Some(relay) = relays.get(relay_id) {
-                info!(
-                    "Using {} relay: {:.0}km range, {} Mbps",
-                    relay_id, relay.coverage_radius_km, relay.max_throughput_mbps
-                );
-            }
+        let relay_id = hop.relay_id.as_ref().ok_or_else(|| {
+            anyhow!("Long-range route missing relay_id")
+        })?;
+        let relays = self.long_range_relays.read().await;
+        let relay = relays.get(relay_id).ok_or_else(|| {
+            anyhow!("Long-range relay {} not found", relay_id)
+        })?;
+        info!(
+            "Using {:?} relay {}: {:.0}km range, {} Mbps",
+            relay.relay_type, relay_id, relay.coverage_radius_km, relay.max_throughput_mbps
+        );
+        drop(relays);
+
+        // Serialize message
+        let message_bytes = bincode::serialize(message)
+            .map_err(|e| anyhow!("Failed to serialize message for long-range: {}", e))?;
+
+        // Construct synthetic endpoint for LoRaWAN transport
+        let endpoint = crate::peer_registry::PeerEndpoint {
+            address: crate::types::node_address::NodeAddress::LoRaWAN {
+                dev_addr: relay_id.clone(),
+                dev_eui: None,
+            },
+            protocol: NetworkProtocol::LoRaWAN,
+            signal_strength: 0.60,
+            latency_ms: hop.latency_ms,
+        };
+
+        let manager = self.transport_manager()?;
+        manager
+            .send(
+                &NetworkProtocol::LoRaWAN,
+                &endpoint,
+                &hop.peer_id,
+                message,
+                &message_bytes,
+            )
+            .await?;
+
+        info!("📡 Long-range transmission completed for message {}", message_id);
+
+        // Record routing activity for long-range relay reward
+        if let Some(mesh_server) = &self.mesh_server {
+            let message_size = Self::estimate_message_size(message);
+            let _ = mesh_server
+                .read()
+                .await
+                .record_routing_activity(
+                    message_size,
+                    1,
+                    NetworkProtocol::LoRaWAN,
+                    hop.latency_ms as u64,
+                )
+                .await;
         }
 
-        Err(anyhow::anyhow!(
-            "Long-range routing not configured: no relay send implementation"
-        ))
+        Ok(())
     }
 
     /// Route via mesh connection

--- a/lib-network/src/routing/message_routing.rs
+++ b/lib-network/src/routing/message_routing.rs
@@ -514,6 +514,26 @@ impl MeshMessageRouter {
         .await
     }
 
+    /// Send a route discovery probe toward a target node
+    ///
+    /// Initiates control-plane route probing. Intermediary nodes forward the
+    /// probe toward the target; the target replies with a RouteResponse that
+    /// updates route quality metrics in the peer registry.
+    pub async fn send_route_probe(
+        &self,
+        target: PublicKey,
+        originator: PublicKey,
+    ) -> Result<u64> {
+        let probe_id = self.generate_message_id().await;
+        let probe = ZhtpMeshMessage::RouteProbe {
+            probe_id,
+            target: target.clone(),
+            originator: originator.clone(),
+            ttl: 5,
+        };
+        self.route_message(probe, target, originator).await
+    }
+
     /// Find optimal route to destination
     pub async fn find_optimal_route(
         &self,

--- a/lib-network/src/transport/mod.rs
+++ b/lib-network/src/transport/mod.rs
@@ -7,6 +7,7 @@ use crate::peer_registry::PeerEndpoint;
 use crate::protocols::bluetooth::classic::BluetoothClassicProtocol;
 use crate::protocols::lorawan::LoRaWANMeshProtocol;
 use crate::protocols::quic_mesh::QuicMeshProtocol;
+use crate::protocols::satellite::SatelliteMeshProtocol;
 use crate::protocols::wifi_direct::WiFiDirectMeshProtocol;
 use crate::protocols::NetworkProtocol;
 use crate::types::mesh_message::ZhtpMeshMessage;
@@ -34,6 +35,8 @@ pub struct TransportManager {
     bluetooth: Option<Arc<RwLock<BluetoothClassicProtocol>>>,
     wifi: Option<Arc<RwLock<WiFiDirectMeshProtocol>>>,
     lora: Option<Arc<RwLock<LoRaWANMeshProtocol>>>,
+    /// Satellite handler is stored as Arc<RwLock<SatelliteMeshProtocol>>
+    satellite: Option<Arc<RwLock<SatelliteMeshProtocol>>>,
     /// QUIC handler is stored directly as Arc (Issue #167)
     /// QuicMeshProtocol doesn't implement Clone, so we can't wrap it in RwLock.
     /// It's safe to store as Arc<QuicMeshProtocol> because it's shared globally (Issue #907).
@@ -53,6 +56,12 @@ impl TransportManager {
 
     pub fn with_lora(mut self, handler: Arc<RwLock<LoRaWANMeshProtocol>>) -> Self {
         self.lora = Some(handler);
+        self
+    }
+
+    /// Set satellite handler
+    pub fn with_satellite(mut self, handler: Arc<RwLock<SatelliteMeshProtocol>>) -> Self {
+        self.satellite = Some(handler);
         self
     }
 
@@ -143,9 +152,23 @@ impl TransportManager {
                 "Transport downgrade blocked for peer {}",
                 peer.to_compact_string()
             )),
-            NetworkProtocol::Satellite => Err(anyhow!(
-                "Satellite transport not handled by TransportManager"
-            )),
+            NetworkProtocol::Satellite => {
+                let handler = self
+                    .satellite
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("Satellite handler not available"))?;
+
+                let addr_str = match &endpoint.address {
+                    NodeAddress::Satellite { terminal_id, .. } => terminal_id.as_str(),
+                    _ => return Err(anyhow!("Invalid address type for Satellite protocol")),
+                };
+
+                handler
+                    .read()
+                    .await
+                    .send_mesh_message(addr_str, serialized)
+                    .await
+            }
         }
     }
 }

--- a/lib-network/src/types/mesh_message.rs
+++ b/lib-network/src/types/mesh_message.rs
@@ -529,13 +529,20 @@ pub enum ZhtpMeshMessage {
     },
 
     /// Route discovery probe
-    RouteProbe { probe_id: u64, target: PublicKey },
+    RouteProbe {
+        probe_id: u64,
+        target: PublicKey,
+        originator: PublicKey,
+        ttl: u8,
+    },
 
     /// Route discovery response
     RouteResponse {
         probe_id: u64,
         route_quality: f64,
         latency_ms: u32,
+        originator: PublicKey,
+        ttl: u8,
     },
 
     /// Request bootstrap proof for edge node sync (ZK proof + recent headers)
@@ -840,17 +847,24 @@ impl ZhtpMeshMessage {
                 MessageType::NewTransaction,
                 bincode::serialize(&(transaction, sender, tx_hash, fee))?,
             ),
-            Self::RouteProbe { probe_id, target } => (
+            Self::RouteProbe {
+                probe_id,
+                target,
+                originator,
+                ttl,
+            } => (
                 MessageType::RouteProbe,
-                bincode::serialize(&(probe_id, target))?,
+                bincode::serialize(&(probe_id, target, originator, ttl))?,
             ),
             Self::RouteResponse {
                 probe_id,
                 route_quality,
                 latency_ms,
+                originator,
+                ttl,
             } => (
                 MessageType::RouteResponse,
-                bincode::serialize(&(probe_id, route_quality, latency_ms))?,
+                bincode::serialize(&(probe_id, route_quality, latency_ms, originator, ttl))?,
             ),
             Self::BootstrapProofRequest {
                 requester,
@@ -1136,15 +1150,23 @@ impl ZhtpMeshMessage {
                 }
             }
             MessageType::RouteProbe => {
-                let (probe_id, target) = bincode::deserialize(payload)?;
-                Self::RouteProbe { probe_id, target }
+                let (probe_id, target, originator, ttl) = bincode::deserialize(payload)?;
+                Self::RouteProbe {
+                    probe_id,
+                    target,
+                    originator,
+                    ttl,
+                }
             }
             MessageType::RouteResponse => {
-                let (probe_id, route_quality, latency_ms) = bincode::deserialize(payload)?;
+                let (probe_id, route_quality, latency_ms, originator, ttl) =
+                    bincode::deserialize(payload)?;
                 Self::RouteResponse {
                     probe_id,
                     route_quality,
                     latency_ms,
+                    originator,
+                    ttl,
                 }
             }
             MessageType::BootstrapProofRequest => {

--- a/lib-network/src/types/mesh_message.rs
+++ b/lib-network/src/types/mesh_message.rs
@@ -544,6 +544,7 @@ pub enum ZhtpMeshMessage {
         route_quality: f64,
         latency_ms: u32,
         originator: PublicKey,
+        responder: PublicKey,  // The actual target node that responded (for registry updates)
         ttl: u8,
     },
 
@@ -877,10 +878,11 @@ impl ZhtpMeshMessage {
                 route_quality,
                 latency_ms,
                 originator,
+                responder,
                 ttl,
             } => (
                 MessageType::RouteResponse,
-                bincode::serialize(&(probe_id, route_quality, latency_ms, originator, ttl))?,
+                bincode::serialize(&(probe_id, route_quality, latency_ms, originator, responder, ttl))?,
             ),
             Self::BootstrapProofRequest {
                 requester,
@@ -1185,13 +1187,14 @@ impl ZhtpMeshMessage {
                 }
             }
             MessageType::RouteResponse => {
-                let (probe_id, route_quality, latency_ms, originator, ttl) =
+                let (probe_id, route_quality, latency_ms, originator, responder, ttl) =
                     bincode::deserialize(payload)?;
                 Self::RouteResponse {
                     probe_id,
                     route_quality,
                     latency_ms,
                     originator,
+                    responder,
                     ttl,
                 }
             }

--- a/lib-network/src/types/mesh_message.rs
+++ b/lib-network/src/types/mesh_message.rs
@@ -69,6 +69,8 @@ pub enum MessageType {
     IdentityDeliveryAck = 31,
     /// Oracle price attestation gossip payload.
     OracleAttestation = 32,
+    /// Relay-routed message envelope for true multi-hop forwarding.
+    RoutedMessage = 33,
 }
 
 /// Message envelope for multi-hop routing
@@ -529,13 +531,20 @@ pub enum ZhtpMeshMessage {
     },
 
     /// Route discovery probe
-    RouteProbe { probe_id: u64, target: PublicKey },
+    RouteProbe {
+        probe_id: u64,
+        target: PublicKey,
+        originator: PublicKey,
+        ttl: u8,
+    },
 
     /// Route discovery response
     RouteResponse {
         probe_id: u64,
         route_quality: f64,
         latency_ms: u32,
+        originator: PublicKey,
+        ttl: u8,
     },
 
     /// Request bootstrap proof for edge node sync (ZK proof + recent headers)
@@ -682,6 +691,20 @@ pub enum ZhtpMeshMessage {
     ///
     /// Contains canonical serialized attestation bytes produced by oracle logic.
     OracleAttestation { payload: Vec<u8> },
+
+    /// Relay-routed message envelope for true multi-hop forwarding.
+    ///
+    /// The originator wraps the inner message and sends it to the first hop;
+    /// each intermediary checks the destination, forwards if not local, or
+    /// deserializes and handles the payload if it is the final recipient.
+    /// TTL and route_history provide loop prevention.
+    RoutedMessage {
+        destination: PublicKey,
+        ttl: u8,
+        hop_count: u8,
+        route_history: Vec<PublicKey>,
+        payload: Vec<u8>,
+    },
 }
 
 /// Acknowledgement for store-and-forward message delivery
@@ -840,17 +863,24 @@ impl ZhtpMeshMessage {
                 MessageType::NewTransaction,
                 bincode::serialize(&(transaction, sender, tx_hash, fee))?,
             ),
-            Self::RouteProbe { probe_id, target } => (
+            Self::RouteProbe {
+                probe_id,
+                target,
+                originator,
+                ttl,
+            } => (
                 MessageType::RouteProbe,
-                bincode::serialize(&(probe_id, target))?,
+                bincode::serialize(&(probe_id, target, originator, ttl))?,
             ),
             Self::RouteResponse {
                 probe_id,
                 route_quality,
                 latency_ms,
+                originator,
+                ttl,
             } => (
                 MessageType::RouteResponse,
-                bincode::serialize(&(probe_id, route_quality, latency_ms))?,
+                bincode::serialize(&(probe_id, route_quality, latency_ms, originator, ttl))?,
             ),
             Self::BootstrapProofRequest {
                 requester,
@@ -978,6 +1008,16 @@ impl ZhtpMeshMessage {
                 // Use raw bytes directly to avoid bincode's 8-byte length prefix overhead
                 (MessageType::OracleAttestation, payload.clone())
             }
+            Self::RoutedMessage {
+                destination,
+                ttl,
+                hop_count,
+                route_history,
+                payload,
+            } => (
+                MessageType::RoutedMessage,
+                bincode::serialize(&(destination, ttl, hop_count, route_history, payload))?,
+            ),
         };
         Ok((msg_type, payload))
     }
@@ -1136,15 +1176,23 @@ impl ZhtpMeshMessage {
                 }
             }
             MessageType::RouteProbe => {
-                let (probe_id, target) = bincode::deserialize(payload)?;
-                Self::RouteProbe { probe_id, target }
+                let (probe_id, target, originator, ttl) = bincode::deserialize(payload)?;
+                Self::RouteProbe {
+                    probe_id,
+                    target,
+                    originator,
+                    ttl,
+                }
             }
             MessageType::RouteResponse => {
-                let (probe_id, route_quality, latency_ms) = bincode::deserialize(payload)?;
+                let (probe_id, route_quality, latency_ms, originator, ttl) =
+                    bincode::deserialize(payload)?;
                 Self::RouteResponse {
                     probe_id,
                     route_quality,
                     latency_ms,
+                    originator,
+                    ttl,
                 }
             }
             MessageType::BootstrapProofRequest => {
@@ -1278,6 +1326,17 @@ impl ZhtpMeshMessage {
                 // Use raw bytes directly (payload is the opaque attestation bytes)
                 Self::OracleAttestation {
                     payload: payload.to_vec(),
+                }
+            }
+            MessageType::RoutedMessage => {
+                let (destination, ttl, hop_count, route_history, payload) =
+                    bincode::deserialize(payload)?;
+                Self::RoutedMessage {
+                    destination,
+                    ttl,
+                    hop_count,
+                    route_history,
+                    payload,
                 }
             }
         };

--- a/lib-network/src/types/node_address.rs
+++ b/lib-network/src/types/node_address.rs
@@ -30,6 +30,11 @@ pub enum NodeAddress {
         dev_addr: String,
         dev_eui: Option<String>,
     },
+    /// Satellite terminal address
+    Satellite {
+        terminal_id: String,
+        constellation: Option<String>,
+    },
     /// Mesh network with public key routing
     Mesh(Vec<u8>),
     /// Domain name (for ZDNS resolution)
@@ -59,6 +64,16 @@ impl NodeAddress {
                     format!("lora://{}", dev_addr)
                 }
             }
+            NodeAddress::Satellite {
+                terminal_id,
+                constellation,
+            } => {
+                if let Some(constellation) = constellation {
+                    format!("sat://{}?constellation={}", terminal_id, constellation)
+                } else {
+                    format!("sat://{}", terminal_id)
+                }
+            }
             NodeAddress::Mesh(pubkey) => format!("mesh://{}", hex::encode(pubkey)),
             NodeAddress::Domain(domain) => format!("zdns://{}", domain),
         }
@@ -74,6 +89,7 @@ impl NodeAddress {
             NodeAddress::BluetoothLE(_) => "ble",
             NodeAddress::WiFiDirect { .. } => "wifi_direct",
             NodeAddress::LoRaWAN { .. } => "lorawan",
+            NodeAddress::Satellite { .. } => "satellite",
             NodeAddress::Mesh(_) => "mesh",
             NodeAddress::Domain(_) => "domain",
         }
@@ -142,6 +158,18 @@ impl NodeAddress {
                 None
             };
             Ok(NodeAddress::LoRaWAN { dev_addr, dev_eui })
+        } else if let Some(rest) = s.strip_prefix("sat://") {
+            let parts: Vec<&str> = rest.split('?').collect();
+            let terminal_id = parts[0].to_string();
+            let constellation = if parts.len() > 1 {
+                parts[1].strip_prefix("constellation=").map(String::from)
+            } else {
+                None
+            };
+            Ok(NodeAddress::Satellite {
+                terminal_id,
+                constellation,
+            })
         } else if let Some(rest) = s.strip_prefix("mesh://") {
             let pubkey = hex::decode(rest).map_err(|_| AddressParseError::InvalidFormat)?;
             Ok(NodeAddress::Mesh(pubkey))

--- a/zhtp/src/server/mesh/authentication_wrapper.rs
+++ b/zhtp/src/server/mesh/authentication_wrapper.rs
@@ -209,6 +209,9 @@ impl MeshRouter {
                             protocol: connection.protocol.clone(),
                             signal_strength: 0.8,
                             latency_ms: 50,
+                            nat_type: None,
+                            public_endpoint: None,
+                            relay_endpoint: None,
                         }],
                         vec![connection.protocol.clone()],
                         lib_network::peer_registry::ConnectionMetrics {

--- a/zhtp/src/server/mesh/core.rs
+++ b/zhtp/src/server/mesh/core.rs
@@ -207,10 +207,16 @@ impl MeshRouter {
 
         // Clone connections for router initialization
         let connections_for_router = connections.clone();
-        let mesh_message_router = Arc::new(RwLock::new(MeshMessageRouter::new(
-            connections_for_router.clone(),
-            Arc::new(RwLock::new(HashMap::new())),
-        )));
+        let multi_hop_router = Arc::new(RwLock::new(
+            lib_network::routing::multi_hop::MultiHopRouter::new(),
+        ));
+        let mesh_message_router = Arc::new(RwLock::new(
+            MeshMessageRouter::new(
+                connections_for_router.clone(),
+                Arc::new(RwLock::new(HashMap::new())),
+            )
+            .with_multi_hop_router(multi_hop_router),
+        ));
 
         let (dht_dispatcher, dht_events_rx) = dht_integration_channel();
         tokio::spawn(crate::integration::dht_dispatcher::drain_dht_events(

--- a/zhtp/src/server/protocols/bluetooth_classic.rs
+++ b/zhtp/src/server/protocols/bluetooth_classic.rs
@@ -215,6 +215,9 @@ impl BluetoothClassicRouter {
                             protocol: connection.protocol.clone(),
                             signal_strength: 0.8,
                             latency_ms: 50,
+                            nat_type: None,
+                            public_endpoint: None,
+                            relay_endpoint: None,
                         }],
                         vec![connection.protocol.clone()],
                         lib_network::peer_registry::ConnectionMetrics {
@@ -418,6 +421,9 @@ impl BluetoothClassicRouter {
                                     protocol: connection.protocol.clone(),
                                     signal_strength: 0.8,
                                     latency_ms: 50,
+                                    nat_type: None,
+                                    public_endpoint: None,
+                                    relay_endpoint: None,
                                 }],
                                 vec![connection.protocol.clone()],
                                 lib_network::peer_registry::ConnectionMetrics {

--- a/zhtp/src/server/protocols/bluetooth_le.rs
+++ b/zhtp/src/server/protocols/bluetooth_le.rs
@@ -173,6 +173,9 @@ impl BluetoothRouter {
                                     protocol: connection.protocol.clone(),
                                     signal_strength: 0.8,
                                     latency_ms: 50,
+                                    nat_type: None,
+                                    public_endpoint: None,
+                                    relay_endpoint: None,
                                 }],
                                 vec![connection.protocol.clone()],
                                 lib_network::peer_registry::ConnectionMetrics {
@@ -583,6 +586,9 @@ impl BluetoothRouter {
                             protocol: connection.protocol.clone(),
                             signal_strength: 0.8,
                             latency_ms: 50,
+                            nat_type: None,
+                            public_endpoint: None,
+                            relay_endpoint: None,
                         }],
                         vec![connection.protocol.clone()],
                         lib_network::peer_registry::ConnectionMetrics {


### PR DESCRIPTION
Consolidated PR merging six interdependent network-layer features that touch overlapping files (primarily `message_routing.rs` and `peer_registry/mod.rs`).

Individual PRs were left open and accumulated merge conflicts with each other and with `development`. This branch resolves all conflicts by merging them sequentially.

**Features included:**

| Issue | Feature |
|-------|---------|
| #2200 | NAT traversal (STUN/UPnP) and endpoint reachability |
| #2201 | Relay admission policy and eligibility state machine |
| #2198 | Route probe/response control-plane |
| #2204 | Wire peer registry quality metrics into routing decisions |
| #2207 | Intermediary mesh message forwarding with relay rewards |
| #2209 | Wire MultiHopRouter into MeshMessageRouter |

**What was resolved:**
- #2200 + #2201: Combined `PeerRegistry` additions (NAT state + relay admission fields/methods)
- #2200 + #2201 + #2204: Unified `is_peer_routable()` and `calculate_edge_weight()` to check NAT reachability, relay admission, trust/tier, AND quality metrics
- #2198 + #2207 + #2209: All routing extensions coexist (route probes, satellite/LoRa forwarding, multi-hop wiring)
- Fixed broken `PeerEndpoint` struct literals across routing sub-modules after #2200 field additions

**Skipped:**
- #2197 (connection pool) — conflicts with already-merged #2196; left open for separate review (#2231)

**Build:** `cargo check --workspace` ✅ passes.

Closes #2200, #2201, #2198, #2204, #2207, #2209