### PR TITLE
Node setup web UI + directory routing fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,6 +2987,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,6 +3004,16 @@ dependencies = [
  "hermit-abi 0.5.2",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -4500,6 +4519,17 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "open"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
 
 [[package]]
 name = "openssl"
@@ -9399,6 +9429,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "axum",
  "base64 0.22.1",
  "bincode",
  "chrono",
@@ -9417,6 +9448,7 @@ dependencies = [
  "lib-proofs",
  "lib-protocols",
  "mime_guess",
+ "open",
  "regex",
  "rpassword",
  "self_update",
@@ -9424,6 +9456,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "sysinfo",
  "tar",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9386,6 +9386,7 @@ dependencies = [
  "lib-protocols",
  "lib-storage",
  "lib-types",
+ "libc",
  "local-ip-address 0.6.10",
  "lru 0.12.5",
  "lz4_flex",

--- a/zhtp-cli/Cargo.toml
+++ b/zhtp-cli/Cargo.toml
@@ -30,6 +30,11 @@ clap_mangen = "0.2"
 # Configuration editing
 toml_edit = "0.22"
 
+# Setup UI (localhost HTTP bridge)
+axum = { version = "0.7", features = ["json"] }
+open = "5.0"
+sha2 = "0.10"
+
 # Async runtime and utilities (workspace shared)
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1.0"

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -264,6 +264,8 @@ pub enum NodeAction {
     Status,
     /// Restart the node
     Restart,
+    /// Open the node setup web UI (localhost browser dashboard)
+    SetupUi,
 }
 
 /// Wallet operation commands

--- a/zhtp-cli/src/commands/mod.rs
+++ b/zhtp-cli/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod monitor;
 pub mod nft;
 pub mod network;
 pub mod node;
+pub mod setup_ui;
 pub mod oracle;
 pub mod rewards;
 pub mod server;

--- a/zhtp-cli/src/commands/node.rs
+++ b/zhtp-cli/src/commands/node.rs
@@ -51,6 +51,7 @@ pub fn action_to_operation(action: &NodeAction) -> NodeOperation {
         NodeAction::Stop => NodeOperation::Stop,
         NodeAction::Status => NodeOperation::Status,
         NodeAction::Restart => NodeOperation::Restart,
+        NodeAction::SetupUi => NodeOperation::Status, // handled separately
     }
 }
 
@@ -100,6 +101,11 @@ async fn handle_node_command_impl(
     cli: &ZhtpCli,
     output: &dyn Output,
 ) -> CliResult<()> {
+    // Handle setup-ui separately (it starts its own HTTP server)
+    if matches!(args.action, NodeAction::SetupUi) {
+        return crate::commands::setup_ui::run_setup_ui(cli, output).await;
+    }
+
     let op = action_to_operation(&args.action);
     output.info(&format!("{}...", op.description()))?;
 
@@ -224,6 +230,10 @@ async fn handle_node_command_impl(
             output.warning("Restarting node...")?;
             output.print("Stop the current node and start it again.")?;
             Ok(())
+        }
+        NodeAction::SetupUi => {
+            // Already handled above, unreachable
+            unreachable!("SetupUi handled before match")
         }
     }
 }

--- a/zhtp-cli/src/commands/setup_ui.rs
+++ b/zhtp-cli/src/commands/setup_ui.rs
@@ -4,11 +4,11 @@
 //! opens the browser, and proxies API calls to the QUIC node.
 
 use crate::argument_parsing::ZhtpCli;
-use crate::commands::web4_utils::{connect_default, default_keystore_path, load_identity_from_keystore};
+use crate::commands::web4_utils::{default_keystore_path, load_identity_from_keystore};
 use crate::error::{CliError, CliResult};
 use crate::output::Output;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
 
 const UI_HTML: &str = include_str!("../ui/setup.html");
 const DEFAULT_UI_PORT: u16 = 7840;
@@ -23,6 +23,7 @@ pub async fn run_setup_ui(cli: &ZhtpCli, output: &dyn Output) -> CliResult<()> {
     // Try to connect to the QUIC node
     let quic_server = cli.server.clone();
     let node_connected = Arc::new(RwLock::new(false));
+    let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
 
     // Build HTTP routes
     use axum::{
@@ -37,17 +38,19 @@ pub async fn run_setup_ui(cli: &ZhtpCli, output: &dyn Output) -> CliResult<()> {
     struct AppState {
         quic_server: String,
         node_connected: Arc<RwLock<bool>>,
+        shutdown_tx: watch::Sender<bool>,
     }
 
     let state = AppState {
         quic_server,
         node_connected: node_connected.clone(),
+        shutdown_tx,
     };
 
     let app = Router::new()
         .route("/", get(serve_ui))
         .route("/api/status", get(proxy_status))
-        .route("/api/setup", post(proxy_setup))
+        .route("/api/control", post(proxy_control))
         .with_state(state);
 
     async fn serve_ui() -> Html<&'static str> {
@@ -74,29 +77,52 @@ pub async fn run_setup_ui(cli: &ZhtpCli, output: &dyn Output) -> CliResult<()> {
         }
     }
 
-    async fn proxy_setup(
+    async fn proxy_control(
         State(state): State<AppState>,
         Json(body): Json<serde_json::Value>,
     ) -> impl IntoResponse {
         let action = body.get("action").and_then(|a| a.as_str()).unwrap_or("");
         match action {
-            "restore" => {
+            "restore_identity" => {
                 let seed = body.get("seed_phrase").and_then(|s| s.as_str()).unwrap_or("");
-                match try_restore_seed(seed, &state.quic_server).await {
+                match try_restore_seed(seed).await {
                     Ok(json) => (StatusCode::OK, Json(json)),
                     Err(e) => (StatusCode::OK, Json(serde_json::json!({ "error": e }))),
                 }
             }
-            "create" => {
+            "create_identity" => {
                 let name = body.get("node_name").and_then(|s| s.as_str()).unwrap_or("sovereign-node");
-                match try_create_new(name, &state.quic_server).await {
+                match try_create_new(name).await {
                     Ok(json) => (StatusCode::OK, Json(json)),
                     Err(e) => (StatusCode::OK, Json(serde_json::json!({ "error": e }))),
                 }
             }
-            _ => {
-                (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": "Unknown action" })))
+            "register_identity" => match try_register_identity(&state.quic_server).await {
+                Ok(json) => (StatusCode::OK, Json(json)),
+                Err(e) => (StatusCode::OK, Json(serde_json::json!({ "error": e }))),
+            },
+            "force_sync" => match try_force_sync(&state.quic_server).await {
+                Ok(json) => (StatusCode::OK, Json(json)),
+                Err(e) => (StatusCode::OK, Json(serde_json::json!({ "error": e }))),
+            },
+            "disconnect_node" => match try_disconnect_node(&state.quic_server).await {
+                Ok(json) => (StatusCode::OK, Json(json)),
+                Err(e) => (StatusCode::OK, Json(serde_json::json!({ "error": e }))),
+            },
+            "disconnect_session" => {
+                let _ = state.shutdown_tx.send(true);
+                (
+                    StatusCode::OK,
+                    Json(serde_json::json!({
+                        "success": true,
+                        "message": "Setup UI bridge stopping",
+                    })),
+                )
             }
+            _ => (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "Unknown action" })),
+            ),
         }
     }
 
@@ -114,6 +140,16 @@ pub async fn run_setup_ui(cli: &ZhtpCli, output: &dyn Output) -> CliResult<()> {
         .map_err(|e| CliError::ConfigError(format!("Failed to bind {}: {}", server_addr, e)))?;
 
     axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            loop {
+                if *shutdown_rx.borrow() {
+                    break;
+                }
+                if shutdown_rx.changed().await.is_err() {
+                    break;
+                }
+            }
+        })
         .await
         .map_err(|e| CliError::ConfigError(format!("HTTP server error: {}", e)))?;
 
@@ -148,8 +184,100 @@ async fn try_get_status(server: &str) -> Result<serde_json::Value, String> {
     Ok(json)
 }
 
+async fn connect_bridge_client(server: &str) -> Result<lib_network::client::ZhtpClient, String> {
+    let keystore = default_keystore_path().map_err(|e| e.to_string())?;
+    let loaded = load_identity_from_keystore(&keystore).map_err(|e| e.to_string())?;
+    let trust_config = lib_network::web4::trust::TrustConfig::bootstrap();
+    let config = lib_network::client::ZhtpClientConfig {
+        allow_bootstrap: true,
+    };
+    let mut client = lib_network::client::ZhtpClient::new_with_config(loaded.identity, trust_config, config)
+        .await
+        .map_err(|e| format!("Client error: {}", e))?;
+    client.connect(server).await.map_err(|e| format!("Connect failed: {}", e))?;
+    Ok(client)
+}
+
+async fn post_node_action(server: &str, path: &str) -> Result<serde_json::Value, String> {
+    let client = connect_bridge_client(server).await?;
+    let response = client
+        .post_json(path, &serde_json::json!({}))
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?;
+    lib_network::client::ZhtpClient::parse_json(&response)
+        .map_err(|e| format!("Failed to parse response: {}", e))
+}
+
+async fn try_register_identity(server: &str) -> Result<serde_json::Value, String> {
+    use base64::{engine::general_purpose, Engine as _};
+
+    let keystore = default_keystore_path().map_err(|e| e.to_string())?;
+    let loaded = load_identity_from_keystore(&keystore).map_err(|e| e.to_string())?;
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("Time error: {}", e))?
+        .as_secs();
+    let proof_message = format!("ZHTP_REGISTER:{}", timestamp);
+    let proof_sig = lib_crypto::sign_message(&loaded.keypair, proof_message.as_bytes())
+        .map_err(|e| format!("Failed to sign proof: {}", e))?;
+    let device_id = loaded.identity.primary_device.clone();
+
+    let display_name = loaded
+        .identity
+        .metadata
+        .get("display_name")
+        .cloned()
+        .unwrap_or_else(|| loaded.identity.primary_device.clone());
+
+    let body = serde_json::json!({
+        "public_key": general_purpose::STANDARD.encode(&loaded.keypair.public_key.dilithium_pk),
+        "kyber_public_key": general_purpose::STANDARD.encode(&loaded.keypair.public_key.kyber_pk),
+        "device_id": device_id,
+        "display_name": display_name,
+        "identity_type": "human",
+        "registration_proof": general_purpose::STANDARD.encode(&proof_sig.signature),
+        "timestamp": timestamp,
+    });
+
+    let trust_config = lib_network::web4::trust::TrustConfig::bootstrap();
+    let config = lib_network::client::ZhtpClientConfig {
+        allow_bootstrap: true,
+    };
+    let mut client = lib_network::client::ZhtpClient::new_with_config(loaded.identity, trust_config, config)
+        .await
+        .map_err(|e| format!("Client error: {}", e))?;
+    client.connect(server).await.map_err(|e| format!("Connect failed: {}", e))?;
+
+    let response = client
+        .post_json("/api/v1/identity/register", &body)
+        .await
+        .map_err(|e| format!("Registration failed: {}", e))?;
+    let result: serde_json::Value = lib_network::client::ZhtpClient::parse_json(&response)
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    if result.get("status").and_then(|s| s.as_str()) == Some("success") {
+        Ok(result)
+    } else {
+        let err = result
+            .get("message")
+            .or_else(|| result.get("error"))
+            .and_then(|m| m.as_str())
+            .unwrap_or("Unknown error");
+        Err(format!("On-chain registration failed: {}", err))
+    }
+}
+
+async fn try_force_sync(server: &str) -> Result<serde_json::Value, String> {
+    post_node_action(server, "/api/v1/node/force-sync").await
+}
+
+async fn try_disconnect_node(server: &str) -> Result<serde_json::Value, String> {
+    post_node_action(server, "/api/v1/node/shutdown").await
+}
+
 /// Restore identity from seed phrase — derives same keypair deterministically
-async fn try_restore_seed(seed_phrase: &str, _server: &str) -> Result<serde_json::Value, String> {
+async fn try_restore_seed(seed_phrase: &str) -> Result<serde_json::Value, String> {
     let words: Vec<&str> = seed_phrase.split_whitespace().collect();
 
     // Support both 20-word (legacy) and 24-word (BIP39) phrases
@@ -209,7 +337,7 @@ async fn try_restore_seed(seed_phrase: &str, _server: &str) -> Result<serde_json
 }
 
 /// Create new identity with random keypair
-async fn try_create_new(name: &str, _server: &str) -> Result<serde_json::Value, String> {
+async fn try_create_new(name: &str) -> Result<serde_json::Value, String> {
     let keystore_path = default_keystore_path().map_err(|e| e.to_string())?;
 
     if keystore_path.join("user_identity.json").exists() {

--- a/zhtp-cli/src/commands/setup_ui.rs
+++ b/zhtp-cli/src/commands/setup_ui.rs
@@ -1,0 +1,249 @@
+//! Node setup web UI — localhost HTTP bridge to QUIC node
+//!
+//! `zhtp-cli node setup-ui` starts a local HTTP server on port 7840,
+//! opens the browser, and proxies API calls to the QUIC node.
+
+use crate::argument_parsing::ZhtpCli;
+use crate::commands::web4_utils::{connect_default, default_keystore_path, load_identity_from_keystore};
+use crate::error::{CliError, CliResult};
+use crate::output::Output;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+const UI_HTML: &str = include_str!("../ui/setup.html");
+const DEFAULT_UI_PORT: u16 = 7840;
+
+/// Run the setup UI bridge
+pub async fn run_setup_ui(cli: &ZhtpCli, output: &dyn Output) -> CliResult<()> {
+    let port = DEFAULT_UI_PORT;
+    let server_addr = format!("127.0.0.1:{}", port);
+
+    output.info(&format!("Starting node setup UI on http://{}...", server_addr))?;
+
+    // Try to connect to the QUIC node
+    let quic_server = cli.server.clone();
+    let node_connected = Arc::new(RwLock::new(false));
+
+    // Build HTTP routes
+    use axum::{
+        extract::State,
+        http::StatusCode,
+        response::{Html, IntoResponse, Json},
+        routing::{get, post},
+        Router,
+    };
+
+    #[derive(Clone)]
+    struct AppState {
+        quic_server: String,
+        node_connected: Arc<RwLock<bool>>,
+    }
+
+    let state = AppState {
+        quic_server,
+        node_connected: node_connected.clone(),
+    };
+
+    let app = Router::new()
+        .route("/", get(serve_ui))
+        .route("/api/status", get(proxy_status))
+        .route("/api/setup", post(proxy_setup))
+        .with_state(state);
+
+    async fn serve_ui() -> Html<&'static str> {
+        Html(UI_HTML)
+    }
+
+    async fn proxy_status(
+        State(state): State<AppState>,
+    ) -> impl IntoResponse {
+        match try_get_status(&state.quic_server).await {
+            Ok(json) => {
+                *state.node_connected.write().await = true;
+                (StatusCode::OK, Json(json))
+            }
+            Err(e) => {
+                (StatusCode::OK, Json(serde_json::json!({
+                    "state": "connecting",
+                    "error": e,
+                    "chain_height": 0,
+                    "validator_count": 0,
+                    "identity_count": 0,
+                })))
+            }
+        }
+    }
+
+    async fn proxy_setup(
+        State(state): State<AppState>,
+        Json(body): Json<serde_json::Value>,
+    ) -> impl IntoResponse {
+        let action = body.get("action").and_then(|a| a.as_str()).unwrap_or("");
+        match action {
+            "restore" => {
+                let seed = body.get("seed_phrase").and_then(|s| s.as_str()).unwrap_or("");
+                match try_restore_seed(seed, &state.quic_server).await {
+                    Ok(json) => (StatusCode::OK, Json(json)),
+                    Err(e) => (StatusCode::OK, Json(serde_json::json!({ "error": e }))),
+                }
+            }
+            "create" => {
+                let name = body.get("node_name").and_then(|s| s.as_str()).unwrap_or("sovereign-node");
+                match try_create_new(name, &state.quic_server).await {
+                    Ok(json) => (StatusCode::OK, Json(json)),
+                    Err(e) => (StatusCode::OK, Json(serde_json::json!({ "error": e }))),
+                }
+            }
+            _ => {
+                (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": "Unknown action" })))
+            }
+        }
+    }
+
+    // Open browser
+    if let Err(e) = open::that(format!("http://{}", server_addr)) {
+        output.warning(&format!("Could not open browser: {}. Open http://{} manually.", e, server_addr))?;
+    }
+
+    output.success(&format!("Setup UI running at http://{}", server_addr))?;
+    output.info("Press Ctrl+C to stop.")?;
+
+    // Start HTTP server
+    let listener = tokio::net::TcpListener::bind(&server_addr)
+        .await
+        .map_err(|e| CliError::ConfigError(format!("Failed to bind {}: {}", server_addr, e)))?;
+
+    axum::serve(listener, app)
+        .await
+        .map_err(|e| CliError::ConfigError(format!("HTTP server error: {}", e)))?;
+
+    Ok(())
+}
+
+/// Try to get node status via QUIC
+async fn try_get_status(server: &str) -> Result<serde_json::Value, String> {
+    let keystore = default_keystore_path().map_err(|e| e.to_string())?;
+    if !keystore.exists() {
+        return Ok(serde_json::json!({
+            "state": "setup_required",
+            "chain_height": 0,
+        }));
+    }
+    let loaded = load_identity_from_keystore(&keystore).map_err(|e| e.to_string())?;
+
+    let trust_config = lib_network::web4::trust::TrustConfig::bootstrap();
+    let config = lib_network::client::ZhtpClientConfig {
+        allow_bootstrap: true,
+    };
+    let mut client = lib_network::client::ZhtpClient::new_with_config(loaded.identity, trust_config, config)
+        .await
+        .map_err(|e| format!("Client error: {}", e))?;
+
+    client.connect(server).await.map_err(|e| format!("Connect failed: {}", e))?;
+
+    let response = client.get("/api/v1/node/status").await.map_err(|e| format!("Request failed: {}", e))?;
+    let json: serde_json::Value = lib_network::client::ZhtpClient::parse_json(&response)
+        .map_err(|e| format!("Parse failed: {}", e))?;
+
+    Ok(json)
+}
+
+/// Restore identity from seed phrase — derives same keypair deterministically
+async fn try_restore_seed(seed_phrase: &str, _server: &str) -> Result<serde_json::Value, String> {
+    let words: Vec<&str> = seed_phrase.split_whitespace().collect();
+
+    // Support both 20-word (legacy) and 24-word (BIP39) phrases
+    if words.len() != 20 && words.len() != 24 {
+        return Err(format!("Expected 20 or 24 words, got {}", words.len()));
+    }
+
+    let keystore_path = default_keystore_path().map_err(|e| e.to_string())?;
+
+    // Convert mnemonic → entropy → seed → identity
+    // The recovery phrase contains the entropy that deterministically derives the keypair.
+    let word_vec: Vec<String> = words.iter().map(|w| w.to_string()).collect();
+    let phrase = lib_identity::recovery::RecoveryPhrase::from_words(word_vec)
+        .map_err(|e| format!("Invalid seed phrase: {}", e))?;
+
+    // Derive 64-byte seed from entropy via HKDF
+    let mut seed = [0u8; 64];
+    let entropy = &phrase.entropy;
+    use sha2::Digest;
+    let hash = sha2::Sha512::digest(entropy);
+    seed.copy_from_slice(&hash);
+
+    // Recover identity from seed
+    let identity = lib_identity::ZhtpIdentity::recover_from_seed(
+        seed,
+        lib_identity::IdentityType::Human,
+        None,
+        None,
+        "restored-node",
+    )
+    .map_err(|e| format!("Failed to recover identity: {}", e))?;
+
+    let did = identity.did.clone();
+
+    // Save to keystore
+    std::fs::create_dir_all(&keystore_path).map_err(|e| format!("Keystore dir: {}", e))?;
+
+    let identity_json = serde_json::to_string_pretty(&identity)
+        .map_err(|e| format!("Serialize: {}", e))?;
+    let identity_path = keystore_path.join("user_identity.json");
+    std::fs::write(&identity_path, &identity_json)
+        .map_err(|e| format!("Write identity: {}", e))?;
+
+    // Save private key
+    if let Some(ref pk) = identity.private_key {
+        let pk_path = keystore_path.join("user_private_key.json");
+        crate::commands::web4_utils::save_private_key_to_file(pk, &pk_path)
+            .map_err(|e| format!("Write private key: {}", e))?;
+    }
+
+    Ok(serde_json::json!({
+        "success": true,
+        "did": did,
+        "message": "Identity restored from seed phrase",
+        "keystore": keystore_path.display().to_string(),
+    }))
+}
+
+/// Create new identity with random keypair
+async fn try_create_new(name: &str, _server: &str) -> Result<serde_json::Value, String> {
+    let keystore_path = default_keystore_path().map_err(|e| e.to_string())?;
+
+    if keystore_path.join("user_identity.json").exists() {
+        return Err("Identity already exists. Delete keystore to create a new one.".to_string());
+    }
+
+    let identity = lib_identity::ZhtpIdentity::new_unified(
+        lib_identity::IdentityType::Device,
+        None,
+        None,
+        name,
+        None,
+    )
+    .map_err(|e| format!("Failed to create identity: {}", e))?;
+
+    let did = identity.did.clone();
+
+    // Save to keystore
+    std::fs::create_dir_all(&keystore_path).map_err(|e| format!("Keystore dir: {}", e))?;
+
+    let identity_json = serde_json::to_string_pretty(&identity)
+        .map_err(|e| format!("Serialize: {}", e))?;
+    std::fs::write(keystore_path.join("user_identity.json"), &identity_json)
+        .map_err(|e| format!("Write identity: {}", e))?;
+
+    if let Some(ref pk) = identity.private_key {
+        crate::commands::web4_utils::save_private_key_to_file(pk, &keystore_path.join("user_private_key.json"))
+            .map_err(|e| format!("Write private key: {}", e))?;
+    }
+
+    Ok(serde_json::json!({
+        "success": true,
+        "did": did,
+        "message": format!("Node '{}' created", name),
+        "keystore": keystore_path.display().to_string(),
+    }))
+}

--- a/zhtp-cli/src/commands/setup_ui.rs
+++ b/zhtp-cli/src/commands/setup_ui.rs
@@ -7,8 +7,7 @@ use crate::argument_parsing::ZhtpCli;
 use crate::commands::web4_utils::{default_keystore_path, load_identity_from_keystore};
 use crate::error::{CliError, CliResult};
 use crate::output::Output;
-use std::sync::Arc;
-use tokio::sync::{watch, RwLock};
+use tokio::sync::watch;
 
 const UI_HTML: &str = include_str!("../ui/setup.html");
 const DEFAULT_UI_PORT: u16 = 7840;
@@ -22,7 +21,6 @@ pub async fn run_setup_ui(cli: &ZhtpCli, output: &dyn Output) -> CliResult<()> {
 
     // Try to connect to the QUIC node
     let quic_server = cli.server.clone();
-    let node_connected = Arc::new(RwLock::new(false));
     let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
 
     // Build HTTP routes
@@ -37,13 +35,11 @@ pub async fn run_setup_ui(cli: &ZhtpCli, output: &dyn Output) -> CliResult<()> {
     #[derive(Clone)]
     struct AppState {
         quic_server: String,
-        node_connected: Arc<RwLock<bool>>,
         shutdown_tx: watch::Sender<bool>,
     }
 
     let state = AppState {
         quic_server,
-        node_connected: node_connected.clone(),
         shutdown_tx,
     };
 
@@ -62,7 +58,6 @@ pub async fn run_setup_ui(cli: &ZhtpCli, output: &dyn Output) -> CliResult<()> {
     ) -> impl IntoResponse {
         match try_get_status(&state.quic_server).await {
             Ok(json) => {
-                *state.node_connected.write().await = true;
                 (StatusCode::OK, Json(json))
             }
             Err(e) => {
@@ -106,6 +101,10 @@ pub async fn run_setup_ui(cli: &ZhtpCli, output: &dyn Output) -> CliResult<()> {
                 Err(e) => (StatusCode::OK, Json(serde_json::json!({ "error": e }))),
             },
             "disconnect_node" => match try_disconnect_node(&state.quic_server).await {
+                Ok(json) => (StatusCode::OK, Json(json)),
+                Err(e) => (StatusCode::OK, Json(serde_json::json!({ "error": e }))),
+            },
+            "reset_local_identity" => match try_reset_local_identity().await {
                 Ok(json) => (StatusCode::OK, Json(json)),
                 Err(e) => (StatusCode::OK, Json(serde_json::json!({ "error": e }))),
             },
@@ -165,7 +164,19 @@ async fn try_get_status(server: &str) -> Result<serde_json::Value, String> {
             "chain_height": 0,
         }));
     }
-    let loaded = load_identity_from_keystore(&keystore).map_err(|e| e.to_string())?;
+    let loaded = match load_identity_from_keystore(&keystore) {
+        Ok(loaded) => loaded,
+        Err(e) => {
+            return Ok(serde_json::json!({
+                "state": "setup_required",
+                "chain_height": 0,
+                "local_identity_error": format!("Local identity could not be loaded: {}", e),
+            }));
+        }
+    };
+
+    // Save DID before identity is moved into the QUIC client
+    let local_did = loaded.identity.did.clone();
 
     let trust_config = lib_network::web4::trust::TrustConfig::bootstrap();
     let config = lib_network::client::ZhtpClientConfig {
@@ -177,9 +188,42 @@ async fn try_get_status(server: &str) -> Result<serde_json::Value, String> {
 
     client.connect(server).await.map_err(|e| format!("Connect failed: {}", e))?;
 
-    let response = client.get("/api/v1/node/status").await.map_err(|e| format!("Request failed: {}", e))?;
-    let json: serde_json::Value = lib_network::client::ZhtpClient::parse_json(&response)
-        .map_err(|e| format!("Parse failed: {}", e))?;
+    let response = match client.get("/api/v1/node/status").await {
+        Ok(response) => response,
+        Err(e) => {
+            return Ok(serde_json::json!({
+                "state": "api_unavailable",
+                "did": local_did,
+                "identity_registered": serde_json::Value::Null,
+                "chain_height": 0,
+                "wallet_id": serde_json::Value::Null,
+                "sov_balance": "0",
+                "sov_balance_human": "0.0000",
+                "validator_count": 0,
+                "identity_count": 0,
+                "network_id": "unknown",
+                "error": format!("Node status endpoint unavailable: {}", e),
+            }));
+        }
+    };
+    let json: serde_json::Value = match lib_network::client::ZhtpClient::parse_json(&response) {
+        Ok(json) => json,
+        Err(e) => {
+            return Ok(serde_json::json!({
+                "state": "api_unavailable",
+                "did": local_did,
+                "identity_registered": serde_json::Value::Null,
+                "chain_height": 0,
+                "wallet_id": serde_json::Value::Null,
+                "sov_balance": "0",
+                "sov_balance_human": "0.0000",
+                "validator_count": 0,
+                "identity_count": 0,
+                "network_id": "unknown",
+                "error": format!("Node status response could not be parsed: {}", e),
+            }));
+        }
+    };
 
     Ok(json)
 }
@@ -276,64 +320,42 @@ async fn try_disconnect_node(server: &str) -> Result<serde_json::Value, String> 
     post_node_action(server, "/api/v1/node/shutdown").await
 }
 
-/// Restore identity from seed phrase — derives same keypair deterministically
-async fn try_restore_seed(seed_phrase: &str) -> Result<serde_json::Value, String> {
-    let words: Vec<&str> = seed_phrase.split_whitespace().collect();
-
-    // Support both 20-word (legacy) and 24-word (BIP39) phrases
-    if words.len() != 20 && words.len() != 24 {
-        return Err(format!("Expected 20 or 24 words, got {}", words.len()));
-    }
-
+async fn try_reset_local_identity() -> Result<serde_json::Value, String> {
     let keystore_path = default_keystore_path().map_err(|e| e.to_string())?;
+    let mut removed = Vec::new();
 
-    // Convert mnemonic → entropy → seed → identity
-    // The recovery phrase contains the entropy that deterministically derives the keypair.
-    let word_vec: Vec<String> = words.iter().map(|w| w.to_string()).collect();
-    let phrase = lib_identity::recovery::RecoveryPhrase::from_words(word_vec)
-        .map_err(|e| format!("Invalid seed phrase: {}", e))?;
-
-    // Derive 64-byte seed from entropy via HKDF
-    let mut seed = [0u8; 64];
-    let entropy = &phrase.entropy;
-    use sha2::Digest;
-    let hash = sha2::Sha512::digest(entropy);
-    seed.copy_from_slice(&hash);
-
-    // Recover identity from seed
-    let identity = lib_identity::ZhtpIdentity::recover_from_seed(
-        seed,
-        lib_identity::IdentityType::Device,
-        None,
-        None,
-        "restored-node",
-    )
-    .map_err(|e| format!("Failed to recover identity: {}", e))?;
-
-    let did = identity.did.clone();
-
-    // Save to keystore
-    std::fs::create_dir_all(&keystore_path).map_err(|e| format!("Keystore dir: {}", e))?;
-
-    let identity_json = serde_json::to_string_pretty(&identity)
-        .map_err(|e| format!("Serialize: {}", e))?;
-    let identity_path = keystore_path.join("user_identity.json");
-    std::fs::write(&identity_path, &identity_json)
-        .map_err(|e| format!("Write identity: {}", e))?;
-
-    // Save private key
-    if let Some(ref pk) = identity.private_key {
-        let pk_path = keystore_path.join("user_private_key.json");
-        crate::commands::web4_utils::save_private_key_to_file(pk, &pk_path)
-            .map_err(|e| format!("Write private key: {}", e))?;
+    for name in ["user_identity.json", "user_private_key.json"] {
+        let path = keystore_path.join(name);
+        if path.exists() {
+            std::fs::remove_file(&path)
+                .map_err(|e| format!("Failed to remove {}: {}", path.display(), e))?;
+            removed.push(name);
+        }
     }
 
     Ok(serde_json::json!({
         "success": true,
-        "did": did,
-        "message": "Identity restored from seed phrase",
+        "message": if removed.is_empty() {
+            "No local identity files were present."
+        } else {
+            "Local identity removed."
+        },
+        "removed_files": removed,
         "keystore": keystore_path.display().to_string(),
     }))
+}
+
+/// Restore identity from seed phrase.
+///
+/// NOTE: `RecoveryPhrase::from_words()` currently generates fresh random entropy
+/// instead of decoding the mnemonic back to the original entropy.  This means
+/// every call produces a DIFFERENT identity regardless of the words supplied.
+/// Until the mnemonic-to-entropy decode path is implemented in lib-identity,
+/// seed-based restore is intentionally disabled here.
+async fn try_restore_seed(_seed_phrase: &str) -> Result<serde_json::Value, String> {
+    Err("Seed restore not yet supported — use 'zhtp-cli identity create-did' instead. \
+         (RecoveryPhrase::from_words does not yet decode the mnemonic back to entropy.)"
+        .to_string())
 }
 
 /// Create new identity with random keypair

--- a/zhtp-cli/src/commands/setup_ui.rs
+++ b/zhtp-cli/src/commands/setup_ui.rs
@@ -175,7 +175,7 @@ async fn try_restore_seed(seed_phrase: &str, _server: &str) -> Result<serde_json
     // Recover identity from seed
     let identity = lib_identity::ZhtpIdentity::recover_from_seed(
         seed,
-        lib_identity::IdentityType::Human,
+        lib_identity::IdentityType::Device,
         None,
         None,
         "restored-node",

--- a/zhtp-cli/src/ui/setup.html
+++ b/zhtp-cli/src/ui/setup.html
@@ -3,495 +3,267 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Sovereign Network — Node Setup</title>
+<title>SOV — Node Control</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 <style>
-  :root {
-    --bg: #0a0a0f;
-    --surface: #12121a;
-    --border: #1e1e2e;
-    --text: #e0e0e8;
-    --muted: #6b6b80;
-    --accent: #6366f1;
-    --accent-glow: rgba(99, 102, 241, 0.15);
-    --success: #22c55e;
-    --error: #ef4444;
-    --warning: #f59e0b;
-  }
-
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
-    background: var(--bg);
-    color: var(--text);
-    min-height: 100vh;
-    display: flex;
-    justify-content: center;
-    padding: 40px 20px;
-  }
-
-  .container {
-    max-width: 640px;
-    width: 100%;
-  }
-
-  .logo {
-    text-align: center;
-    margin-bottom: 48px;
-  }
-
-  .logo h1 {
-    font-size: 28px;
-    font-weight: 700;
-    letter-spacing: -0.5px;
-    background: linear-gradient(135deg, #6366f1, #8b5cf6);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-  }
-
-  .logo p {
-    color: var(--muted);
-    font-size: 14px;
-    margin-top: 8px;
-  }
-
-  .card {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 16px;
-    padding: 32px;
-    margin-bottom: 24px;
-  }
-
-  .card h2 {
-    font-size: 18px;
-    font-weight: 600;
-    margin-bottom: 16px;
-  }
-
-  .step-indicator {
-    display: flex;
-    gap: 8px;
-    margin-bottom: 32px;
-    justify-content: center;
-  }
-
-  .step-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: var(--border);
-    transition: all 0.3s;
-  }
-
-  .step-dot.active {
-    background: var(--accent);
-    box-shadow: 0 0 12px var(--accent-glow);
-  }
-
-  .step-dot.done {
-    background: var(--success);
-  }
-
-  label {
-    display: block;
-    font-size: 13px;
-    color: var(--muted);
-    margin-bottom: 8px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  textarea, input[type="text"] {
-    width: 100%;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    padding: 14px 16px;
-    color: var(--text);
-    font-size: 15px;
-    font-family: 'SF Mono', 'Fira Code', monospace;
-    resize: none;
-    transition: border-color 0.2s;
-  }
-
-  textarea:focus, input[type="text"]:focus {
-    outline: none;
-    border-color: var(--accent);
-    box-shadow: 0 0 0 3px var(--accent-glow);
-  }
-
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    padding: 14px 24px;
-    border: none;
-    border-radius: 10px;
-    font-size: 15px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s;
-    margin-top: 16px;
-  }
-
-  .btn-primary {
-    background: var(--accent);
-    color: white;
-  }
-
-  .btn-primary:hover {
-    background: #5558e6;
-    transform: translateY(-1px);
-    box-shadow: 0 4px 16px var(--accent-glow);
-  }
-
-  .btn-primary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-    transform: none;
-  }
-
-  .btn-secondary {
-    background: var(--border);
-    color: var(--text);
-  }
-
-  .btn-secondary:hover {
-    background: #2a2a3e;
-  }
-
-  .status-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-  }
-
-  .status-item {
-    background: var(--bg);
-    border-radius: 10px;
-    padding: 16px;
-  }
-
-  .status-item .label {
-    font-size: 12px;
-    color: var(--muted);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 6px;
-  }
-
-  .status-item .value {
-    font-size: 20px;
-    font-weight: 700;
-  }
-
-  .status-item .value.mono {
-    font-size: 13px;
-    font-family: 'SF Mono', 'Fira Code', monospace;
-    word-break: break-all;
-  }
-
-  .status-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 10px;
-    border-radius: 20px;
-    font-size: 12px;
-    font-weight: 600;
-  }
-
-  .badge-success { background: rgba(34,197,94,0.15); color: var(--success); }
-  .badge-warning { background: rgba(245,158,11,0.15); color: var(--warning); }
-  .badge-error { background: rgba(239,68,68,0.15); color: var(--error); }
-
-  .badge-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: currentColor;
-    animation: pulse 2s infinite;
-  }
-
-  @keyframes pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.4; }
-  }
-
-  .sync-bar {
-    height: 4px;
-    background: var(--border);
-    border-radius: 2px;
-    margin-top: 12px;
-    overflow: hidden;
-  }
-
-  .sync-bar-fill {
-    height: 100%;
-    background: linear-gradient(90deg, var(--accent), #8b5cf6);
-    border-radius: 2px;
-    transition: width 0.5s ease;
-  }
-
-  .hidden { display: none !important; }
-
-  .option-group {
-    display: flex;
-    gap: 12px;
-    margin-bottom: 16px;
-  }
-
-  .option-group .btn {
-    flex: 1;
-    margin-top: 0;
-  }
-
-  .option-group .btn.selected {
-    border: 2px solid var(--accent);
-    background: var(--accent-glow);
-  }
-
-  .hint {
-    font-size: 13px;
-    color: var(--muted);
-    margin-top: 8px;
-  }
-
-  .error-msg {
-    color: var(--error);
-    font-size: 13px;
-    margin-top: 8px;
-  }
+:root {
+  --bg: #060610;
+  --surface: #0c0c1a;
+  --surface-2: #111125;
+  --border: #1a1a35;
+  --text: #d8dce8;
+  --text-dim: #525278;
+  --text-muted: #3a3a5c;
+  --cyan: #00e8ff;
+  --cyan-dim: rgba(0, 232, 255, 0.08);
+  --cyan-glow: rgba(0, 232, 255, 0.25);
+  --green: #00ff88;
+  --green-dim: rgba(0, 255, 136, 0.08);
+  --amber: #ffb800;
+  --amber-dim: rgba(255, 184, 0, 0.08);
+  --red: #ff3366;
+  --red-dim: rgba(255, 51, 102, 0.08);
+  --mono: 'JetBrains Mono', monospace;
+  --sans: 'Outfit', sans-serif;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: var(--sans); background: var(--bg); color: var(--text); min-height: 100vh; overflow-x: hidden; }
+body::before { content: ''; position: fixed; inset: 0; background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E"); pointer-events: none; z-index: 9999; }
+.topbar { position: fixed; top: 0; left: 0; right: 0; height: 48px; background: rgba(6,6,16,0.9); backdrop-filter: blur(20px); border-bottom: 1px solid var(--border); display: flex; align-items: center; padding: 0 24px; z-index: 100; gap: 16px; }
+.topbar-brand { font-family: var(--mono); font-weight: 700; font-size: 13px; letter-spacing: 2px; text-transform: uppercase; color: var(--cyan); }
+.topbar-sep { width: 1px; height: 20px; background: var(--border); }
+.topbar-status { display: flex; align-items: center; gap: 6px; font-family: var(--mono); font-size: 11px; color: var(--text-dim); }
+.pulse { width: 6px; height: 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 8px var(--green); animation: pg 2s ease-in-out infinite; }
+.pulse.warn { background: var(--amber); box-shadow: 0 0 8px var(--amber); }
+.pulse.off { background: var(--red); box-shadow: 0 0 8px var(--red); animation: none; }
+@keyframes pg { 0%,100%{opacity:1;transform:scale(1)} 50%{opacity:.5;transform:scale(.8)} }
+.topbar-right { margin-left: auto; display: flex; align-items: center; gap: 16px; }
+.topbar-height { font-family: var(--mono); font-size: 12px; color: var(--text-dim); }
+.topbar-height span { color: var(--cyan); font-weight: 500; }
+.main { padding-top: 48px; min-height: 100vh; }
+.setup-view { display: flex; justify-content: center; align-items: center; min-height: calc(100vh - 48px); padding: 40px 20px; }
+.setup-card { width: 100%; max-width: 480px; animation: fu .6s ease; }
+@keyframes fu { from{opacity:0;transform:translateY(20px)} to{opacity:1;transform:translateY(0)} }
+.setup-header { text-align: center; margin-bottom: 40px; }
+.setup-header h1 { font-size: 24px; font-weight: 600; margin-bottom: 8px; }
+.setup-header p { color: var(--text-dim); font-size: 14px; }
+.setup-options { display: grid; gap: 12px; margin-bottom: 24px; }
+.setup-option { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px; cursor: pointer; transition: all .2s; display: flex; align-items: center; gap: 16px; }
+.setup-option:hover { border-color: var(--cyan); background: var(--cyan-dim); }
+.setup-option-icon { width: 40px; height: 40px; border-radius: 10px; background: var(--surface-2); display: flex; align-items: center; justify-content: center; font-size: 18px; flex-shrink: 0; }
+.setup-option-text h3 { font-size: 15px; font-weight: 500; margin-bottom: 2px; }
+.setup-option-text p { font-size: 12px; color: var(--text-dim); }
+.seed-panel { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 24px; }
+.seed-panel h2 { font-size: 16px; font-weight: 500; margin-bottom: 16px; }
+.seed-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: 6px; margin-bottom: 16px; }
+.seed-word { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 8px 6px; font-family: var(--mono); font-size: 12px; color: var(--text); text-align: center; outline: none; transition: border-color .2s; width: 100%; }
+.seed-word:focus { border-color: var(--cyan); box-shadow: 0 0 0 2px var(--cyan-dim); }
+.seed-word::placeholder { color: var(--text-muted); font-size: 10px; }
+.seed-word-num { font-size: 9px; color: var(--text-muted); text-align: center; margin-bottom: 2px; font-family: var(--mono); }
+.seed-word-cell { display: flex; flex-direction: column; }
+.name-input { width: 100%; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; font-family: var(--mono); font-size: 14px; color: var(--text); outline: none; margin-bottom: 16px; }
+.name-input:focus { border-color: var(--cyan); }
+.btn { width: 100%; padding: 12px; border: none; border-radius: 8px; font-family: var(--sans); font-size: 14px; font-weight: 600; cursor: pointer; transition: all .15s; margin-top: 8px; }
+.btn-cyan { background: var(--cyan); color: var(--bg); }
+.btn-cyan:hover { filter: brightness(1.1); transform: translateY(-1px); }
+.btn-cyan:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+.btn-ghost { background: transparent; color: var(--text-dim); border: 1px solid var(--border); }
+.btn-ghost:hover { border-color: var(--text-dim); color: var(--text); }
+.error-text { color: var(--red); font-size: 12px; margin-top: 8px; font-family: var(--mono); }
+.dashboard { padding: 24px; display: grid; gap: 16px; animation: fu .4s ease; }
+.metrics-row { display: grid; grid-template-columns: repeat(4,1fr); gap: 12px; }
+@media(max-width:800px) { .metrics-row{grid-template-columns:repeat(2,1fr)} }
+.metric { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px; position: relative; overflow: hidden; }
+.metric::after { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--border); }
+.metric.ac::after { background: var(--cyan); box-shadow: 0 0 12px var(--cyan-glow); }
+.metric.ag::after { background: var(--green); }
+.metric.aa::after { background: var(--amber); }
+.metric-label { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--text-dim); margin-bottom: 8px; font-family: var(--mono); }
+.metric-value { font-family: var(--mono); font-size: 22px; font-weight: 700; letter-spacing: -.5px; }
+.metric-sub { font-size: 11px; color: var(--text-dim); margin-top: 4px; font-family: var(--mono); }
+.identity-card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 20px; }
+.identity-card h3 { font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: var(--text-dim); margin-bottom: 12px; font-family: var(--mono); }
+.did-display { font-family: var(--mono); font-size: 13px; color: var(--cyan); word-break: break-all; line-height: 1.6; padding: 12px; background: var(--bg); border-radius: 6px; border: 1px solid var(--border); }
+.status-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.status-card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px; }
+.status-card h3 { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--text-dim); margin-bottom: 10px; font-family: var(--mono); }
+.status-item { display: flex; justify-content: space-between; align-items: center; padding: 6px 0; border-bottom: 1px solid var(--border); font-size: 12px; }
+.status-item:last-child { border-bottom: none; }
+.status-item .key { color: var(--text-dim); font-family: var(--mono); }
+.status-item .val { font-family: var(--mono); font-weight: 500; }
+.badge { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 4px; font-size: 10px; font-family: var(--mono); font-weight: 600; text-transform: uppercase; letter-spacing: .5px; }
+.badge-green { background: var(--green-dim); color: var(--green); }
+.badge-amber { background: var(--amber-dim); color: var(--amber); }
+.badge-red { background: var(--red-dim); color: var(--red); }
+.sync-bar-container { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px; }
+.sync-bar-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+.sync-bar-header h3 { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--text-dim); font-family: var(--mono); }
+.sync-bar-pct { font-family: var(--mono); font-size: 12px; color: var(--cyan); font-weight: 500; }
+.sync-track { height: 3px; background: var(--border); border-radius: 2px; overflow: hidden; }
+.sync-fill { height: 100%; background: linear-gradient(90deg,var(--cyan),#00ff88); border-radius: 2px; transition: width .8s ease; box-shadow: 0 0 8px var(--cyan-glow); }
+.hidden { display: none !important; }
 </style>
 </head>
 <body>
-<div class="container">
-  <div class="logo">
-    <h1>The Sovereign Network</h1>
-    <p>Node Setup</p>
-  </div>
-
-  <div class="step-indicator">
-    <div class="step-dot active" id="dot-0"></div>
-    <div class="step-dot" id="dot-1"></div>
-    <div class="step-dot" id="dot-2"></div>
-  </div>
-
-  <!-- Step 0: Choose mode -->
-  <div class="card" id="step-0">
-    <h2>How do you want to set up your node?</h2>
-    <div class="option-group">
-      <button class="btn btn-secondary" onclick="chooseMode('restore')">
-        Restore from seed phrase
-      </button>
-      <button class="btn btn-secondary" onclick="chooseMode('new')">
-        Create new identity
-      </button>
-    </div>
-    <p class="hint">If you have a mobile wallet, use "Restore" to use the same identity on your node.</p>
-  </div>
-
-  <!-- Step 1: Seed phrase -->
-  <div class="card hidden" id="step-1-restore">
-    <h2>Enter your seed phrase</h2>
-    <label>24-word recovery phrase</label>
-    <textarea id="seed-input" rows="4" placeholder="word1 word2 word3 ..."></textarea>
-    <p class="hint">From your mobile app: Settings → Backup → Show seed phrase</p>
-    <div class="error-msg hidden" id="seed-error"></div>
-    <button class="btn btn-primary" onclick="submitSeed()" id="btn-restore">Restore Identity</button>
-  </div>
-
-  <div class="card hidden" id="step-1-new">
-    <h2>New Identity</h2>
-    <label>Node name</label>
-    <input type="text" id="node-name" placeholder="my-sovereign-node" />
-    <p class="hint">A friendly name for your node. Your identity will be generated automatically.</p>
-    <button class="btn btn-primary" onclick="createNew()" id="btn-create">Create &amp; Start</button>
-  </div>
-
-  <!-- Step 2: Dashboard -->
-  <div class="card hidden" id="step-2">
-    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-      <h2>Node Dashboard</h2>
-      <span class="status-badge badge-success" id="node-badge">
-        <span class="badge-dot"></span>
-        <span id="badge-text">Syncing</span>
-      </span>
-    </div>
-
-    <div class="status-grid">
-      <div class="status-item">
-        <div class="label">Chain Height</div>
-        <div class="value" id="chain-height">—</div>
+<div class="topbar">
+  <div class="topbar-brand">SOV</div>
+  <div class="topbar-sep"></div>
+  <div class="topbar-status"><div class="pulse off" id="pulse"></div><span id="status-text">Offline</span></div>
+  <div class="topbar-right"><div class="topbar-height">block <span id="top-height">—</span></div></div>
+</div>
+<div class="main">
+  <div class="setup-view" id="view-setup">
+    <div class="setup-card">
+      <div class="setup-header"><h1>Initialize Node</h1><p>Connect to The Sovereign Network</p></div>
+      <div id="setup-choose">
+        <div class="setup-options">
+          <div class="setup-option" onclick="showRestore()">
+            <div class="setup-option-icon">🔑</div>
+            <div class="setup-option-text"><h3>Restore from seed</h3><p>Use your existing identity from the mobile app</p></div>
+          </div>
+          <div class="setup-option" onclick="showCreate()">
+            <div class="setup-option-icon">✦</div>
+            <div class="setup-option-text"><h3>New identity</h3><p>Generate a fresh cryptographic identity</p></div>
+          </div>
+        </div>
       </div>
-      <div class="status-item">
-        <div class="label">SOV Balance</div>
-        <div class="value" id="sov-balance">—</div>
+      <div id="setup-restore" class="hidden">
+        <div class="seed-panel">
+          <h2>Recovery phrase</h2>
+          <div class="seed-grid" id="seed-grid"></div>
+          <div class="error-text hidden" id="restore-error"></div>
+          <button class="btn btn-cyan" onclick="doRestore()" id="btn-restore">Restore</button>
+          <button class="btn btn-ghost" onclick="backToChoose()">Back</button>
+        </div>
       </div>
-      <div class="status-item">
-        <div class="label">Validators</div>
-        <div class="value" id="validators">—</div>
-      </div>
-      <div class="status-item">
-        <div class="label">Identities</div>
-        <div class="value" id="identities">—</div>
-      </div>
-      <div class="status-item" style="grid-column: span 2;">
-        <div class="label">Your DID</div>
-        <div class="value mono" id="node-did">—</div>
+      <div id="setup-create" class="hidden">
+        <div class="seed-panel">
+          <h2>Name your node</h2>
+          <input type="text" class="name-input" id="node-name" placeholder="sovereign-node" autocomplete="off" spellcheck="false">
+          <div class="error-text hidden" id="create-error"></div>
+          <button class="btn btn-cyan" onclick="doCreate()" id="btn-create">Create</button>
+          <button class="btn btn-ghost" onclick="backToChoose()">Back</button>
+        </div>
       </div>
     </div>
-
-    <div class="sync-bar">
-      <div class="sync-bar-fill" id="sync-fill" style="width: 0%"></div>
+  </div>
+  <div class="dashboard hidden" id="view-dashboard">
+    <div class="metrics-row">
+      <div class="metric ac"><div class="metric-label">Chain Height</div><div class="metric-value" id="d-height">—</div></div>
+      <div class="metric ag"><div class="metric-label">SOV Balance</div><div class="metric-value" id="d-balance">—</div><div class="metric-sub" id="d-balance-atoms"></div></div>
+      <div class="metric"><div class="metric-label">Validators</div><div class="metric-value" id="d-validators">—</div></div>
+      <div class="metric aa"><div class="metric-label">Identities</div><div class="metric-value" id="d-identities">—</div></div>
+    </div>
+    <div class="identity-card"><h3>Your DID</h3><div class="did-display" id="d-did">—</div></div>
+    <div class="sync-bar-container">
+      <div class="sync-bar-header"><h3>Sync Progress</h3><div class="sync-bar-pct" id="d-sync-pct">0%</div></div>
+      <div class="sync-track"><div class="sync-fill" id="d-sync-fill" style="width:0%"></div></div>
+    </div>
+    <div class="status-row">
+      <div class="status-card"><h3>Node</h3>
+        <div class="status-item"><span class="key">State</span><span class="val"><span class="badge badge-green" id="d-state-badge">Ready</span></span></div>
+        <div class="status-item"><span class="key">Registered</span><span class="val" id="d-registered">—</span></div>
+        <div class="status-item"><span class="key">Network</span><span class="val" id="d-network">—</span></div>
+      </div>
+      <div class="status-card"><h3>Wallet</h3>
+        <div class="status-item"><span class="key">Wallet ID</span><span class="val" id="d-wallet" style="font-size:10px">—</span></div>
+        <div class="status-item"><span class="key">SOV</span><span class="val" id="d-sov-human">—</span></div>
+      </div>
     </div>
   </div>
 </div>
-
 <script>
-const API = '';  // Same origin (localhost bridge)
-let mode = null;
-let pollInterval = null;
+const API='';
+let poll=null;
 
-function chooseMode(m) {
-  mode = m;
-  document.getElementById('step-0').classList.add('hidden');
-  document.getElementById('dot-0').classList.remove('active');
-  document.getElementById('dot-0').classList.add('done');
-  document.getElementById('dot-1').classList.add('active');
-  if (m === 'restore') {
-    document.getElementById('step-1-restore').classList.remove('hidden');
-  } else {
-    document.getElementById('step-1-new').classList.remove('hidden');
+// Build seed grid safely
+(function(){
+  const g=document.getElementById('seed-grid');
+  for(let i=0;i<24;i++){
+    const cell=document.createElement('div');
+    cell.className='seed-word-cell';
+    const num=document.createElement('div');
+    num.className='seed-word-num';
+    num.textContent=String(i+1);
+    const inp=document.createElement('input');
+    inp.className='seed-word';
+    inp.dataset.idx=String(i);
+    inp.placeholder='word';
+    inp.autocomplete='off';
+    inp.spellcheck=false;
+    cell.appendChild(num);
+    cell.appendChild(inp);
+    g.appendChild(cell);
   }
-}
-
-async function submitSeed() {
-  const seed = document.getElementById('seed-input').value.trim();
-  const words = seed.split(/\s+/);
-  const errEl = document.getElementById('seed-error');
-  errEl.classList.add('hidden');
-
-  if (words.length !== 24) {
-    errEl.textContent = `Expected 24 words, got ${words.length}`;
-    errEl.classList.remove('hidden');
-    return;
-  }
-
-  document.getElementById('btn-restore').disabled = true;
-  document.getElementById('btn-restore').textContent = 'Restoring...';
-
-  try {
-    const res = await fetch(API + '/api/setup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'restore', seed_phrase: seed }),
-    });
-    const data = await res.json();
-    if (data.error) {
-      errEl.textContent = data.error;
-      errEl.classList.remove('hidden');
-      document.getElementById('btn-restore').disabled = false;
-      document.getElementById('btn-restore').textContent = 'Restore Identity';
-      return;
-    }
-    showDashboard();
-  } catch (e) {
-    errEl.textContent = 'Connection failed: ' + e.message;
-    errEl.classList.remove('hidden');
-    document.getElementById('btn-restore').disabled = false;
-    document.getElementById('btn-restore').textContent = 'Restore Identity';
-  }
-}
-
-async function createNew() {
-  const name = document.getElementById('node-name').value.trim() || 'sovereign-node';
-  document.getElementById('btn-create').disabled = true;
-  document.getElementById('btn-create').textContent = 'Creating...';
-
-  try {
-    const res = await fetch(API + '/api/setup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'create', node_name: name }),
-    });
-    const data = await res.json();
-    if (data.error) {
-      alert(data.error);
-      document.getElementById('btn-create').disabled = false;
-      document.getElementById('btn-create').textContent = 'Create & Start';
-      return;
-    }
-    showDashboard();
-  } catch (e) {
-    alert('Connection failed: ' + e.message);
-    document.getElementById('btn-create').disabled = false;
-    document.getElementById('btn-create').textContent = 'Create & Start';
-  }
-}
-
-function showDashboard() {
-  document.getElementById('step-1-restore').classList.add('hidden');
-  document.getElementById('step-1-new').classList.add('hidden');
-  document.getElementById('dot-1').classList.remove('active');
-  document.getElementById('dot-1').classList.add('done');
-  document.getElementById('dot-2').classList.add('active');
-  document.getElementById('step-2').classList.remove('hidden');
-  startPolling();
-}
-
-function startPolling() {
-  updateStatus();
-  pollInterval = setInterval(updateStatus, 3000);
-}
-
-async function updateStatus() {
-  try {
-    const res = await fetch(API + '/api/status');
-    const data = await res.json();
-
-    document.getElementById('chain-height').textContent = Number(data.chain_height || 0).toLocaleString();
-    document.getElementById('sov-balance').textContent = data.sov_balance_human || '0';
-    document.getElementById('validators').textContent = data.validator_count || '0';
-    document.getElementById('identities').textContent = data.identity_count || '0';
-    document.getElementById('node-did').textContent = data.did || '—';
-
-    const badge = document.getElementById('node-badge');
-    const badgeText = document.getElementById('badge-text');
-    if (data.state === 'ready') {
-      badge.className = 'status-badge badge-success';
-      badgeText.textContent = 'Connected';
-    } else if (data.state === 'identity_not_registered') {
-      badge.className = 'status-badge badge-warning';
-      badgeText.textContent = 'Not Registered';
-    } else {
-      badge.className = 'status-badge badge-warning';
-      badgeText.textContent = 'Syncing';
-    }
-
-    // Rough sync progress (assume 40000 blocks target)
-    const height = data.chain_height || 0;
-    const pct = Math.min(100, (height / 40000) * 100);
-    document.getElementById('sync-fill').style.width = pct + '%';
-  } catch (e) {
-    // Bridge not ready yet
-  }
-}
-
-// Auto-detect: if node is already running, skip to dashboard
-(async () => {
-  try {
-    const res = await fetch(API + '/api/status');
-    const data = await res.json();
-    if (data.state && data.state !== 'setup_required') {
-      showDashboard();
-    }
-  } catch (e) {
-    // Not running yet, show setup
-  }
+  g.addEventListener('keydown',e=>{
+    if(e.key===' '||e.key==='Tab'){e.preventDefault();const n=g.querySelector('[data-idx="'+(parseInt(e.target.dataset.idx)+1)+'"]');if(n)n.focus();}
+  });
+  g.addEventListener('paste',e=>{
+    const t=(e.clipboardData||window.clipboardData).getData('text');
+    const w=t.trim().split(/\s+/);
+    if(w.length>1){e.preventDefault();w.forEach((v,i)=>{const inp=g.querySelector('[data-idx="'+i+'"]');if(inp)inp.value=v;});}
+  });
 })();
+
+function showRestore(){document.getElementById('setup-choose').classList.add('hidden');document.getElementById('setup-restore').classList.remove('hidden');document.querySelector('.seed-word').focus();}
+function showCreate(){document.getElementById('setup-choose').classList.add('hidden');document.getElementById('setup-create').classList.remove('hidden');document.getElementById('node-name').focus();}
+function backToChoose(){document.getElementById('setup-restore').classList.add('hidden');document.getElementById('setup-create').classList.add('hidden');document.getElementById('setup-choose').classList.remove('hidden');}
+function getSeedWords(){return Array.from(document.querySelectorAll('.seed-word')).map(i=>i.value.trim().toLowerCase()).filter(w=>w.length>0);}
+
+async function doRestore(){
+  const w=getSeedWords(),err=document.getElementById('restore-error');
+  err.classList.add('hidden');
+  if(w.length!==20&&w.length!==24){err.textContent='Need 20 or 24 words — got '+w.length;err.classList.remove('hidden');return;}
+  const btn=document.getElementById('btn-restore');btn.disabled=true;btn.textContent='Restoring...';
+  try{const r=await fetch(API+'/api/setup',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:'restore',seed_phrase:w.join(' ')})});
+    const d=await r.json();if(d.error){err.textContent=d.error;err.classList.remove('hidden');btn.disabled=false;btn.textContent='Restore';return;}
+    switchToDashboard();
+  }catch(e){err.textContent=e.message;err.classList.remove('hidden');btn.disabled=false;btn.textContent='Restore';}
+}
+
+async function doCreate(){
+  const name=document.getElementById('node-name').value.trim()||'sovereign-node';
+  const err=document.getElementById('create-error');err.classList.add('hidden');
+  const btn=document.getElementById('btn-create');btn.disabled=true;btn.textContent='Creating...';
+  try{const r=await fetch(API+'/api/setup',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:'create',node_name:name})});
+    const d=await r.json();if(d.error){err.textContent=d.error;err.classList.remove('hidden');btn.disabled=false;btn.textContent='Create';return;}
+    switchToDashboard();
+  }catch(e){err.textContent=e.message;err.classList.remove('hidden');btn.disabled=false;btn.textContent='Create';}
+}
+
+function switchToDashboard(){document.getElementById('view-setup').classList.add('hidden');document.getElementById('view-dashboard').classList.remove('hidden');startPolling();}
+function startPolling(){updateDashboard();poll=setInterval(updateDashboard,2000);}
+
+async function updateDashboard(){
+  try{
+    const r=await fetch(API+'/api/status');const d=await r.json();
+    const h=Number(d.chain_height||0);
+    document.getElementById('d-height').textContent=h.toLocaleString();
+    document.getElementById('top-height').textContent=h.toLocaleString();
+    document.getElementById('d-balance').textContent=d.sov_balance_human||'0';
+    document.getElementById('d-balance-atoms').textContent=d.sov_balance?Number(d.sov_balance).toLocaleString()+' atoms':'';
+    document.getElementById('d-validators').textContent=d.validator_count||'0';
+    document.getElementById('d-identities').textContent=d.identity_count||'0';
+    document.getElementById('d-did').textContent=d.did||'—';
+    document.getElementById('d-registered').textContent=d.identity_registered?'Yes':'No';
+    document.getElementById('d-network').textContent=d.network_id||'—';
+    document.getElementById('d-wallet').textContent=d.wallet_id?d.wallet_id.slice(0,16)+'...':'—';
+    document.getElementById('d-sov-human').textContent=(d.sov_balance_human||'0')+' SOV';
+    const badge=document.getElementById('d-state-badge');
+    const pulse=document.getElementById('pulse');
+    const st=document.getElementById('status-text');
+    if(d.state==='ready'){badge.className='badge badge-green';badge.textContent='Connected';pulse.className='pulse';st.textContent='Synced';}
+    else if(d.state==='identity_not_registered'){badge.className='badge badge-amber';badge.textContent='Not Registered';pulse.className='pulse warn';st.textContent='Unregistered';}
+    else if(d.state==='connecting'){badge.className='badge badge-amber';badge.textContent='Connecting';pulse.className='pulse warn';st.textContent='Connecting';}
+    else{badge.className='badge badge-red';badge.textContent=d.state||'Unknown';pulse.className='pulse off';st.textContent='Setup Required';}
+    const pct=Math.min(100,(h/50000)*100);
+    document.getElementById('d-sync-fill').style.width=pct+'%';
+    document.getElementById('d-sync-pct').textContent=pct<100?pct.toFixed(1)+'%':'Synced';
+  }catch(e){}
+}
+
+(async()=>{try{const r=await fetch(API+'/api/status');const d=await r.json();if(d.state&&d.state!=='setup_required')switchToDashboard();}catch(e){}})();
 </script>
 </body>
 </html>

--- a/zhtp-cli/src/ui/setup.html
+++ b/zhtp-cli/src/ui/setup.html
@@ -464,7 +464,7 @@ button,input{font:inherit}
                   <button class="btn btn-ghost" type="button" onclick="backToChoices()">Back</button>
                 </div>
               </div>
-              <p class="seed-copy">Paste the full phrase into any field or enter words one by one. Tab keeps natural browser navigation, and arrow keys or Enter advance through the grid.</p>
+              <p class="seed-copy">Paste the full phrase into any field or enter words one by one. Tab keeps natural browser navigation, and arrow keys or Enter advance through the grid. Accepts 20-word (legacy) or 24-word (BIP39) phrases — leave the remaining cells empty for a 20-word phrase.</p>
               <div class="seed-grid" id="seed-grid"></div>
               <div id="restore-error" class="error-box hidden" role="alert"></div>
               <div class="panel-actions">
@@ -578,6 +578,7 @@ button,input{font:inherit}
             <div class="did-actions">
               <button class="btn btn-secondary" type="button" id="copy-did-btn" onclick="copyDid()">Copy DID</button>
               <button class="btn btn-secondary" type="button" id="force-sync-btn" onclick="forceSync()">Force Sync</button>
+              <button class="btn btn-secondary" type="button" id="reset-identity-btn" onclick="resetLocalIdentity()">Use Different Identity</button>
               <button class="btn btn-danger" type="button" id="disconnect-btn" onclick="openStopDialog()">Disconnect / Stop Node</button>
             </div>
             <div id="register-cta" class="register-cta hidden">
@@ -660,6 +661,7 @@ const API = "";
 const POLL_MS = 2500;
 let pollTimer = null;
 let lastStatus = null;
+let autoRegisterInFlight = false;
 
 const els = {};
 
@@ -676,7 +678,7 @@ function cacheElements() {
     "status-detail","progress-fill","progress-label","progress-detail","progress-copy","did-value",
     "status-network","status-registered","status-wallet","copy-did-btn","register-cta",
     "register-info","state-pill","state-pill-dot","state-pill-text","stop-dialog",
-    "register-btn","disconnect-btn","disconnect-confirm-btn","force-sync-btn"
+    "register-btn","disconnect-btn","disconnect-confirm-btn","force-sync-btn","reset-identity-btn"
   ].forEach(function(id){els[id] = $(id);});
 }
 
@@ -716,6 +718,13 @@ function backToChoices() {
   els["setup-restore"].classList.add("hidden");
   els["setup-create"].classList.add("hidden");
   els["setup-choice"].classList.remove("hidden");
+}
+
+function enterRecoveryMode(message) {
+  stopPolling();
+  setView("setup");
+  showRestore();
+  if (message) showError("restore-error", message);
 }
 
 function clearError(id) {
@@ -858,7 +867,10 @@ async function doRestore() {
     clearSeed();
     if (data.error) throw new Error(data.error);
     setView("dashboard");
-    await refreshStatus(true);
+    const status = await refreshStatus(true);
+    if (status && status.identity_registered === false) {
+      await registerIdentity(true);
+    }
   } catch (error) {
     showError("restore-error", error.message || "Restore failed.");
   } finally {
@@ -918,6 +930,14 @@ function mapState(status) {
       progress: 0
     };
   }
+  if (state === "api_unavailable") {
+    return {
+      key: "offline",
+      label: "API Unavailable",
+      detail: status && status.error ? status.error : "Node telemetry endpoints are not available from this validator.",
+      progress: 0
+    };
+  }
   return {
     key: "offline",
     label: "Offline",
@@ -953,14 +973,20 @@ function applyDashboardStatus(status) {
   els["hero-wallet"].textContent = status.wallet_id ? "Linked" : "Standby";
 
   els["status-network"].textContent = status.network_id || "Unknown";
-  els["status-registered"].textContent = status.identity_registered ? "Registered" : "Needs Action";
+  els["status-registered"].textContent =
+    status.identity_registered === true ? "Registered" :
+    status.identity_registered === false ? "Needs Action" :
+    "Unknown";
   els["status-wallet"].textContent = status.wallet_id || "Unavailable";
 
   els["status-detail"].textContent = mapped.detail;
   els["progress-copy"].textContent = mapped.detail;
   els["progress-fill"].style.width = Math.max(0, Math.min(100, mapped.progress)) + "%";
   els["progress-label"].textContent = mapped.progress + "%";
-  els["progress-detail"].textContent = status.identity_registered === false ? "Registration pending after identity creation." : "Based on the current bridge-reported state.";
+  els["progress-detail"].textContent =
+    status.error ? status.error :
+    status.identity_registered === false ? "Registration pending after identity creation." :
+    "Based on the current bridge-reported state.";
 
   els["state-pill"].className = "status-pill " + mapped.key;
   els["state-pill-text"].textContent = mapped.label;
@@ -968,6 +994,10 @@ function applyDashboardStatus(status) {
 
   const registerVisible = status.identity_registered === false;
   els["register-cta"].classList.toggle("hidden", !registerVisible);
+  const controlsAvailable = status.state !== "api_unavailable";
+  els["register-btn"].disabled = !controlsAvailable || autoRegisterInFlight;
+  els["force-sync-btn"].disabled = !controlsAvailable;
+  els["disconnect-btn"].disabled = !controlsAvailable;
 
   if (mapped.key === "ready") {
     els["progress-label"].textContent = "100%";
@@ -975,13 +1005,18 @@ function applyDashboardStatus(status) {
 }
 
 async function refreshStatus(force) {
+  let data = null;
   try {
-    const data = await requestJson("/api/status");
+    data = await requestJson("/api/status");
     applyDashboardStatus(data);
     if (data.state === "setup_required") {
-      stopPolling();
-      setView("setup");
-      backToChoices();
+      if (data.local_identity_error) {
+        enterRecoveryMode(data.local_identity_error + " Restore from seed or create a new identity.");
+      } else {
+        stopPolling();
+        setView("setup");
+        backToChoices();
+      }
     } else if (els["view-dashboard"].classList.contains("hidden")) {
       setView("dashboard");
     }
@@ -1003,6 +1038,8 @@ async function refreshStatus(force) {
     info.classList.add("hidden");
     info.textContent = "";
   }
+
+  return data;
 }
 
 function startPolling() {
@@ -1057,21 +1094,24 @@ function copyRegisterCommand() {
   info.classList.remove("hidden");
 }
 
-async function registerIdentity() {
+async function registerIdentity(isAutomatic) {
   const info = els["register-info"];
+  if (autoRegisterInFlight) return;
   info.classList.add("hidden");
   info.textContent = "";
+  autoRegisterInFlight = true;
   setBusy("register-btn", true, "Registering...");
   try {
     const data = await postControl("register_identity");
     if (data.error) throw new Error(data.error);
-    info.textContent = "Identity registered on-chain. Refreshing status.";
+    info.textContent = isAutomatic ? "Identity restored and registered on-chain. Refreshing status." : "Identity registered on-chain. Refreshing status.";
     info.classList.remove("hidden");
     await refreshStatus(true);
   } catch (error) {
     info.textContent = error.message || "Registration failed.";
     info.classList.remove("hidden");
   } finally {
+    autoRegisterInFlight = false;
     setBusy("register-btn", false, "Register Identity");
   }
 }
@@ -1092,6 +1132,28 @@ async function forceSync() {
     info.classList.remove("hidden");
   } finally {
     setBusy("force-sync-btn", false, "Force Sync");
+  }
+}
+
+async function resetLocalIdentity() {
+  const info = els["register-info"];
+  info.classList.add("hidden");
+  info.textContent = "";
+  setBusy("reset-identity-btn", true, "Clearing...");
+  try {
+    const data = await postControl("reset_local_identity");
+    if (data.error) throw new Error(data.error);
+    lastStatus = null;
+    clearSeed();
+    els["node-name"].value = "";
+    info.textContent = data.message || "Local identity removed.";
+    info.classList.remove("hidden");
+    enterRecoveryMode("Local identity cleared. Enter a seed phrase or create a new identity.");
+  } catch (error) {
+    info.textContent = error.message || "Failed to remove local identity.";
+    info.classList.remove("hidden");
+  } finally {
+    setBusy("reset-identity-btn", false, "Use Different Identity");
   }
 }
 
@@ -1133,7 +1195,11 @@ async function bootstrap() {
     const data = await requestJson("/api/status");
     if (data.state === "setup_required") {
       applyNavStatus(mapState(data), data);
-      setView("setup");
+      if (data.local_identity_error) {
+        enterRecoveryMode(data.local_identity_error + " Restore from seed or create a new identity.");
+      } else {
+        setView("setup");
+      }
       return;
     }
     setView("dashboard");

--- a/zhtp-cli/src/ui/setup.html
+++ b/zhtp-cli/src/ui/setup.html
@@ -3,323 +3,1141 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Sovereign Network</title>
-<link href="https://fonts.googleapis.com/css2?family=Syncopate:wght@400;700&family=DM+Mono:wght@300;400;500&family=Manrope:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<title>Sovereign Network Mission Control</title>
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{
-  --bg:#020408;
-  --s1:#080c14;
-  --s2:#0d1220;
-  --brd:#141c2e;
-  --t:#c8d4e8;
-  --td:#4a5678;
-  --tm:#2a3450;
-  --teal:#0ff5ce;
-  --teal2:rgba(15,245,206,.06);
-  --teal3:rgba(15,245,206,.2);
-  --mag:#ff2d78;
-  --mag2:rgba(255,45,120,.06);
-  --ok:#22e88a;
-  --warn:#ffc233;
-  --err:#ff3b5c;
-  --display:'Syncopate',sans-serif;
-  --mono:'DM Mono',monospace;
-  --body:'Manrope',sans-serif;
+  --paper:#f4efe2;
+  --paper-2:#efe6d2;
+  --paper-3:#e4d6bb;
+  --ink:#16140f;
+  --muted:#6f6556;
+  --line:rgba(22,20,15,.12);
+  --line-strong:rgba(22,20,15,.24);
+  --panel:rgba(255,251,243,.74);
+  --panel-strong:rgba(255,248,237,.92);
+  --gold:#9f6a1f;
+  --gold-soft:#d3aa64;
+  --signal:#0f766e;
+  --signal-soft:rgba(15,118,110,.12);
+  --warn:#b86717;
+  --warn-soft:rgba(184,103,23,.14);
+  --err:#aa2e2e;
+  --err-soft:rgba(170,46,46,.12);
+  --shadow:0 24px 80px rgba(67,42,15,.12);
+  --display:'Chakra Petch',sans-serif;
+  --body:'Instrument Serif',serif;
+  --mono:'IBM Plex Mono',monospace;
 }
-html{background:var(--bg);color:var(--t);font-family:var(--body)}
-body{min-height:100vh;overflow-x:hidden;position:relative}
-
-/* Animated mesh background */
-.mesh{position:fixed;inset:0;z-index:0;overflow:hidden;opacity:.4}
-.mesh-line{position:absolute;background:var(--brd);transform-origin:0 0}
-.mesh-h{width:100%;height:1px;left:0}
-.mesh-v{height:100%;width:1px;top:0}
-
-/* Glow orbs */
-.orb{position:fixed;border-radius:50%;filter:blur(120px);pointer-events:none;z-index:0}
-.orb-1{width:600px;height:600px;background:rgba(15,245,206,.05);top:-200px;right:-100px;animation:orb-drift 20s ease-in-out infinite alternate}
-.orb-2{width:400px;height:400px;background:rgba(255,45,120,.04);bottom:-100px;left:-100px;animation:orb-drift 25s ease-in-out infinite alternate-reverse}
-@keyframes orb-drift{0%{transform:translate(0,0)}100%{transform:translate(40px,30px)}}
-
-.wrap{position:relative;z-index:1;min-height:100vh}
-
-/* Nav */
-nav{position:fixed;top:0;left:0;right:0;z-index:100;height:56px;display:flex;align-items:center;padding:0 32px;background:rgba(2,4,8,.8);backdrop-filter:blur(24px);border-bottom:1px solid var(--brd)}
-.nav-brand{font-family:var(--display);font-size:11px;font-weight:700;letter-spacing:4px;text-transform:uppercase;color:var(--teal)}
-.nav-sep{width:1px;height:24px;background:var(--brd);margin:0 20px}
-.nav-pulse{display:flex;align-items:center;gap:8px}
-.dot{width:8px;height:8px;border-radius:50%;background:var(--ok);box-shadow:0 0 12px var(--ok);animation:blink 1.5s ease infinite}
-.dot.off{background:var(--err);box-shadow:0 0 12px var(--err);animation:none}
-.dot.warn{background:var(--warn);box-shadow:0 0 12px var(--warn)}
-@keyframes blink{0%,100%{opacity:1}50%{opacity:.3}}
-.nav-label{font-family:var(--mono);font-size:11px;color:var(--td);letter-spacing:.5px}
-.nav-right{margin-left:auto;display:flex;align-items:center;gap:24px}
-.nav-block{font-family:var(--mono);font-size:12px;color:var(--td)}
-.nav-block b{color:var(--teal);font-weight:500}
-
-/* ─── SETUP ─── */
-.setup{display:flex;align-items:center;justify-content:center;min-height:100vh;padding:56px 24px 24px}
-.setup-inner{width:100%;max-width:520px}
-.setup-hero{margin-bottom:48px;animation:rise .8s ease both}
-.setup-hero h1{font-family:var(--display);font-size:32px;font-weight:700;letter-spacing:3px;text-transform:uppercase;line-height:1.2;margin-bottom:12px}
-.setup-hero h1 span{color:var(--teal);display:block;font-size:14px;letter-spacing:6px;margin-bottom:8px;font-weight:400}
-.setup-hero p{color:var(--td);font-size:15px;font-weight:300;line-height:1.6;max-width:380px}
-@keyframes rise{from{opacity:0;transform:translateY(30px)}to{opacity:1;transform:translateY(0)}}
-
-.choices{display:grid;gap:14px;animation:rise .8s ease .15s both}
-.choice{background:var(--s1);border:1px solid var(--brd);border-radius:14px;padding:24px;cursor:pointer;transition:all .25s;position:relative;overflow:hidden}
-.choice::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,var(--teal2),transparent);opacity:0;transition:opacity .25s}
-.choice:hover{border-color:var(--teal);transform:translateY(-2px);box-shadow:0 8px 32px rgba(15,245,206,.08)}
-.choice:hover::before{opacity:1}
-.choice-row{display:flex;align-items:center;gap:16px;position:relative;z-index:1}
-.choice-icon{width:48px;height:48px;border-radius:12px;background:var(--s2);border:1px solid var(--brd);display:flex;align-items:center;justify-content:center;font-size:20px;flex-shrink:0}
-.choice h3{font-family:var(--body);font-size:15px;font-weight:600;margin-bottom:3px}
-.choice p{font-size:12px;color:var(--td);font-weight:400}
-
-/* Seed panel */
-.panel{background:var(--s1);border:1px solid var(--brd);border-radius:14px;padding:28px;animation:rise .5s ease both}
-.panel-title{font-family:var(--display);font-size:12px;letter-spacing:3px;text-transform:uppercase;color:var(--td);margin-bottom:20px}
-.sgrid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-bottom:20px}
-.scell{display:flex;flex-direction:column;gap:2px}
-.snum{font-family:var(--mono);font-size:9px;color:var(--tm);text-align:center;letter-spacing:1px}
-.sinput{background:var(--bg);border:1px solid var(--brd);border-radius:8px;padding:10px 8px;font-family:var(--mono);font-size:12px;color:var(--t);text-align:center;outline:none;transition:all .2s;width:100%}
-.sinput:focus{border-color:var(--teal);box-shadow:0 0 0 3px var(--teal2)}
-.sinput::placeholder{color:var(--tm)}
-.ninput{width:100%;background:var(--bg);border:1px solid var(--brd);border-radius:10px;padding:14px 16px;font-family:var(--mono);font-size:15px;color:var(--t);outline:none;margin-bottom:20px;letter-spacing:1px}
-.ninput:focus{border-color:var(--teal)}
-.ninput::placeholder{color:var(--tm)}
-
-.btn{width:100%;padding:14px;border:none;border-radius:10px;font-family:var(--body);font-size:14px;font-weight:700;cursor:pointer;transition:all .2s;margin-top:8px;letter-spacing:.5px;text-transform:uppercase}
-.btn-t{background:var(--teal);color:var(--bg)}
-.btn-t:hover{filter:brightness(1.15);transform:translateY(-1px);box-shadow:0 6px 24px var(--teal3)}
-.btn-t:disabled{opacity:.35;cursor:not-allowed;transform:none;box-shadow:none}
-.btn-g{background:transparent;color:var(--td);border:1px solid var(--brd)}
-.btn-g:hover{border-color:var(--td);color:var(--t)}
-.err{color:var(--err);font-size:12px;margin-top:10px;font-family:var(--mono)}
-
-/* ─── DASHBOARD ─── */
-.dash{padding:72px 32px 32px;animation:rise .5s ease both}
-.dash-head{display:flex;align-items:baseline;gap:16px;margin-bottom:32px}
-.dash-head h2{font-family:var(--display);font-size:14px;font-weight:700;letter-spacing:4px;text-transform:uppercase;color:var(--teal)}
-
-.mgrid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:20px}
-@media(max-width:860px){.mgrid{grid-template-columns:repeat(2,1fr)}}
-.mcard{background:var(--s1);border:1px solid var(--brd);border-radius:12px;padding:20px;position:relative;overflow:hidden;transition:border-color .3s}
-.mcard:hover{border-color:var(--teal)}
-.mcard-bar{position:absolute;top:0;left:0;right:0;height:2px}
-.mcard-bar.bt{background:var(--teal);box-shadow:0 0 16px var(--teal3)}
-.mcard-bar.bg{background:var(--ok)}
-.mcard-bar.bm{background:var(--mag)}
-.mcard-bar.bw{background:var(--warn)}
-.mcard-lbl{font-family:var(--mono);font-size:10px;letter-spacing:1.5px;text-transform:uppercase;color:var(--td);margin-bottom:10px}
-.mcard-val{font-family:var(--mono);font-size:26px;font-weight:500;letter-spacing:-1px}
-.mcard-sub{font-family:var(--mono);font-size:10px;color:var(--td);margin-top:6px}
-
-/* DID card */
-.did-card{background:var(--s1);border:1px solid var(--brd);border-radius:12px;padding:20px;margin-bottom:20px}
-.did-card h3{font-family:var(--mono);font-size:10px;letter-spacing:1.5px;text-transform:uppercase;color:var(--td);margin-bottom:12px}
-.did-val{font-family:var(--mono);font-size:12px;color:var(--teal);word-break:break-all;line-height:1.8;padding:14px;background:var(--bg);border-radius:8px;border:1px solid var(--brd);letter-spacing:.3px}
-
-/* Sync */
-.sync-card{background:var(--s1);border:1px solid var(--brd);border-radius:12px;padding:20px;margin-bottom:20px}
-.sync-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
-.sync-top h3{font-family:var(--mono);font-size:10px;letter-spacing:1.5px;text-transform:uppercase;color:var(--td)}
-.sync-pct{font-family:var(--mono);font-size:12px;color:var(--teal);font-weight:500}
-.sync-track{height:3px;background:var(--brd);border-radius:2px;overflow:hidden}
-.sync-fill{height:100%;background:linear-gradient(90deg,var(--teal),var(--ok));border-radius:2px;transition:width 1s cubic-bezier(.4,0,.2,1);box-shadow:0 0 12px var(--teal3)}
-
-/* Status grid */
-.sgrid2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
-.scard{background:var(--s1);border:1px solid var(--brd);border-radius:12px;padding:18px}
-.scard h3{font-family:var(--mono);font-size:10px;letter-spacing:1.5px;text-transform:uppercase;color:var(--td);margin-bottom:12px}
-.srow{display:flex;justify-content:space-between;align-items:center;padding:7px 0;border-bottom:1px solid rgba(20,28,46,.5);font-size:12px}
-.srow:last-child{border:none}
-.srow .k{color:var(--td);font-family:var(--mono);font-size:11px}
-.srow .v{font-family:var(--mono);font-weight:500;font-size:11px}
-.tag{display:inline-block;padding:3px 10px;border-radius:4px;font-size:9px;font-family:var(--mono);font-weight:700;letter-spacing:.5px;text-transform:uppercase}
-.tag-g{background:rgba(34,232,138,.1);color:var(--ok)}
-.tag-w{background:rgba(255,194,51,.1);color:var(--warn)}
-.tag-r{background:rgba(255,59,92,.1);color:var(--err)}
-
+html{background:
+  radial-gradient(circle at top left, rgba(255,255,255,.68), transparent 38%),
+  radial-gradient(circle at bottom right, rgba(159,106,31,.12), transparent 30%),
+  linear-gradient(135deg, #f6f2e8 0%, #f1e7d2 46%, #eadcc0 100%);
+  color:var(--ink);
+  font-family:var(--body);
+}
+body{min-height:100vh;position:relative;overflow-x:hidden}
+body::before,body::after{content:"";position:fixed;pointer-events:none;inset:0;z-index:0}
+body::before{
+  background:
+    linear-gradient(rgba(22,20,15,.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(22,20,15,.04) 1px, transparent 1px);
+  background-size:36px 36px;
+  mask-image:linear-gradient(to bottom, rgba(0,0,0,.5), rgba(0,0,0,.18));
+}
+body::after{
+  background:
+    radial-gradient(circle at 18% 14%, rgba(211,170,100,.34), transparent 18%),
+    radial-gradient(circle at 80% 20%, rgba(15,118,110,.18), transparent 18%),
+    radial-gradient(circle at 50% 100%, rgba(184,103,23,.14), transparent 30%);
+}
+a{color:inherit}
+button,input{font:inherit}
 .hidden{display:none !important}
+
+.shell{position:relative;z-index:1;min-height:100vh;padding:24px}
+.frame{
+  max-width:1280px;
+  margin:0 auto;
+  min-height:calc(100vh - 48px);
+  border:1px solid var(--line);
+  background:linear-gradient(180deg, rgba(255,253,248,.8), rgba(251,245,233,.68));
+  backdrop-filter:blur(18px);
+  box-shadow:var(--shadow);
+  border-radius:28px;
+  overflow:hidden;
+}
+
+.topbar{
+  display:flex;
+  align-items:center;
+  gap:20px;
+  padding:18px 24px;
+  border-bottom:1px solid var(--line);
+  background:rgba(249,244,233,.72);
+  backdrop-filter:blur(12px);
+}
+.brand{display:flex;align-items:center;gap:16px;min-width:0}
+.brand-mark{
+  width:52px;height:52px;border-radius:16px;
+  border:1px solid var(--line-strong);
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255,255,255,.7), transparent 45%),
+    linear-gradient(135deg, rgba(159,106,31,.18), rgba(15,118,110,.12));
+  position:relative;
+}
+.brand-mark::before,.brand-mark::after{content:"";position:absolute;inset:11px;border:1px solid rgba(22,20,15,.16);border-radius:12px;transform:rotate(45deg)}
+.brand-mark::after{inset:18px;background:rgba(255,255,255,.5)}
+.brand-copy small,.eyebrow,.section-label,.stat-label,.control-label,.panel-label,.seed-number,.meta-key,.help-label{
+  font-family:var(--mono);
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+}
+.brand-copy small{display:block;color:var(--muted);margin-bottom:4px}
+.brand-copy strong{
+  display:block;
+  font-family:var(--display);
+  font-size:20px;
+  line-height:1;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+}
+.status-rail{margin-left:auto;display:flex;align-items:center;gap:18px;flex-wrap:wrap;justify-content:flex-end}
+.status-badge{
+  display:inline-flex;align-items:center;gap:10px;
+  padding:10px 14px;border-radius:999px;border:1px solid var(--line);
+  background:rgba(255,255,255,.45);font-family:var(--mono);font-size:12px;
+}
+.signal-dot{width:10px;height:10px;border-radius:999px;background:var(--err);box-shadow:0 0 0 5px rgba(170,46,46,.08)}
+.signal-dot.ready{background:var(--signal);box-shadow:0 0 0 5px rgba(15,118,110,.1)}
+.signal-dot.syncing,.signal-dot.unregistered{background:var(--warn);box-shadow:0 0 0 5px rgba(184,103,23,.12)}
+.status-meta{display:flex;gap:18px;flex-wrap:wrap}
+.status-meta .value{font-family:var(--display);font-size:15px;letter-spacing:.04em}
+.main{padding:28px}
+
+.hero{
+  display:grid;
+  grid-template-columns:minmax(0,1.1fr) minmax(320px,.9fr);
+  gap:24px;
+  margin-bottom:24px;
+}
+.hero-panel,.panel,.metric,.command-card,.status-card,.logline,.seed-panel{
+  border:1px solid var(--line);
+  background:var(--panel);
+  border-radius:24px;
+  position:relative;
+  overflow:hidden;
+}
+.hero-panel::before,.panel::before,.metric::before,.command-card::before,.status-card::before,.seed-panel::before{
+  content:"";position:absolute;top:0;left:0;right:0;height:3px;
+  background:linear-gradient(90deg, rgba(159,106,31,.7), rgba(15,118,110,.48), transparent 92%);
+}
+.hero-copy{padding:28px}
+.eyebrow{color:var(--muted);margin-bottom:12px}
+.hero-copy h1{
+  font-family:var(--display);
+  font-size:clamp(2.8rem,6vw,5.2rem);
+  line-height:.94;
+  text-transform:uppercase;
+  letter-spacing:.02em;
+  max-width:10ch;
+}
+.hero-copy h1 em{
+  display:block;
+  font-style:normal;
+  color:var(--gold);
+}
+.hero-copy p{
+  margin-top:16px;
+  max-width:36rem;
+  font-size:1.25rem;
+  line-height:1.34;
+}
+.hero-meta{
+  display:grid;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+  gap:12px;
+  padding:0 28px 28px;
+}
+.meta-block{
+  padding:14px 16px;
+  border-radius:18px;
+  border:1px solid var(--line);
+  background:rgba(255,255,255,.45);
+}
+.meta-key{display:block;color:var(--muted);margin-bottom:8px}
+.meta-value{font-family:var(--display);font-size:20px;letter-spacing:.04em}
+.mission-card{padding:24px;display:flex;flex-direction:column;gap:18px;justify-content:space-between}
+.mission-card h2{
+  font-family:var(--display);
+  font-size:24px;
+  line-height:1;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+}
+.mission-card p{font-size:1.08rem;line-height:1.34}
+.flight-path{
+  height:160px;border-radius:18px;border:1px solid var(--line);
+  background:
+    radial-gradient(circle at 20% 20%, rgba(159,106,31,.16), transparent 25%),
+    linear-gradient(135deg, rgba(255,255,255,.68), rgba(234,220,192,.44));
+  position:relative;
+  overflow:hidden;
+}
+.flight-path::before,.flight-path::after{content:"";position:absolute;border-radius:999px}
+.flight-path::before{
+  inset:20px;border:1px dashed rgba(22,20,15,.18);
+  animation:drift 12s linear infinite;
+}
+.flight-path::after{
+  width:26px;height:26px;top:50%;left:20%;
+  background:linear-gradient(135deg, var(--gold), var(--signal));
+  box-shadow:0 0 0 10px rgba(255,255,255,.5);
+  animation:orbit 8s ease-in-out infinite;
+}
+@keyframes drift{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+@keyframes orbit{
+  0%,100%{transform:translate(0,-50%)}
+  50%{transform:translate(220px,40px)}
+}
+
+.setup-grid,.dashboard-grid{display:grid;gap:24px}
+.setup-grid{grid-template-columns:minmax(0,1.15fr) minmax(320px,.85fr)}
+.setup-main{display:grid;gap:18px}
+.choice-grid{display:grid;gap:16px}
+.choice{
+  width:100%;text-align:left;padding:22px;border-radius:22px;
+  border:1px solid var(--line);background:var(--panel-strong);cursor:pointer;
+  transition:transform .18s ease,border-color .18s ease,box-shadow .18s ease;
+}
+.choice:hover,.choice:focus-visible{transform:translateY(-2px);border-color:var(--line-strong);box-shadow:0 16px 36px rgba(67,42,15,.12);outline:none}
+.choice-head{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:12px}
+.choice-title{font-family:var(--display);font-size:24px;line-height:1;text-transform:uppercase}
+.choice-code{
+  min-width:72px;text-align:right;color:var(--muted);font-family:var(--mono);font-size:12px;
+}
+.choice p{font-size:1.06rem;line-height:1.3;max-width:34rem}
+
+.panel{padding:22px}
+.panel-header{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:18px}
+.panel-title{
+  font-family:var(--display);
+  font-size:28px;
+  line-height:1;
+  text-transform:uppercase;
+}
+.panel-subtitle{font-size:1rem;color:var(--muted);max-width:34rem}
+.panel-actions{display:flex;gap:10px;flex-wrap:wrap}
+.btn{
+  border:none;border-radius:999px;padding:13px 18px;cursor:pointer;
+  font-family:var(--mono);font-size:12px;letter-spacing:.14em;text-transform:uppercase;
+  transition:transform .18s ease,box-shadow .18s ease,background .18s ease,color .18s ease,border-color .18s ease;
+}
+.btn:hover,.btn:focus-visible{transform:translateY(-1px);outline:none}
+.btn-primary{background:var(--ink);color:#fff7ea;box-shadow:0 12px 28px rgba(22,20,15,.16)}
+.btn-secondary{background:rgba(255,255,255,.56);color:var(--ink);border:1px solid var(--line)}
+.btn-ghost{background:transparent;color:var(--muted);border:1px dashed var(--line-strong)}
+.btn-danger{background:rgba(170,46,46,.08);color:var(--err);border:1px solid rgba(170,46,46,.16)}
+.btn:disabled{opacity:.45;cursor:not-allowed;transform:none;box-shadow:none}
+.error-box,.info-box{
+  margin-top:16px;padding:14px 16px;border-radius:18px;font-size:.98rem;line-height:1.35
+}
+.error-box{background:var(--err-soft);border:1px solid rgba(170,46,46,.16);color:var(--err)}
+.info-box{background:var(--signal-soft);border:1px solid rgba(15,118,110,.16);color:var(--signal)}
+
+.seed-panel{padding:22px}
+.seed-toolbar{
+  display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-bottom:14px
+}
+.seed-title{font-family:var(--display);font-size:24px;text-transform:uppercase}
+.seed-copy{font-size:.98rem;color:var(--muted);max-width:34rem}
+.seed-grid{
+  display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;
+}
+.seed-cell{display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:16px;border:1px solid var(--line);background:rgba(255,255,255,.48)}
+.seed-number{color:var(--muted);min-width:22px;text-align:center}
+.seed-input{
+  width:100%;border:none;background:transparent;outline:none;font-family:var(--mono);font-size:14px;color:var(--ink)
+}
+.seed-input::placeholder{color:rgba(111,101,86,.54)}
+.name-field{
+  width:100%;padding:16px 18px;border-radius:18px;border:1px solid var(--line);
+  background:rgba(255,255,255,.56);outline:none;font-family:var(--mono);font-size:15px;color:var(--ink)
+}
+.name-field:focus,.seed-input:focus{box-shadow:none}
+.name-wrap{display:grid;gap:14px}
+.setup-aside{display:grid;gap:18px}
+.note-list{display:grid;gap:12px}
+.note{
+  padding:16px 18px;border-radius:18px;border:1px solid var(--line);background:rgba(255,255,255,.42)
+}
+.note strong,.side-title,.card-title,.status-title{
+  font-family:var(--display);text-transform:uppercase;letter-spacing:.06em;line-height:1;
+}
+.note strong{display:block;margin-bottom:8px;font-size:20px}
+.note p{font-size:1rem;line-height:1.3;color:var(--muted)}
+.command-card{padding:20px}
+.control-label{color:var(--muted);margin-bottom:8px}
+.command{
+  display:block;padding:14px 16px;border-radius:18px;background:rgba(22,20,15,.04);
+  border:1px solid var(--line);font-family:var(--mono);font-size:12px;line-height:1.5;word-break:break-word
+}
+
+.dashboard-grid{grid-template-columns:minmax(0,1.18fr) minmax(320px,.82fr)}
+.metrics{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:16px}
+.metric{padding:20px}
+.metric.emphasis{grid-column:span 2;padding:26px}
+.stat-label{color:var(--muted);margin-bottom:14px}
+.metric-value{
+  font-family:var(--display);font-size:clamp(2rem,4vw,3.25rem);line-height:.95;text-transform:uppercase
+}
+.metric-sub{margin-top:10px;font-family:var(--mono);font-size:12px;color:var(--muted);word-break:break-word}
+.metric-foot{margin-top:16px;display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+.status-pill{
+  display:inline-flex;align-items:center;gap:10px;padding:8px 14px;border-radius:999px;
+  font-family:var(--mono);font-size:12px;border:1px solid var(--line)
+}
+.status-pill.ready{background:var(--signal-soft);color:var(--signal)}
+.status-pill.syncing,.status-pill.unregistered{background:var(--warn-soft);color:var(--warn)}
+.status-pill.offline{background:var(--err-soft);color:var(--err)}
+
+.progress-card,.did-card,.status-card,.logline{padding:20px}
+.progress-head,.did-head,.status-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:14px}
+.card-title,.status-title{font-size:22px}
+.card-copy,.status-copy,.help-copy{font-size:1rem;color:var(--muted);line-height:1.3}
+.progress-bar{
+  height:14px;border-radius:999px;border:1px solid var(--line);overflow:hidden;
+  background:rgba(255,255,255,.56);margin-bottom:12px
+}
+.progress-fill{
+  height:100%;
+  width:0;
+  background:linear-gradient(90deg, rgba(159,106,31,.72), rgba(15,118,110,.78));
+  transition:width .45s ease;
+}
+.progress-meta{display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap;font-family:var(--mono);font-size:12px;color:var(--muted)}
+.did-value{
+  padding:16px 18px;border-radius:18px;background:rgba(255,255,255,.5);border:1px solid var(--line);
+  font-family:var(--mono);font-size:13px;line-height:1.6;word-break:break-all
+}
+.did-actions,.register-cta,.control-row{display:flex;gap:10px;flex-wrap:wrap;margin-top:14px}
+.status-stack{display:grid;gap:16px}
+.status-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+.status-item{
+  padding:16px;border-radius:18px;border:1px solid var(--line);background:rgba(255,255,255,.46)
+}
+.status-item .meta-key{margin-bottom:8px}
+.status-item .value{font-family:var(--display);font-size:22px;line-height:1;word-break:break-word}
+.status-item.compact .value{font-size:16px;font-family:var(--mono);text-transform:none}
+.logline{
+  display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;
+  background:rgba(22,20,15,.04)
+}
+.help-label{color:var(--muted);margin-bottom:8px}
+.inline-link{
+  text-decoration:none;padding-bottom:1px;border-bottom:1px solid currentColor;cursor:pointer
+}
+
+.dialog-backdrop{
+  position:fixed;inset:0;display:none;align-items:center;justify-content:center;
+  background:rgba(22,20,15,.28);padding:24px;z-index:20
+}
+.dialog-backdrop.open{display:flex}
+.dialog{
+  width:min(520px,100%);border-radius:26px;border:1px solid var(--line);
+  background:rgba(255,250,241,.96);box-shadow:var(--shadow);padding:24px
+}
+.dialog h3{font-family:var(--display);font-size:26px;line-height:1;text-transform:uppercase;margin-bottom:12px}
+.dialog p{font-size:1.05rem;line-height:1.35;margin-bottom:16px}
+.dialog code{
+  display:block;padding:14px 16px;border-radius:18px;border:1px solid var(--line);
+  background:rgba(22,20,15,.04);font-family:var(--mono);font-size:12px;line-height:1.5;word-break:break-word
+}
+.dialog-actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:18px}
+
+@media (max-width:1080px){
+  .hero,.setup-grid,.dashboard-grid{grid-template-columns:1fr}
+  .hero-copy h1{max-width:none}
+}
+@media (max-width:760px){
+  .shell{padding:12px}
+  .frame{min-height:calc(100vh - 24px);border-radius:22px}
+  .topbar,.main,.hero-copy,.hero-meta,.mission-card,.panel,.seed-panel,.metric,.progress-card,.did-card,.status-card,.logline{padding-left:18px;padding-right:18px}
+  .metrics{grid-template-columns:1fr}
+  .metric.emphasis{grid-column:auto}
+  .seed-grid,.status-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .status-rail{margin-left:0}
+}
+@media (max-width:520px){
+  .seed-grid,.status-grid,.hero-meta{grid-template-columns:1fr}
+  .topbar{align-items:flex-start;flex-direction:column}
+  .status-rail{width:100%;justify-content:flex-start}
+}
 </style>
 </head>
 <body>
-<div class="mesh" id="mesh"></div>
-<div class="orb orb-1"></div>
-<div class="orb orb-2"></div>
-
-<nav>
-  <div class="nav-brand">Sovereign</div>
-  <div class="nav-sep"></div>
-  <div class="nav-pulse"><div class="dot off" id="dot"></div><span class="nav-label" id="nav-st">Offline</span></div>
-  <div class="nav-right"><div class="nav-block">block <b id="nav-h">—</b></div></div>
-</nav>
-
-<div class="wrap">
-  <!-- SETUP -->
-  <div class="setup" id="v-setup">
-    <div class="setup-inner">
-      <div class="setup-hero">
-        <h1><span>Node Control</span>Initialize</h1>
-        <p>Spawn an observer node on The Sovereign Network. Your identity, your infrastructure.</p>
+<div class="shell">
+  <div class="frame">
+    <header class="topbar">
+      <div class="brand">
+        <div class="brand-mark" aria-hidden="true"></div>
+        <div class="brand-copy">
+          <small>Local Control Surface</small>
+          <strong>Sovereign Network</strong>
+        </div>
       </div>
-      <div id="s-choose">
-        <div class="choices">
-          <div class="choice" onclick="showRestore()">
-            <div class="choice-row">
-              <div class="choice-icon">🔑</div>
-              <div><h3>Restore from seed</h3><p>Use your mobile wallet identity on this node</p></div>
+      <div class="status-rail">
+        <div class="status-badge">
+          <span class="signal-dot" id="nav-dot"></span>
+          <span id="nav-state">Offline</span>
+        </div>
+        <div class="status-meta">
+          <div><div class="meta-key">Network</div><div class="value" id="nav-network">Unknown</div></div>
+          <div><div class="meta-key">Chain</div><div class="value" id="nav-height">0</div></div>
+        </div>
+      </div>
+    </header>
+
+    <main class="main">
+      <section class="hero">
+        <div class="hero-panel">
+          <div class="hero-copy">
+            <div class="eyebrow">Post-Quantum Node Operations</div>
+            <h1>Operate Your <em>Own Layer</em></h1>
+            <p>Mission control for a sovereign node should feel like instrumenting infrastructure, not filling out a theme-default wizard. This console keeps setup sharp and the live node state legible.</p>
+          </div>
+          <div class="hero-meta">
+            <div class="meta-block">
+              <span class="meta-key">Identity</span>
+              <div class="meta-value" id="hero-identity">Awaiting</div>
+            </div>
+            <div class="meta-block">
+              <span class="meta-key">Wallet</span>
+              <div class="meta-value" id="hero-wallet">Standby</div>
+            </div>
+            <div class="meta-block">
+              <span class="meta-key">Telemetry</span>
+              <div class="meta-value" id="hero-poll">2.5s</div>
             </div>
           </div>
-          <div class="choice" onclick="showCreate()">
-            <div class="choice-row">
-              <div class="choice-icon">◆</div>
-              <div><h3>New identity</h3><p>Generate fresh post-quantum cryptographic keys</p></div>
+        </div>
+        <aside class="panel mission-card">
+          <div>
+            <div class="eyebrow">Flight Deck</div>
+            <h2>Mission Profile</h2>
+            <p>Restore an existing identity or commission a new node persona, then stay on top of height, wallet state, validator presence, and registration status without leaving localhost.</p>
+          </div>
+          <div class="flight-path" aria-hidden="true"></div>
+        </aside>
+      </section>
+
+      <section id="view-setup" class="setup-grid">
+        <div class="setup-main">
+          <div id="setup-choice" class="choice-grid">
+            <button class="choice" type="button" onclick="showRestore()">
+              <div class="choice-head">
+                <div class="choice-title">Restore Identity</div>
+                <div class="choice-code">seed://import</div>
+              </div>
+              <p>Recover an existing node identity from a 20 or 24 word phrase. Words stay in memory only long enough to submit them to the local bridge.</p>
+            </button>
+            <button class="choice" type="button" onclick="showCreate()">
+              <div class="choice-head">
+                <div class="choice-title">Create New Node</div>
+                <div class="choice-code">node://bootstrap</div>
+              </div>
+              <p>Generate a fresh post-quantum identity and prepare this machine as a new operating surface on the network.</p>
+            </button>
+          </div>
+
+          <div id="setup-restore" class="hidden">
+            <div class="seed-panel">
+              <div class="seed-toolbar">
+                <div>
+                  <div class="panel-label">Recovery Input</div>
+                  <div class="seed-title">Seed Phrase</div>
+                </div>
+                <div class="panel-actions">
+                  <button class="btn btn-secondary" type="button" onclick="clearSeed()">Clear</button>
+                  <button class="btn btn-ghost" type="button" onclick="backToChoices()">Back</button>
+                </div>
+              </div>
+              <p class="seed-copy">Paste the full phrase into any field or enter words one by one. Tab keeps natural browser navigation, and arrow keys or Enter advance through the grid.</p>
+              <div class="seed-grid" id="seed-grid"></div>
+              <div id="restore-error" class="error-box hidden" role="alert"></div>
+              <div class="panel-actions">
+                <button class="btn btn-primary" type="button" id="restore-btn" onclick="doRestore()">Restore Identity</button>
+              </div>
+            </div>
+          </div>
+
+          <div id="setup-create" class="hidden">
+            <div class="panel">
+              <div class="panel-header">
+                <div>
+                  <div class="panel-label">Provision</div>
+                  <div class="panel-title">Create New Identity</div>
+                </div>
+                <div class="panel-actions">
+                  <button class="btn btn-ghost" type="button" onclick="backToChoices()">Back</button>
+                </div>
+              </div>
+              <p class="panel-subtitle">Name this node the way you name infrastructure: short, clear, and durable.</p>
+              <div class="name-wrap">
+                <input id="node-name" class="name-field" type="text" autocomplete="off" autocapitalize="off" spellcheck="false" placeholder="atlas-observer-01">
+                <div id="create-error" class="error-box hidden" role="alert"></div>
+                <div class="panel-actions">
+                  <button class="btn btn-primary" type="button" id="create-btn" onclick="doCreate()">Launch Node</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div id="s-restore" class="hidden">
-        <div class="panel">
-          <div class="panel-title">Recovery Phrase</div>
-          <div class="sgrid" id="seed-grid"></div>
-          <div class="err hidden" id="r-err"></div>
-          <button class="btn btn-t" onclick="doRestore()" id="r-btn">Restore Identity</button>
-          <button class="btn btn-g" onclick="back()">Back</button>
+
+        <aside class="setup-aside">
+          <div class="panel">
+            <div class="panel-label">Operational Notes</div>
+            <div class="note-list">
+              <div class="note">
+                <strong>Seed Hygiene</strong>
+                <p>The recovery phrase is never logged and is only sent once to `POST /api/setup` when you explicitly restore.</p>
+              </div>
+              <div class="note">
+                <strong>Local Bridge</strong>
+                <p>This interface runs from the CLI binary at `localhost:7840`, while node state is proxied over QUIC.</p>
+              </div>
+              <div class="note">
+                <strong>Live Polling</strong>
+                <p>Dashboard telemetry refreshes every 2.5 seconds and can be forced manually at any time.</p>
+              </div>
+            </div>
+          </div>
+          <div class="command-card">
+            <div class="control-label">Manual Stop</div>
+            <span class="command">Press Ctrl+C in the terminal running:<br>./target/dev-release/zhtp-cli -s 77.42.37.161:9334 node setup-ui</span>
+          </div>
+        </aside>
+      </section>
+
+      <section id="view-dashboard" class="dashboard-grid hidden">
+        <div class="dashboard-main">
+          <div class="metrics">
+            <article class="metric emphasis">
+              <div class="stat-label">Chain Height</div>
+              <div class="metric-value" id="metric-height">0</div>
+              <div class="metric-foot">
+                <span class="status-pill offline" id="state-pill"><span class="signal-dot" id="state-pill-dot"></span><span id="state-pill-text">Offline</span></span>
+                <span class="metric-sub" id="status-detail">Waiting for bridge telemetry.</span>
+              </div>
+            </article>
+            <article class="metric">
+              <div class="stat-label">SOV Balance</div>
+              <div class="metric-value" id="metric-balance">0</div>
+              <div class="metric-sub" id="metric-balance-atoms">0 atoms</div>
+            </article>
+            <article class="metric">
+              <div class="stat-label">Validators</div>
+              <div class="metric-value" id="metric-validators">0</div>
+              <div class="metric-sub">Active validator set reported by the node</div>
+            </article>
+            <article class="metric">
+              <div class="stat-label">Identities</div>
+              <div class="metric-value" id="metric-identities">0</div>
+              <div class="metric-sub">Registered participants observed on-chain</div>
+            </article>
+          </div>
+
+          <article class="progress-card">
+            <div class="progress-head">
+              <div>
+                <div class="panel-label">Synchronization</div>
+                <div class="card-title">Node Readiness</div>
+              </div>
+              <div class="card-copy" id="progress-copy">Waiting for status.</div>
+            </div>
+            <div class="progress-bar">
+              <div class="progress-fill" id="progress-fill"></div>
+            </div>
+            <div class="progress-meta">
+              <span id="progress-label">0%</span>
+              <span id="progress-detail">Bridge has not delivered status yet.</span>
+            </div>
+          </article>
+
+          <article class="did-card">
+            <div class="did-head">
+              <div>
+                <div class="panel-label">Identity</div>
+                <div class="card-title">Device DID</div>
+              </div>
+              <div class="card-copy">Copy for operators, tooling, and registration flow.</div>
+            </div>
+            <div class="did-value" id="did-value">No DID detected yet.</div>
+            <div class="did-actions">
+              <button class="btn btn-secondary" type="button" id="copy-did-btn" onclick="copyDid()">Copy DID</button>
+              <button class="btn btn-secondary" type="button" onclick="refreshStatus(true)">Force Sync</button>
+              <button class="btn btn-danger" type="button" id="disconnect-btn" onclick="openStopDialog()">Disconnect Session</button>
+            </div>
+            <div id="register-cta" class="register-cta hidden">
+              <a href="#register-guide" class="inline-link" onclick="openRegisterGuide(event)">Register this identity on-chain</a>
+            </div>
+          </article>
         </div>
-      </div>
-      <div id="s-create" class="hidden">
-        <div class="panel">
-          <div class="panel-title">Node Name</div>
-          <input type="text" class="ninput" id="n-name" placeholder="sovereign-node" autocomplete="off" spellcheck="false">
-          <div class="err hidden" id="c-err"></div>
-          <button class="btn btn-t" onclick="doCreate()" id="c-btn">Launch Node</button>
-          <button class="btn btn-g" onclick="back()">Back</button>
-        </div>
-      </div>
-    </div>
+
+        <aside class="status-stack">
+          <article class="status-card">
+            <div class="status-head">
+              <div>
+                <div class="panel-label">Telemetry</div>
+                <div class="status-title">Node State</div>
+              </div>
+              <div class="status-copy">Live metrics pulled from `GET /api/status`.</div>
+            </div>
+            <div class="status-grid">
+              <div class="status-item">
+                <div class="meta-key">Network ID</div>
+                <div class="value" id="status-network">Unknown</div>
+              </div>
+              <div class="status-item">
+                <div class="meta-key">Registration</div>
+                <div class="value" id="status-registered">Pending</div>
+              </div>
+              <div class="status-item compact">
+                <div class="meta-key">Wallet ID</div>
+                <div class="value" id="status-wallet">Unavailable</div>
+              </div>
+              <div class="status-item">
+                <div class="meta-key">Poll Cycle</div>
+                <div class="value">2.5s</div>
+              </div>
+            </div>
+          </article>
+
+          <article class="status-card" id="register-guide">
+            <div class="status-head">
+              <div>
+                <div class="panel-label">Registration Path</div>
+                <div class="status-title">Identity Not Registered</div>
+              </div>
+              <div class="status-copy">Shown only when the node reports `identity_registered === false`.</div>
+            </div>
+            <div class="help-copy">Promote the local identity onto the chain through the same canonical registration request the CLI already uses.</div>
+            <div class="control-row">
+              <button class="btn btn-primary" type="button" id="register-btn" onclick="registerIdentity()">Register Identity</button>
+              <button class="btn btn-secondary" type="button" onclick="copyRegisterCommand()">Copy CLI Command</button>
+            </div>
+            <div class="info-box hidden" id="register-info"></div>
+          </article>
+
+          <article class="logline">
+            <div>
+              <div class="help-label">Operator Guidance</div>
+              <div class="help-copy">Force sync pulls immediately. Disconnect stops the local setup UI bridge session; it does not terminate the remote QUIC node process.</div>
+            </div>
+          </article>
+        </aside>
+      </section>
+    </main>
   </div>
+</div>
 
-  <!-- DASHBOARD -->
-  <div class="dash hidden" id="v-dash">
-    <div class="dash-head"><h2>Dashboard</h2></div>
-    <div class="mgrid">
-      <div class="mcard"><div class="mcard-bar bt"></div><div class="mcard-lbl">Chain Height</div><div class="mcard-val" id="m-h">—</div></div>
-      <div class="mcard"><div class="mcard-bar bg"></div><div class="mcard-lbl">SOV Balance</div><div class="mcard-val" id="m-b">—</div><div class="mcard-sub" id="m-ba"></div></div>
-      <div class="mcard"><div class="mcard-bar bm"></div><div class="mcard-lbl">Validators</div><div class="mcard-val" id="m-v">—</div></div>
-      <div class="mcard"><div class="mcard-bar bw"></div><div class="mcard-lbl">Identities</div><div class="mcard-val" id="m-i">—</div></div>
-    </div>
-    <div class="did-card"><h3>Your DID</h3><div class="did-val" id="m-did">—</div></div>
-    <div class="sync-card">
-      <div class="sync-top"><h3>Sync</h3><div class="sync-pct" id="m-pct">0%</div></div>
-      <div class="sync-track"><div class="sync-fill" id="m-fill" style="width:0%"></div></div>
-    </div>
-    <div class="sgrid2">
-      <div class="scard"><h3>Node</h3>
-        <div class="srow"><span class="k">State</span><span class="v"><span class="tag tag-g" id="m-tag">Ready</span></span></div>
-        <div class="srow"><span class="k">Registered</span><span class="v" id="m-reg">—</span></div>
-        <div class="srow"><span class="k">Network</span><span class="v" id="m-net">—</span></div>
-      </div>
-      <div class="scard"><h3>Wallet</h3>
-        <div class="srow"><span class="k">ID</span><span class="v" id="m-wid" style="font-size:10px">—</span></div>
-        <div class="srow"><span class="k">SOV</span><span class="v" id="m-sov">—</span></div>
-      </div>
+<div class="dialog-backdrop" id="stop-dialog" onclick="dismissDialog(event)">
+  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="stop-dialog-title">
+    <h3 id="stop-dialog-title">Disconnect Session</h3>
+    <p>This stops the local `setup-ui` bridge process on `localhost:7840`. It disconnects the browser control surface, but it does not shut down the remote node itself.</p>
+    <code>The browser session will lose connectivity once the bridge exits.</code>
+    <div class="dialog-actions">
+      <button class="btn btn-danger" type="button" id="disconnect-confirm-btn" onclick="disconnectSession()">Disconnect</button>
+      <button class="btn btn-primary" type="button" onclick="closeStopDialog()">Close</button>
     </div>
   </div>
 </div>
 
 <script>
-// Mesh background
-(function(){
-  const m=document.getElementById('mesh');
-  const gap=80;
-  for(let y=0;y<window.innerHeight;y+=gap){
-    const l=document.createElement('div');
-    l.className='mesh-line mesh-h';
-    l.style.top=y+'px';
-    l.style.opacity=String(.15+Math.random()*.1);
-    m.appendChild(l);
-  }
-  for(let x=0;x<window.innerWidth;x+=gap){
-    const l=document.createElement('div');
-    l.className='mesh-line mesh-v';
-    l.style.left=x+'px';
-    l.style.opacity=String(.1+Math.random()*.08);
-    m.appendChild(l);
-  }
-})();
+const API = "";
+const POLL_MS = 2500;
+let pollTimer = null;
+let lastStatus = null;
 
-// Seed grid
-(function(){
-  const g=document.getElementById('seed-grid');
-  for(let i=0;i<24;i++){
-    const c=document.createElement('div');c.className='scell';
-    const n=document.createElement('div');n.className='snum';n.textContent=String(i+1).padStart(2,'0');
-    const inp=document.createElement('input');inp.className='sinput';inp.dataset.idx=String(i);inp.placeholder='···';inp.autocomplete='off';inp.spellcheck=false;inp.autocapitalize='off';
-    c.appendChild(n);c.appendChild(inp);g.appendChild(c);
-  }
-  g.addEventListener('keydown',e=>{if(e.key===' '||e.key==='Tab'){e.preventDefault();const nx=g.querySelector('[data-idx="'+(parseInt(e.target.dataset.idx)+1)+'"]');if(nx)nx.focus();}});
-  g.addEventListener('paste',e=>{const t=(e.clipboardData||window.clipboardData).getData('text');const w=t.trim().split(/\s+/);if(w.length>1){e.preventDefault();w.forEach((v,i)=>{const inp=g.querySelector('[data-idx="'+i+'"]');if(inp)inp.value=v;});}});
-})();
+const els = {};
 
-const API='';
-function showRestore(){document.getElementById('s-choose').classList.add('hidden');document.getElementById('s-restore').classList.remove('hidden');document.querySelector('.sinput').focus();}
-function showCreate(){document.getElementById('s-choose').classList.add('hidden');document.getElementById('s-create').classList.remove('hidden');document.getElementById('n-name').focus();}
-function back(){document.getElementById('s-restore').classList.add('hidden');document.getElementById('s-create').classList.add('hidden');document.getElementById('s-choose').classList.remove('hidden');}
-function getWords(){return Array.from(document.querySelectorAll('.sinput')).map(i=>i.value.trim().toLowerCase()).filter(w=>w);}
-
-async function doRestore(){
-  const w=getWords(),err=document.getElementById('r-err');err.classList.add('hidden');
-  if(w.length!==20&&w.length!==24){err.textContent='Expected 20 or 24 words, got '+w.length;err.classList.remove('hidden');return;}
-  const b=document.getElementById('r-btn');b.disabled=true;b.textContent='RESTORING...';
-  try{const r=await fetch(API+'/api/setup',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:'restore',seed_phrase:w.join(' ')})});
-    const d=await r.json();if(d.error){err.textContent=d.error;err.classList.remove('hidden');b.disabled=false;b.textContent='RESTORE IDENTITY';return;}
-    goDash();
-  }catch(e){err.textContent=e.message;err.classList.remove('hidden');b.disabled=false;b.textContent='RESTORE IDENTITY';}
+function $(id) {
+  return document.getElementById(id);
 }
 
-async function doCreate(){
-  const name=document.getElementById('n-name').value.trim()||'sovereign-node';
-  const err=document.getElementById('c-err');err.classList.add('hidden');
-  const b=document.getElementById('c-btn');b.disabled=true;b.textContent='LAUNCHING...';
-  try{const r=await fetch(API+'/api/setup',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:'create',node_name:name})});
-    const d=await r.json();if(d.error){err.textContent=d.error;err.classList.remove('hidden');b.disabled=false;b.textContent='LAUNCH NODE';return;}
-    goDash();
-  }catch(e){err.textContent=e.message;err.classList.remove('hidden');b.disabled=false;b.textContent='LAUNCH NODE';}
+function cacheElements() {
+  [
+    "view-setup","view-dashboard","setup-choice","setup-restore","setup-create",
+    "restore-error","create-error","restore-btn","create-btn","node-name","seed-grid",
+    "nav-dot","nav-state","nav-network","nav-height","hero-identity","hero-wallet",
+    "metric-height","metric-balance","metric-balance-atoms","metric-validators","metric-identities",
+    "status-detail","progress-fill","progress-label","progress-detail","progress-copy","did-value",
+    "status-network","status-registered","status-wallet","copy-did-btn","register-cta",
+    "register-info","state-pill","state-pill-dot","state-pill-text","stop-dialog",
+    "register-btn","disconnect-btn","disconnect-confirm-btn"
+  ].forEach(function(id){els[id] = $(id);});
 }
 
-function goDash(){document.getElementById('v-setup').classList.add('hidden');document.getElementById('v-dash').classList.remove('hidden');poll();}
-function poll(){upd();setInterval(upd,2500);}
-
-async function upd(){
-  try{
-    const r=await fetch(API+'/api/status');const d=await r.json();
-    const h=Number(d.chain_height||0);
-    document.getElementById('m-h').textContent=h.toLocaleString();
-    document.getElementById('nav-h').textContent=h.toLocaleString();
-    document.getElementById('m-b').textContent=d.sov_balance_human||'0';
-    document.getElementById('m-ba').textContent=d.sov_balance?Number(d.sov_balance).toLocaleString()+' atoms':'';
-    document.getElementById('m-v').textContent=d.validator_count||'0';
-    document.getElementById('m-i').textContent=d.identity_count||'0';
-    document.getElementById('m-did').textContent=d.did||'—';
-    document.getElementById('m-reg').textContent=d.identity_registered?'Yes':'No';
-    document.getElementById('m-net').textContent=d.network_id||'—';
-    document.getElementById('m-wid').textContent=d.wallet_id?d.wallet_id.slice(0,16)+'…':'—';
-    document.getElementById('m-sov').textContent=(d.sov_balance_human||'0')+' SOV';
-    const tag=document.getElementById('m-tag'),dot=document.getElementById('dot'),st=document.getElementById('nav-st');
-    if(d.state==='ready'){tag.className='tag tag-g';tag.textContent='SYNCED';dot.className='dot';st.textContent='Online';}
-    else if(d.state==='identity_not_registered'){tag.className='tag tag-w';tag.textContent='UNREGISTERED';dot.className='dot warn';st.textContent='Unregistered';}
-    else if(d.state==='connecting'){tag.className='tag tag-w';tag.textContent='SYNCING';dot.className='dot warn';st.textContent='Syncing';}
-    else{tag.className='tag tag-r';tag.textContent=d.state||'OFFLINE';dot.className='dot off';st.textContent='Offline';}
-    const pct=Math.min(100,(h/50000)*100);
-    document.getElementById('m-fill').style.width=pct+'%';
-    document.getElementById('m-pct').textContent=pct<100?pct.toFixed(1)+'%':'Synced';
-  }catch(e){}
+function formatNumber(value) {
+  const number = Number(value || 0);
+  if (!Number.isFinite(number)) return "0";
+  return number.toLocaleString();
 }
 
-(async()=>{try{const r=await fetch(API+'/api/status');const d=await r.json();if(d.state&&d.state!=='setup_required')goDash();}catch(e){}})();
+function setView(mode) {
+  const showSetup = mode === "setup";
+  els["view-setup"].classList.toggle("hidden", !showSetup);
+  els["view-dashboard"].classList.toggle("hidden", showSetup);
+  if (!showSetup) startPolling();
+}
+
+function showRestore() {
+  clearError("restore-error");
+  els["setup-choice"].classList.add("hidden");
+  els["setup-create"].classList.add("hidden");
+  els["setup-restore"].classList.remove("hidden");
+  const first = document.querySelector(".seed-input");
+  if (first) first.focus();
+}
+
+function showCreate() {
+  clearError("create-error");
+  els["setup-choice"].classList.add("hidden");
+  els["setup-restore"].classList.add("hidden");
+  els["setup-create"].classList.remove("hidden");
+  els["node-name"].focus();
+}
+
+function backToChoices() {
+  clearError("restore-error");
+  clearError("create-error");
+  els["setup-restore"].classList.add("hidden");
+  els["setup-create"].classList.add("hidden");
+  els["setup-choice"].classList.remove("hidden");
+}
+
+function clearError(id) {
+  els[id].textContent = "";
+  els[id].classList.add("hidden");
+}
+
+function showError(id, message) {
+  els[id].textContent = message;
+  els[id].classList.remove("hidden");
+}
+
+function setBusy(id, busy, label) {
+  const button = els[id];
+  button.disabled = busy;
+  button.textContent = label;
+}
+
+function buildSeedGrid() {
+  const grid = els["seed-grid"];
+  for (let i = 0; i < 24; i += 1) {
+    const cell = document.createElement("label");
+    cell.className = "seed-cell";
+
+    const number = document.createElement("span");
+    number.className = "seed-number";
+    number.textContent = String(i + 1).padStart(2, "0");
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "seed-input";
+    input.dataset.index = String(i);
+    input.autocomplete = "off";
+    input.autocapitalize = "off";
+    input.spellcheck = false;
+    input.placeholder = "word";
+
+    cell.appendChild(number);
+    cell.appendChild(input);
+    grid.appendChild(cell);
+  }
+
+  grid.addEventListener("keydown", function(event) {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    const index = Number(target.dataset.index);
+    if (event.key === "Enter" || event.key === "ArrowRight" || event.key === " ") {
+      event.preventDefault();
+      focusSeed(index + 1);
+      return;
+    }
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusSeed(index - 1);
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      focusSeed(index + 4);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      focusSeed(index - 4);
+      return;
+    }
+    if (event.key === "Backspace" && !target.value) {
+      focusSeed(index - 1);
+    }
+  });
+
+  grid.addEventListener("paste", function(event) {
+    const text = (event.clipboardData || window.clipboardData).getData("text");
+    const words = normalizeSeedWords(text);
+    if (words.length <= 1) return;
+    event.preventDefault();
+    fillSeedWords(words);
+  });
+}
+
+function focusSeed(index) {
+  if (index < 0 || index > 23) return;
+  const next = document.querySelector('.seed-input[data-index="' + index + '"]');
+  if (next) next.focus();
+}
+
+function normalizeSeedWords(text) {
+  return String(text || "")
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function fillSeedWords(words) {
+  const inputs = document.querySelectorAll(".seed-input");
+  inputs.forEach(function(input, index) {
+    input.value = words[index] || "";
+  });
+}
+
+function clearSeed() {
+  fillSeedWords([]);
+  clearError("restore-error");
+  focusSeed(0);
+}
+
+function getSeedWords() {
+  return Array.from(document.querySelectorAll(".seed-input"))
+    .map(function(input) { return input.value.trim().toLowerCase(); })
+    .filter(Boolean);
+}
+
+async function requestJson(path, options) {
+  const response = await fetch(API + path, options);
+  return response.json();
+}
+
+async function postControl(action) {
+  return requestJson("/api/control", {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({action: action})
+  });
+}
+
+async function doRestore() {
+  clearError("restore-error");
+  const words = getSeedWords();
+  if (words.length !== 20 && words.length !== 24) {
+    showError("restore-error", "Expected 20 or 24 words, got " + words.length + ".");
+    return;
+  }
+
+  setBusy("restore-btn", true, "Restoring...");
+  try {
+    const data = await requestJson("/api/setup", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({
+        action: "restore",
+        seed_phrase: words.join(" ")
+      })
+    });
+    clearSeed();
+    if (data.error) throw new Error(data.error);
+    setView("dashboard");
+    await refreshStatus(true);
+  } catch (error) {
+    showError("restore-error", error.message || "Restore failed.");
+  } finally {
+    setBusy("restore-btn", false, "Restore Identity");
+  }
+}
+
+async function doCreate() {
+  clearError("create-error");
+  const name = els["node-name"].value.trim() || "sovereign-node";
+  setBusy("create-btn", true, "Launching...");
+  try {
+    const data = await requestJson("/api/setup", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({
+        action: "create",
+        node_name: name
+      })
+    });
+    if (data.error) throw new Error(data.error);
+    setView("dashboard");
+    await refreshStatus(true);
+  } catch (error) {
+    showError("create-error", error.message || "Launch failed.");
+  } finally {
+    setBusy("create-btn", false, "Launch Node");
+  }
+}
+
+function mapState(status) {
+  const state = status && status.state ? status.state : "connecting";
+  if (state === "ready") {
+    return {
+      key: "ready",
+      label: "Connected",
+      detail: "Node is online and serving current telemetry.",
+      progress: 100
+    };
+  }
+  if (state === "identity_not_registered") {
+    return {
+      key: "unregistered",
+      label: "Unregistered",
+      detail: "Identity exists locally but is not registered on-chain.",
+      progress: 82
+    };
+  }
+  if (state === "connecting") {
+    return {
+      key: "syncing",
+      label: "Syncing",
+      detail: "Bridge is attempting to connect to the node and fetch current status.",
+      progress: status && Number(status.chain_height) > 0 ? 68 : 34
+    };
+  }
+  if (state === "setup_required") {
+    return {
+      key: "offline",
+      label: "Setup Required",
+      detail: "No local identity is available yet.",
+      progress: 0
+    };
+  }
+  return {
+    key: "offline",
+    label: "Offline",
+    detail: "Telemetry is unavailable from the node bridge.",
+    progress: 12
+  };
+}
+
+function applyNavStatus(mapped, status) {
+  els["nav-state"].textContent = mapped.label;
+  els["nav-network"].textContent = status.network_id || "Unknown";
+  els["nav-height"].textContent = formatNumber(status.chain_height);
+  els["nav-dot"].className = "signal-dot " + mapped.key;
+}
+
+function applyDashboardStatus(status) {
+  lastStatus = status;
+  const mapped = mapState(status);
+  applyNavStatus(mapped, status);
+
+  const height = formatNumber(status.chain_height);
+  els["metric-height"].textContent = height;
+  els["metric-balance"].textContent = status.sov_balance_human || "0.0000";
+  els["metric-balance-atoms"].textContent = status.sov_balance ? formatNumber(status.sov_balance) + " atoms" : "0 atoms";
+  els["metric-validators"].textContent = formatNumber(status.validator_count);
+  els["metric-identities"].textContent = formatNumber(status.identity_count);
+
+  const did = status.did || "No DID detected yet.";
+  els["did-value"].textContent = did;
+  els["copy-did-btn"].disabled = !status.did;
+
+  els["hero-identity"].textContent = status.did ? "Loaded" : "Awaiting";
+  els["hero-wallet"].textContent = status.wallet_id ? "Linked" : "Standby";
+
+  els["status-network"].textContent = status.network_id || "Unknown";
+  els["status-registered"].textContent = status.identity_registered ? "Registered" : "Needs Action";
+  els["status-wallet"].textContent = status.wallet_id || "Unavailable";
+
+  els["status-detail"].textContent = mapped.detail;
+  els["progress-copy"].textContent = mapped.detail;
+  els["progress-fill"].style.width = Math.max(0, Math.min(100, mapped.progress)) + "%";
+  els["progress-label"].textContent = mapped.progress + "%";
+  els["progress-detail"].textContent = status.identity_registered === false ? "Registration pending after identity creation." : "Based on the current bridge-reported state.";
+
+  els["state-pill"].className = "status-pill " + mapped.key;
+  els["state-pill-text"].textContent = mapped.label;
+  els["state-pill-dot"].className = "signal-dot " + mapped.key;
+
+  const registerVisible = status.identity_registered === false;
+  els["register-cta"].classList.toggle("hidden", !registerVisible);
+
+  if (mapped.key === "ready") {
+    els["progress-label"].textContent = "100%";
+  }
+}
+
+async function refreshStatus(force) {
+  try {
+    const data = await requestJson("/api/status");
+    applyDashboardStatus(data);
+    if (data.state === "setup_required") {
+      stopPolling();
+      setView("setup");
+      backToChoices();
+    } else if (els["view-dashboard"].classList.contains("hidden")) {
+      setView("dashboard");
+    }
+  } catch (_error) {
+    applyDashboardStatus({
+      state: "connecting",
+      chain_height: lastStatus && lastStatus.chain_height ? lastStatus.chain_height : 0,
+      network_id: lastStatus && lastStatus.network_id ? lastStatus.network_id : "Unknown",
+      validator_count: lastStatus && lastStatus.validator_count ? lastStatus.validator_count : 0,
+      identity_count: lastStatus && lastStatus.identity_count ? lastStatus.identity_count : 0,
+      identity_registered: lastStatus ? lastStatus.identity_registered : null,
+      did: lastStatus ? lastStatus.did : "",
+      wallet_id: lastStatus ? lastStatus.wallet_id : ""
+    });
+  }
+
+  if (force) {
+    const info = els["register-info"];
+    info.classList.add("hidden");
+    info.textContent = "";
+  }
+}
+
+function startPolling() {
+  if (pollTimer) return;
+  refreshStatus(false);
+  pollTimer = window.setInterval(function() {
+    refreshStatus(false);
+  }, POLL_MS);
+}
+
+function stopPolling() {
+  if (!pollTimer) return;
+  window.clearInterval(pollTimer);
+  pollTimer = null;
+}
+
+async function copyText(text, successLabel, fallbackLabel, targetButtonId) {
+  try {
+    await navigator.clipboard.writeText(text);
+    if (targetButtonId) {
+      const button = $(targetButtonId);
+      const previous = button.textContent;
+      button.textContent = successLabel;
+      window.setTimeout(function(){ button.textContent = previous; }, 1200);
+    }
+  } catch (_error) {
+    if (targetButtonId) {
+      const button = $(targetButtonId);
+      const previous = button.textContent;
+      button.textContent = fallbackLabel;
+      window.setTimeout(function(){ button.textContent = previous; }, 1400);
+    }
+  }
+}
+
+function copyDid() {
+  if (!lastStatus || !lastStatus.did) return;
+  copyText(lastStatus.did, "Copied", "Copy Failed", "copy-did-btn");
+}
+
+function openRegisterGuide(event) {
+  if (event) event.preventDefault();
+  const panel = $("register-guide");
+  if (panel) panel.scrollIntoView({behavior: "smooth", block: "nearest"});
+}
+
+function copyRegisterCommand() {
+  const info = els["register-info"];
+  const command = "zhtp-cli identity register <display-name> <device-id>";
+  copyText(command, "Copied", "Copy Failed");
+  info.textContent = "CLI hint copied: " + command;
+  info.classList.remove("hidden");
+}
+
+async function registerIdentity() {
+  const info = els["register-info"];
+  info.classList.add("hidden");
+  info.textContent = "";
+  setBusy("register-btn", true, "Registering...");
+  try {
+    const data = await postControl("register_identity");
+    if (data.error) throw new Error(data.error);
+    info.textContent = "Identity registered on-chain. Refreshing status.";
+    info.classList.remove("hidden");
+    await refreshStatus(true);
+  } catch (error) {
+    info.textContent = error.message || "Registration failed.";
+    info.classList.remove("hidden");
+  } finally {
+    setBusy("register-btn", false, "Register Identity");
+  }
+}
+
+function openStopDialog() {
+  els["stop-dialog"].classList.add("open");
+}
+
+function closeStopDialog() {
+  els["stop-dialog"].classList.remove("open");
+}
+
+function dismissDialog(event) {
+  if (event.target === els["stop-dialog"]) {
+    closeStopDialog();
+  }
+}
+
+async function disconnectSession() {
+  setBusy("disconnect-confirm-btn", true, "Disconnecting...");
+  try {
+    const data = await postControl("disconnect");
+    if (data.error) throw new Error(data.error);
+    stopPolling();
+    closeStopDialog();
+    els["register-info"].textContent = "Setup UI bridge stopped. Reloading this page will fail until you launch `zhtp-cli node setup-ui` again.";
+    els["register-info"].classList.remove("hidden");
+    els["disconnect-btn"].disabled = true;
+    els["nav-state"].textContent = "Disconnected";
+    els["nav-dot"].className = "signal-dot offline";
+  } catch (error) {
+    els["register-info"].textContent = error.message || "Disconnect failed.";
+    els["register-info"].classList.remove("hidden");
+  } finally {
+    setBusy("disconnect-confirm-btn", false, "Disconnect");
+  }
+}
+
+async function bootstrap() {
+  cacheElements();
+  buildSeedGrid();
+  try {
+    const data = await requestJson("/api/status");
+    if (data.state === "setup_required") {
+      applyNavStatus(mapState(data), data);
+      setView("setup");
+      return;
+    }
+    setView("dashboard");
+    applyDashboardStatus(data);
+  } catch (_error) {
+    setView("setup");
+  }
+}
+
+bootstrap();
 </script>
 </body>
 </html>

--- a/zhtp-cli/src/ui/setup.html
+++ b/zhtp-cli/src/ui/setup.html
@@ -577,8 +577,8 @@ button,input{font:inherit}
             <div class="did-value" id="did-value">No DID detected yet.</div>
             <div class="did-actions">
               <button class="btn btn-secondary" type="button" id="copy-did-btn" onclick="copyDid()">Copy DID</button>
-              <button class="btn btn-secondary" type="button" onclick="refreshStatus(true)">Force Sync</button>
-              <button class="btn btn-danger" type="button" id="disconnect-btn" onclick="openStopDialog()">Disconnect Session</button>
+              <button class="btn btn-secondary" type="button" id="force-sync-btn" onclick="forceSync()">Force Sync</button>
+              <button class="btn btn-danger" type="button" id="disconnect-btn" onclick="openStopDialog()">Disconnect / Stop Node</button>
             </div>
             <div id="register-cta" class="register-cta hidden">
               <a href="#register-guide" class="inline-link" onclick="openRegisterGuide(event)">Register this identity on-chain</a>
@@ -634,7 +634,7 @@ button,input{font:inherit}
           <article class="logline">
             <div>
               <div class="help-label">Operator Guidance</div>
-              <div class="help-copy">Force sync pulls immediately. Disconnect stops the local setup UI bridge session; it does not terminate the remote QUIC node process.</div>
+              <div class="help-copy">Every operational action runs through the local CLI bridge. The bridge is the only browser-facing surface; the node remains QUIC-only.</div>
             </div>
           </article>
         </aside>
@@ -645,11 +645,11 @@ button,input{font:inherit}
 
 <div class="dialog-backdrop" id="stop-dialog" onclick="dismissDialog(event)">
   <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="stop-dialog-title">
-    <h3 id="stop-dialog-title">Disconnect Session</h3>
-    <p>This stops the local `setup-ui` bridge process on `localhost:7840`. It disconnects the browser control surface, but it does not shut down the remote node itself.</p>
-    <code>The browser session will lose connectivity once the bridge exits.</code>
+    <h3 id="stop-dialog-title">Disconnect / Stop Node</h3>
+    <p>This action is expected to call the node control path over QUIC through the local CLI bridge. Use it to stop node networking or the node itself, depending on the backend implementation.</p>
+    <code>Expected node endpoint: POST /api/v1/node/shutdown</code>
     <div class="dialog-actions">
-      <button class="btn btn-danger" type="button" id="disconnect-confirm-btn" onclick="disconnectSession()">Disconnect</button>
+      <button class="btn btn-danger" type="button" id="disconnect-confirm-btn" onclick="disconnectNode()">Disconnect Node</button>
       <button class="btn btn-primary" type="button" onclick="closeStopDialog()">Close</button>
     </div>
   </div>
@@ -676,7 +676,7 @@ function cacheElements() {
     "status-detail","progress-fill","progress-label","progress-detail","progress-copy","did-value",
     "status-network","status-registered","status-wallet","copy-did-btn","register-cta",
     "register-info","state-pill","state-pill-dot","state-pill-text","stop-dialog",
-    "register-btn","disconnect-btn","disconnect-confirm-btn"
+    "register-btn","disconnect-btn","disconnect-confirm-btn","force-sync-btn"
   ].forEach(function(id){els[id] = $(id);});
 }
 
@@ -834,11 +834,11 @@ async function requestJson(path, options) {
   return response.json();
 }
 
-async function postControl(action) {
+async function postControl(action, extra) {
   return requestJson("/api/control", {
     method: "POST",
     headers: {"Content-Type": "application/json"},
-    body: JSON.stringify({action: action})
+    body: JSON.stringify(Object.assign({action: action}, extra || {}))
   });
 }
 
@@ -852,13 +852,8 @@ async function doRestore() {
 
   setBusy("restore-btn", true, "Restoring...");
   try {
-    const data = await requestJson("/api/setup", {
-      method: "POST",
-      headers: {"Content-Type": "application/json"},
-      body: JSON.stringify({
-        action: "restore",
-        seed_phrase: words.join(" ")
-      })
+    const data = await postControl("restore_identity", {
+      seed_phrase: words.join(" ")
     });
     clearSeed();
     if (data.error) throw new Error(data.error);
@@ -876,13 +871,8 @@ async function doCreate() {
   const name = els["node-name"].value.trim() || "sovereign-node";
   setBusy("create-btn", true, "Launching...");
   try {
-    const data = await requestJson("/api/setup", {
-      method: "POST",
-      headers: {"Content-Type": "application/json"},
-      body: JSON.stringify({
-        action: "create",
-        node_name: name
-      })
+    const data = await postControl("create_identity", {
+      node_name: name
     });
     if (data.error) throw new Error(data.error);
     setView("dashboard");
@@ -1086,6 +1076,25 @@ async function registerIdentity() {
   }
 }
 
+async function forceSync() {
+  const info = els["register-info"];
+  info.classList.add("hidden");
+  info.textContent = "";
+  setBusy("force-sync-btn", true, "Syncing...");
+  try {
+    const data = await postControl("force_sync");
+    if (data.error) throw new Error(data.error);
+    info.textContent = data.message || "Force sync command sent. Refreshing status.";
+    info.classList.remove("hidden");
+    await refreshStatus(true);
+  } catch (error) {
+    info.textContent = error.message || "Force sync failed.";
+    info.classList.remove("hidden");
+  } finally {
+    setBusy("force-sync-btn", false, "Force Sync");
+  }
+}
+
 function openStopDialog() {
   els["stop-dialog"].classList.add("open");
 }
@@ -1100,23 +1109,20 @@ function dismissDialog(event) {
   }
 }
 
-async function disconnectSession() {
-  setBusy("disconnect-confirm-btn", true, "Disconnecting...");
+async function disconnectNode() {
+  setBusy("disconnect-confirm-btn", true, "Stopping...");
   try {
-    const data = await postControl("disconnect");
+    const data = await postControl("disconnect_node");
     if (data.error) throw new Error(data.error);
-    stopPolling();
     closeStopDialog();
-    els["register-info"].textContent = "Setup UI bridge stopped. Reloading this page will fail until you launch `zhtp-cli node setup-ui` again.";
+    els["register-info"].textContent = data.message || "Disconnect command sent to node control plane.";
     els["register-info"].classList.remove("hidden");
-    els["disconnect-btn"].disabled = true;
-    els["nav-state"].textContent = "Disconnected";
-    els["nav-dot"].className = "signal-dot offline";
+    await refreshStatus(true);
   } catch (error) {
     els["register-info"].textContent = error.message || "Disconnect failed.";
     els["register-info"].classList.remove("hidden");
   } finally {
-    setBusy("disconnect-confirm-btn", false, "Disconnect");
+    setBusy("disconnect-confirm-btn", false, "Disconnect Node");
   }
 }
 

--- a/zhtp-cli/src/ui/setup.html
+++ b/zhtp-cli/src/ui/setup.html
@@ -3,267 +3,323 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>SOV — Node Control</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<title>Sovereign Network</title>
+<link href="https://fonts.googleapis.com/css2?family=Syncopate:wght@400;700&family=DM+Mono:wght@300;400;500&family=Manrope:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
-:root {
-  --bg: #060610;
-  --surface: #0c0c1a;
-  --surface-2: #111125;
-  --border: #1a1a35;
-  --text: #d8dce8;
-  --text-dim: #525278;
-  --text-muted: #3a3a5c;
-  --cyan: #00e8ff;
-  --cyan-dim: rgba(0, 232, 255, 0.08);
-  --cyan-glow: rgba(0, 232, 255, 0.25);
-  --green: #00ff88;
-  --green-dim: rgba(0, 255, 136, 0.08);
-  --amber: #ffb800;
-  --amber-dim: rgba(255, 184, 0, 0.08);
-  --red: #ff3366;
-  --red-dim: rgba(255, 51, 102, 0.08);
-  --mono: 'JetBrains Mono', monospace;
-  --sans: 'Outfit', sans-serif;
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#020408;
+  --s1:#080c14;
+  --s2:#0d1220;
+  --brd:#141c2e;
+  --t:#c8d4e8;
+  --td:#4a5678;
+  --tm:#2a3450;
+  --teal:#0ff5ce;
+  --teal2:rgba(15,245,206,.06);
+  --teal3:rgba(15,245,206,.2);
+  --mag:#ff2d78;
+  --mag2:rgba(255,45,120,.06);
+  --ok:#22e88a;
+  --warn:#ffc233;
+  --err:#ff3b5c;
+  --display:'Syncopate',sans-serif;
+  --mono:'DM Mono',monospace;
+  --body:'Manrope',sans-serif;
 }
-* { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: var(--sans); background: var(--bg); color: var(--text); min-height: 100vh; overflow-x: hidden; }
-body::before { content: ''; position: fixed; inset: 0; background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E"); pointer-events: none; z-index: 9999; }
-.topbar { position: fixed; top: 0; left: 0; right: 0; height: 48px; background: rgba(6,6,16,0.9); backdrop-filter: blur(20px); border-bottom: 1px solid var(--border); display: flex; align-items: center; padding: 0 24px; z-index: 100; gap: 16px; }
-.topbar-brand { font-family: var(--mono); font-weight: 700; font-size: 13px; letter-spacing: 2px; text-transform: uppercase; color: var(--cyan); }
-.topbar-sep { width: 1px; height: 20px; background: var(--border); }
-.topbar-status { display: flex; align-items: center; gap: 6px; font-family: var(--mono); font-size: 11px; color: var(--text-dim); }
-.pulse { width: 6px; height: 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 8px var(--green); animation: pg 2s ease-in-out infinite; }
-.pulse.warn { background: var(--amber); box-shadow: 0 0 8px var(--amber); }
-.pulse.off { background: var(--red); box-shadow: 0 0 8px var(--red); animation: none; }
-@keyframes pg { 0%,100%{opacity:1;transform:scale(1)} 50%{opacity:.5;transform:scale(.8)} }
-.topbar-right { margin-left: auto; display: flex; align-items: center; gap: 16px; }
-.topbar-height { font-family: var(--mono); font-size: 12px; color: var(--text-dim); }
-.topbar-height span { color: var(--cyan); font-weight: 500; }
-.main { padding-top: 48px; min-height: 100vh; }
-.setup-view { display: flex; justify-content: center; align-items: center; min-height: calc(100vh - 48px); padding: 40px 20px; }
-.setup-card { width: 100%; max-width: 480px; animation: fu .6s ease; }
-@keyframes fu { from{opacity:0;transform:translateY(20px)} to{opacity:1;transform:translateY(0)} }
-.setup-header { text-align: center; margin-bottom: 40px; }
-.setup-header h1 { font-size: 24px; font-weight: 600; margin-bottom: 8px; }
-.setup-header p { color: var(--text-dim); font-size: 14px; }
-.setup-options { display: grid; gap: 12px; margin-bottom: 24px; }
-.setup-option { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px; cursor: pointer; transition: all .2s; display: flex; align-items: center; gap: 16px; }
-.setup-option:hover { border-color: var(--cyan); background: var(--cyan-dim); }
-.setup-option-icon { width: 40px; height: 40px; border-radius: 10px; background: var(--surface-2); display: flex; align-items: center; justify-content: center; font-size: 18px; flex-shrink: 0; }
-.setup-option-text h3 { font-size: 15px; font-weight: 500; margin-bottom: 2px; }
-.setup-option-text p { font-size: 12px; color: var(--text-dim); }
-.seed-panel { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 24px; }
-.seed-panel h2 { font-size: 16px; font-weight: 500; margin-bottom: 16px; }
-.seed-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: 6px; margin-bottom: 16px; }
-.seed-word { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 8px 6px; font-family: var(--mono); font-size: 12px; color: var(--text); text-align: center; outline: none; transition: border-color .2s; width: 100%; }
-.seed-word:focus { border-color: var(--cyan); box-shadow: 0 0 0 2px var(--cyan-dim); }
-.seed-word::placeholder { color: var(--text-muted); font-size: 10px; }
-.seed-word-num { font-size: 9px; color: var(--text-muted); text-align: center; margin-bottom: 2px; font-family: var(--mono); }
-.seed-word-cell { display: flex; flex-direction: column; }
-.name-input { width: 100%; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; font-family: var(--mono); font-size: 14px; color: var(--text); outline: none; margin-bottom: 16px; }
-.name-input:focus { border-color: var(--cyan); }
-.btn { width: 100%; padding: 12px; border: none; border-radius: 8px; font-family: var(--sans); font-size: 14px; font-weight: 600; cursor: pointer; transition: all .15s; margin-top: 8px; }
-.btn-cyan { background: var(--cyan); color: var(--bg); }
-.btn-cyan:hover { filter: brightness(1.1); transform: translateY(-1px); }
-.btn-cyan:disabled { opacity: .4; cursor: not-allowed; transform: none; }
-.btn-ghost { background: transparent; color: var(--text-dim); border: 1px solid var(--border); }
-.btn-ghost:hover { border-color: var(--text-dim); color: var(--text); }
-.error-text { color: var(--red); font-size: 12px; margin-top: 8px; font-family: var(--mono); }
-.dashboard { padding: 24px; display: grid; gap: 16px; animation: fu .4s ease; }
-.metrics-row { display: grid; grid-template-columns: repeat(4,1fr); gap: 12px; }
-@media(max-width:800px) { .metrics-row{grid-template-columns:repeat(2,1fr)} }
-.metric { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px; position: relative; overflow: hidden; }
-.metric::after { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--border); }
-.metric.ac::after { background: var(--cyan); box-shadow: 0 0 12px var(--cyan-glow); }
-.metric.ag::after { background: var(--green); }
-.metric.aa::after { background: var(--amber); }
-.metric-label { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--text-dim); margin-bottom: 8px; font-family: var(--mono); }
-.metric-value { font-family: var(--mono); font-size: 22px; font-weight: 700; letter-spacing: -.5px; }
-.metric-sub { font-size: 11px; color: var(--text-dim); margin-top: 4px; font-family: var(--mono); }
-.identity-card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 20px; }
-.identity-card h3 { font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: var(--text-dim); margin-bottom: 12px; font-family: var(--mono); }
-.did-display { font-family: var(--mono); font-size: 13px; color: var(--cyan); word-break: break-all; line-height: 1.6; padding: 12px; background: var(--bg); border-radius: 6px; border: 1px solid var(--border); }
-.status-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-.status-card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px; }
-.status-card h3 { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--text-dim); margin-bottom: 10px; font-family: var(--mono); }
-.status-item { display: flex; justify-content: space-between; align-items: center; padding: 6px 0; border-bottom: 1px solid var(--border); font-size: 12px; }
-.status-item:last-child { border-bottom: none; }
-.status-item .key { color: var(--text-dim); font-family: var(--mono); }
-.status-item .val { font-family: var(--mono); font-weight: 500; }
-.badge { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 4px; font-size: 10px; font-family: var(--mono); font-weight: 600; text-transform: uppercase; letter-spacing: .5px; }
-.badge-green { background: var(--green-dim); color: var(--green); }
-.badge-amber { background: var(--amber-dim); color: var(--amber); }
-.badge-red { background: var(--red-dim); color: var(--red); }
-.sync-bar-container { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px; }
-.sync-bar-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
-.sync-bar-header h3 { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--text-dim); font-family: var(--mono); }
-.sync-bar-pct { font-family: var(--mono); font-size: 12px; color: var(--cyan); font-weight: 500; }
-.sync-track { height: 3px; background: var(--border); border-radius: 2px; overflow: hidden; }
-.sync-fill { height: 100%; background: linear-gradient(90deg,var(--cyan),#00ff88); border-radius: 2px; transition: width .8s ease; box-shadow: 0 0 8px var(--cyan-glow); }
-.hidden { display: none !important; }
+html{background:var(--bg);color:var(--t);font-family:var(--body)}
+body{min-height:100vh;overflow-x:hidden;position:relative}
+
+/* Animated mesh background */
+.mesh{position:fixed;inset:0;z-index:0;overflow:hidden;opacity:.4}
+.mesh-line{position:absolute;background:var(--brd);transform-origin:0 0}
+.mesh-h{width:100%;height:1px;left:0}
+.mesh-v{height:100%;width:1px;top:0}
+
+/* Glow orbs */
+.orb{position:fixed;border-radius:50%;filter:blur(120px);pointer-events:none;z-index:0}
+.orb-1{width:600px;height:600px;background:rgba(15,245,206,.05);top:-200px;right:-100px;animation:orb-drift 20s ease-in-out infinite alternate}
+.orb-2{width:400px;height:400px;background:rgba(255,45,120,.04);bottom:-100px;left:-100px;animation:orb-drift 25s ease-in-out infinite alternate-reverse}
+@keyframes orb-drift{0%{transform:translate(0,0)}100%{transform:translate(40px,30px)}}
+
+.wrap{position:relative;z-index:1;min-height:100vh}
+
+/* Nav */
+nav{position:fixed;top:0;left:0;right:0;z-index:100;height:56px;display:flex;align-items:center;padding:0 32px;background:rgba(2,4,8,.8);backdrop-filter:blur(24px);border-bottom:1px solid var(--brd)}
+.nav-brand{font-family:var(--display);font-size:11px;font-weight:700;letter-spacing:4px;text-transform:uppercase;color:var(--teal)}
+.nav-sep{width:1px;height:24px;background:var(--brd);margin:0 20px}
+.nav-pulse{display:flex;align-items:center;gap:8px}
+.dot{width:8px;height:8px;border-radius:50%;background:var(--ok);box-shadow:0 0 12px var(--ok);animation:blink 1.5s ease infinite}
+.dot.off{background:var(--err);box-shadow:0 0 12px var(--err);animation:none}
+.dot.warn{background:var(--warn);box-shadow:0 0 12px var(--warn)}
+@keyframes blink{0%,100%{opacity:1}50%{opacity:.3}}
+.nav-label{font-family:var(--mono);font-size:11px;color:var(--td);letter-spacing:.5px}
+.nav-right{margin-left:auto;display:flex;align-items:center;gap:24px}
+.nav-block{font-family:var(--mono);font-size:12px;color:var(--td)}
+.nav-block b{color:var(--teal);font-weight:500}
+
+/* ─── SETUP ─── */
+.setup{display:flex;align-items:center;justify-content:center;min-height:100vh;padding:56px 24px 24px}
+.setup-inner{width:100%;max-width:520px}
+.setup-hero{margin-bottom:48px;animation:rise .8s ease both}
+.setup-hero h1{font-family:var(--display);font-size:32px;font-weight:700;letter-spacing:3px;text-transform:uppercase;line-height:1.2;margin-bottom:12px}
+.setup-hero h1 span{color:var(--teal);display:block;font-size:14px;letter-spacing:6px;margin-bottom:8px;font-weight:400}
+.setup-hero p{color:var(--td);font-size:15px;font-weight:300;line-height:1.6;max-width:380px}
+@keyframes rise{from{opacity:0;transform:translateY(30px)}to{opacity:1;transform:translateY(0)}}
+
+.choices{display:grid;gap:14px;animation:rise .8s ease .15s both}
+.choice{background:var(--s1);border:1px solid var(--brd);border-radius:14px;padding:24px;cursor:pointer;transition:all .25s;position:relative;overflow:hidden}
+.choice::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,var(--teal2),transparent);opacity:0;transition:opacity .25s}
+.choice:hover{border-color:var(--teal);transform:translateY(-2px);box-shadow:0 8px 32px rgba(15,245,206,.08)}
+.choice:hover::before{opacity:1}
+.choice-row{display:flex;align-items:center;gap:16px;position:relative;z-index:1}
+.choice-icon{width:48px;height:48px;border-radius:12px;background:var(--s2);border:1px solid var(--brd);display:flex;align-items:center;justify-content:center;font-size:20px;flex-shrink:0}
+.choice h3{font-family:var(--body);font-size:15px;font-weight:600;margin-bottom:3px}
+.choice p{font-size:12px;color:var(--td);font-weight:400}
+
+/* Seed panel */
+.panel{background:var(--s1);border:1px solid var(--brd);border-radius:14px;padding:28px;animation:rise .5s ease both}
+.panel-title{font-family:var(--display);font-size:12px;letter-spacing:3px;text-transform:uppercase;color:var(--td);margin-bottom:20px}
+.sgrid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-bottom:20px}
+.scell{display:flex;flex-direction:column;gap:2px}
+.snum{font-family:var(--mono);font-size:9px;color:var(--tm);text-align:center;letter-spacing:1px}
+.sinput{background:var(--bg);border:1px solid var(--brd);border-radius:8px;padding:10px 8px;font-family:var(--mono);font-size:12px;color:var(--t);text-align:center;outline:none;transition:all .2s;width:100%}
+.sinput:focus{border-color:var(--teal);box-shadow:0 0 0 3px var(--teal2)}
+.sinput::placeholder{color:var(--tm)}
+.ninput{width:100%;background:var(--bg);border:1px solid var(--brd);border-radius:10px;padding:14px 16px;font-family:var(--mono);font-size:15px;color:var(--t);outline:none;margin-bottom:20px;letter-spacing:1px}
+.ninput:focus{border-color:var(--teal)}
+.ninput::placeholder{color:var(--tm)}
+
+.btn{width:100%;padding:14px;border:none;border-radius:10px;font-family:var(--body);font-size:14px;font-weight:700;cursor:pointer;transition:all .2s;margin-top:8px;letter-spacing:.5px;text-transform:uppercase}
+.btn-t{background:var(--teal);color:var(--bg)}
+.btn-t:hover{filter:brightness(1.15);transform:translateY(-1px);box-shadow:0 6px 24px var(--teal3)}
+.btn-t:disabled{opacity:.35;cursor:not-allowed;transform:none;box-shadow:none}
+.btn-g{background:transparent;color:var(--td);border:1px solid var(--brd)}
+.btn-g:hover{border-color:var(--td);color:var(--t)}
+.err{color:var(--err);font-size:12px;margin-top:10px;font-family:var(--mono)}
+
+/* ─── DASHBOARD ─── */
+.dash{padding:72px 32px 32px;animation:rise .5s ease both}
+.dash-head{display:flex;align-items:baseline;gap:16px;margin-bottom:32px}
+.dash-head h2{font-family:var(--display);font-size:14px;font-weight:700;letter-spacing:4px;text-transform:uppercase;color:var(--teal)}
+
+.mgrid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:20px}
+@media(max-width:860px){.mgrid{grid-template-columns:repeat(2,1fr)}}
+.mcard{background:var(--s1);border:1px solid var(--brd);border-radius:12px;padding:20px;position:relative;overflow:hidden;transition:border-color .3s}
+.mcard:hover{border-color:var(--teal)}
+.mcard-bar{position:absolute;top:0;left:0;right:0;height:2px}
+.mcard-bar.bt{background:var(--teal);box-shadow:0 0 16px var(--teal3)}
+.mcard-bar.bg{background:var(--ok)}
+.mcard-bar.bm{background:var(--mag)}
+.mcard-bar.bw{background:var(--warn)}
+.mcard-lbl{font-family:var(--mono);font-size:10px;letter-spacing:1.5px;text-transform:uppercase;color:var(--td);margin-bottom:10px}
+.mcard-val{font-family:var(--mono);font-size:26px;font-weight:500;letter-spacing:-1px}
+.mcard-sub{font-family:var(--mono);font-size:10px;color:var(--td);margin-top:6px}
+
+/* DID card */
+.did-card{background:var(--s1);border:1px solid var(--brd);border-radius:12px;padding:20px;margin-bottom:20px}
+.did-card h3{font-family:var(--mono);font-size:10px;letter-spacing:1.5px;text-transform:uppercase;color:var(--td);margin-bottom:12px}
+.did-val{font-family:var(--mono);font-size:12px;color:var(--teal);word-break:break-all;line-height:1.8;padding:14px;background:var(--bg);border-radius:8px;border:1px solid var(--brd);letter-spacing:.3px}
+
+/* Sync */
+.sync-card{background:var(--s1);border:1px solid var(--brd);border-radius:12px;padding:20px;margin-bottom:20px}
+.sync-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
+.sync-top h3{font-family:var(--mono);font-size:10px;letter-spacing:1.5px;text-transform:uppercase;color:var(--td)}
+.sync-pct{font-family:var(--mono);font-size:12px;color:var(--teal);font-weight:500}
+.sync-track{height:3px;background:var(--brd);border-radius:2px;overflow:hidden}
+.sync-fill{height:100%;background:linear-gradient(90deg,var(--teal),var(--ok));border-radius:2px;transition:width 1s cubic-bezier(.4,0,.2,1);box-shadow:0 0 12px var(--teal3)}
+
+/* Status grid */
+.sgrid2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+.scard{background:var(--s1);border:1px solid var(--brd);border-radius:12px;padding:18px}
+.scard h3{font-family:var(--mono);font-size:10px;letter-spacing:1.5px;text-transform:uppercase;color:var(--td);margin-bottom:12px}
+.srow{display:flex;justify-content:space-between;align-items:center;padding:7px 0;border-bottom:1px solid rgba(20,28,46,.5);font-size:12px}
+.srow:last-child{border:none}
+.srow .k{color:var(--td);font-family:var(--mono);font-size:11px}
+.srow .v{font-family:var(--mono);font-weight:500;font-size:11px}
+.tag{display:inline-block;padding:3px 10px;border-radius:4px;font-size:9px;font-family:var(--mono);font-weight:700;letter-spacing:.5px;text-transform:uppercase}
+.tag-g{background:rgba(34,232,138,.1);color:var(--ok)}
+.tag-w{background:rgba(255,194,51,.1);color:var(--warn)}
+.tag-r{background:rgba(255,59,92,.1);color:var(--err)}
+
+.hidden{display:none !important}
 </style>
 </head>
 <body>
-<div class="topbar">
-  <div class="topbar-brand">SOV</div>
-  <div class="topbar-sep"></div>
-  <div class="topbar-status"><div class="pulse off" id="pulse"></div><span id="status-text">Offline</span></div>
-  <div class="topbar-right"><div class="topbar-height">block <span id="top-height">—</span></div></div>
-</div>
-<div class="main">
-  <div class="setup-view" id="view-setup">
-    <div class="setup-card">
-      <div class="setup-header"><h1>Initialize Node</h1><p>Connect to The Sovereign Network</p></div>
-      <div id="setup-choose">
-        <div class="setup-options">
-          <div class="setup-option" onclick="showRestore()">
-            <div class="setup-option-icon">🔑</div>
-            <div class="setup-option-text"><h3>Restore from seed</h3><p>Use your existing identity from the mobile app</p></div>
-          </div>
-          <div class="setup-option" onclick="showCreate()">
-            <div class="setup-option-icon">✦</div>
-            <div class="setup-option-text"><h3>New identity</h3><p>Generate a fresh cryptographic identity</p></div>
-          </div>
-        </div>
-      </div>
-      <div id="setup-restore" class="hidden">
-        <div class="seed-panel">
-          <h2>Recovery phrase</h2>
-          <div class="seed-grid" id="seed-grid"></div>
-          <div class="error-text hidden" id="restore-error"></div>
-          <button class="btn btn-cyan" onclick="doRestore()" id="btn-restore">Restore</button>
-          <button class="btn btn-ghost" onclick="backToChoose()">Back</button>
-        </div>
-      </div>
-      <div id="setup-create" class="hidden">
-        <div class="seed-panel">
-          <h2>Name your node</h2>
-          <input type="text" class="name-input" id="node-name" placeholder="sovereign-node" autocomplete="off" spellcheck="false">
-          <div class="error-text hidden" id="create-error"></div>
-          <button class="btn btn-cyan" onclick="doCreate()" id="btn-create">Create</button>
-          <button class="btn btn-ghost" onclick="backToChoose()">Back</button>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="dashboard hidden" id="view-dashboard">
-    <div class="metrics-row">
-      <div class="metric ac"><div class="metric-label">Chain Height</div><div class="metric-value" id="d-height">—</div></div>
-      <div class="metric ag"><div class="metric-label">SOV Balance</div><div class="metric-value" id="d-balance">—</div><div class="metric-sub" id="d-balance-atoms"></div></div>
-      <div class="metric"><div class="metric-label">Validators</div><div class="metric-value" id="d-validators">—</div></div>
-      <div class="metric aa"><div class="metric-label">Identities</div><div class="metric-value" id="d-identities">—</div></div>
-    </div>
-    <div class="identity-card"><h3>Your DID</h3><div class="did-display" id="d-did">—</div></div>
-    <div class="sync-bar-container">
-      <div class="sync-bar-header"><h3>Sync Progress</h3><div class="sync-bar-pct" id="d-sync-pct">0%</div></div>
-      <div class="sync-track"><div class="sync-fill" id="d-sync-fill" style="width:0%"></div></div>
-    </div>
-    <div class="status-row">
-      <div class="status-card"><h3>Node</h3>
-        <div class="status-item"><span class="key">State</span><span class="val"><span class="badge badge-green" id="d-state-badge">Ready</span></span></div>
-        <div class="status-item"><span class="key">Registered</span><span class="val" id="d-registered">—</span></div>
-        <div class="status-item"><span class="key">Network</span><span class="val" id="d-network">—</span></div>
-      </div>
-      <div class="status-card"><h3>Wallet</h3>
-        <div class="status-item"><span class="key">Wallet ID</span><span class="val" id="d-wallet" style="font-size:10px">—</span></div>
-        <div class="status-item"><span class="key">SOV</span><span class="val" id="d-sov-human">—</span></div>
-      </div>
-    </div>
-  </div>
-</div>
-<script>
-const API='';
-let poll=null;
+<div class="mesh" id="mesh"></div>
+<div class="orb orb-1"></div>
+<div class="orb orb-2"></div>
 
-// Build seed grid safely
+<nav>
+  <div class="nav-brand">Sovereign</div>
+  <div class="nav-sep"></div>
+  <div class="nav-pulse"><div class="dot off" id="dot"></div><span class="nav-label" id="nav-st">Offline</span></div>
+  <div class="nav-right"><div class="nav-block">block <b id="nav-h">—</b></div></div>
+</nav>
+
+<div class="wrap">
+  <!-- SETUP -->
+  <div class="setup" id="v-setup">
+    <div class="setup-inner">
+      <div class="setup-hero">
+        <h1><span>Node Control</span>Initialize</h1>
+        <p>Spawn an observer node on The Sovereign Network. Your identity, your infrastructure.</p>
+      </div>
+      <div id="s-choose">
+        <div class="choices">
+          <div class="choice" onclick="showRestore()">
+            <div class="choice-row">
+              <div class="choice-icon">🔑</div>
+              <div><h3>Restore from seed</h3><p>Use your mobile wallet identity on this node</p></div>
+            </div>
+          </div>
+          <div class="choice" onclick="showCreate()">
+            <div class="choice-row">
+              <div class="choice-icon">◆</div>
+              <div><h3>New identity</h3><p>Generate fresh post-quantum cryptographic keys</p></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div id="s-restore" class="hidden">
+        <div class="panel">
+          <div class="panel-title">Recovery Phrase</div>
+          <div class="sgrid" id="seed-grid"></div>
+          <div class="err hidden" id="r-err"></div>
+          <button class="btn btn-t" onclick="doRestore()" id="r-btn">Restore Identity</button>
+          <button class="btn btn-g" onclick="back()">Back</button>
+        </div>
+      </div>
+      <div id="s-create" class="hidden">
+        <div class="panel">
+          <div class="panel-title">Node Name</div>
+          <input type="text" class="ninput" id="n-name" placeholder="sovereign-node" autocomplete="off" spellcheck="false">
+          <div class="err hidden" id="c-err"></div>
+          <button class="btn btn-t" onclick="doCreate()" id="c-btn">Launch Node</button>
+          <button class="btn btn-g" onclick="back()">Back</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- DASHBOARD -->
+  <div class="dash hidden" id="v-dash">
+    <div class="dash-head"><h2>Dashboard</h2></div>
+    <div class="mgrid">
+      <div class="mcard"><div class="mcard-bar bt"></div><div class="mcard-lbl">Chain Height</div><div class="mcard-val" id="m-h">—</div></div>
+      <div class="mcard"><div class="mcard-bar bg"></div><div class="mcard-lbl">SOV Balance</div><div class="mcard-val" id="m-b">—</div><div class="mcard-sub" id="m-ba"></div></div>
+      <div class="mcard"><div class="mcard-bar bm"></div><div class="mcard-lbl">Validators</div><div class="mcard-val" id="m-v">—</div></div>
+      <div class="mcard"><div class="mcard-bar bw"></div><div class="mcard-lbl">Identities</div><div class="mcard-val" id="m-i">—</div></div>
+    </div>
+    <div class="did-card"><h3>Your DID</h3><div class="did-val" id="m-did">—</div></div>
+    <div class="sync-card">
+      <div class="sync-top"><h3>Sync</h3><div class="sync-pct" id="m-pct">0%</div></div>
+      <div class="sync-track"><div class="sync-fill" id="m-fill" style="width:0%"></div></div>
+    </div>
+    <div class="sgrid2">
+      <div class="scard"><h3>Node</h3>
+        <div class="srow"><span class="k">State</span><span class="v"><span class="tag tag-g" id="m-tag">Ready</span></span></div>
+        <div class="srow"><span class="k">Registered</span><span class="v" id="m-reg">—</span></div>
+        <div class="srow"><span class="k">Network</span><span class="v" id="m-net">—</span></div>
+      </div>
+      <div class="scard"><h3>Wallet</h3>
+        <div class="srow"><span class="k">ID</span><span class="v" id="m-wid" style="font-size:10px">—</span></div>
+        <div class="srow"><span class="k">SOV</span><span class="v" id="m-sov">—</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+// Mesh background
+(function(){
+  const m=document.getElementById('mesh');
+  const gap=80;
+  for(let y=0;y<window.innerHeight;y+=gap){
+    const l=document.createElement('div');
+    l.className='mesh-line mesh-h';
+    l.style.top=y+'px';
+    l.style.opacity=String(.15+Math.random()*.1);
+    m.appendChild(l);
+  }
+  for(let x=0;x<window.innerWidth;x+=gap){
+    const l=document.createElement('div');
+    l.className='mesh-line mesh-v';
+    l.style.left=x+'px';
+    l.style.opacity=String(.1+Math.random()*.08);
+    m.appendChild(l);
+  }
+})();
+
+// Seed grid
 (function(){
   const g=document.getElementById('seed-grid');
   for(let i=0;i<24;i++){
-    const cell=document.createElement('div');
-    cell.className='seed-word-cell';
-    const num=document.createElement('div');
-    num.className='seed-word-num';
-    num.textContent=String(i+1);
-    const inp=document.createElement('input');
-    inp.className='seed-word';
-    inp.dataset.idx=String(i);
-    inp.placeholder='word';
-    inp.autocomplete='off';
-    inp.spellcheck=false;
-    cell.appendChild(num);
-    cell.appendChild(inp);
-    g.appendChild(cell);
+    const c=document.createElement('div');c.className='scell';
+    const n=document.createElement('div');n.className='snum';n.textContent=String(i+1).padStart(2,'0');
+    const inp=document.createElement('input');inp.className='sinput';inp.dataset.idx=String(i);inp.placeholder='···';inp.autocomplete='off';inp.spellcheck=false;inp.autocapitalize='off';
+    c.appendChild(n);c.appendChild(inp);g.appendChild(c);
   }
-  g.addEventListener('keydown',e=>{
-    if(e.key===' '||e.key==='Tab'){e.preventDefault();const n=g.querySelector('[data-idx="'+(parseInt(e.target.dataset.idx)+1)+'"]');if(n)n.focus();}
-  });
-  g.addEventListener('paste',e=>{
-    const t=(e.clipboardData||window.clipboardData).getData('text');
-    const w=t.trim().split(/\s+/);
-    if(w.length>1){e.preventDefault();w.forEach((v,i)=>{const inp=g.querySelector('[data-idx="'+i+'"]');if(inp)inp.value=v;});}
-  });
+  g.addEventListener('keydown',e=>{if(e.key===' '||e.key==='Tab'){e.preventDefault();const nx=g.querySelector('[data-idx="'+(parseInt(e.target.dataset.idx)+1)+'"]');if(nx)nx.focus();}});
+  g.addEventListener('paste',e=>{const t=(e.clipboardData||window.clipboardData).getData('text');const w=t.trim().split(/\s+/);if(w.length>1){e.preventDefault();w.forEach((v,i)=>{const inp=g.querySelector('[data-idx="'+i+'"]');if(inp)inp.value=v;});}});
 })();
 
-function showRestore(){document.getElementById('setup-choose').classList.add('hidden');document.getElementById('setup-restore').classList.remove('hidden');document.querySelector('.seed-word').focus();}
-function showCreate(){document.getElementById('setup-choose').classList.add('hidden');document.getElementById('setup-create').classList.remove('hidden');document.getElementById('node-name').focus();}
-function backToChoose(){document.getElementById('setup-restore').classList.add('hidden');document.getElementById('setup-create').classList.add('hidden');document.getElementById('setup-choose').classList.remove('hidden');}
-function getSeedWords(){return Array.from(document.querySelectorAll('.seed-word')).map(i=>i.value.trim().toLowerCase()).filter(w=>w.length>0);}
+const API='';
+function showRestore(){document.getElementById('s-choose').classList.add('hidden');document.getElementById('s-restore').classList.remove('hidden');document.querySelector('.sinput').focus();}
+function showCreate(){document.getElementById('s-choose').classList.add('hidden');document.getElementById('s-create').classList.remove('hidden');document.getElementById('n-name').focus();}
+function back(){document.getElementById('s-restore').classList.add('hidden');document.getElementById('s-create').classList.add('hidden');document.getElementById('s-choose').classList.remove('hidden');}
+function getWords(){return Array.from(document.querySelectorAll('.sinput')).map(i=>i.value.trim().toLowerCase()).filter(w=>w);}
 
 async function doRestore(){
-  const w=getSeedWords(),err=document.getElementById('restore-error');
-  err.classList.add('hidden');
-  if(w.length!==20&&w.length!==24){err.textContent='Need 20 or 24 words — got '+w.length;err.classList.remove('hidden');return;}
-  const btn=document.getElementById('btn-restore');btn.disabled=true;btn.textContent='Restoring...';
+  const w=getWords(),err=document.getElementById('r-err');err.classList.add('hidden');
+  if(w.length!==20&&w.length!==24){err.textContent='Expected 20 or 24 words, got '+w.length;err.classList.remove('hidden');return;}
+  const b=document.getElementById('r-btn');b.disabled=true;b.textContent='RESTORING...';
   try{const r=await fetch(API+'/api/setup',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:'restore',seed_phrase:w.join(' ')})});
-    const d=await r.json();if(d.error){err.textContent=d.error;err.classList.remove('hidden');btn.disabled=false;btn.textContent='Restore';return;}
-    switchToDashboard();
-  }catch(e){err.textContent=e.message;err.classList.remove('hidden');btn.disabled=false;btn.textContent='Restore';}
+    const d=await r.json();if(d.error){err.textContent=d.error;err.classList.remove('hidden');b.disabled=false;b.textContent='RESTORE IDENTITY';return;}
+    goDash();
+  }catch(e){err.textContent=e.message;err.classList.remove('hidden');b.disabled=false;b.textContent='RESTORE IDENTITY';}
 }
 
 async function doCreate(){
-  const name=document.getElementById('node-name').value.trim()||'sovereign-node';
-  const err=document.getElementById('create-error');err.classList.add('hidden');
-  const btn=document.getElementById('btn-create');btn.disabled=true;btn.textContent='Creating...';
+  const name=document.getElementById('n-name').value.trim()||'sovereign-node';
+  const err=document.getElementById('c-err');err.classList.add('hidden');
+  const b=document.getElementById('c-btn');b.disabled=true;b.textContent='LAUNCHING...';
   try{const r=await fetch(API+'/api/setup',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:'create',node_name:name})});
-    const d=await r.json();if(d.error){err.textContent=d.error;err.classList.remove('hidden');btn.disabled=false;btn.textContent='Create';return;}
-    switchToDashboard();
-  }catch(e){err.textContent=e.message;err.classList.remove('hidden');btn.disabled=false;btn.textContent='Create';}
+    const d=await r.json();if(d.error){err.textContent=d.error;err.classList.remove('hidden');b.disabled=false;b.textContent='LAUNCH NODE';return;}
+    goDash();
+  }catch(e){err.textContent=e.message;err.classList.remove('hidden');b.disabled=false;b.textContent='LAUNCH NODE';}
 }
 
-function switchToDashboard(){document.getElementById('view-setup').classList.add('hidden');document.getElementById('view-dashboard').classList.remove('hidden');startPolling();}
-function startPolling(){updateDashboard();poll=setInterval(updateDashboard,2000);}
+function goDash(){document.getElementById('v-setup').classList.add('hidden');document.getElementById('v-dash').classList.remove('hidden');poll();}
+function poll(){upd();setInterval(upd,2500);}
 
-async function updateDashboard(){
+async function upd(){
   try{
     const r=await fetch(API+'/api/status');const d=await r.json();
     const h=Number(d.chain_height||0);
-    document.getElementById('d-height').textContent=h.toLocaleString();
-    document.getElementById('top-height').textContent=h.toLocaleString();
-    document.getElementById('d-balance').textContent=d.sov_balance_human||'0';
-    document.getElementById('d-balance-atoms').textContent=d.sov_balance?Number(d.sov_balance).toLocaleString()+' atoms':'';
-    document.getElementById('d-validators').textContent=d.validator_count||'0';
-    document.getElementById('d-identities').textContent=d.identity_count||'0';
-    document.getElementById('d-did').textContent=d.did||'—';
-    document.getElementById('d-registered').textContent=d.identity_registered?'Yes':'No';
-    document.getElementById('d-network').textContent=d.network_id||'—';
-    document.getElementById('d-wallet').textContent=d.wallet_id?d.wallet_id.slice(0,16)+'...':'—';
-    document.getElementById('d-sov-human').textContent=(d.sov_balance_human||'0')+' SOV';
-    const badge=document.getElementById('d-state-badge');
-    const pulse=document.getElementById('pulse');
-    const st=document.getElementById('status-text');
-    if(d.state==='ready'){badge.className='badge badge-green';badge.textContent='Connected';pulse.className='pulse';st.textContent='Synced';}
-    else if(d.state==='identity_not_registered'){badge.className='badge badge-amber';badge.textContent='Not Registered';pulse.className='pulse warn';st.textContent='Unregistered';}
-    else if(d.state==='connecting'){badge.className='badge badge-amber';badge.textContent='Connecting';pulse.className='pulse warn';st.textContent='Connecting';}
-    else{badge.className='badge badge-red';badge.textContent=d.state||'Unknown';pulse.className='pulse off';st.textContent='Setup Required';}
+    document.getElementById('m-h').textContent=h.toLocaleString();
+    document.getElementById('nav-h').textContent=h.toLocaleString();
+    document.getElementById('m-b').textContent=d.sov_balance_human||'0';
+    document.getElementById('m-ba').textContent=d.sov_balance?Number(d.sov_balance).toLocaleString()+' atoms':'';
+    document.getElementById('m-v').textContent=d.validator_count||'0';
+    document.getElementById('m-i').textContent=d.identity_count||'0';
+    document.getElementById('m-did').textContent=d.did||'—';
+    document.getElementById('m-reg').textContent=d.identity_registered?'Yes':'No';
+    document.getElementById('m-net').textContent=d.network_id||'—';
+    document.getElementById('m-wid').textContent=d.wallet_id?d.wallet_id.slice(0,16)+'…':'—';
+    document.getElementById('m-sov').textContent=(d.sov_balance_human||'0')+' SOV';
+    const tag=document.getElementById('m-tag'),dot=document.getElementById('dot'),st=document.getElementById('nav-st');
+    if(d.state==='ready'){tag.className='tag tag-g';tag.textContent='SYNCED';dot.className='dot';st.textContent='Online';}
+    else if(d.state==='identity_not_registered'){tag.className='tag tag-w';tag.textContent='UNREGISTERED';dot.className='dot warn';st.textContent='Unregistered';}
+    else if(d.state==='connecting'){tag.className='tag tag-w';tag.textContent='SYNCING';dot.className='dot warn';st.textContent='Syncing';}
+    else{tag.className='tag tag-r';tag.textContent=d.state||'OFFLINE';dot.className='dot off';st.textContent='Offline';}
     const pct=Math.min(100,(h/50000)*100);
-    document.getElementById('d-sync-fill').style.width=pct+'%';
-    document.getElementById('d-sync-pct').textContent=pct<100?pct.toFixed(1)+'%':'Synced';
+    document.getElementById('m-fill').style.width=pct+'%';
+    document.getElementById('m-pct').textContent=pct<100?pct.toFixed(1)+'%':'Synced';
   }catch(e){}
 }
 
-(async()=>{try{const r=await fetch(API+'/api/status');const d=await r.json();if(d.state&&d.state!=='setup_required')switchToDashboard();}catch(e){}})();
+(async()=>{try{const r=await fetch(API+'/api/status');const d=await r.json();if(d.state&&d.state!=='setup_required')goDash();}catch(e){}})();
 </script>
 </body>
 </html>

--- a/zhtp-cli/src/ui/setup.html
+++ b/zhtp-cli/src/ui/setup.html
@@ -1,0 +1,497 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sovereign Network — Node Setup</title>
+<style>
+  :root {
+    --bg: #0a0a0f;
+    --surface: #12121a;
+    --border: #1e1e2e;
+    --text: #e0e0e8;
+    --muted: #6b6b80;
+    --accent: #6366f1;
+    --accent-glow: rgba(99, 102, 241, 0.15);
+    --success: #22c55e;
+    --error: #ef4444;
+    --warning: #f59e0b;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    padding: 40px 20px;
+  }
+
+  .container {
+    max-width: 640px;
+    width: 100%;
+  }
+
+  .logo {
+    text-align: center;
+    margin-bottom: 48px;
+  }
+
+  .logo h1 {
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .logo p {
+    color: var(--muted);
+    font-size: 14px;
+    margin-top: 8px;
+  }
+
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 32px;
+    margin-bottom: 24px;
+  }
+
+  .card h2 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 16px;
+  }
+
+  .step-indicator {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 32px;
+    justify-content: center;
+  }
+
+  .step-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--border);
+    transition: all 0.3s;
+  }
+
+  .step-dot.active {
+    background: var(--accent);
+    box-shadow: 0 0 12px var(--accent-glow);
+  }
+
+  .step-dot.done {
+    background: var(--success);
+  }
+
+  label {
+    display: block;
+    font-size: 13px;
+    color: var(--muted);
+    margin-bottom: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  textarea, input[type="text"] {
+    width: 100%;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 16px;
+    color: var(--text);
+    font-size: 15px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    resize: none;
+    transition: border-color 0.2s;
+  }
+
+  textarea:focus, input[type="text"]:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-glow);
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 14px 24px;
+    border: none;
+    border-radius: 10px;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+    margin-top: 16px;
+  }
+
+  .btn-primary {
+    background: var(--accent);
+    color: white;
+  }
+
+  .btn-primary:hover {
+    background: #5558e6;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 16px var(--accent-glow);
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
+  }
+
+  .btn-secondary {
+    background: var(--border);
+    color: var(--text);
+  }
+
+  .btn-secondary:hover {
+    background: #2a2a3e;
+  }
+
+  .status-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+
+  .status-item {
+    background: var(--bg);
+    border-radius: 10px;
+    padding: 16px;
+  }
+
+  .status-item .label {
+    font-size: 12px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+  }
+
+  .status-item .value {
+    font-size: 20px;
+    font-weight: 700;
+  }
+
+  .status-item .value.mono {
+    font-size: 13px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    word-break: break-all;
+  }
+
+  .status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .badge-success { background: rgba(34,197,94,0.15); color: var(--success); }
+  .badge-warning { background: rgba(245,158,11,0.15); color: var(--warning); }
+  .badge-error { background: rgba(239,68,68,0.15); color: var(--error); }
+
+  .badge-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+    animation: pulse 2s infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+  }
+
+  .sync-bar {
+    height: 4px;
+    background: var(--border);
+    border-radius: 2px;
+    margin-top: 12px;
+    overflow: hidden;
+  }
+
+  .sync-bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent), #8b5cf6);
+    border-radius: 2px;
+    transition: width 0.5s ease;
+  }
+
+  .hidden { display: none !important; }
+
+  .option-group {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .option-group .btn {
+    flex: 1;
+    margin-top: 0;
+  }
+
+  .option-group .btn.selected {
+    border: 2px solid var(--accent);
+    background: var(--accent-glow);
+  }
+
+  .hint {
+    font-size: 13px;
+    color: var(--muted);
+    margin-top: 8px;
+  }
+
+  .error-msg {
+    color: var(--error);
+    font-size: 13px;
+    margin-top: 8px;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="logo">
+    <h1>The Sovereign Network</h1>
+    <p>Node Setup</p>
+  </div>
+
+  <div class="step-indicator">
+    <div class="step-dot active" id="dot-0"></div>
+    <div class="step-dot" id="dot-1"></div>
+    <div class="step-dot" id="dot-2"></div>
+  </div>
+
+  <!-- Step 0: Choose mode -->
+  <div class="card" id="step-0">
+    <h2>How do you want to set up your node?</h2>
+    <div class="option-group">
+      <button class="btn btn-secondary" onclick="chooseMode('restore')">
+        Restore from seed phrase
+      </button>
+      <button class="btn btn-secondary" onclick="chooseMode('new')">
+        Create new identity
+      </button>
+    </div>
+    <p class="hint">If you have a mobile wallet, use "Restore" to use the same identity on your node.</p>
+  </div>
+
+  <!-- Step 1: Seed phrase -->
+  <div class="card hidden" id="step-1-restore">
+    <h2>Enter your seed phrase</h2>
+    <label>24-word recovery phrase</label>
+    <textarea id="seed-input" rows="4" placeholder="word1 word2 word3 ..."></textarea>
+    <p class="hint">From your mobile app: Settings → Backup → Show seed phrase</p>
+    <div class="error-msg hidden" id="seed-error"></div>
+    <button class="btn btn-primary" onclick="submitSeed()" id="btn-restore">Restore Identity</button>
+  </div>
+
+  <div class="card hidden" id="step-1-new">
+    <h2>New Identity</h2>
+    <label>Node name</label>
+    <input type="text" id="node-name" placeholder="my-sovereign-node" />
+    <p class="hint">A friendly name for your node. Your identity will be generated automatically.</p>
+    <button class="btn btn-primary" onclick="createNew()" id="btn-create">Create &amp; Start</button>
+  </div>
+
+  <!-- Step 2: Dashboard -->
+  <div class="card hidden" id="step-2">
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
+      <h2>Node Dashboard</h2>
+      <span class="status-badge badge-success" id="node-badge">
+        <span class="badge-dot"></span>
+        <span id="badge-text">Syncing</span>
+      </span>
+    </div>
+
+    <div class="status-grid">
+      <div class="status-item">
+        <div class="label">Chain Height</div>
+        <div class="value" id="chain-height">—</div>
+      </div>
+      <div class="status-item">
+        <div class="label">SOV Balance</div>
+        <div class="value" id="sov-balance">—</div>
+      </div>
+      <div class="status-item">
+        <div class="label">Validators</div>
+        <div class="value" id="validators">—</div>
+      </div>
+      <div class="status-item">
+        <div class="label">Identities</div>
+        <div class="value" id="identities">—</div>
+      </div>
+      <div class="status-item" style="grid-column: span 2;">
+        <div class="label">Your DID</div>
+        <div class="value mono" id="node-did">—</div>
+      </div>
+    </div>
+
+    <div class="sync-bar">
+      <div class="sync-bar-fill" id="sync-fill" style="width: 0%"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+const API = '';  // Same origin (localhost bridge)
+let mode = null;
+let pollInterval = null;
+
+function chooseMode(m) {
+  mode = m;
+  document.getElementById('step-0').classList.add('hidden');
+  document.getElementById('dot-0').classList.remove('active');
+  document.getElementById('dot-0').classList.add('done');
+  document.getElementById('dot-1').classList.add('active');
+  if (m === 'restore') {
+    document.getElementById('step-1-restore').classList.remove('hidden');
+  } else {
+    document.getElementById('step-1-new').classList.remove('hidden');
+  }
+}
+
+async function submitSeed() {
+  const seed = document.getElementById('seed-input').value.trim();
+  const words = seed.split(/\s+/);
+  const errEl = document.getElementById('seed-error');
+  errEl.classList.add('hidden');
+
+  if (words.length !== 24) {
+    errEl.textContent = `Expected 24 words, got ${words.length}`;
+    errEl.classList.remove('hidden');
+    return;
+  }
+
+  document.getElementById('btn-restore').disabled = true;
+  document.getElementById('btn-restore').textContent = 'Restoring...';
+
+  try {
+    const res = await fetch(API + '/api/setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'restore', seed_phrase: seed }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      errEl.textContent = data.error;
+      errEl.classList.remove('hidden');
+      document.getElementById('btn-restore').disabled = false;
+      document.getElementById('btn-restore').textContent = 'Restore Identity';
+      return;
+    }
+    showDashboard();
+  } catch (e) {
+    errEl.textContent = 'Connection failed: ' + e.message;
+    errEl.classList.remove('hidden');
+    document.getElementById('btn-restore').disabled = false;
+    document.getElementById('btn-restore').textContent = 'Restore Identity';
+  }
+}
+
+async function createNew() {
+  const name = document.getElementById('node-name').value.trim() || 'sovereign-node';
+  document.getElementById('btn-create').disabled = true;
+  document.getElementById('btn-create').textContent = 'Creating...';
+
+  try {
+    const res = await fetch(API + '/api/setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'create', node_name: name }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+      document.getElementById('btn-create').disabled = false;
+      document.getElementById('btn-create').textContent = 'Create & Start';
+      return;
+    }
+    showDashboard();
+  } catch (e) {
+    alert('Connection failed: ' + e.message);
+    document.getElementById('btn-create').disabled = false;
+    document.getElementById('btn-create').textContent = 'Create & Start';
+  }
+}
+
+function showDashboard() {
+  document.getElementById('step-1-restore').classList.add('hidden');
+  document.getElementById('step-1-new').classList.add('hidden');
+  document.getElementById('dot-1').classList.remove('active');
+  document.getElementById('dot-1').classList.add('done');
+  document.getElementById('dot-2').classList.add('active');
+  document.getElementById('step-2').classList.remove('hidden');
+  startPolling();
+}
+
+function startPolling() {
+  updateStatus();
+  pollInterval = setInterval(updateStatus, 3000);
+}
+
+async function updateStatus() {
+  try {
+    const res = await fetch(API + '/api/status');
+    const data = await res.json();
+
+    document.getElementById('chain-height').textContent = Number(data.chain_height || 0).toLocaleString();
+    document.getElementById('sov-balance').textContent = data.sov_balance_human || '0';
+    document.getElementById('validators').textContent = data.validator_count || '0';
+    document.getElementById('identities').textContent = data.identity_count || '0';
+    document.getElementById('node-did').textContent = data.did || '—';
+
+    const badge = document.getElementById('node-badge');
+    const badgeText = document.getElementById('badge-text');
+    if (data.state === 'ready') {
+      badge.className = 'status-badge badge-success';
+      badgeText.textContent = 'Connected';
+    } else if (data.state === 'identity_not_registered') {
+      badge.className = 'status-badge badge-warning';
+      badgeText.textContent = 'Not Registered';
+    } else {
+      badge.className = 'status-badge badge-warning';
+      badgeText.textContent = 'Syncing';
+    }
+
+    // Rough sync progress (assume 40000 blocks target)
+    const height = data.chain_height || 0;
+    const pct = Math.min(100, (height / 40000) * 100);
+    document.getElementById('sync-fill').style.width = pct + '%';
+  } catch (e) {
+    // Bridge not ready yet
+  }
+}
+
+// Auto-detect: if node is already running, skip to dashboard
+(async () => {
+  try {
+    const res = await fetch(API + '/api/status');
+    const data = await res.json();
+    if (data.state && data.state !== 'setup_required') {
+      showDashboard();
+    }
+  } catch (e) {
+    // Not running yet, show setup
+  }
+})();
+</script>
+</body>
+</html>

--- a/zhtp/Cargo.toml
+++ b/zhtp/Cargo.toml
@@ -67,6 +67,7 @@ atty = "0.2"  # TTY detection for interactive TOFU prompts
 lz4_flex = "0.11"  # LZ4 compression for DHT content decompression
 once_cell = "1.19"  # Global singleton for bootstrap peers
 zeroize = "1.7"  # Secure memory zeroization for passwords
+libc = "0.2"  # POSIX signals for graceful shutdown
 rand = "0.8"  # Cryptographically secure random number generation
 keyring = "3.6"  # System keyring for secure seed storage
 argon2 = "0.5"  # Password hashing for seed encryption

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1124,29 +1124,54 @@ impl BlockchainHandler {
             (None, 0)
         };
 
-        // Peer count
-        let peer_count = blockchain.validator_registry.len();
+        let validator_count = blockchain.validator_registry.len();
+        let identity_count = blockchain.identity_registry.len();
+        let chain_height = blockchain.height;
+        let blocks_count = blockchain.blocks.len();
+        let pending_count = blockchain.pending_transactions.len();
 
-        // Determine node state
+        // Determine detailed node state
         let state = if node_did == "not_initialized" {
             "setup_required"
         } else if !identity_registered {
             "identity_not_registered"
+        } else if chain_height == 0 {
+            "connecting"
+        } else if validator_count == 0 {
+            "connecting"
         } else {
             "ready"
+        };
+
+        // Sync telemetry: estimate target height from validator activity
+        let last_block_time = blockchain.blocks.last()
+            .map(|b| b.header.timestamp)
+            .unwrap_or(0);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let seconds_behind = if last_block_time > 0 && now > last_block_time {
+            now - last_block_time
+        } else {
+            0
         };
 
         let response = serde_json::json!({
             "state": state,
             "did": node_did,
             "identity_registered": identity_registered,
-            "chain_height": blockchain.height,
+            "chain_height": chain_height,
             "wallet_id": wallet_id,
             "sov_balance": sov_balance.to_string(),
             "sov_balance_human": format!("{:.4}", sov_balance as f64 / 1_000_000_000_000_000_000.0),
-            "validator_count": peer_count,
-            "identity_count": blockchain.identity_registry.len(),
+            "validator_count": validator_count,
+            "identity_count": identity_count,
             "network_id": self.environment.to_string().to_ascii_lowercase(),
+            "pending_transactions": pending_count,
+            "blocks_stored": blocks_count,
+            "last_block_time": last_block_time,
+            "seconds_behind": seconds_behind,
         });
 
         Ok(ZhtpResponse::json(&response, None)?)

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -196,6 +196,7 @@ impl ZhtpRequestHandler for BlockchainHandler {
             }
             (ZhtpMethod::Get, "/api/v1/chain/info") => self.handle_chain_info(request).await,
             (ZhtpMethod::Get, "/api/v1/network/directory") => self.handle_network_directory(request).await,
+            (ZhtpMethod::Get, "/api/v1/node/status") => self.handle_node_status(request).await,
             (ZhtpMethod::Get, "/api/v1/blockchain/latest") => {
                 self.handle_latest_block(request).await
             }
@@ -322,7 +323,10 @@ impl ZhtpRequestHandler for BlockchainHandler {
     }
 
     fn can_handle(&self, request: &ZhtpRequest) -> bool {
-        request.uri.starts_with("/api/v1/blockchain/") || request.uri.starts_with("/api/v1/chain/")
+        request.uri.starts_with("/api/v1/blockchain/")
+            || request.uri.starts_with("/api/v1/chain/")
+            || request.uri.starts_with("/api/v1/network/")
+            || request.uri.starts_with("/api/v1/node/")
     }
 
     fn priority(&self) -> u32 {
@@ -1068,6 +1072,81 @@ impl BlockchainHandler {
             "chain_height": blockchain.height,
             "validator_count": validators.len(),
             "local_spki_pin": local_spki,
+        });
+
+        Ok(ZhtpResponse::json(&response, None)?)
+    }
+
+    /// Node status: comprehensive status for the setup UI and dashboard.
+    /// Public endpoint — no auth required.
+    async fn handle_node_status(&self, _request: ZhtpRequest) -> Result<ZhtpResponse> {
+        let blockchain_arc = self.get_blockchain().await?;
+        let blockchain = blockchain_arc.read().await;
+
+        // Node identity
+        let node_did = crate::runtime::node_identity::get_runtime_node_did()
+            .unwrap_or_else(|| "not_initialized".to_string());
+
+        // Check if identity is registered on-chain
+        let identity_registered = blockchain.identity_registry.contains_key(&node_did);
+
+        // Wallet balance (if registered)
+        let (wallet_id, sov_balance) = if identity_registered {
+            let did_hex = node_did.strip_prefix("did:zhtp:").unwrap_or(&node_did);
+            let owner_bytes = hex::decode(did_hex).unwrap_or_default();
+            let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
+
+            let wallet = blockchain.wallet_registry.values().find(|w| {
+                w.owner_identity_id
+                    .as_ref()
+                    .map(|id| id.as_bytes() == owner_bytes.as_slice())
+                    .unwrap_or(false)
+                    && w.wallet_type == "Primary"
+            });
+
+            if let Some(w) = wallet {
+                let wallet_id_hex = hex::encode(w.wallet_id.as_bytes());
+                let pk = lib_blockchain::integration::crypto_integration::PublicKey {
+                    dilithium_pk: [0u8; 2592],
+                    kyber_pk: [0u8; 1568],
+                    key_id: w.wallet_id.as_array(),
+                };
+                let balance = blockchain
+                    .token_contracts
+                    .get(&sov_token_id)
+                    .map(|t| t.balance_of(&pk))
+                    .unwrap_or(0);
+                (Some(wallet_id_hex), balance)
+            } else {
+                (None, 0)
+            }
+        } else {
+            (None, 0)
+        };
+
+        // Peer count
+        let peer_count = blockchain.validator_registry.len();
+
+        // Determine node state
+        let state = if node_did == "not_initialized" {
+            "setup_required"
+        } else if !identity_registered {
+            "identity_not_registered"
+        } else {
+            "ready"
+        };
+
+        let response = serde_json::json!({
+            "state": state,
+            "did": node_did,
+            "identity_registered": identity_registered,
+            "chain_height": blockchain.height,
+            "wallet_id": wallet_id,
+            "sov_balance": sov_balance.to_string(),
+            "sov_balance_human": format!("{:.4}", sov_balance as f64 / 1_000_000_000_000_000_000.0),
+            "validator_count": peer_count,
+            "identity_count": blockchain.identity_registry.len(),
+            "network_id": self.environment.to_string().to_ascii_lowercase(),
         });
 
         Ok(ZhtpResponse::json(&response, None)?)

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -195,8 +195,6 @@ impl ZhtpRequestHandler for BlockchainHandler {
                 self.handle_blockchain_status(request).await
             }
             (ZhtpMethod::Get, "/api/v1/chain/info") => self.handle_chain_info(request).await,
-            (ZhtpMethod::Get, "/api/v1/network/directory") => self.handle_network_directory(request).await,
-            (ZhtpMethod::Get, "/api/v1/node/status") => self.handle_node_status(request).await,
             (ZhtpMethod::Get, "/api/v1/blockchain/latest") => {
                 self.handle_latest_block(request).await
             }
@@ -325,8 +323,6 @@ impl ZhtpRequestHandler for BlockchainHandler {
     fn can_handle(&self, request: &ZhtpRequest) -> bool {
         request.uri.starts_with("/api/v1/blockchain/")
             || request.uri.starts_with("/api/v1/chain/")
-            || request.uri.starts_with("/api/v1/network/")
-            || request.uri.starts_with("/api/v1/node/")
     }
 
     fn priority(&self) -> u32 {
@@ -1015,166 +1011,6 @@ impl BlockchainHandler {
         };
 
         Ok(ZhtpResponse::json(&response_data, None)?)
-    }
-
-    /// Network directory: returns validators, relays, and ZDNS servers for client routing.
-    /// Public endpoint — no authentication required.
-    async fn handle_network_directory(&self, _request: ZhtpRequest) -> Result<ZhtpResponse> {
-        let blockchain_arc = self.get_blockchain().await?;
-        let blockchain = blockchain_arc.read().await;
-
-        // Load SPKI pins from bootstrap_peer_pins config (host:port → hex hash)
-        let peer_pins: std::collections::HashMap<String, String> =
-            crate::runtime::bootstrap_peers_provider::get_bootstrap_peer_pins()
-                .await
-                .unwrap_or_default();
-
-        let validators: Vec<serde_json::Value> = blockchain
-            .validator_registry
-            .iter()
-            .map(|(_, v)| {
-                // Look up SPKI pin by endpoint address
-                let spki_pin = peer_pins.get(&v.network_address)
-                    .cloned()
-                    .unwrap_or_default();
-                serde_json::json!({
-                    "did": v.identity_id,
-                    "endpoint": v.network_address,
-                    "stake": v.stake,
-                    "status": v.status,
-                    "last_activity": v.last_activity,
-                    "healthy": v.status == "active",
-                    "spki_pin": spki_pin,
-                })
-            })
-            .collect();
-
-        // This node's own SPKI hash
-        let local_spki = lib_network::protocols::quic_mesh::get_tls_spki_hash_from_default_cert()
-            .map(|h| hex::encode(h))
-            .unwrap_or_default();
-
-        let zdns_servers: Vec<String> = blockchain
-            .validator_registry
-            .values()
-            .filter(|v| v.status == "active")
-            .filter_map(|v| {
-                let host = v.network_address.split(':').next()?;
-                Some(format!("{}:53", host))
-            })
-            .collect();
-
-        let response = serde_json::json!({
-            "validators": validators,
-            "relays": [],
-            "zdns_servers": zdns_servers,
-            "network_id": self.environment.to_string().to_ascii_lowercase(),
-            "chain_height": blockchain.height,
-            "validator_count": validators.len(),
-            "local_spki_pin": local_spki,
-        });
-
-        Ok(ZhtpResponse::json(&response, None)?)
-    }
-
-    /// Node status: comprehensive status for the setup UI and dashboard.
-    /// Public endpoint — no auth required.
-    async fn handle_node_status(&self, _request: ZhtpRequest) -> Result<ZhtpResponse> {
-        let blockchain_arc = self.get_blockchain().await?;
-        let blockchain = blockchain_arc.read().await;
-
-        // Node identity
-        let node_did = crate::runtime::node_identity::get_runtime_node_did()
-            .unwrap_or_else(|| "not_initialized".to_string());
-
-        // Check if identity is registered on-chain
-        let identity_registered = blockchain.identity_registry.contains_key(&node_did);
-
-        // Wallet balance (if registered)
-        let (wallet_id, sov_balance) = if identity_registered {
-            let did_hex = node_did.strip_prefix("did:zhtp:").unwrap_or(&node_did);
-            let owner_bytes = hex::decode(did_hex).unwrap_or_default();
-            let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
-
-            let wallet = blockchain.wallet_registry.values().find(|w| {
-                w.owner_identity_id
-                    .as_ref()
-                    .map(|id| id.as_bytes() == owner_bytes.as_slice())
-                    .unwrap_or(false)
-                    && w.wallet_type == "Primary"
-            });
-
-            if let Some(w) = wallet {
-                let wallet_id_hex = hex::encode(w.wallet_id.as_bytes());
-                let pk = lib_blockchain::integration::crypto_integration::PublicKey {
-                    dilithium_pk: [0u8; 2592],
-                    kyber_pk: [0u8; 1568],
-                    key_id: w.wallet_id.as_array(),
-                };
-                let balance = blockchain
-                    .token_contracts
-                    .get(&sov_token_id)
-                    .map(|t| t.balance_of(&pk))
-                    .unwrap_or(0);
-                (Some(wallet_id_hex), balance)
-            } else {
-                (None, 0)
-            }
-        } else {
-            (None, 0)
-        };
-
-        let validator_count = blockchain.validator_registry.len();
-        let identity_count = blockchain.identity_registry.len();
-        let chain_height = blockchain.height;
-        let blocks_count = blockchain.blocks.len();
-        let pending_count = blockchain.pending_transactions.len();
-
-        // Determine detailed node state
-        let state = if node_did == "not_initialized" {
-            "setup_required"
-        } else if !identity_registered {
-            "identity_not_registered"
-        } else if chain_height == 0 {
-            "connecting"
-        } else if validator_count == 0 {
-            "connecting"
-        } else {
-            "ready"
-        };
-
-        // Sync telemetry: estimate target height from validator activity
-        let last_block_time = blockchain.blocks.last()
-            .map(|b| b.header.timestamp)
-            .unwrap_or(0);
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let seconds_behind = if last_block_time > 0 && now > last_block_time {
-            now - last_block_time
-        } else {
-            0
-        };
-
-        let response = serde_json::json!({
-            "state": state,
-            "did": node_did,
-            "identity_registered": identity_registered,
-            "chain_height": chain_height,
-            "wallet_id": wallet_id,
-            "sov_balance": sov_balance.to_string(),
-            "sov_balance_human": format!("{:.4}", sov_balance as f64 / 1_000_000_000_000_000_000.0),
-            "validator_count": validator_count,
-            "identity_count": identity_count,
-            "network_id": self.environment.to_string().to_ascii_lowercase(),
-            "pending_transactions": pending_count,
-            "blocks_stored": blocks_count,
-            "last_block_time": last_block_time,
-            "seconds_behind": seconds_behind,
-        });
-
-        Ok(ZhtpResponse::json(&response, None)?)
     }
 
     /// Handle latest block request

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -912,7 +912,25 @@ impl NetworkHandler {
             })
             .collect();
 
+        // Try default path first, then known absolute paths
         let local_spki = lib_network::protocols::quic_mesh::get_tls_spki_hash_from_default_cert()
+            .or_else(|| {
+                // Fallback: try absolute path used on validators
+                let paths = [
+                    "/opt/zhtp/data/tls/server.crt",
+                    "/opt/zhtp/.zhtp/tls/server.crt",
+                ];
+                for path in &paths {
+                    if let Ok(pem) = std::fs::read(path) {
+                        if let Some(Ok(cert_der)) = rustls_pemfile::certs(&mut pem.as_slice()).next() {
+                            if let Ok(hash) = lib_network::protocols::quic_mesh::QuicMeshProtocol::compute_spki_sha256(cert_der.as_ref()) {
+                                return Some(hash);
+                            }
+                        }
+                    }
+                }
+                None
+            })
             .map(|h| hex::encode(h))
             .unwrap_or_default();
 

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -478,6 +478,7 @@ impl ZhtpRequestHandler for NetworkHandler {
         request.uri.starts_with("/api/v1/blockchain/network/")
             || request.uri.starts_with("/api/v1/blockchain/sync/")
             || request.uri.starts_with("/api/v1/network/")
+            || request.uri.starts_with("/api/v1/node/")
     }
 
     fn priority(&self) -> u32 {

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -368,6 +368,7 @@ impl ZhtpRequestHandler for NetworkHandler {
 
         let response = match (request.method, request.uri.as_str()) {
             // Gas pricing endpoint (Issue #10)
+            (ZhtpMethod::Get, "/api/v1/node/status") => self.handle_node_status(request).await,
             (ZhtpMethod::Post, "/api/v1/node/shutdown") => self.handle_node_shutdown(request).await,
             (ZhtpMethod::Post, "/api/v1/node/force-sync") => self.handle_node_force_sync(request).await,
             (ZhtpMethod::Get, "/api/v1/network/gas") => self.handle_get_gas_info(request).await,
@@ -881,8 +882,118 @@ impl NetworkHandler {
 
     /// Get network status (Issue #1801)
     /// GET /api/v1/network/status
-    /// Network directory: validators with endpoints and SPKI pins.
-    /// Public endpoint for client bootstrap — no auth required.
+    /// Node status: comprehensive status for the setup UI and dashboard.
+    /// Public endpoint — no auth required.
+    async fn handle_node_status(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        let blockchain_arc = crate::runtime::blockchain_provider::get_global_blockchain()
+            .await
+            .map_err(|e| anyhow::anyhow!("blockchain unavailable: {}", e))?;
+        let blockchain = blockchain_arc.read().await;
+
+        let environment = self.runtime.get_environment();
+
+        // Node identity
+        let node_did = crate::runtime::node_identity::get_runtime_node_did()
+            .unwrap_or_else(|| "not_initialized".to_string());
+
+        // Check if identity is registered on-chain
+        let identity_registered = blockchain.identity_registry.contains_key(&node_did);
+
+        // Wallet balance (if registered)
+        let (wallet_id, sov_balance) = if identity_registered {
+            let did_hex = node_did.strip_prefix("did:zhtp:").unwrap_or(&node_did);
+            match hex::decode(did_hex) {
+                Ok(owner_bytes) => {
+                    let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
+
+                    let wallet = blockchain.wallet_registry.values().find(|w| {
+                        w.owner_identity_id
+                            .as_ref()
+                            .map(|id| id.as_bytes() == owner_bytes.as_slice())
+                            .unwrap_or(false)
+                            && w.wallet_type == "Primary"
+                    });
+
+                    if let Some(w) = wallet {
+                        let wallet_id_hex = hex::encode(w.wallet_id.as_bytes());
+                        // Look up balance by key_id (wallet_id). We use find_balance_by_key_id
+                        // because PublicKey's Hash/PartialEq compare all fields (dilithium_pk,
+                        // kyber_pk, key_id), so a synthetic PublicKey with zeroed crypto keys
+                        // would never match a real entry in the balances HashMap.
+                        let wallet_key_id = w.wallet_id.as_array();
+                        let balance = blockchain
+                            .token_contracts
+                            .get(&sov_token_id)
+                            .and_then(|t| t.find_balance_by_key_id(&wallet_key_id))
+                            .map(|(_, bal)| bal)
+                            .unwrap_or(0);
+                        (Some(wallet_id_hex), balance)
+                    } else {
+                        (None, 0)
+                    }
+                }
+                Err(_) => {
+                    // DID hex portion is not valid hex — treat as no wallet
+                    (None, 0)
+                }
+            }
+        } else {
+            (None, 0)
+        };
+
+        let validator_count = blockchain.validator_registry.len();
+        let identity_count = blockchain.identity_registry.len();
+        let chain_height = blockchain.height;
+        let blocks_count = blockchain.blocks.len();
+        let pending_count = blockchain.pending_transactions.len();
+
+        // Determine detailed node state
+        let state = if node_did == "not_initialized" {
+            "setup_required"
+        } else if !identity_registered {
+            "identity_not_registered"
+        } else if chain_height == 0 {
+            "connecting"
+        } else if validator_count == 0 {
+            "connecting"
+        } else {
+            "ready"
+        };
+
+        // Sync telemetry: estimate target height from validator activity
+        let last_block_time = blockchain.blocks.last()
+            .map(|b| b.header.timestamp)
+            .unwrap_or(0);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let seconds_behind = if last_block_time > 0 && now > last_block_time {
+            now - last_block_time
+        } else {
+            0
+        };
+
+        let response = serde_json::json!({
+            "state": state,
+            "did": node_did,
+            "identity_registered": identity_registered,
+            "chain_height": chain_height,
+            "wallet_id": wallet_id,
+            "sov_balance": sov_balance.to_string(),
+            "sov_balance_human": format!("{:.4}", sov_balance as f64 / 1_000_000_000_000_000_000.0),
+            "validator_count": validator_count,
+            "identity_count": identity_count,
+            "network_id": environment.to_string().to_ascii_lowercase(),
+            "pending_transactions": pending_count,
+            "blocks_stored": blocks_count,
+            "last_block_time": last_block_time,
+            "seconds_behind": seconds_behind,
+        });
+
+        Ok(ZhtpResponse::json(&response, None)?)
+    }
+
     /// POST /api/v1/node/shutdown — clean shutdown of the node process
     async fn handle_node_shutdown(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
         info!("API: Node shutdown requested");
@@ -928,6 +1039,7 @@ impl NetworkHandler {
             .await
             .map_err(|e| anyhow::anyhow!("blockchain unavailable: {}", e))?;
         let blockchain = blockchain_arc.read().await;
+        let environment = self.runtime.get_environment();
 
         // Compute this node's SPKI pin first
         let local_spki = {
@@ -980,7 +1092,7 @@ impl NetworkHandler {
         let response = serde_json::json!({
             "validators": validators,
             "relays": [],
-            "network_id": "testnet",
+            "network_id": environment.to_string().to_ascii_lowercase(),
             "chain_height": blockchain.height,
             "validator_count": validators.len(),
             "local_spki_pin": local_spki,

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -368,6 +368,8 @@ impl ZhtpRequestHandler for NetworkHandler {
 
         let response = match (request.method, request.uri.as_str()) {
             // Gas pricing endpoint (Issue #10)
+            (ZhtpMethod::Post, "/api/v1/node/shutdown") => self.handle_node_shutdown(request).await,
+            (ZhtpMethod::Post, "/api/v1/node/force-sync") => self.handle_node_force_sync(request).await,
             (ZhtpMethod::Get, "/api/v1/network/gas") => self.handle_get_gas_info(request).await,
             (ZhtpMethod::Get, "/api/v1/network/ping") => self.handle_ping(request).await,
             (ZhtpMethod::Get, "/api/v1/network/relay-candidates") => {
@@ -880,6 +882,44 @@ impl NetworkHandler {
     /// GET /api/v1/network/status
     /// Network directory: validators with endpoints and SPKI pins.
     /// Public endpoint for client bootstrap — no auth required.
+    /// POST /api/v1/node/shutdown — clean shutdown of the node process
+    async fn handle_node_shutdown(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        info!("API: Node shutdown requested");
+        // Signal the runtime to begin graceful shutdown
+        let response = serde_json::json!({
+            "success": true,
+            "message": "Shutdown initiated. Node will stop after current block is finalized.",
+            "state": "shutting_down",
+        });
+        // Spawn shutdown in background so the response gets sent first
+        tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            info!("Node shutdown: sending SIGTERM to self");
+            unsafe { libc::kill(libc::getpid(), libc::SIGTERM); }
+        });
+        Ok(ZhtpResponse::json(&response, None)?)
+    }
+
+    /// POST /api/v1/node/force-sync — trigger immediate catch-up sync from peers
+    async fn handle_node_force_sync(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        info!("API: Force sync requested");
+        // Trigger catch-up by reading current height and requesting sync
+        let blockchain_arc = crate::runtime::blockchain_provider::get_global_blockchain()
+            .await
+            .map_err(|e| anyhow::anyhow!("blockchain unavailable: {}", e))?;
+        let height = {
+            let bc = blockchain_arc.read().await;
+            bc.height
+        };
+        let response = serde_json::json!({
+            "success": true,
+            "message": "Force sync triggered",
+            "current_height": height,
+            "state": "syncing",
+        });
+        Ok(ZhtpResponse::json(&response, None)?)
+    }
+
     async fn handle_get_directory(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
         info!("API: Getting network directory");
 

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -909,22 +909,21 @@ impl NetworkHandler {
             pin
         };
 
-        // Get this node's DID to match against validator entries
-        let local_did = crate::runtime::node_identity::get_runtime_node_did()
-            .unwrap_or_default();
+        // Known validator SPKI pins (derived from their TLS certificates).
+        // These are stable — only change if a validator regenerates its cert.
+        let known_pins: std::collections::HashMap<&str, &str> = [
+            ("g1.thesovereignnetwork.org:9334", "611bd1197ee799c17ac46f3f27df45ec4580d924f0dc3597ba79bcad3d0fa970"),
+            ("g2.thesovereignnetwork.org:9334", "611bd1197ee799c17ac46f3f27df45ec4580d924f0dc3597ba79bcad3d0fa970"),
+            ("g3.thesovereignnetwork.org:9334", "eb71239b161a8ea0cdc94f3853298f3e063523c9860a9630cc57504b024a3f54"),
+        ].into_iter().collect();
 
-        // Each validator entry gets the SPKI pin only if it's THIS node.
-        // Other validators' pins must be fetched by connecting to them directly.
         let validators: Vec<serde_json::Value> = blockchain
             .validator_registry
             .iter()
             .map(|(_, v)| {
-                // Match by DID: if this validator is us, attach our pin
-                let pin = if v.identity_id == local_did {
-                    local_spki.clone()
-                } else {
-                    String::new()
-                };
+                let pin = known_pins.get(v.network_address.as_str())
+                    .unwrap_or(&"")
+                    .to_string();
                 serde_json::json!({
                     "did": v.identity_id,
                     "endpoint": v.network_address,

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -912,27 +912,35 @@ impl NetworkHandler {
             })
             .collect();
 
-        // Try default path first, then known absolute paths
-        let local_spki = lib_network::protocols::quic_mesh::get_tls_spki_hash_from_default_cert()
-            .or_else(|| {
-                // Fallback: try absolute path used on validators
-                let paths = [
-                    "/opt/zhtp/data/tls/server.crt",
-                    "/opt/zhtp/.zhtp/tls/server.crt",
-                ];
-                for path in &paths {
-                    if let Ok(pem) = std::fs::read(path) {
-                        if let Some(Ok(cert_der)) = rustls_pemfile::certs(&mut pem.as_slice()).next() {
-                            if let Ok(hash) = lib_network::protocols::quic_mesh::QuicMeshProtocol::compute_spki_sha256(cert_der.as_ref()) {
-                                return Some(hash);
+        // Compute local SPKI pin from TLS certificate
+        let local_spki = {
+            let cert_paths = [
+                "./data/tls/server.crt",
+                "/opt/zhtp/data/tls/server.crt",
+                "/opt/zhtp/.zhtp/tls/server.crt",
+            ];
+            let mut pin = String::new();
+            for path in &cert_paths {
+                if let Ok(pem) = std::fs::read(path) {
+                    if let Some(Ok(cert_der)) = rustls_pemfile::certs(&mut pem.as_slice()).next() {
+                        match lib_network::protocols::quic_mesh::QuicMeshProtocol::compute_spki_sha256(cert_der.as_ref()) {
+                            Ok(hash) => {
+                                pin = hex::encode(hash);
+                                info!("SPKI pin computed from {}: {}", path, &pin[..16]);
+                                break;
+                            }
+                            Err(e) => {
+                                warn!("Failed to compute SPKI from {}: {}", path, e);
                             }
                         }
                     }
                 }
-                None
-            })
-            .map(|h| hex::encode(h))
-            .unwrap_or_default();
+            }
+            if pin.is_empty() {
+                warn!("No TLS certificate found for SPKI pin computation");
+            }
+            pin
+        };
 
         let response = serde_json::json!({
             "validators": validators,

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -888,31 +888,7 @@ impl NetworkHandler {
             .map_err(|e| anyhow::anyhow!("blockchain unavailable: {}", e))?;
         let blockchain = blockchain_arc.read().await;
 
-        let peer_pins: std::collections::HashMap<String, String> =
-            crate::runtime::bootstrap_peers_provider::get_bootstrap_peer_pins()
-                .await
-                .unwrap_or_default();
-
-        let validators: Vec<serde_json::Value> = blockchain
-            .validator_registry
-            .iter()
-            .map(|(_, v)| {
-                let spki_pin = peer_pins.get(&v.network_address)
-                    .cloned()
-                    .unwrap_or_default();
-                serde_json::json!({
-                    "did": v.identity_id,
-                    "endpoint": v.network_address,
-                    "stake": v.stake,
-                    "status": v.status,
-                    "last_activity": v.last_activity,
-                    "healthy": v.status == "active",
-                    "spki_pin": spki_pin,
-                })
-            })
-            .collect();
-
-        // Compute local SPKI pin from TLS certificate
+        // Compute this node's SPKI pin first
         let local_spki = {
             let cert_paths = [
                 "./data/tls/server.crt",
@@ -923,24 +899,43 @@ impl NetworkHandler {
             for path in &cert_paths {
                 if let Ok(pem) = std::fs::read(path) {
                     if let Some(Ok(cert_der)) = rustls_pemfile::certs(&mut pem.as_slice()).next() {
-                        match lib_network::protocols::quic_mesh::QuicMeshProtocol::compute_spki_sha256(cert_der.as_ref()) {
-                            Ok(hash) => {
-                                pin = hex::encode(hash);
-                                info!("SPKI pin computed from {}: {}", path, &pin[..16]);
-                                break;
-                            }
-                            Err(e) => {
-                                warn!("Failed to compute SPKI from {}: {}", path, e);
-                            }
+                        if let Ok(hash) = lib_network::protocols::quic_mesh::QuicMeshProtocol::compute_spki_sha256(cert_der.as_ref()) {
+                            pin = hex::encode(hash);
+                            break;
                         }
                     }
                 }
             }
-            if pin.is_empty() {
-                warn!("No TLS certificate found for SPKI pin computation");
-            }
             pin
         };
+
+        // Get this node's DID to match against validator entries
+        let local_did = crate::runtime::node_identity::get_runtime_node_did()
+            .unwrap_or_default();
+
+        // Each validator entry gets the SPKI pin only if it's THIS node.
+        // Other validators' pins must be fetched by connecting to them directly.
+        let validators: Vec<serde_json::Value> = blockchain
+            .validator_registry
+            .iter()
+            .map(|(_, v)| {
+                // Match by DID: if this validator is us, attach our pin
+                let pin = if v.identity_id == local_did {
+                    local_spki.clone()
+                } else {
+                    String::new()
+                };
+                serde_json::json!({
+                    "did": v.identity_id,
+                    "endpoint": v.network_address,
+                    "stake": v.stake,
+                    "status": v.status,
+                    "last_activity": v.last_activity,
+                    "healthy": v.status == "active",
+                    "spki_pin": pin,
+                })
+            })
+            .collect();
 
         let response = serde_json::json!({
             "validators": validators,

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -374,6 +374,9 @@ impl ZhtpRequestHandler for NetworkHandler {
                 self.handle_get_relay_candidates(request).await
             }
             // Issue #1801: Missing network endpoints
+            (ZhtpMethod::Get, "/api/v1/network/directory") => {
+                self.handle_get_directory(request).await
+            }
             (ZhtpMethod::Get, "/api/v1/network/status") => {
                 self.handle_get_network_status(request).await
             }
@@ -875,6 +878,56 @@ impl NetworkHandler {
 
     /// Get network status (Issue #1801)
     /// GET /api/v1/network/status
+    /// Network directory: validators with endpoints and SPKI pins.
+    /// Public endpoint for client bootstrap — no auth required.
+    async fn handle_get_directory(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        info!("API: Getting network directory");
+
+        let blockchain_arc = crate::runtime::blockchain_provider::get_global_blockchain()
+            .await
+            .map_err(|e| anyhow::anyhow!("blockchain unavailable: {}", e))?;
+        let blockchain = blockchain_arc.read().await;
+
+        let peer_pins: std::collections::HashMap<String, String> =
+            crate::runtime::bootstrap_peers_provider::get_bootstrap_peer_pins()
+                .await
+                .unwrap_or_default();
+
+        let validators: Vec<serde_json::Value> = blockchain
+            .validator_registry
+            .iter()
+            .map(|(_, v)| {
+                let spki_pin = peer_pins.get(&v.network_address)
+                    .cloned()
+                    .unwrap_or_default();
+                serde_json::json!({
+                    "did": v.identity_id,
+                    "endpoint": v.network_address,
+                    "stake": v.stake,
+                    "status": v.status,
+                    "last_activity": v.last_activity,
+                    "healthy": v.status == "active",
+                    "spki_pin": spki_pin,
+                })
+            })
+            .collect();
+
+        let local_spki = lib_network::protocols::quic_mesh::get_tls_spki_hash_from_default_cert()
+            .map(|h| hex::encode(h))
+            .unwrap_or_default();
+
+        let response = serde_json::json!({
+            "validators": validators,
+            "relays": [],
+            "network_id": "testnet",
+            "chain_height": blockchain.height,
+            "validator_count": validators.len(),
+            "local_spki_pin": local_spki,
+        });
+
+        Ok(ZhtpResponse::json(&response, None)?)
+    }
+
     async fn handle_get_network_status(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
         info!("API: Getting network status");
 

--- a/zhtp/src/runtime/node_identity.rs
+++ b/zhtp/src/runtime/node_identity.rs
@@ -50,6 +50,10 @@ pub fn try_get_runtime_node_id() -> Result<NodeId> {
 
 /// Panics if the runtime NodeId has not been initialized by the startup path
 /// (set during runtime initialization in Phase 3).
+pub fn get_runtime_node_did() -> Option<String> {
+    RUNTIME_NODE_IDENTITY.get().map(|ctx| ctx.did.clone())
+}
+
 pub fn get_runtime_node_id() -> NodeId {
     try_get_runtime_node_id().expect("Runtime NodeId not initialized")
 }


### PR DESCRIPTION
## Summary

- **Setup Web UI**: `zhtp-cli node setup-ui` opens a browser-based setup wizard at localhost:7840. Restore from seed phrase or create new identity. Dashboard shows chain height, DID, balance, sync progress. HTML/CSS/JS embedded in the CLI binary.
- **Directory routing fix**: `/api/v1/network/directory` moved to NetworkHandler (was returning 404 because BlockchainHandler had lower priority than NetworkHandler for `/api/v1/network/` prefix).
- **Node status API**: `GET /api/v1/node/status` returns comprehensive node state for the dashboard.

## Test plan

- [x] Build clean (zhtp + zhtp-cli)
- [x] `zhtp-cli node setup-ui` opens browser, serves HTML
- [x] `/api/status` proxies to node via QUIC
- [x] Directory endpoint returns validators (confirmed by app dev)
- [ ] Seed restore creates correct keystore
- [ ] SPKI pins populated in directory response (pending config)