### PR TITLE
fix: deterministic state root + restore SPKI pins in directory API

### DIFF
--- a/lib-blockchain/src/contracts/dev_grants/core.rs
+++ b/lib-blockchain/src/contracts/dev_grants/core.rs
@@ -2,7 +2,7 @@ use super::types::*;
 use crate::contracts::tokens::core::TokenContract;
 use crate::integration::crypto_integration::PublicKey;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Development Grants Fund Contract - Phase 2 Final Implementation
 ///
@@ -41,7 +41,7 @@ pub struct DevGrants {
     /// Approved grants (governance-binding payload storage)
     /// Maps proposal_id -> ApprovedGrant
     /// Once stored, recipient and amount are immutable
-    approved: HashMap<ProposalId, ApprovedGrant>,
+    approved: BTreeMap<ProposalId, ApprovedGrant>,
 
     /// Disbursement log (append-only, immutable)
     /// Each record includes actual token_burned amount
@@ -62,7 +62,7 @@ impl DevGrants {
             balance: 0,
             total_received: 0,
             total_disbursed: 0,
-            approved: HashMap::new(),
+            approved: BTreeMap::new(),
             disbursements: vec![],
         }
     }

--- a/lib-blockchain/src/contracts/executor/mod.rs
+++ b/lib-blockchain/src/contracts/executor/mod.rs
@@ -41,7 +41,7 @@ pub const CALL_DEPTH_EXCEEDED: &str = "Call depth limit exceeded";
 #[derive(Debug, Clone)]
 struct PendingStateChanges {
     /// Custom token mutations pending commit
-    pub token_changes: std::collections::HashMap<[u8; 32], TokenContract>,
+    pub token_changes: std::collections::BTreeMap<[u8; 32], TokenContract>,
     /// UBI contract mutations pending commit
     pub ubi_change: Option<crate::contracts::UbiDistributor>,
     /// DevGrants contract mutations pending commit
@@ -54,7 +54,7 @@ impl PendingStateChanges {
     /// Create new pending state for the given block height
     fn new(block_height: u64) -> Self {
         Self {
-            token_changes: std::collections::HashMap::new(),
+            token_changes: std::collections::BTreeMap::new(),
             ubi_change: None,
             dev_grants_change: None,
             block_height,
@@ -681,11 +681,15 @@ impl<S: ContractStorage> ContractExecutor<S> {
         // block-level consensus. With persistent-contracts feature, the storage layer
         // can compute more comprehensive state roots post-finalization via StateRootComputation.
         let state_root = {
-            // Compute hash over all writes being committed (deterministic ordering)
+            // Sort writes by key for deterministic ordering across all binary versions.
+            // BTreeMap already iterates in sorted order, but UBI/DevGrants writes are
+            // appended after token writes — sorting the full vector guarantees order.
+            let mut sorted_writes = writes.clone();
+            sorted_writes.sort_by(|a, b| a.0.cmp(&b.0));
+
             let mut hasher = blake3::Hasher::new();
 
-            // Hash token changes
-            for (token_id, token) in &writes {
+            for (token_id, token) in &sorted_writes {
                 hasher.update(token_id);
                 hasher.update(token);
             }

--- a/lib-blockchain/src/contracts/tokens/core.rs
+++ b/lib-blockchain/src/contracts/tokens/core.rs
@@ -1,7 +1,7 @@
 use crate::contracts::executor::{CallOrigin, ExecutionContext};
 use crate::integration::crypto_integration::PublicKey;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 
 /// Errors for token contract operations
@@ -50,10 +50,10 @@ pub struct TokenContract {
     pub is_deflationary: bool,
     /// Amount burned per transfer (if deflationary)
     pub burn_rate: u128,
-    /// Account balances mapping
-    balances: HashMap<PublicKey, u128>,
-    /// Allowances for third-party transfers
-    allowances: HashMap<PublicKey, HashMap<PublicKey, u128>>,
+    /// Account balances mapping (BTreeMap for deterministic serialization order)
+    balances: BTreeMap<PublicKey, u128>,
+    /// Allowances for third-party transfers (BTreeMap for deterministic serialization order)
+    allowances: BTreeMap<PublicKey, BTreeMap<PublicKey, u128>>,
     /// Token creator
     pub creator: PublicKey,
     /// Kernel minting authority (for UBI distribution)
@@ -64,7 +64,7 @@ pub struct TokenContract {
     /// Locked balances per account (non-transferable until released)
     /// Used by Treasury Kernel for staking, vesting, escrow
     #[serde(default)]
-    locked_balances: HashMap<PublicKey, u128>,
+    locked_balances: BTreeMap<PublicKey, u128>,
     /// When true, only Treasury Kernel (kernel_mint_authority) can call
     /// mint(), burn(), and transfer(). Defaults to false for backward compat.
     #[serde(default)]
@@ -98,11 +98,11 @@ impl TokenContract {
             max_supply,
             is_deflationary,
             burn_rate,
-            balances: HashMap::new(),
-            allowances: HashMap::new(),
+            balances: BTreeMap::new(),
+            allowances: BTreeMap::new(),
             creator,
             kernel_mint_authority: None,
-            locked_balances: HashMap::new(),
+            locked_balances: BTreeMap::new(),
             kernel_only_mode: false,
             creator_did: None,
             fee_schedule_bps: None,
@@ -326,7 +326,7 @@ impl TokenContract {
         // Reduce allowance
         self.allowances
             .entry(owner.clone())
-            .or_insert_with(HashMap::new)
+            .or_insert_with(BTreeMap::new)
             .insert(spender.clone(), allowance - amount);
 
         // Perform transfer from owner to recipient
@@ -358,7 +358,7 @@ impl TokenContract {
     pub fn approve(&mut self, owner: &PublicKey, spender: &PublicKey, amount: u128) {
         self.allowances
             .entry(owner.clone())
-            .or_insert_with(HashMap::new)
+            .or_insert_with(BTreeMap::new)
             .insert(spender.clone(), amount);
     }
 
@@ -587,7 +587,7 @@ impl TokenContract {
     }
 
     /// Get all allowances for a given owner
-    pub fn get_owner_allowances(&self, owner: &PublicKey) -> Option<&HashMap<PublicKey, u128>> {
+    pub fn get_owner_allowances(&self, owner: &PublicKey) -> Option<&BTreeMap<PublicKey, u128>> {
         self.allowances.get(owner)
     }
 

--- a/lib-blockchain/src/contracts/tokens/functions.rs
+++ b/lib-blockchain/src/contracts/tokens/functions.rs
@@ -2,7 +2,7 @@ use super::core::{TokenContract, TokenInfo};
 use crate::contracts::treasury_kernel::{CreditReason, DebitReason, KernelOpError, TreasuryKernel};
 use crate::contracts::utils;
 use crate::integration::crypto_integration::PublicKey;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Token operation functions for contract system integration
 ///
@@ -171,7 +171,7 @@ pub fn create_deflationary_token(
 /// Batch transfers should be implemented using the new transfer(ctx, to, amount) API.
 
 /// Get all non-zero balances
-pub fn get_all_balances(contract: &TokenContract) -> HashMap<PublicKey, u128> {
+pub fn get_all_balances(contract: &TokenContract) -> BTreeMap<PublicKey, u128> {
     contract
         .balances_iter()
         .filter(|(_, &balance)| balance > 0)
@@ -180,7 +180,7 @@ pub fn get_all_balances(contract: &TokenContract) -> HashMap<PublicKey, u128> {
 }
 
 /// Get all allowances for an owner
-pub fn get_all_allowances(contract: &TokenContract, owner: &PublicKey) -> HashMap<PublicKey, u128> {
+pub fn get_all_allowances(contract: &TokenContract, owner: &PublicKey) -> BTreeMap<PublicKey, u128> {
     contract
         .get_owner_allowances(owner)
         .map(|allowances| {

--- a/lib-blockchain/src/contracts/ubi_distribution/core.rs
+++ b/lib-blockchain/src/contracts/ubi_distribution/core.rs
@@ -3,7 +3,7 @@ use crate::contracts::tokens::core::TokenContract;
 use crate::contracts::treasury_kernel::TreasuryKernel;
 use crate::integration::crypto_integration::PublicKey;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Universal Basic Income Distribution Contract
 ///
@@ -46,12 +46,12 @@ pub struct UbiDistributor {
 
     /// Registered citizens (by key_id only, never full PublicKey)
     /// Invariant U1: Each key_id appears at most once
-    registered: HashSet<[u8; 32]>,
+    registered: BTreeSet<[u8; 32]>,
 
     /// Payment tracking: (month_index, citizen_key_id) membership
     /// Invariant P1: Each citizen can claim at most once per month
     /// Implementation: per-month set of paid key_ids
-    paid: HashMap<MonthIndex, HashSet<[u8; 32]>>,
+    paid: BTreeMap<MonthIndex, BTreeSet<[u8; 32]>>,
 
     /// Schedule: month_index -> per-citizen amount
     /// Governance controls this; if not set, amount defaults to 0
@@ -61,7 +61,7 @@ pub struct UbiDistributor {
     /// - Not tied to calendar years or dates
     /// - Governance sets amounts for specific month indices
     /// - Examples: months 0-11 (year 1), 12-23 (year 2), 24-35 (year 3), etc.
-    schedule: HashMap<MonthIndex, u64>,
+    schedule: BTreeMap<MonthIndex, u64>,
 
     /// Phase C: UBI claim intent events (epoch -> list of claims)
     /// Records UbiClaimRecorded events for Treasury Kernel to process
@@ -70,7 +70,7 @@ pub struct UbiDistributor {
     /// **Design:** Passive client pattern - just record intent, Kernel executes
     /// - key: epoch (u64)
     /// - value: Vec<UbiClaimRecorded> events for that epoch
-    claim_events: HashMap<u64, Vec<UbiClaimRecorded>>,
+    claim_events: BTreeMap<u64, Vec<UbiClaimRecorded>>,
 }
 
 impl UbiDistributor {
@@ -96,10 +96,10 @@ impl UbiDistributor {
             balance: 0,
             total_received: 0,
             total_paid: 0,
-            registered: HashSet::new(),
-            paid: HashMap::new(),
-            schedule: HashMap::new(),
-            claim_events: HashMap::new(),
+            registered: BTreeSet::new(),
+            paid: BTreeMap::new(),
+            schedule: BTreeMap::new(),
+            claim_events: BTreeMap::new(),
         })
     }
 
@@ -332,7 +332,7 @@ impl UbiDistributor {
         }
 
         // Invariant P1: Check not already paid this month
-        let month_set = self.paid.entry(month).or_insert_with(HashSet::new);
+        let month_set = self.paid.entry(month).or_insert_with(BTreeSet::new);
         if month_set.contains(&id) {
             return Err(Error::AlreadyPaidThisMonth);
         }
@@ -519,10 +519,10 @@ impl UbiDistributor {
             balance: 0,
             total_received: 0,
             total_paid: 0,
-            registered: HashSet::with_capacity(expected_citizens),
-            paid: HashMap::new(),
-            schedule: HashMap::new(),
-            claim_events: HashMap::new(),
+            registered: BTreeSet::new(),
+            paid: BTreeMap::new(),
+            schedule: BTreeMap::new(),
+            claim_events: BTreeMap::new(),
         })
     }
 

--- a/lib-crypto/src/types/keys.rs
+++ b/lib-crypto/src/types/keys.rs
@@ -117,6 +117,23 @@ impl PartialEq for PublicKey {
 
 impl Eq for PublicKey {}
 
+// Deterministic ordering for BTreeMap keys in consensus-critical state.
+// Orders by key_id first (fast), then full key bytes if key_ids collide.
+impl PartialOrd for PublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PublicKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.key_id
+            .cmp(&other.key_id)
+            .then_with(|| self.dilithium_pk.cmp(&other.dilithium_pk))
+            .then_with(|| self.kyber_pk.cmp(&other.kyber_pk))
+    }
+}
+
 // Manual Hash implementation to match manual PartialEq implementation
 impl std::hash::Hash for PublicKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/lib-crypto/src/types/keys.rs
+++ b/lib-crypto/src/types/keys.rs
@@ -134,6 +134,67 @@ impl Ord for PublicKey {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::PublicKey;
+
+    fn make_public_key(key_id_byte: u8, dilithium_byte: u8, kyber_byte: u8) -> PublicKey {
+        let mut key_id = [0u8; 32];
+        key_id[0] = key_id_byte;
+
+        let mut dilithium_pk = [0u8; 2592];
+        dilithium_pk[0] = dilithium_byte;
+
+        let mut kyber_pk = [0u8; 1568];
+        kyber_pk[0] = kyber_byte;
+
+        PublicKey {
+            dilithium_pk,
+            kyber_pk,
+            key_id,
+        }
+    }
+
+    #[test]
+    fn public_key_ord_orders_by_key_id_first() {
+        let lower = make_public_key(1, 255, 255);
+        let higher = make_public_key(2, 0, 0);
+
+        assert!(lower < higher);
+        assert!(higher > lower);
+    }
+
+    #[test]
+    fn public_key_ord_uses_dilithium_as_tie_breaker() {
+        let lower = make_public_key(7, 1, 255);
+        let higher = make_public_key(7, 2, 0);
+
+        assert!(lower < higher);
+        assert!(higher > lower);
+    }
+
+    #[test]
+    fn public_key_ord_uses_kyber_as_final_tie_breaker() {
+        let lower = make_public_key(9, 3, 1);
+        let higher = make_public_key(9, 3, 2);
+
+        assert!(lower < higher);
+        assert!(higher > lower);
+    }
+
+    #[test]
+    fn public_key_ord_is_consistent_with_eq() {
+        let a = make_public_key(11, 22, 33);
+        let b = make_public_key(11, 22, 33);
+        let c = make_public_key(11, 22, 34);
+
+        assert_eq!(a, b);
+        assert_eq!(a.cmp(&b), std::cmp::Ordering::Equal);
+
+        assert_ne!(a, c);
+        assert_ne!(a.cmp(&c), std::cmp::Ordering::Equal);
+    }
+}
 // Manual Hash implementation to match manual PartialEq implementation
 impl std::hash::Hash for PublicKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1053,6 +1053,18 @@ impl NetworkHandler {
             .unwrap_or_default();
         let node_role = format!("{:?}", self.runtime.get_node_role().await).to_ascii_lowercase();
 
+        // Known validator/gateway SPKI pins (SHA-256 of SubjectPublicKeyInfo DER).
+        // Keyed by IP. These are stable unless a node regenerates its TLS cert.
+        // TODO: move to on-chain validator registry so nodes publish their own pins.
+        let known_spki_pins: std::collections::HashMap<&str, &str> = [
+            ("77.42.37.161",   "611bd1197ee799c17ac46f3f27df45ec4580d924f0dc3597ba79bcad3d0fa970"), // g1
+            ("77.42.74.80",    "611bd1197ee799c17ac46f3f27df45ec4580d924f0dc3597ba79bcad3d0fa970"), // g2
+            ("178.105.9.247",  "eb71239b161a8ea0cdc94f3853298f3e063523c9860a9630cc57504b024a3f54"), // g3
+            ("148.113.140.176","939828e5fc146d3b2efb3255d53ba12b48f9da9c0a823bae145f6720eab3937c"), // g4
+            ("51.75.62.133",   "154afc2efe9d834f5264fd21033d49362599e358233d1c0d67ad487bab366d09"), // g5
+            ("91.98.113.188",  "611bd1197ee799c17ac46f3f27df45ec4580d924f0dc3597ba79bcad3d0fa970"), // gateway
+        ].into_iter().collect();
+
         // Build validator entries from on-chain registry
         let validators: Vec<serde_json::Value> = blockchain
             .validator_registry
@@ -1060,6 +1072,7 @@ impl NetworkHandler {
             .filter(|v| v.status == "active")
             .map(|v| {
                 let ip = v.network_address.split(':').next().unwrap_or("");
+                let spki_pin = known_spki_pins.get(ip).unwrap_or(&"").to_string();
                 serde_json::json!({
                     "did": v.identity_id,
                     "role": "validator",
@@ -1073,6 +1086,7 @@ impl NetworkHandler {
                     "last_activity": v.last_activity,
                     "commission_rate": v.commission_rate,
                     "admission": v.admission_source,
+                    "spki_pin": spki_pin,
                 })
             })
             .collect();
@@ -1084,6 +1098,7 @@ impl NetworkHandler {
             .filter(|g| g.status == "active")
             .map(|g| {
                 let ip = g.endpoints.split(':').next().unwrap_or("");
+                let spki_pin = known_spki_pins.get(ip).unwrap_or(&"").to_string();
                 serde_json::json!({
                     "did": g.identity_id,
                     "role": "gateway",
@@ -1094,6 +1109,7 @@ impl NetworkHandler {
                     "status": g.status,
                     "stake": g.stake,
                     "commission_rate": g.commission_rate,
+                    "spki_pin": spki_pin,
                 })
             })
             .collect();
@@ -1110,6 +1126,11 @@ impl NetworkHandler {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs(),
+            // Back-compat: top-level fields for older clients
+            "validators": validators,
+            "validator_count": validators.len(),
+            "local_spki_pin": local_spki,
+            // New structured format
             "this_node": {
                 "did": node_did,
                 "role": node_role,


### PR DESCRIPTION
## Summary

- **Deterministic state root**: Replace `HashMap` with `BTreeMap` in all consensus-critical structs (`TokenContract`, `UbiDistributor`, `DevGrants`, `PendingStateChanges`). HashMap iteration order is randomized per process — any restart could produce different state roots for identical state, causing intermittent consensus failures and sync breaks. This was the root cause of the recurring consensus instability.

- **Restore SPKI pins**: PR #2271 removed per-validator `spki_pin` fields and the top-level backward-compat fields (`validators`, `validator_count`, `local_spki_pin`) from the `/api/v1/network/directory` endpoint. This broke the mobile app's pinned UHP connections. Pins are restored for all 5 validators and gateway, keyed by IP.

## Files changed

**Deterministic hash (consensus-critical):**
- `lib-crypto/src/types/keys.rs` — add `Ord`/`PartialOrd` to `PublicKey`
- `lib-blockchain/src/contracts/tokens/core.rs` — `balances`, `allowances`, `locked_balances` → `BTreeMap`
- `lib-blockchain/src/contracts/tokens/functions.rs` — return types updated
- `lib-blockchain/src/contracts/ubi_distribution/core.rs` — all collections → `BTreeMap`/`BTreeSet`
- `lib-blockchain/src/contracts/dev_grants/core.rs` — `approved` → `BTreeMap`
- `lib-blockchain/src/contracts/executor/mod.rs` — `token_changes` → `BTreeMap`, sort writes before hashing

**SPKI pins (API fix):**
- `zhtp/src/api/handlers/network/mod.rs` — restore `spki_pin` per validator/gateway + top-level backward-compat fields

## Test plan

- [x] All 7 nodes deployed and running with deterministic hash fix
- [x] Consensus stable at height ~96,000+ with no hash mismatches
- [x] Local observer node syncs full chain without errors
- [x] Directory endpoint returns `spki_pin` for all validators
- [x] Top-level `validators`/`validator_count`/`local_spki_pin` present for mobile app compat
- [ ] Mobile app can read topology and connect with pinned UHP