### PR TITLE
Consensus Rewrite v2 — CONS-108 Delete theatrical features block (closes #2333)

### DIFF
--- a/lib-consensus/Cargo.toml
+++ b/lib-consensus/Cargo.toml
@@ -40,11 +40,6 @@ proptest = "1.0"
 tracing-subscriber = "0.3"
 
 [features]
-default = ["full"]
-full = ["dao", "byzantine", "rewards", "ubi"]
-dao = []
-byzantine = []
-rewards = []
-ubi = []
-testing = []
+default      = []
+testing      = []
 dev-insecure = []

--- a/lib-consensus/src/lib.rs
+++ b/lib-consensus/src/lib.rs
@@ -59,13 +59,10 @@ pub use validators::{
     Validator, ValidatorManager, MAX_VALIDATORS, MAX_VALIDATORS_HARD_CAP, MIN_VALIDATORS,
 };
 
-#[cfg(feature = "dao")]
 pub use dao::*;
 
-#[cfg(feature = "byzantine")]
 pub use byzantine::*;
 
-#[cfg(feature = "rewards")]
 pub use rewards::*;
 
 /// Result type alias for consensus operations


### PR DESCRIPTION
Closes #2333 / Part of #2365.

## Summary
Deletes the `dao`, `byzantine`, `rewards`, `ubi`, `full` features from `lib-consensus/Cargo.toml` — they only gated `pub use` re-exports, never compilation (per architecture doc § 2.1). Re-exports become unconditional. Only `default = []`, `testing = []`, `dev-insecure = []` remain.

## Architecture compliance
Implements `docs/epics/consensus-rewrite-epic.md` § CONS-108 and `docs/epics/consensus-rewrite-decisions.md` AD-013.

## Test plan
- [x] `cargo build --workspace --no-default-features` succeeds.
- [x] `cargo build --workspace` (default) succeeds.
- [x] grep for `#[cfg(feature = "(dao|byzantine|rewards|ubi|full)"` in `lib-consensus/src/` returns zero matches.

## Pre-existing breakage surfaced (not caused by this PR)
`cargo build --workspace --all-features` fails with two `u64`/`u128` mismatches in `lib-blockchain/src/contracts/testing/mod.rs:90,100` from PR #2287 (UTXO widening). Verified pre-existing by stashing the changes here and rerunning. Out of scope for this PR; tracked as a follow-up.

## Risk
Low. Two-file change. No production code logic touched.