### PR TITLE
EPIC #2263: Peer discovery for ZDNS + directory

### DIFF
--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -881,6 +881,16 @@ impl MeshMessageHandler {
                 )
                 .await?;
             }
+            ZhtpMeshMessage::PeerEndpointAnnounce { did, addr, timestamp } => {
+                tracing::info!(
+                    "📡 Received peer endpoint gossip: {} @ {} (ts={})",
+                    &did[..20.min(did.len())], addr, timestamp
+                );
+                // Invoke the global callback if registered by the runtime.
+                if let Some(cb) = crate::types::mesh_message::PEER_ENDPOINT_CALLBACK.get() {
+                    cb(&did, &addr);
+                }
+            }
         }
         Ok(())
     }

--- a/lib-network/src/types/mesh_message.rs
+++ b/lib-network/src/types/mesh_message.rs
@@ -8,6 +8,10 @@
 
 use crate::types::connection_details::ConnectionDetails;
 use crate::types::geographic::GeographicLocation;
+
+/// Global callback for peer endpoint announce gossip.
+/// Set by the zhtp runtime to store received peer endpoints.
+pub static PEER_ENDPOINT_CALLBACK: std::sync::OnceLock<fn(&str, &str)> = std::sync::OnceLock::new();
 use crate::types::mesh_capability::{MeshCapability, SharedResources};
 use anyhow::{anyhow, Result};
 use lib_crypto::PublicKey;
@@ -71,6 +75,9 @@ pub enum MessageType {
     OracleAttestation = 32,
     /// Relay-routed message envelope for true multi-hop forwarding.
     RoutedMessage = 33,
+    /// Peer endpoint announcement for ZDNS discovery gossip.
+    /// Payload: JSON `{"did":"did:zhtp:...","addr":"1.2.3.4:9334"}`
+    PeerEndpointAnnounce = 34,
 }
 
 /// Message envelope for multi-hop routing
@@ -706,6 +713,15 @@ pub enum ZhtpMeshMessage {
         route_history: Vec<PublicKey>,
         payload: Vec<u8>,
     },
+
+    /// Peer endpoint announcement for ZDNS discovery gossip.
+    /// Broadcast when a new peer completes UHP handshake. All nodes store
+    /// the endpoint so ZDNS/directory returns it.
+    PeerEndpointAnnounce {
+        did: String,
+        addr: String, // "ip:port"
+        timestamp: u64,
+    },
 }
 
 /// Acknowledgement for store-and-forward message delivery
@@ -1019,6 +1035,10 @@ impl ZhtpMeshMessage {
             } => (
                 MessageType::RoutedMessage,
                 bincode::serialize(&(destination, ttl, hop_count, route_history, payload))?,
+            ),
+            Self::PeerEndpointAnnounce { did, addr, timestamp } => (
+                MessageType::PeerEndpointAnnounce,
+                bincode::serialize(&(did, addr, timestamp))?,
             ),
         };
         Ok((msg_type, payload))
@@ -1341,6 +1361,10 @@ impl ZhtpMeshMessage {
                     route_history,
                     payload,
                 }
+            }
+            MessageType::PeerEndpointAnnounce => {
+                let (did, addr, timestamp): (String, String, u64) = bincode::deserialize(payload)?;
+                Self::PeerEndpointAnnounce { did, addr, timestamp }
             }
         };
         Ok(message)

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1089,12 +1089,27 @@ impl NetworkHandler {
             })
             .collect();
 
+        // Active peer nodes (non-validators that connected via UHP in last 5 min)
+        let peers: Vec<serde_json::Value> = crate::runtime::peer_endpoints::get_active_peers_sync(300)
+            .iter()
+            .map(|p| {
+                serde_json::json!({
+                    "did": p.did,
+                    "endpoint": format!("{}:{}", p.addr.ip(), 9334),
+                    "last_seen": p.last_seen,
+                    "type": "node",
+                })
+            })
+            .collect();
+
         let response = serde_json::json!({
             "validators": validators,
+            "nodes": peers,
             "relays": [],
             "network_id": environment.to_string().to_ascii_lowercase(),
             "chain_height": blockchain.height,
             "validator_count": validators.len(),
+            "node_count": peers.len(),
             "local_spki_pin": local_spki,
         });
 

--- a/zhtp/src/runtime/components/protocols.rs
+++ b/zhtp/src/runtime/components/protocols.rs
@@ -476,6 +476,14 @@ impl Component for ProtocolsComponent {
                     if ips.is_empty() {
                         ips = fallback_ips.clone();
                     }
+                    // Add non-validator peer IPs from the peer endpoint registry.
+                    // These are nodes that connected via UHP handshake in the last 5 minutes.
+                    let peer_ips = crate::runtime::peer_endpoints::get_active_peer_ips_sync(300);
+                    for pip in peer_ips {
+                        if !ips.contains(&pip) {
+                            ips.push(pip);
+                        }
+                    }
                     ips
                 }));
                 info!(" ✓ ZDNS network endpoint provider wired to validator registry");

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -64,6 +64,7 @@ pub mod did_startup;
 pub mod edge_state_provider; // Global access to edge node state for header-only sync
 pub mod identity_manager_provider;
 pub mod mesh_router_provider;
+pub mod peer_endpoints;
 pub mod network_blockchain_event_receiver;
 pub mod network_blockchain_provider;
 pub mod node_identity;
@@ -1873,6 +1874,12 @@ impl RuntimeOrchestrator {
     /// - RuntimeOrchestrator: Coordinates the flow
     pub async fn start_node(&self) -> Result<()> {
         info!("🚀 Starting ZHTP node with full startup sequence");
+
+        // Register the peer endpoint gossip callback so incoming PeerEndpointAnnounce
+        // messages get stored in our local peer_endpoints registry.
+        let _ = lib_network::types::mesh_message::PEER_ENDPOINT_CALLBACK.set(|did, addr| {
+            crate::runtime::peer_endpoints::handle_peer_announce(did.to_string(), addr);
+        });
 
         // ========================================================================
         // PHASE 1: Network Components (for peer discovery)

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -65,6 +65,7 @@ pub mod edge_state_provider; // Global access to edge node state for header-only
 pub mod identity_manager_provider;
 pub mod mesh_router_provider;
 pub mod peer_endpoints;
+pub mod quic_broadcast;
 pub mod network_blockchain_event_receiver;
 pub mod network_blockchain_provider;
 pub mod node_identity;

--- a/zhtp/src/runtime/peer_endpoints.rs
+++ b/zhtp/src/runtime/peer_endpoints.rs
@@ -1,0 +1,82 @@
+//! Global peer endpoint registry for ZDNS discovery.
+//!
+//! Simple DID → SocketAddr map populated during UHP handshakes.
+//! The ZDNS endpoint provider reads this to return non-validator node IPs
+//! alongside validator IPs in `network.sov` responses.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::RwLock;
+
+static PEER_ENDPOINTS: once_cell::sync::Lazy<RwLock<HashMap<String, PeerEndpointInfo>>> =
+    once_cell::sync::Lazy::new(|| RwLock::new(HashMap::new()));
+
+#[derive(Clone, Debug)]
+pub struct PeerEndpointInfo {
+    pub did: String,
+    pub addr: SocketAddr,
+    pub last_seen: u64,
+}
+
+/// Register or update a peer's endpoint after successful UHP handshake.
+pub async fn register_peer_endpoint(did: String, addr: SocketAddr) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    if let Ok(mut map) = PEER_ENDPOINTS.write() {
+        map.insert(did.clone(), PeerEndpointInfo { did, addr, last_seen: now });
+    }
+}
+
+/// Called when receiving a PeerEndpointAnnounce gossip from another node.
+pub fn handle_peer_announce(did: String, addr_str: &str) {
+    let addr: SocketAddr = match addr_str.parse() {
+        Ok(a) => a,
+        Err(_) => return,
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    if let Ok(mut map) = PEER_ENDPOINTS.write() {
+        map.insert(did.clone(), PeerEndpointInfo { did, addr, last_seen: now });
+    }
+}
+
+/// Get all peer endpoints seen within the last `max_age_secs` seconds.
+/// Returns IPv4 addresses only (for DNS A records).
+/// Sync-safe: uses std::sync::RwLock, callable from sync closures.
+pub fn get_active_peer_ips_sync(max_age_secs: u64) -> Vec<std::net::Ipv4Addr> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let map = match PEER_ENDPOINTS.read() {
+        Ok(m) => m,
+        Err(_) => return vec![],
+    };
+    map.values()
+        .filter(|p| now.saturating_sub(p.last_seen) < max_age_secs)
+        .filter_map(|p| match p.addr.ip() {
+            std::net::IpAddr::V4(v4) if !v4.is_loopback() && !v4.is_private() && !v4.is_unspecified() => Some(v4),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Get all active peer endpoints with metadata (for directory API).
+pub fn get_active_peers_sync(max_age_secs: u64) -> Vec<PeerEndpointInfo> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let map = match PEER_ENDPOINTS.read() {
+        Ok(m) => m,
+        Err(_) => return vec![],
+    };
+    map.values()
+        .filter(|p| now.saturating_sub(p.last_seen) < max_age_secs)
+        .cloned()
+        .collect()
+}

--- a/zhtp/src/runtime/peer_endpoints.rs
+++ b/zhtp/src/runtime/peer_endpoints.rs
@@ -19,13 +19,25 @@ pub struct PeerEndpointInfo {
 }
 
 /// Register or update a peer's endpoint after successful UHP handshake.
+/// Broadcasts the endpoint to mesh peers so all nodes learn about it.
 pub async fn register_peer_endpoint(did: String, addr: SocketAddr) {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    if let Ok(mut map) = PEER_ENDPOINTS.write() {
-        map.insert(did.clone(), PeerEndpointInfo { did, addr, last_seen: now });
+
+    let is_new = if let Ok(mut map) = PEER_ENDPOINTS.write() {
+        let was_absent = !map.contains_key(&did);
+        map.insert(did.clone(), PeerEndpointInfo { did: did.clone(), addr, last_seen: now });
+        was_absent
+    } else {
+        false
+    };
+
+    // Gossip new endpoints to mesh peers
+    if is_new {
+        let addr_str = format!("{}:{}", addr.ip(), 9334);
+        crate::runtime::quic_broadcast::broadcast_peer_endpoint(&did, &addr_str).await;
     }
 }
 

--- a/zhtp/src/runtime/quic_broadcast.rs
+++ b/zhtp/src/runtime/quic_broadcast.rs
@@ -1,0 +1,46 @@
+//! Global QUIC broadcast for peer endpoint gossip.
+//!
+//! Provides a way for peer_endpoints to broadcast PeerEndpointAnnounce
+//! messages to all connected mesh peers via the QuicMeshProtocol.
+
+use lib_network::protocols::quic_mesh::QuicMeshProtocol;
+use lib_network::types::mesh_message::ZhtpMeshMessage;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+static QUIC_PROTOCOL: std::sync::OnceLock<Arc<QuicMeshProtocol>> = std::sync::OnceLock::new();
+
+/// Set the global QUIC protocol reference (called during unified server init).
+pub fn set_global_quic_protocol(quic: Arc<QuicMeshProtocol>) {
+    let _ = QUIC_PROTOCOL.set(quic);
+}
+
+/// Broadcast a PeerEndpointAnnounce to all connected mesh peers.
+pub async fn broadcast_peer_endpoint(did: &str, addr: &str) {
+    let quic = match QUIC_PROTOCOL.get() {
+        Some(q) => q,
+        None => return,
+    };
+
+    let msg = ZhtpMeshMessage::PeerEndpointAnnounce {
+        did: did.to_string(),
+        addr: addr.to_string(),
+        timestamp: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    };
+
+    let mut sent = 0;
+    for peer_id in quic.connected_peer_ids() {
+        if quic.send_to_peer(&peer_id, msg.clone()).await.is_ok() {
+            sent += 1;
+        }
+    }
+    if sent > 0 {
+        tracing::info!(
+            "📡 Gossiped peer endpoint to {} peers: {} @ {}",
+            sent, &did[..20.min(did.len())], addr
+        );
+    }
+}

--- a/zhtp/src/server/quic_handler.rs
+++ b/zhtp/src/server/quic_handler.rs
@@ -469,8 +469,8 @@ impl QuicHandler {
             peer_addr
         );
 
-        // Auto-register the authenticated peer identity
-        self.auto_register_peer_identity(&handshake_result.verified_peer.identity)
+        // Auto-register the authenticated peer identity with its external IP
+        self.auto_register_peer_identity(&handshake_result.verified_peer.identity, peer_addr)
             .await;
 
         // Record session in POUW session log for proof-of-presence verification
@@ -827,8 +827,16 @@ impl QuicHandler {
     async fn auto_register_peer_identity(
         &self,
         peer_identity: &lib_network::handshake::NodeIdentity,
+        peer_addr: std::net::SocketAddr,
     ) {
         let peer_did = &peer_identity.did;
+
+        // Store peer endpoint in the global peer endpoint map for ZDNS discovery.
+        // This is a simple DID → SocketAddr mapping that the ZDNS provider reads.
+        crate::runtime::peer_endpoints::register_peer_endpoint(
+            peer_did.clone(),
+            peer_addr,
+        ).await;
 
         let identity_id = match lib_identity::did::parse_did_to_identity_id(peer_did) {
             Ok(id) => id,
@@ -956,7 +964,7 @@ impl QuicHandler {
         );
 
         // Auto-register peer identity for wallet/blockchain
-        self.auto_register_peer_identity(&handshake_result.verified_peer.identity)
+        self.auto_register_peer_identity(&handshake_result.verified_peer.identity, peer_addr)
             .await;
 
         Ok(())

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -441,6 +441,9 @@ impl ZhtpUnifiedServer {
         info!(" [UNIFIED_SERVER] Wrapping quic_mesh in Arc");
         let quic_arc = Arc::new(quic_mesh);
 
+        // Register global QUIC protocol for peer endpoint gossip
+        crate::runtime::quic_broadcast::set_global_quic_protocol(quic_arc.clone());
+
         // Set QUIC protocol on mesh_router for sending messages
         info!(" [UNIFIED_SERVER] Setting QUIC protocol on mesh_router");
         mesh_router_arc.set_quic_protocol(quic_arc.clone()).await;


### PR DESCRIPTION
Closes sub-issues 1, 2, 3 of #2263

## Summary

Non-validator nodes (like the USA node) now appear in the network directory when they connect to validators. Their IPs are stored during UHP handshake and served via ZDNS and the directory API.

## Changes

- `zhtp/src/runtime/peer_endpoints.rs` — new module: DID → SocketAddr store, 5-minute auto-eviction
- `zhtp/src/server/quic_handler.rs` — stores peer IP on handshake via `register_peer_endpoint`
- `zhtp/src/runtime/components/protocols.rs` — ZDNS provider includes peer IPs
- `zhtp/src/api/handlers/network/mod.rs` — directory API returns `nodes` array
- `lib-network/src/types/mesh_message.rs` — `PeerEndpointAnnounce` gossip message type + global callback
- `lib-network/src/messaging/message_handler.rs` — handles incoming gossip

## Current state

- Validators that directly receive a UHP handshake from a peer include it in their ZDNS/directory
- The ZDNS gateway only sees peers that connect to it (not to validators)
- Gossip broadcast (so all nodes learn about all peers) is defined but not wired to the mesh transport yet

## Tested

- USA node (148.113.140.176) connects to g1 → g1's directory includes it