### PR TITLE
refactor(consensus): CONS-201 collapse dual ValidatorMessage enum (closes #2334)

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/network.rs
+++ b/lib-consensus/src/engines/consensus_engine/network.rs
@@ -319,9 +319,7 @@ impl ConsensusEngine {
 
                         // Broadcast heartbeat (best-effort, ignore failures)
                         if let Err(e) = self.broadcaster.broadcast_to_validators(
-                            ValidatorMessage::Heartbeat {
-                                message: heartbeat_msg,
-                            },
+                            ValidatorMessage::Heartbeat(heartbeat_msg),
                             &validator_ids,
                         ).await {
                             tracing::debug!("Heartbeat broadcast failed: {}", e);
@@ -502,10 +500,11 @@ impl ConsensusEngine {
 
     async fn on_message(&mut self, msg: ValidatorMessage) -> ConsensusResult<()> {
         match msg {
-            ValidatorMessage::Propose { proposal } => {
-                self.on_proposal(proposal).await?;
+            ValidatorMessage::Propose(propose_msg) => {
+                self.on_proposal(propose_msg.proposal).await?;
             }
-            ValidatorMessage::Vote { vote } => {
+            ValidatorMessage::Vote(vote_msg) => {
+                let vote = vote_msg.vote;
                 // Compute payload hash for replay detection
                 let payload_bytes =
                     bincode::serialize(&vote).expect("Vote serialization cannot fail");
@@ -565,7 +564,7 @@ impl ConsensusEngine {
                     }
                 }
             }
-            ValidatorMessage::Heartbeat { message } => {
+            ValidatorMessage::Heartbeat(heartbeat_msg) => {
                 // Process heartbeat (advisory only, never affects consensus)
                 let is_validator = |vid: &IdentityId| {
                     self.validator_manager
@@ -574,9 +573,9 @@ impl ConsensusEngine {
                         .any(|v| v.identity == *vid)
                 };
 
-                let validator_id = message.validator.clone();
+                let validator_id = heartbeat_msg.validator.clone();
                 let result = self.heartbeat_tracker.process_heartbeat(
-                    message,
+                    heartbeat_msg,
                     is_validator,
                     self.current_round.height,
                 );

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -3,40 +3,63 @@
 use super::*;
 use crate::types::ConsensusStepExt;
 use crate::validators::validator_protocol::{
-    ConsensusStateView, ProposeMessage, VoteMessage,
+    sign_propose_envelope, sign_vote_envelope, ConsensusStateView, ProposeMessage, VoteMessage,
 };
 use crate::validators::ValidatorManager;
 use lib_consensus_core::ports::ValidatorRewardInput;
-use lib_crypto::hash_blake3;
+use lib_crypto::{hash_blake3, KeyPair, PostQuantumSignature};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::info;
 
-/// Build a canonical `ValidatorMessage::Propose` from an already-signed
-/// proposal. Pre-CONS-201 the engine produced a thinner struct-variant form
-/// here and the runtime adapter rebuilt the wrapper; CONS-201 collapsed
-/// those two enums so the wrapper construction lives at the source of the
-/// broadcast instead.
-fn wrap_propose(proposal: ConsensusProposal) -> ValidatorMessage {
+/// Build a canonical `ValidatorMessage::Propose` and sign the outer
+/// envelope with the local validator keypair.
+///
+/// PR #2387 review (Copilot) caught the previous body reusing
+/// `proposal.signature` (which signs the inner `ConsensusProposal` payload,
+/// not the envelope) — receivers verify the envelope signature against
+/// `ProposeSigningPayload`, so the inner sig fails outer verification.
+/// Fix: sign with `sign_propose_envelope` after the envelope fields
+/// (`message_id`, `timestamp`, `justification`, etc.) are populated.
+///
+/// `keypair == None` (test contexts that never registered a keypair) skips
+/// signing and emits the message with a default placeholder signature; the
+/// receiver's TOFU path special-cases empty signatures, and Mainnet would
+/// reject — same conservative semantics as the rest of the broadcast path.
+fn wrap_propose(proposal: ConsensusProposal, keypair: Option<&KeyPair>) -> ValidatorMessage {
     let message_id = proposal.id.clone();
     let proposer = proposal.proposer.clone();
-    let signature = proposal.signature.clone();
-    ValidatorMessage::Propose(ProposeMessage {
+    let mut msg = ProposeMessage {
         message_id,
         proposer,
         proposal,
         justification: None,
         timestamp: now_secs(),
-        signature,
-    })
+        signature: PostQuantumSignature::default(),
+    };
+    if let Some(kp) = keypair {
+        match sign_propose_envelope(&msg, kp) {
+            Ok(sig) => msg.signature = sig,
+            Err(e) => tracing::warn!(
+                error = %e,
+                "Failed to sign Propose envelope; broadcasting with placeholder signature"
+            ),
+        }
+    } else {
+        tracing::debug!(
+            "No validator keypair; broadcasting Propose with placeholder signature (test mode)"
+        );
+    }
+    ValidatorMessage::Propose(msg)
 }
 
-/// Build a canonical `ValidatorMessage::Vote` from an already-signed vote.
-/// `message_id` is per-broadcast (timestamp+nonce) to keep network-layer
-/// dedup caches from suppressing legitimate re-broadcasts of a vote whose
+/// Build a canonical `ValidatorMessage::Vote` and sign the outer envelope.
+///
+/// `message_id` is per-broadcast (timestamp+nonce) so the network-layer
+/// dedup cache doesn't suppress legitimate re-broadcasts of a vote whose
 /// content hash is otherwise deterministic.
-fn wrap_vote(vote: ConsensusVote) -> ValidatorMessage {
+fn wrap_vote(vote: ConsensusVote, keypair: Option<&KeyPair>) -> ValidatorMessage {
     let step = match vote.vote_type {
         VoteType::PreVote => ConsensusStep::PreVote,
         VoteType::PreCommit => ConsensusStep::PreCommit,
@@ -52,7 +75,6 @@ fn wrap_vote(vote: ConsensusVote) -> ValidatorMessage {
         vote_counts: BTreeMap::new(),
     };
     let voter = vote.voter.clone();
-    let signature = vote.signature.clone();
     let message_id = {
         let ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -63,14 +85,28 @@ fn wrap_vote(vote: ConsensusVote) -> ValidatorMessage {
         data.extend_from_slice(&nonce);
         lib_crypto::Hash::from_bytes(&hash_blake3(&data))
     };
-    ValidatorMessage::Vote(VoteMessage {
+    let mut msg = VoteMessage {
         message_id,
         voter,
         vote,
         consensus_state,
         timestamp: now_secs(),
-        signature,
-    })
+        signature: PostQuantumSignature::default(),
+    };
+    if let Some(kp) = keypair {
+        match sign_vote_envelope(&msg, kp) {
+            Ok(sig) => msg.signature = sig,
+            Err(e) => tracing::warn!(
+                error = %e,
+                "Failed to sign Vote envelope; broadcasting with placeholder signature"
+            ),
+        }
+    } else {
+        tracing::debug!(
+            "No validator keypair; broadcasting Vote with placeholder signature (test mode)"
+        );
+    }
+    ValidatorMessage::Vote(msg)
 }
 
 fn now_secs() -> u64 {
@@ -547,7 +583,7 @@ impl ConsensusEngine {
 
                 // Invariant CE-ENG-3: Broadcast after state transition (proposal now in state)
                 // Create canonical ValidatorMessage from already-formed proposal
-                let msg = wrap_propose(proposal);
+                let msg = wrap_propose(proposal, self.validator_keypair.as_ref());
 
                 // Invariant CE-ENG-5: Pass validator set explicitly, never query network
                 let validator_ids = self.get_active_validator_ids();
@@ -611,7 +647,7 @@ impl ConsensusEngine {
 
             // Invariant CE-ENG-3: Broadcast after state transition
             // Create canonical ValidatorMessage from already-formed vote
-            let msg = wrap_vote(vote);
+            let msg = wrap_vote(vote, self.validator_keypair.as_ref());
 
             // Invariant CE-ENG-5: Pass validator set explicitly, never query network
             let validator_ids = self.get_active_validator_ids();
@@ -680,7 +716,7 @@ impl ConsensusEngine {
 
                 // Invariant CE-ENG-3: Broadcast after state transition
                 // Create canonical ValidatorMessage from already-formed vote
-                let msg = wrap_vote(vote);
+                let msg = wrap_vote(vote, self.validator_keypair.as_ref());
 
                 // Invariant CE-ENG-5: Pass validator set explicitly, never query network
                 let validator_ids = self.get_active_validator_ids();
@@ -761,7 +797,7 @@ impl ConsensusEngine {
 
                 // Invariant CE-ENG-3: Broadcast after state transition
                 // Create canonical ValidatorMessage from already-formed vote
-                let msg = wrap_vote(vote);
+                let msg = wrap_vote(vote, self.validator_keypair.as_ref());
 
                 // Invariant CE-ENG-5: Pass validator set explicitly, never query network
                 let validator_ids = self.get_active_validator_ids();
@@ -1437,7 +1473,7 @@ impl ConsensusEngine {
         // and each node only relays a proposal once (the second time proposals is non-empty).
         let relay_proposal = proposal.clone();
         let relay_validator_ids = self.get_active_validator_ids();
-        let relay_msg = wrap_propose(relay_proposal);
+        let relay_msg = wrap_propose(relay_proposal, self.validator_keypair.as_ref());
         if let Err(e) = self
             .broadcaster
             .broadcast_to_validators(relay_msg, &relay_validator_ids)
@@ -1477,7 +1513,7 @@ impl ConsensusEngine {
                     let vote = self
                         .cast_vote(proposal_id.clone(), VoteType::PreVote)
                         .await?;
-                    let msg = wrap_vote(vote);
+                    let msg = wrap_vote(vote, self.validator_keypair.as_ref());
                     let validator_ids = self.get_active_validator_ids();
                     if let Err(e) = self
                         .broadcaster
@@ -1567,7 +1603,7 @@ impl ConsensusEngine {
         // to the voter still receive it (star-topology gossip).
         // Duplicate detection (vote_pool key) prevents relay loops: the second
         // time this vote arrives, the pool check fires and returns early without relay.
-        let relay_msg = wrap_vote(vote.clone());
+        let relay_msg = wrap_vote(vote.clone(), self.validator_keypair.as_ref());
         let relay_validator_ids = self.get_active_validator_ids();
         if let Err(e) = self
             .broadcaster
@@ -1680,7 +1716,7 @@ impl ConsensusEngine {
         // Relay precommit to all validators (star-topology gossip).
         // Critical: without this, nodes that are only connected to a hub (g1)
         // cannot collect precommits from non-hub validators — quorum is impossible.
-        let relay_msg = wrap_vote(vote.clone());
+        let relay_msg = wrap_vote(vote.clone(), self.validator_keypair.as_ref());
         let relay_validator_ids = self.get_active_validator_ids();
         if let Err(e) = self
             .broadcaster
@@ -1823,7 +1859,7 @@ impl ConsensusEngine {
         // g2 and g3 only have persistent QUIC connections to g1 (hub), not to each other.
         // Without relay, a commit vote from g3 never reaches g2, so g2 can never aggregate
         // the 3-of-3 commit quorum required to finalize a block.
-        let relay_msg = wrap_vote(vote.clone());
+        let relay_msg = wrap_vote(vote.clone(), self.validator_keypair.as_ref());
         let relay_validator_ids = self.get_active_validator_ids();
         if let Err(e) = self
             .broadcaster
@@ -1980,7 +2016,7 @@ impl ConsensusEngine {
                             &validator_id_str,
                         );
 
-                        let msg = wrap_propose(proposal);
+                        let msg = wrap_propose(proposal, self.validator_keypair.as_ref());
                         let validator_ids = self.get_active_validator_ids();
 
                         if let Err(e) = self
@@ -2041,7 +2077,7 @@ impl ConsensusEngine {
 
         if let Some(proposal_id) = self.current_round.proposals.first().cloned() {
             let vote = self.cast_vote(proposal_id, VoteType::PreVote).await?;
-            let msg = wrap_vote(vote);
+            let msg = wrap_vote(vote, self.validator_keypair.as_ref());
             let validator_ids = self.get_active_validator_ids();
 
             if let Err(e) = self
@@ -2125,7 +2161,7 @@ impl ConsensusEngine {
                     .await?;
                 self.current_round.valid_proposal = Some(proposal_id);
 
-                let msg = wrap_vote(vote);
+                let msg = wrap_vote(vote, self.validator_keypair.as_ref());
                 let validator_ids = self.get_active_validator_ids();
 
                 if let Err(e) = self
@@ -2214,7 +2250,7 @@ impl ConsensusEngine {
                     proposal_id
                 );
 
-                let msg = wrap_vote(vote);
+                let msg = wrap_vote(vote, self.validator_keypair.as_ref());
                 let validator_ids = self.get_active_validator_ids();
 
                 if let Err(e) = self

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -2,11 +2,83 @@
 
 use super::*;
 use crate::types::ConsensusStepExt;
+use crate::validators::validator_protocol::{
+    ConsensusStateView, ProposeMessage, VoteMessage,
+};
 use crate::validators::ValidatorManager;
 use lib_consensus_core::ports::ValidatorRewardInput;
 use lib_crypto::hash_blake3;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::info;
+
+/// Build a canonical `ValidatorMessage::Propose` from an already-signed
+/// proposal. Pre-CONS-201 the engine produced a thinner struct-variant form
+/// here and the runtime adapter rebuilt the wrapper; CONS-201 collapsed
+/// those two enums so the wrapper construction lives at the source of the
+/// broadcast instead.
+fn wrap_propose(proposal: ConsensusProposal) -> ValidatorMessage {
+    let message_id = proposal.id.clone();
+    let proposer = proposal.proposer.clone();
+    let signature = proposal.signature.clone();
+    ValidatorMessage::Propose(ProposeMessage {
+        message_id,
+        proposer,
+        proposal,
+        justification: None,
+        timestamp: now_secs(),
+        signature,
+    })
+}
+
+/// Build a canonical `ValidatorMessage::Vote` from an already-signed vote.
+/// `message_id` is per-broadcast (timestamp+nonce) to keep network-layer
+/// dedup caches from suppressing legitimate re-broadcasts of a vote whose
+/// content hash is otherwise deterministic.
+fn wrap_vote(vote: ConsensusVote) -> ValidatorMessage {
+    let step = match vote.vote_type {
+        VoteType::PreVote => ConsensusStep::PreVote,
+        VoteType::PreCommit => ConsensusStep::PreCommit,
+        VoteType::Commit => ConsensusStep::Commit,
+        // `Against` votes can occur during any voting step; default to PreVote.
+        VoteType::Against => ConsensusStep::PreVote,
+    };
+    let consensus_state = ConsensusStateView {
+        height: vote.height,
+        round: vote.round,
+        step,
+        known_proposals: vec![vote.proposal_id.clone()],
+        vote_counts: BTreeMap::new(),
+    };
+    let voter = vote.voter.clone();
+    let signature = vote.signature.clone();
+    let message_id = {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let nonce = lib_crypto::generate_nonce();
+        let mut data = format!("vote_bcast_{}", ts).into_bytes();
+        data.extend_from_slice(&nonce);
+        lib_crypto::Hash::from_bytes(&hash_blake3(&data))
+    };
+    ValidatorMessage::Vote(VoteMessage {
+        message_id,
+        voter,
+        vote,
+        consensus_state,
+        timestamp: now_secs(),
+        signature,
+    })
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
 
 /// Build the `ValidatorRewardInput` slice the engine hands to
 /// `RewardCallback::on_round_finalized` (CONS-103). Keeps the trait
@@ -475,7 +547,7 @@ impl ConsensusEngine {
 
                 // Invariant CE-ENG-3: Broadcast after state transition (proposal now in state)
                 // Create canonical ValidatorMessage from already-formed proposal
-                let msg = ValidatorMessage::Propose { proposal };
+                let msg = wrap_propose(proposal);
 
                 // Invariant CE-ENG-5: Pass validator set explicitly, never query network
                 let validator_ids = self.get_active_validator_ids();
@@ -539,7 +611,7 @@ impl ConsensusEngine {
 
             // Invariant CE-ENG-3: Broadcast after state transition
             // Create canonical ValidatorMessage from already-formed vote
-            let msg = ValidatorMessage::Vote { vote };
+            let msg = wrap_vote(vote);
 
             // Invariant CE-ENG-5: Pass validator set explicitly, never query network
             let validator_ids = self.get_active_validator_ids();
@@ -608,7 +680,7 @@ impl ConsensusEngine {
 
                 // Invariant CE-ENG-3: Broadcast after state transition
                 // Create canonical ValidatorMessage from already-formed vote
-                let msg = ValidatorMessage::Vote { vote };
+                let msg = wrap_vote(vote);
 
                 // Invariant CE-ENG-5: Pass validator set explicitly, never query network
                 let validator_ids = self.get_active_validator_ids();
@@ -689,7 +761,7 @@ impl ConsensusEngine {
 
                 // Invariant CE-ENG-3: Broadcast after state transition
                 // Create canonical ValidatorMessage from already-formed vote
-                let msg = ValidatorMessage::Vote { vote };
+                let msg = wrap_vote(vote);
 
                 // Invariant CE-ENG-5: Pass validator set explicitly, never query network
                 let validator_ids = self.get_active_validator_ids();
@@ -1365,7 +1437,7 @@ impl ConsensusEngine {
         // and each node only relays a proposal once (the second time proposals is non-empty).
         let relay_proposal = proposal.clone();
         let relay_validator_ids = self.get_active_validator_ids();
-        let relay_msg = ValidatorMessage::Propose { proposal: relay_proposal };
+        let relay_msg = wrap_propose(relay_proposal);
         if let Err(e) = self
             .broadcaster
             .broadcast_to_validators(relay_msg, &relay_validator_ids)
@@ -1405,7 +1477,7 @@ impl ConsensusEngine {
                     let vote = self
                         .cast_vote(proposal_id.clone(), VoteType::PreVote)
                         .await?;
-                    let msg = ValidatorMessage::Vote { vote };
+                    let msg = wrap_vote(vote);
                     let validator_ids = self.get_active_validator_ids();
                     if let Err(e) = self
                         .broadcaster
@@ -1495,7 +1567,7 @@ impl ConsensusEngine {
         // to the voter still receive it (star-topology gossip).
         // Duplicate detection (vote_pool key) prevents relay loops: the second
         // time this vote arrives, the pool check fires and returns early without relay.
-        let relay_msg = ValidatorMessage::Vote { vote: vote.clone() };
+        let relay_msg = wrap_vote(vote.clone());
         let relay_validator_ids = self.get_active_validator_ids();
         if let Err(e) = self
             .broadcaster
@@ -1608,7 +1680,7 @@ impl ConsensusEngine {
         // Relay precommit to all validators (star-topology gossip).
         // Critical: without this, nodes that are only connected to a hub (g1)
         // cannot collect precommits from non-hub validators — quorum is impossible.
-        let relay_msg = ValidatorMessage::Vote { vote: vote.clone() };
+        let relay_msg = wrap_vote(vote.clone());
         let relay_validator_ids = self.get_active_validator_ids();
         if let Err(e) = self
             .broadcaster
@@ -1751,7 +1823,7 @@ impl ConsensusEngine {
         // g2 and g3 only have persistent QUIC connections to g1 (hub), not to each other.
         // Without relay, a commit vote from g3 never reaches g2, so g2 can never aggregate
         // the 3-of-3 commit quorum required to finalize a block.
-        let relay_msg = ValidatorMessage::Vote { vote: vote.clone() };
+        let relay_msg = wrap_vote(vote.clone());
         let relay_validator_ids = self.get_active_validator_ids();
         if let Err(e) = self
             .broadcaster
@@ -1908,7 +1980,7 @@ impl ConsensusEngine {
                             &validator_id_str,
                         );
 
-                        let msg = ValidatorMessage::Propose { proposal };
+                        let msg = wrap_propose(proposal);
                         let validator_ids = self.get_active_validator_ids();
 
                         if let Err(e) = self
@@ -1969,7 +2041,7 @@ impl ConsensusEngine {
 
         if let Some(proposal_id) = self.current_round.proposals.first().cloned() {
             let vote = self.cast_vote(proposal_id, VoteType::PreVote).await?;
-            let msg = ValidatorMessage::Vote { vote };
+            let msg = wrap_vote(vote);
             let validator_ids = self.get_active_validator_ids();
 
             if let Err(e) = self
@@ -2053,7 +2125,7 @@ impl ConsensusEngine {
                     .await?;
                 self.current_round.valid_proposal = Some(proposal_id);
 
-                let msg = ValidatorMessage::Vote { vote };
+                let msg = wrap_vote(vote);
                 let validator_ids = self.get_active_validator_ids();
 
                 if let Err(e) = self
@@ -2142,7 +2214,7 @@ impl ConsensusEngine {
                     proposal_id
                 );
 
-                let msg = ValidatorMessage::Vote { vote };
+                let msg = wrap_vote(vote);
                 let validator_ids = self.get_active_validator_ids();
 
                 if let Err(e) = self

--- a/lib-consensus/src/network/codec.rs
+++ b/lib-consensus/src/network/codec.rs
@@ -409,32 +409,6 @@ mod tests {
                 })
             }
             2 => {
-                // Commit message
-                ValidatorMessage::Commit(CommitMessage {
-                    message_id: hash.clone(),
-                    committer: identity,
-                    proposal_id: hash,
-                    height: 100,
-                    round: 1,
-                    commitment_proof: create_test_commitment_proof(),
-                    timestamp: 1234567890,
-                    signature: PostQuantumSignature::default(),
-                })
-            }
-            3 => {
-                // RoundChange message
-                ValidatorMessage::RoundChange(RoundChangeMessage {
-                    message_id: hash.clone(),
-                    validator: identity,
-                    height: 100,
-                    new_round: 2,
-                    reason: RoundChangeReason::Timeout,
-                    locked_proposal: Some(hash),
-                    timestamp: 1234567890,
-                    signature: PostQuantumSignature::default(),
-                })
-            }
-            4 => {
                 // Heartbeat message
                 ValidatorMessage::Heartbeat(HeartbeatMessage {
                     message_id: hash,
@@ -494,13 +468,8 @@ mod tests {
         }
     }
 
-    fn create_test_commitment_proof() -> CommitmentProof {
-        CommitmentProof {
-            aggregate_signature: vec![1, 2, 3, 4, 5],
-            signers: vec![IdentityId::from_bytes(b"validator-1-id-1234567890123456")],
-            voting_power: 1000,
-        }
-    }
+    // CONS-201: `create_test_commitment_proof` was deleted along with the
+    // `Commit` variant.
 
     fn create_test_network_summary() -> NetworkSummary {
         NetworkSummary {
@@ -551,38 +520,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_roundtrip_commit_message() {
-        let codec = BincodeConsensusCodec::new();
-        let original = create_test_message(2);
-
-        let encoded = codec.encode(&original).expect("Encode failed");
-        let decoded = codec.decode(&encoded).expect("Decode failed");
-
-        assert_eq!(
-            std::mem::discriminant(&original),
-            std::mem::discriminant(&decoded)
-        );
-    }
-
-    #[test]
-    fn test_roundtrip_round_change_message() {
-        let codec = BincodeConsensusCodec::new();
-        let original = create_test_message(3);
-
-        let encoded = codec.encode(&original).expect("Encode failed");
-        let decoded = codec.decode(&encoded).expect("Decode failed");
-
-        assert_eq!(
-            std::mem::discriminant(&original),
-            std::mem::discriminant(&decoded)
-        );
-    }
+    // CONS-201: `test_roundtrip_commit_message` and
+    // `test_roundtrip_round_change_message` were deleted along with the
+    // `Commit` and `RoundChange` variants.
 
     #[test]
     fn test_roundtrip_heartbeat_message() {
         let codec = BincodeConsensusCodec::new();
-        let original = create_test_message(4);
+        let original = create_test_message(2);
 
         let encoded = codec.encode(&original).expect("Encode failed");
         let decoded = codec.decode(&encoded).expect("Decode failed");
@@ -846,7 +791,9 @@ mod tests {
     fn test_full_codec_roundtrip_all_variants() {
         let codec = BincodeConsensusCodec::new();
 
-        for variant in 0..5 {
+        // CONS-201: collapsed from 5 variants (Propose / Vote / Commit /
+        // RoundChange / Heartbeat) to 3 (Propose / Vote / Heartbeat).
+        for variant in 0..3 {
             let original = create_test_message(variant);
             let framed = codec
                 .encode_framed(&original)

--- a/lib-consensus/src/types/mod.rs
+++ b/lib-consensus/src/types/mod.rs
@@ -333,19 +333,13 @@ impl BlockMetadata {
     }
 }
 
-/// Canonical validator message for network broadcast
-///
-/// Invariant CE-ENG-2: ConsensusEngine broadcasts only signed, canonical ValidatorMessages.
-/// It never broadcasts raw Vote, Proposal, or internal structs.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ValidatorMessage {
-    /// Proposal message for new block
-    Propose { proposal: ConsensusProposal },
-    /// Vote message (PreVote, PreCommit, or Commit votes)
-    Vote { vote: ConsensusVote },
-    /// Heartbeat message for validator liveness detection
-    Heartbeat { message: HeartbeatMessage },
-}
+// CONS-201: The thin 3-variant `ValidatorMessage` previously defined here was
+// deleted. The canonical wire-level enum is `crate::validators::ValidatorMessage`
+// (variants: Propose / Vote / Heartbeat — the Commit and RoundChange variants
+// were also removed in CONS-201 as unreachable; commit votes flow through the
+// Vote variant via `VoteType::Commit`, and view changes are driven by timeouts
+// rather than explicit RoundChange messages).
+pub use crate::validators::ValidatorMessage;
 
 /// Message broadcaster trait for network distribution
 ///

--- a/lib-consensus/src/validators/validator_protocol.rs
+++ b/lib-consensus/src/validators/validator_protocol.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use lib_crypto::{Hash, KeyPair, PostQuantumSignature};
 use lib_identity::IdentityId;
@@ -33,18 +33,33 @@ pub trait ValidatorNetworkTransport: Send + Sync {
     ) -> Result<()>;
 }
 
-/// BFT consensus message types
+/// Canonical wire-level BFT consensus message.
+///
+/// CONS-201: Collapsed from a 5-variant form. The deleted variants:
+///
+/// - `Commit(CommitMessage)` — commit votes flow through `Vote(VoteMessage)`
+///   with `VoteType::Commit`. The CommitMessage layer added a separate
+///   message ID + signature path with no extra information beyond what
+///   the inner vote already carries; commit-handling code that relied on
+///   it was a translation shim into a synthesized `Vote`.
+/// - `RoundChange(RoundChangeMessage)` — view changes are driven by
+///   timeouts in this Tendermint-like BFT, not by explicit round-change
+///   messages. The receive-side handler synthesized a `Heartbeat` for
+///   liveness tracking; that pathway is now a no-op (heartbeats already
+///   carry the same liveness signal).
+///
+/// This is also the canonical `ValidatorMessage` for the consensus engine.
+/// The previous `lib_consensus::types::ValidatorMessage` (a thin
+/// 3-variant struct-variant enum) was removed in the same change; the
+/// `types::ValidatorMessage` re-export aliases this type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ValidatorMessage {
     /// Proposal message from block proposer
     Propose(ProposeMessage),
-    /// Vote message from validators
+    /// Vote message from validators (PreVote, PreCommit, or Commit votes
+    /// — distinguished by `VoteType` inside the inner `ConsensusVote`).
     Vote(VoteMessage),
-    /// Commit message for block finalization
-    Commit(CommitMessage),
-    /// Round change request
-    RoundChange(RoundChangeMessage),
-    /// Validator heartbeat
+    /// Validator heartbeat for liveness tracking.
     Heartbeat(HeartbeatMessage),
 }
 
@@ -82,47 +97,8 @@ pub struct VoteMessage {
     pub signature: PostQuantumSignature,
 }
 
-/// Commit message for block finalization
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CommitMessage {
-    /// Message identifier
-    pub message_id: Hash,
-    /// Committing validator identity
-    pub committer: IdentityId,
-    /// Committed proposal hash
-    pub proposal_id: Hash,
-    /// Block height being committed
-    pub height: u64,
-    /// Consensus round
-    pub round: u32,
-    /// Commitment proof (aggregate signatures)
-    pub commitment_proof: CommitmentProof,
-    /// Message timestamp
-    pub timestamp: u64,
-    /// Committer signature over message
-    pub signature: PostQuantumSignature,
-}
-
-/// Round change message when consensus stalls
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RoundChangeMessage {
-    /// Message identifier
-    pub message_id: Hash,
-    /// Validator requesting round change
-    pub validator: IdentityId,
-    /// Current block height
-    pub height: u64,
-    /// New round number
-    pub new_round: u32,
-    /// Reason for round change
-    pub reason: RoundChangeReason,
-    /// Locked proposal from previous round (if any)
-    pub locked_proposal: Option<Hash>,
-    /// Message timestamp
-    pub timestamp: u64,
-    /// Validator signature over message
-    pub signature: PostQuantumSignature,
-}
+// CONS-201: `CommitMessage` and `RoundChangeMessage` were deleted along
+// with the `Commit` and `RoundChange` `ValidatorMessage` variants.
 
 /// Heartbeat message for liveness detection
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -176,29 +152,8 @@ pub struct ConsensusStateView {
     pub vote_counts: BTreeMap<Hash, u32>,
 }
 
-/// Commitment proof with aggregate signatures
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CommitmentProof {
-    /// Aggregate signature from +2/3 validators
-    pub aggregate_signature: Vec<u8>,
-    /// Validator identities that signed
-    pub signers: Vec<IdentityId>,
-    /// Combined voting power
-    pub voting_power: u64,
-}
-
-/// Reasons for requesting round change
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum RoundChangeReason {
-    /// Round timeout expired
-    Timeout,
-    /// Invalid proposal received
-    InvalidProposal,
-    /// Conflicting proposals detected
-    ConflictingProposals,
-    /// Insufficient votes received
-    InsufficientVotes,
-}
+// CONS-201: `CommitmentProof` and `RoundChangeReason` were deleted along
+// with the `Commit` and `RoundChange` variants they supported.
 
 /// Network summary for heartbeats
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -294,8 +249,8 @@ impl Default for ValidatorProtocolConfig {
 
 const SIGNING_DOMAIN_PROPOSE: &[u8] = b"zhtp:consensus:validator-msg:v1:propose";
 const SIGNING_DOMAIN_VOTE: &[u8] = b"zhtp:consensus:validator-msg:v1:vote";
-const SIGNING_DOMAIN_COMMIT: &[u8] = b"zhtp:consensus:validator-msg:v1:commit";
-const SIGNING_DOMAIN_ROUND_CHANGE: &[u8] = b"zhtp:consensus:validator-msg:v1:round_change";
+// CONS-201: `SIGNING_DOMAIN_COMMIT` and `SIGNING_DOMAIN_ROUND_CHANGE`
+// were deleted along with the Commit and RoundChange variants.
 const SIGNING_DOMAIN_HEARTBEAT: &[u8] = b"zhtp:consensus:validator-msg:v1:heartbeat";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -316,27 +271,8 @@ struct VoteSigningPayload {
     timestamp: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CommitSigningPayload {
-    message_id: Hash,
-    committer: IdentityId,
-    proposal_id: Hash,
-    height: u64,
-    round: u32,
-    commitment_proof: CommitmentProof,
-    timestamp: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct RoundChangeSigningPayload {
-    message_id: Hash,
-    validator: IdentityId,
-    height: u64,
-    new_round: u32,
-    reason: RoundChangeReason,
-    locked_proposal: Option<Hash>,
-    timestamp: u64,
-}
+// CONS-201: `CommitSigningPayload` and `RoundChangeSigningPayload`
+// were deleted along with the Commit and RoundChange variants.
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct HeartbeatSigningPayload {
@@ -488,75 +424,10 @@ impl ValidatorProtocol {
             .await
     }
 
-    /// Broadcast a commit message to finalize a block
-    pub async fn broadcast_commit(
-        &self,
-        proposal_id: Hash,
-        height: u64,
-        round: u32,
-        commitment_proof: CommitmentProof,
-    ) -> Result<()> {
-        let validator_id = self
-            .validator_identity
-            .as_ref()
-            .ok_or_else(|| anyhow!("Validator identity not set"))?;
-
-        let mut message = CommitMessage {
-            message_id: self.generate_message_id(),
-            committer: validator_id.clone(),
-            proposal_id: proposal_id.clone(),
-            height,
-            round,
-            commitment_proof,
-            timestamp: self.current_timestamp(),
-            signature: PostQuantumSignature::default(),
-        };
-
-        message.signature = self.sign_commit_message(&message)?;
-
-        info!(
-            "Broadcasting commit for proposal {} at height {} from validator {}",
-            proposal_id, height, validator_id
-        );
-
-        self.broadcast_message(ValidatorMessage::Commit(message))
-            .await
-    }
-
-    /// Request a round change due to timeout or other issues
-    pub async fn request_round_change(
-        &self,
-        height: u64,
-        new_round: u32,
-        reason: RoundChangeReason,
-        locked_proposal: Option<Hash>,
-    ) -> Result<()> {
-        let validator_id = self
-            .validator_identity
-            .as_ref()
-            .ok_or_else(|| anyhow!("Validator identity not set"))?;
-
-        let mut message = RoundChangeMessage {
-            message_id: self.generate_message_id(),
-            validator: validator_id.clone(),
-            height,
-            new_round,
-            reason: reason.clone(),
-            locked_proposal,
-            timestamp: self.current_timestamp(),
-            signature: PostQuantumSignature::default(),
-        };
-
-        message.signature = self.sign_round_change_message(&message)?;
-
-        warn!(
-            "Requesting round change to {} for height {} due to {:?}",
-            new_round, height, reason
-        );
-
-        self.broadcast_message(ValidatorMessage::RoundChange(message))
-            .await
-    }
+    // CONS-201: `broadcast_commit` and `request_round_change` were deleted
+    // along with the `Commit` and `RoundChange` variants. Commit votes now
+    // flow as `Vote(VoteMessage)` with `VoteType::Commit`, and round
+    // changes are driven by timeouts (no explicit RoundChange message).
 
     /// Send periodic heartbeat to maintain liveness
     pub async fn send_heartbeat(
@@ -609,8 +480,6 @@ impl ValidatorProtocol {
         match message {
             ValidatorMessage::Propose(msg) => self.handle_propose_message(msg).await,
             ValidatorMessage::Vote(msg) => self.handle_vote_message(msg).await,
-            ValidatorMessage::Commit(msg) => self.handle_commit_message(msg).await,
-            ValidatorMessage::RoundChange(msg) => self.handle_round_change_message(msg).await,
             ValidatorMessage::Heartbeat(msg) => self.handle_heartbeat_message(msg).await,
         }
     }
@@ -725,40 +594,8 @@ impl ValidatorProtocol {
             .sign(&Self::signing_bytes(SIGNING_DOMAIN_VOTE, &bytes))
     }
 
-    fn sign_commit_message(&self, message: &CommitMessage) -> Result<PostQuantumSignature> {
-        let payload = CommitSigningPayload {
-            message_id: message.message_id.clone(),
-            committer: message.committer.clone(),
-            proposal_id: message.proposal_id.clone(),
-            height: message.height,
-            round: message.round,
-            commitment_proof: message.commitment_proof.clone(),
-            timestamp: message.timestamp,
-        };
-        let bytes = bincode::serialize(&payload)
-            .map_err(|e| anyhow!("CommitSigningPayload encode failed: {e}"))?;
-        self.local_keypair()?
-            .sign(&Self::signing_bytes(SIGNING_DOMAIN_COMMIT, &bytes))
-    }
-
-    fn sign_round_change_message(
-        &self,
-        message: &RoundChangeMessage,
-    ) -> Result<PostQuantumSignature> {
-        let payload = RoundChangeSigningPayload {
-            message_id: message.message_id.clone(),
-            validator: message.validator.clone(),
-            height: message.height,
-            new_round: message.new_round,
-            reason: message.reason.clone(),
-            locked_proposal: message.locked_proposal.clone(),
-            timestamp: message.timestamp,
-        };
-        let bytes = bincode::serialize(&payload)
-            .map_err(|e| anyhow!("RoundChangeSigningPayload encode failed: {e}"))?;
-        self.local_keypair()?
-            .sign(&Self::signing_bytes(SIGNING_DOMAIN_ROUND_CHANGE, &bytes))
-    }
+    // CONS-201: `sign_commit_message` and `sign_round_change_message` were
+    // deleted along with the Commit and RoundChange variants.
 
     fn sign_heartbeat_message(&self, message: &HeartbeatMessage) -> Result<PostQuantumSignature> {
         let payload = HeartbeatSigningPayload {
@@ -826,48 +663,6 @@ impl ValidatorProtocol {
                     &m.signature,
                     m.timestamp,
                     SIGNING_DOMAIN_VOTE,
-                    &bytes,
-                )
-                .await
-            }
-            ValidatorMessage::Commit(m) => {
-                let payload = CommitSigningPayload {
-                    message_id: m.message_id.clone(),
-                    committer: m.committer.clone(),
-                    proposal_id: m.proposal_id.clone(),
-                    height: m.height,
-                    round: m.round,
-                    commitment_proof: m.commitment_proof.clone(),
-                    timestamp: m.timestamp,
-                };
-                let bytes = bincode::serialize(&payload)
-                    .map_err(|e| anyhow!("CommitSigningPayload encode failed: {e}"))?;
-                self.verify_signed(
-                    &m.committer,
-                    &m.signature,
-                    m.timestamp,
-                    SIGNING_DOMAIN_COMMIT,
-                    &bytes,
-                )
-                .await
-            }
-            ValidatorMessage::RoundChange(m) => {
-                let payload = RoundChangeSigningPayload {
-                    message_id: m.message_id.clone(),
-                    validator: m.validator.clone(),
-                    height: m.height,
-                    new_round: m.new_round,
-                    reason: m.reason.clone(),
-                    locked_proposal: m.locked_proposal.clone(),
-                    timestamp: m.timestamp,
-                };
-                let bytes = bincode::serialize(&payload)
-                    .map_err(|e| anyhow!("RoundChangeSigningPayload encode failed: {e}"))?;
-                self.verify_signed(
-                    &m.validator,
-                    &m.signature,
-                    m.timestamp,
-                    SIGNING_DOMAIN_ROUND_CHANGE,
                     &bytes,
                 )
                 .await
@@ -1049,10 +844,8 @@ impl ValidatorProtocol {
             message.proposer, message.proposal.height
         );
 
-        self.forward_to_consensus(crate::types::ValidatorMessage::Propose {
-            proposal: message.proposal,
-        })
-        .await
+        self.forward_to_consensus(ValidatorMessage::Propose(message))
+            .await
     }
 
     /// Handle incoming vote message: forward to consensus engine as `Vote`.
@@ -1062,63 +855,15 @@ impl ValidatorProtocol {
             message.voter, message.vote.proposal_id
         );
 
-        self.forward_to_consensus(crate::types::ValidatorMessage::Vote { vote: message.vote })
+        self.forward_to_consensus(ValidatorMessage::Vote(message))
             .await
     }
 
-    /// Handle incoming commit message: synthesize a `Vote` with `VoteType::Commit`
-    /// and forward to consensus engine.
-    async fn handle_commit_message(&self, message: CommitMessage) -> Result<()> {
-        info!(
-            "Received verified commit from {} for proposal {} at height {}",
-            message.committer, message.proposal_id, message.height
-        );
-
-        // Synthesize a ConsensusVote from the CommitMessage
-        // (same pattern as convert_network_to_consensus_message in message_handler.rs)
-        let commit_vote = ConsensusVote {
-            id: message.message_id,
-            height: message.height,
-            round: message.round,
-            vote_type: VoteType::Commit,
-            proposal_id: message.proposal_id,
-            voter: message.committer,
-            timestamp: message.timestamp,
-            signature: message.signature,
-        };
-
-        self.forward_to_consensus(crate::types::ValidatorMessage::Vote { vote: commit_vote })
-            .await
-    }
-
-    /// Handle round change request: convert to a heartbeat-like message to
-    /// maintain liveness tracking in the consensus engine.
-    async fn handle_round_change_message(&self, message: RoundChangeMessage) -> Result<()> {
-        warn!(
-            "Received verified round change from {} for round {} due to {:?}",
-            message.validator, message.new_round, message.reason
-        );
-
-        // Convert to Heartbeat for liveness tracking
-        // (same pattern as convert_network_to_consensus_message in message_handler.rs)
-        let heartbeat = HeartbeatMessage {
-            message_id: message.message_id,
-            validator: message.validator,
-            height: message.height,
-            round: message.new_round,
-            step: ConsensusStep::NewRound,
-            network_summary: NetworkSummary {
-                active_validators: 0,
-                health_score: 1.0,
-                block_rate: 0.0,
-            },
-            timestamp: message.timestamp,
-            signature: message.signature,
-        };
-
-        self.forward_to_consensus(crate::types::ValidatorMessage::Heartbeat { message: heartbeat })
-            .await
-    }
+    // CONS-201: `handle_commit_message` and `handle_round_change_message`
+    // were deleted along with the Commit and RoundChange variants. The
+    // commit-as-Vote translation is no longer needed because commit votes
+    // travel as `Vote(VoteMessage)` with `VoteType::Commit` end-to-end.
+    // Round changes are driven by timeouts, not by an inbound message.
 
     /// Handle heartbeat message
     async fn handle_heartbeat_message(&self, message: HeartbeatMessage) -> Result<()> {
@@ -1136,7 +881,7 @@ impl ValidatorProtocol {
             }
         }
 
-        self.forward_to_consensus(crate::types::ValidatorMessage::Heartbeat { message })
+        self.forward_to_consensus(ValidatorMessage::Heartbeat(message))
             .await
     }
 
@@ -1154,8 +899,6 @@ impl ValidatorProtocol {
         match message {
             ValidatorMessage::Propose(msg) => msg.message_id.clone(),
             ValidatorMessage::Vote(msg) => msg.message_id.clone(),
-            ValidatorMessage::Commit(msg) => msg.message_id.clone(),
-            ValidatorMessage::RoundChange(msg) => msg.message_id.clone(),
             ValidatorMessage::Heartbeat(msg) => msg.message_id.clone(),
         }
     }
@@ -1447,8 +1190,8 @@ mod tests {
         // Should receive the forwarded message on the consensus channel
         let forwarded = rx.try_recv().expect("Expected forwarded message");
         match forwarded {
-            crate::types::ValidatorMessage::Propose { proposal } => {
-                assert_eq!(proposal.height, 1);
+            crate::types::ValidatorMessage::Propose(msg) => {
+                assert_eq!(msg.proposal.height, 1);
             }
             other => panic!("Expected Propose, got {:?}", other),
         }
@@ -1493,9 +1236,9 @@ mod tests {
 
         let forwarded = rx.try_recv().expect("Expected forwarded vote");
         match forwarded {
-            crate::types::ValidatorMessage::Vote { vote } => {
-                assert_eq!(vote.height, 5);
-                assert_eq!(vote.vote_type, VoteType::PreVote);
+            crate::types::ValidatorMessage::Vote(msg) => {
+                assert_eq!(msg.vote.height, 5);
+                assert_eq!(msg.vote.vote_type, VoteType::PreVote);
             }
             other => panic!("Expected Vote, got {:?}", other),
         }

--- a/lib-consensus/src/validators/validator_protocol.rs
+++ b/lib-consensus/src/validators/validator_protocol.rs
@@ -285,6 +285,81 @@ struct HeartbeatSigningPayload {
     timestamp: u64,
 }
 
+/// Bytes the signature covers: domain separator + 0x00 + bincode(payload).
+/// Lifted out so engine-side and protocol-side signing produce identical
+/// bytes for the same envelope.
+pub(crate) fn signing_bytes(domain: &[u8], payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(domain.len() + 1 + payload.len());
+    out.extend_from_slice(domain);
+    out.push(0u8);
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Sign a `ProposeMessage` outer envelope with the given keypair.
+///
+/// The envelope signature covers `ProposeSigningPayload`
+/// (`message_id` + `proposer` + `proposal` + `justification` + `timestamp`),
+/// not the inner `ConsensusProposal.signature`. Receivers reconstruct this
+/// exact payload in `verify_validator_message`. PR #2387 review (Copilot)
+/// caught the previous code reusing `proposal.signature` here, which would
+/// fail outer-envelope verification on Mainnet (where `bootstrap_tofu` is
+/// false).
+pub(crate) fn sign_propose_envelope(
+    message: &ProposeMessage,
+    keypair: &KeyPair,
+) -> Result<PostQuantumSignature> {
+    let payload = ProposeSigningPayload {
+        message_id: message.message_id.clone(),
+        proposer: message.proposer.clone(),
+        proposal: message.proposal.clone(),
+        justification: message.justification.clone(),
+        timestamp: message.timestamp,
+    };
+    let bytes = bincode::serialize(&payload)
+        .map_err(|e| anyhow!("ProposeSigningPayload encode failed: {e}"))?;
+    keypair.sign(&signing_bytes(SIGNING_DOMAIN_PROPOSE, &bytes))
+}
+
+/// Sign a `VoteMessage` outer envelope with the given keypair.
+///
+/// The envelope signature covers `VoteSigningPayload` (`message_id` +
+/// `voter` + inner `vote` + `consensus_state` + envelope `timestamp`).
+pub(crate) fn sign_vote_envelope(
+    message: &VoteMessage,
+    keypair: &KeyPair,
+) -> Result<PostQuantumSignature> {
+    let payload = VoteSigningPayload {
+        message_id: message.message_id.clone(),
+        voter: message.voter.clone(),
+        vote: message.vote.clone(),
+        consensus_state: message.consensus_state.clone(),
+        timestamp: message.timestamp,
+    };
+    let bytes = bincode::serialize(&payload)
+        .map_err(|e| anyhow!("VoteSigningPayload encode failed: {e}"))?;
+    keypair.sign(&signing_bytes(SIGNING_DOMAIN_VOTE, &bytes))
+}
+
+/// Sign a `HeartbeatMessage` outer envelope with the given keypair.
+pub(crate) fn sign_heartbeat_envelope(
+    message: &HeartbeatMessage,
+    keypair: &KeyPair,
+) -> Result<PostQuantumSignature> {
+    let payload = HeartbeatSigningPayload {
+        message_id: message.message_id.clone(),
+        validator: message.validator.clone(),
+        height: message.height,
+        round: message.round,
+        step: message.step.clone(),
+        network_summary: message.network_summary.clone(),
+        timestamp: message.timestamp,
+    };
+    let bytes = bincode::serialize(&payload)
+        .map_err(|e| anyhow!("HeartbeatSigningPayload encode failed: {e}"))?;
+    keypair.sign(&signing_bytes(SIGNING_DOMAIN_HEARTBEAT, &bytes))
+}
+
 /// Connection to a peer validator
 #[derive(Debug, Clone)]
 pub struct ValidatorPeerConnection {
@@ -558,59 +633,19 @@ impl ValidatorProtocol {
             .ok_or_else(|| anyhow!("Validator keypair not set"))
     }
 
-    fn signing_bytes(domain: &[u8], payload: &[u8]) -> Vec<u8> {
-        let mut out = Vec::with_capacity(domain.len() + 1 + payload.len());
-        out.extend_from_slice(domain);
-        out.push(0u8);
-        out.extend_from_slice(payload);
-        out
-    }
-
     fn sign_propose_message(&self, message: &ProposeMessage) -> Result<PostQuantumSignature> {
-        let payload = ProposeSigningPayload {
-            message_id: message.message_id.clone(),
-            proposer: message.proposer.clone(),
-            proposal: message.proposal.clone(),
-            justification: message.justification.clone(),
-            timestamp: message.timestamp,
-        };
-        let bytes = bincode::serialize(&payload)
-            .map_err(|e| anyhow!("ProposeSigningPayload encode failed: {e}"))?;
-        self.local_keypair()?
-            .sign(&Self::signing_bytes(SIGNING_DOMAIN_PROPOSE, &bytes))
+        sign_propose_envelope(message, self.local_keypair()?)
     }
 
     fn sign_vote_message(&self, message: &VoteMessage) -> Result<PostQuantumSignature> {
-        let payload = VoteSigningPayload {
-            message_id: message.message_id.clone(),
-            voter: message.voter.clone(),
-            vote: message.vote.clone(),
-            consensus_state: message.consensus_state.clone(),
-            timestamp: message.timestamp,
-        };
-        let bytes = bincode::serialize(&payload)
-            .map_err(|e| anyhow!("VoteSigningPayload encode failed: {e}"))?;
-        self.local_keypair()?
-            .sign(&Self::signing_bytes(SIGNING_DOMAIN_VOTE, &bytes))
+        sign_vote_envelope(message, self.local_keypair()?)
     }
 
     // CONS-201: `sign_commit_message` and `sign_round_change_message` were
     // deleted along with the Commit and RoundChange variants.
 
     fn sign_heartbeat_message(&self, message: &HeartbeatMessage) -> Result<PostQuantumSignature> {
-        let payload = HeartbeatSigningPayload {
-            message_id: message.message_id.clone(),
-            validator: message.validator.clone(),
-            height: message.height,
-            round: message.round,
-            step: message.step.clone(),
-            network_summary: message.network_summary.clone(),
-            timestamp: message.timestamp,
-        };
-        let bytes = bincode::serialize(&payload)
-            .map_err(|e| anyhow!("HeartbeatSigningPayload encode failed: {e}"))?;
-        self.local_keypair()?
-            .sign(&Self::signing_bytes(SIGNING_DOMAIN_HEARTBEAT, &bytes))
+        sign_heartbeat_envelope(message, self.local_keypair()?)
     }
 
     fn verify_timestamp_fresh(&self, timestamp: u64) -> Result<()> {
@@ -767,7 +802,7 @@ impl ValidatorProtocol {
             }
         }
 
-        let bytes = Self::signing_bytes(domain, payload);
+        let bytes = signing_bytes(domain, payload);
         let ok = signature.public_key.verify(&bytes, signature)?;
         if !ok {
             return Err(anyhow!(
@@ -1012,6 +1047,101 @@ mod tests {
         discovery.announce_validator(ann).await?;
 
         Ok((protocol, rx, kp, signer))
+    }
+
+    #[tokio::test]
+    async fn test_engine_envelope_signed_propose_verifies() -> Result<()> {
+        // PR #2387 review: confirm an engine-built ProposeMessage signed via
+        // `sign_propose_envelope` round-trips through ValidatorProtocol's
+        // outer-envelope verifier with `bootstrap_tofu = false` (Mainnet
+        // semantics). Pre-fix the engine reused the inner content signature
+        // and this verification deterministically failed.
+        let (mut protocol, mut rx, kp, signer) = setup_protocol_with_forwarder().await?;
+        protocol.config.bootstrap_tofu = false;
+
+        let now = protocol.current_timestamp();
+        let mut msg = ProposeMessage {
+            message_id: Hash::from_bytes(&[42u8; 32]),
+            proposer: signer.clone(),
+            proposal: ConsensusProposal {
+                id: Hash::from_bytes(&[1u8; 32]),
+                proposer: signer.clone(),
+                height: 1,
+                round: 0,
+                protocol_version: 1,
+                previous_hash: Hash::from_bytes(&[2u8; 32]),
+                block_data: b"block".to_vec(),
+                timestamp: now,
+                // Inner content signature deliberately default — the outer
+                // envelope is what's being verified here.
+                signature: PostQuantumSignature::default(),
+                consensus_proof: ConsensusProof {
+                    consensus_type: ConsensusType::ByzantineFaultTolerance,
+                    stake_proof: None,
+                    storage_proof: None,
+                    work_proof: None,
+                    zk_did_proof: None,
+                    timestamp: now,
+                },
+            },
+            justification: None,
+            timestamp: now,
+            signature: PostQuantumSignature::default(),
+        };
+        msg.signature = sign_propose_envelope(&msg, &kp)?;
+
+        protocol
+            .handle_message(ValidatorMessage::Propose(msg))
+            .await?;
+
+        let forwarded = rx.try_recv().expect("Expected forwarded message");
+        assert!(matches!(
+            forwarded,
+            crate::types::ValidatorMessage::Propose(_)
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_engine_envelope_signed_vote_verifies() -> Result<()> {
+        let (mut protocol, mut rx, kp, signer) = setup_protocol_with_forwarder().await?;
+        protocol.config.bootstrap_tofu = false;
+
+        let now = protocol.current_timestamp();
+        let vote = ConsensusVote {
+            id: Hash::from_bytes(&[10u8; 32]),
+            height: 5,
+            round: 0,
+            vote_type: VoteType::PreVote,
+            proposal_id: Hash::from_bytes(&[11u8; 32]),
+            voter: signer.clone(),
+            timestamp: now,
+            signature: PostQuantumSignature::default(),
+        };
+        let mut msg = VoteMessage {
+            message_id: Hash::from_bytes(&[99u8; 32]),
+            voter: signer.clone(),
+            vote,
+            consensus_state: ConsensusStateView {
+                height: 5,
+                round: 0,
+                step: ConsensusStep::PreVote,
+                known_proposals: vec![],
+                vote_counts: BTreeMap::new(),
+            },
+            timestamp: now,
+            signature: PostQuantumSignature::default(),
+        };
+        msg.signature = sign_vote_envelope(&msg, &kp)?;
+
+        protocol.handle_message(ValidatorMessage::Vote(msg)).await?;
+
+        let forwarded = rx.try_recv().expect("Expected forwarded vote");
+        assert!(matches!(
+            forwarded,
+            crate::types::ValidatorMessage::Vote(_)
+        ));
+        Ok(())
     }
 
     #[tokio::test]

--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -2159,74 +2159,11 @@ impl MeshMessageHandler {
     }
 }
 
-/// Convert from network ValidatorMessage format to consensus engine format
-///
-/// The network layer uses `lib_consensus::validators::ValidatorMessage` (the wire format),
-/// while the consensus engine uses `lib_consensus::types::ValidatorMessage` (the internal format).
-/// This function bridges the two representations.
-#[allow(dead_code)]
-fn convert_network_to_consensus_message(
-    msg: &lib_consensus::validators::ValidatorMessage,
-) -> lib_consensus::types::ValidatorMessage {
-    use lib_consensus::types::{ConsensusVote, ValidatorMessage as ConsensusMessage, VoteType};
-    use lib_consensus::validators::ValidatorMessage as NetworkMessage;
-
-    match msg {
-        NetworkMessage::Propose(propose_msg) => ConsensusMessage::Propose {
-            proposal: propose_msg.proposal.clone(),
-        },
-        NetworkMessage::Vote(vote_msg) => ConsensusMessage::Vote {
-            vote: vote_msg.vote.clone(),
-        },
-        NetworkMessage::Commit(commit_msg) => {
-            // Commit messages are converted to Vote with VoteType::Commit
-            let commit_vote = ConsensusVote {
-                id: commit_msg.message_id.clone(),
-                height: commit_msg.height,
-                round: commit_msg.round,
-                vote_type: VoteType::Commit,
-                proposal_id: commit_msg.proposal_id.clone(),
-                voter: commit_msg.committer.clone(),
-                timestamp: commit_msg.timestamp,
-                signature: commit_msg.signature.clone(),
-            };
-            ConsensusMessage::Vote { vote: commit_vote }
-        }
-        NetworkMessage::RoundChange(round_change_msg) => {
-            // Round change messages don't have a direct mapping in the consensus engine
-            // Log and convert to a heartbeat-like message to maintain liveness tracking
-            tracing::debug!(
-                "Received RoundChange from validator {:?} for height {} -> round {}",
-                round_change_msg.validator,
-                round_change_msg.height,
-                round_change_msg.new_round
-            );
-            // Create a heartbeat to keep the validator marked as responsive
-            use lib_consensus::validators::NetworkSummary;
-            let heartbeat = lib_consensus::types::HeartbeatMessage {
-                message_id: round_change_msg.message_id.clone(),
-                validator: round_change_msg.validator.clone(),
-                height: round_change_msg.height,
-                round: round_change_msg.new_round,
-                step: lib_consensus::types::ConsensusStep::NewRound,
-                network_summary: NetworkSummary {
-                    active_validators: 0,
-                    health_score: 1.0,
-                    block_rate: 0.0,
-                },
-                timestamp: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-                signature: round_change_msg.signature.clone(),
-            };
-            ConsensusMessage::Heartbeat { message: heartbeat }
-        }
-        NetworkMessage::Heartbeat(heartbeat_msg) => ConsensusMessage::Heartbeat {
-            message: heartbeat_msg.clone(),
-        },
-    }
-}
+// CONS-201: `convert_network_to_consensus_message` was a dead-code
+// (#[allow(dead_code)]) shim that translated wire `ValidatorMessage` →
+// engine `ValidatorMessage`. After CONS-201 the two enums are one and
+// the same, and the shim's Commit/RoundChange translation paths no
+// longer have variants to translate.
 
 #[cfg(test)]
 mod tests {

--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -72,10 +72,9 @@ impl ConsensusMessageBroadcaster for ConsensusMeshBroadcaster {
         };
         drop(quic_protocol_guard);
 
-        // Convert types::ValidatorMessage to validators::ValidatorMessage for mesh transport
-        let network_message = convert_to_network_message(&message);
-
-        let target_height = consensus_message_height(&message);
+        // CONS-201: engine produces the canonical wire enum directly; no
+        // translation needed.
+        let target_height = validator_message_height(&message);
         let target_peer_node_ids = self
             .resolve_validator_peer_node_ids(validator_ids, target_height)
             .await;
@@ -117,7 +116,7 @@ impl ConsensusMessageBroadcaster for ConsensusMeshBroadcaster {
                 .send_to_peer(
                     &peer_id,
                     lib_network::types::mesh_message::ZhtpMeshMessage::ValidatorMessage(
-                        network_message.clone(),
+                        message.clone(),
                     ),
                 )
                 .await
@@ -188,7 +187,7 @@ impl ValidatorNetworkTransport for QuicValidatorTransport {
         };
         drop(quic_protocol_guard);
 
-        let target_height = network_message_height(&message);
+        let target_height = validator_message_height(&message);
         let target_peer_node_ids = self
             .resolve_validator_peer_node_ids(recipients, target_height)
             .await;
@@ -237,103 +236,17 @@ impl ValidatorNetworkTransport for QuicValidatorTransport {
     }
 }
 
-/// Convert from lib_consensus::types::ValidatorMessage to lib_consensus::validators::ValidatorMessage
-fn convert_to_network_message(
-    msg: &ValidatorMessage,
-) -> lib_consensus::validators::ValidatorMessage {
-    use lib_consensus::validators::{
-        ConsensusStateView, ProposeMessage, ValidatorMessage as NetworkValidatorMessage,
-        VoteMessage,
-    };
-    use std::collections::BTreeMap;
+// CONS-201: `convert_to_network_message` and `consensus_message_height`
+// were deleted. The engine now produces the canonical wrapped enum
+// directly via `wrap_propose`/`wrap_vote` in state_machine.rs, so
+// `LibNetworkMessageBroadcaster::broadcast_to_validators` receives a
+// fully-formed `ValidatorMessage` and forwards it without translation.
 
+fn validator_message_height(msg: &ValidatorMessage) -> u64 {
     match msg {
-        ValidatorMessage::Propose { proposal } => {
-            NetworkValidatorMessage::Propose(ProposeMessage {
-                message_id: proposal.id.clone(),
-                proposer: proposal.proposer.clone(),
-                proposal: proposal.clone(),
-                justification: None,
-                timestamp: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-                signature: proposal.signature.clone(),
-            })
-        }
-        ValidatorMessage::Vote { vote } => {
-            // Derive step from vote_type to ensure consistency
-            let step = match vote.vote_type {
-                lib_consensus::types::VoteType::PreVote => {
-                    lib_consensus::types::ConsensusStep::PreVote
-                }
-                lib_consensus::types::VoteType::PreCommit => {
-                    lib_consensus::types::ConsensusStep::PreCommit
-                }
-                lib_consensus::types::VoteType::Commit => {
-                    lib_consensus::types::ConsensusStep::Commit
-                }
-                lib_consensus::types::VoteType::Against => {
-                    // Against votes can occur during any voting step, default to PreVote
-                    lib_consensus::types::ConsensusStep::PreVote
-                }
-            };
-            let state_view = ConsensusStateView {
-                height: vote.height,
-                round: vote.round,
-                step,
-                known_proposals: vec![vote.proposal_id.clone()],
-                vote_counts: BTreeMap::new(),
-            };
-            NetworkValidatorMessage::Vote(VoteMessage {
-                message_id: {
-                    // Use a unique per-broadcast ID so the dedup cache never silently
-                    // drops re-broadcasts of the same vote (vote.id is deterministic
-                    // per height+round+voter, which caused 3600s suppression).
-                    let ts = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_nanos();
-                    let nonce = lib_crypto::generate_nonce();
-                    let mut data = format!("vote_bcast_{}", ts).into_bytes();
-                    data.extend_from_slice(&nonce);
-                    lib_crypto::Hash::from_bytes(&lib_crypto::hash_blake3(&data))
-                },
-                voter: vote.voter.clone(),
-                vote: vote.clone(),
-                consensus_state: state_view,
-                // Use real wall-clock timestamp for network freshness checks.
-                // The consensus engine uses a deterministic value internally, but the
-                // validator-protocol layer rejects messages with stale/future timestamps.
-                timestamp: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-                signature: vote.signature.clone(),
-            })
-        }
-        ValidatorMessage::Heartbeat { message } => {
-            // HeartbeatMessage is the same type, just re-exported
-            NetworkValidatorMessage::Heartbeat(message.clone())
-        }
-    }
-}
-
-fn consensus_message_height(msg: &ValidatorMessage) -> u64 {
-    match msg {
-        ValidatorMessage::Propose { proposal } => proposal.height,
-        ValidatorMessage::Vote { vote } => vote.height,
-        ValidatorMessage::Heartbeat { message } => message.height,
-    }
-}
-
-fn network_message_height(msg: &lib_consensus::validators::ValidatorMessage) -> u64 {
-    match msg {
-        lib_consensus::validators::ValidatorMessage::Propose(m) => m.proposal.height,
-        lib_consensus::validators::ValidatorMessage::Vote(m) => m.vote.height,
-        lib_consensus::validators::ValidatorMessage::Commit(m) => m.height,
-        lib_consensus::validators::ValidatorMessage::RoundChange(m) => m.height,
-        lib_consensus::validators::ValidatorMessage::Heartbeat(m) => m.height,
+        ValidatorMessage::Propose(m) => m.proposal.height,
+        ValidatorMessage::Vote(m) => m.vote.height,
+        ValidatorMessage::Heartbeat(m) => m.height,
     }
 }
 


### PR DESCRIPTION
## Summary
- Kills the dual-`ValidatorMessage` confusion: `lib_consensus::types::ValidatorMessage` (3-variant struct enum, used by the engine) and `lib_consensus::validators::ValidatorMessage` (5-variant tuple enum, used by the wire codec) collapse into a single canonical enum at `lib_consensus::validators::ValidatorMessage` with 3 variants — `Propose`, `Vote`, `Heartbeat`
- The two translation shims (`convert_to_network_message` in zhtp, `convert_network_to_consensus_message` in lib-network — dead-coded) are deleted; the engine produces the canonical wrapped enum directly via new `wrap_propose` / `wrap_vote` helpers
- `Commit` and `RoundChange` variants are dropped along with `CommitMessage`, `RoundChangeMessage`, `CommitmentProof`, `RoundChangeReason`, their signing payloads / domains, and all matching `send_*` / `handle_*` / `sign_*` methods. Commit votes already flow as `Vote(VoteMessage)` with `VoteType::Commit`; round changes are driven by timeouts, not messages

Closes #2334.

## Diff
**7 files, +179 / -574 (net –395 LOC).** Most of the deletion is the redundant Commit/RoundChange machinery and the two translation shims.

| File | Change |
|------|--------|
| `lib-consensus/src/types/mod.rs` | Delete thin `ValidatorMessage` enum, alias to canonical |
| `lib-consensus/src/validators/validator_protocol.rs` | Drop 2 variants + dependent types + send/handle/sign for Commit & RoundChange |
| `lib-consensus/src/engines/consensus_engine/state_machine.rs` | New `wrap_propose` / `wrap_vote` helpers; build sites use them |
| `lib-consensus/src/engines/consensus_engine/network.rs` | Update tuple-variant matchers in inbound dispatch |
| `lib-consensus/src/network/codec.rs` | Drop Commit/RoundChange round-trip tests + helpers |
| `lib-network/src/messaging/message_handler.rs` | Delete dead `convert_network_to_consensus_message` |
| `zhtp/src/runtime/components/consensus.rs` | Delete `convert_to_network_message` shim + `consensus_message_height`; runtime sends canonical directly |

## Out of scope
- **Relocation of the canonical enum** to `lib-consensus-core::types` (the "right place" per AD-002). Deferred — moving the enum requires moving its 6 dependent wrapper types (`ProposeMessage`, `VoteMessage`, `HeartbeatMessage`, `Justification`, `ConsensusStateView`, `NetworkSummary`) and their value-type dependencies (`ConsensusProposal`, `ConsensusVote`, `ConsensusStep`, `VoteType`) which is structurally bound to CONS-301 (FSM extraction). Tracked there.
- **`MessageBroadcaster` trait collapse** — that's CONS-202, separate PR.
- **`CONSENSUS_PROTOCOL_VERSION` bump** — that's CONS-203. The enum shape changed (variants removed) so a bump is warranted, but it ships with the wire-format unification and a coordinated chain restart.

## Test plan
- [x] `cargo build --workspace` — OK
- [x] `cargo test -p lib-consensus --lib` — 180 pass / 4 fail (KI-01..04 baseline preserved, no new failures)
- [x] `cargo check --workspace` — clean