### PR TITLE
fix(consensus): sign Heartbeat outer envelope at engine (follow-up to #2387)

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/network.rs
+++ b/lib-consensus/src/engines/consensus_engine/network.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::state_machine::wrap_heartbeat;
 
 impl ConsensusEngine {
     /// Main consensus loop with tokio::select!
@@ -317,9 +318,14 @@ impl ConsensusEngine {
                             .map(|v| v.identity.clone())
                             .collect();
 
-                        // Broadcast heartbeat (best-effort, ignore failures)
+                        // Broadcast heartbeat (best-effort, ignore failures).
+                        // wrap_heartbeat signs the outer envelope so receivers
+                        // running with `bootstrap_tofu = false` (Mainnet) can
+                        // verify against `HeartbeatSigningPayload` instead of
+                        // dropping unsigned messages.
+                        let msg = wrap_heartbeat(heartbeat_msg, self.validator_keypair.as_ref());
                         if let Err(e) = self.broadcaster.broadcast_to_validators(
-                            ValidatorMessage::Heartbeat(heartbeat_msg),
+                            msg,
                             &validator_ids,
                         ).await {
                             tracing::debug!("Heartbeat broadcast failed: {}", e);

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -3,7 +3,8 @@
 use super::*;
 use crate::types::ConsensusStepExt;
 use crate::validators::validator_protocol::{
-    sign_propose_envelope, sign_vote_envelope, ConsensusStateView, ProposeMessage, VoteMessage,
+    sign_heartbeat_envelope, sign_propose_envelope, sign_vote_envelope, ConsensusStateView,
+    HeartbeatMessage, ProposeMessage, VoteMessage,
 };
 use crate::validators::ValidatorManager;
 use lib_consensus_core::ports::ValidatorRewardInput;
@@ -107,6 +108,36 @@ fn wrap_vote(vote: ConsensusVote, keypair: Option<&KeyPair>) -> ValidatorMessage
         );
     }
     ValidatorMessage::Vote(msg)
+}
+
+/// Wrap a `HeartbeatMessage` produced by `HeartbeatTracker` and sign the
+/// outer envelope. Same shape as `wrap_propose` / `wrap_vote`.
+///
+/// Pre-fix the engine broadcast heartbeats with a default placeholder
+/// signature (the tracker's `create_heartbeat_message` doesn't sign);
+/// receivers in TOFU mode special-cased the empty-public-key path and
+/// forwarded the message as advisory, but Mainnet (`bootstrap_tofu = false`)
+/// would reject. Pre-existing inheritance from before CONS-201; flagged as
+/// out of scope on PR #2387 and fixed here.
+pub(super) fn wrap_heartbeat(
+    message: HeartbeatMessage,
+    keypair: Option<&KeyPair>,
+) -> ValidatorMessage {
+    let mut msg = message;
+    if let Some(kp) = keypair {
+        match sign_heartbeat_envelope(&msg, kp) {
+            Ok(sig) => msg.signature = sig,
+            Err(e) => tracing::warn!(
+                error = %e,
+                "Failed to sign Heartbeat envelope; broadcasting with placeholder signature"
+            ),
+        }
+    } else {
+        tracing::debug!(
+            "No validator keypair; broadcasting Heartbeat with placeholder signature (test mode)"
+        );
+    }
+    ValidatorMessage::Heartbeat(msg)
 }
 
 fn now_secs() -> u64 {

--- a/lib-consensus/src/validators/validator_protocol.rs
+++ b/lib-consensus/src/validators/validator_protocol.rs
@@ -1103,6 +1103,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_engine_envelope_signed_heartbeat_verifies() -> Result<()> {
+        // Follow-up to PR #2387: confirm an engine-built HeartbeatMessage
+        // signed via `sign_heartbeat_envelope` round-trips through
+        // ValidatorProtocol's outer-envelope verifier with
+        // `bootstrap_tofu = false` (Mainnet semantics). Pre-fix the engine
+        // broadcast unsigned heartbeats; receivers in non-TOFU mode rejected.
+        let (mut protocol, _rx, kp, signer) = setup_protocol_with_forwarder().await?;
+        protocol.config.bootstrap_tofu = false;
+
+        let now = protocol.current_timestamp();
+        let mut msg = HeartbeatMessage {
+            message_id: Hash::from_bytes(&[55u8; 32]),
+            validator: signer.clone(),
+            height: 7,
+            round: 0,
+            step: ConsensusStep::Propose,
+            network_summary: NetworkSummary {
+                active_validators: 4,
+                health_score: 0.95,
+                block_rate: 1.0,
+            },
+            timestamp: now,
+            signature: PostQuantumSignature::default(),
+        };
+        msg.signature = sign_heartbeat_envelope(&msg, &kp)?;
+
+        // handle_message verifies the envelope; success means no error.
+        protocol
+            .handle_message(ValidatorMessage::Heartbeat(msg))
+            .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_engine_envelope_signed_vote_verifies() -> Result<()> {
         let (mut protocol, mut rx, kp, signer) = setup_protocol_with_forwarder().await?;
         protocol.config.bootstrap_tofu = false;


### PR DESCRIPTION
## Summary
Follow-up to #2387. The heartbeat broadcast site emitted `ValidatorMessage::Heartbeat` with `HeartbeatMessage::signature` left at `PostQuantumSignature::default()` because `HeartbeatTracker::create_heartbeat_message` doesn't sign. Same root cause as the Propose/Vote bug Copilot caught in #2387 — `verify_validator_message` reconstructs `HeartbeatSigningPayload` and verifies the outer envelope, so unsigned heartbeats fail Mainnet verification (`bootstrap_tofu = false`). Non-Mainnet was masked by the TOFU empty-key shortcut.

Same fix shape as #2387: a `wrap_heartbeat` helper alongside `wrap_propose`/`wrap_vote` calls `sign_heartbeat_envelope` with `self.validator_keypair` after the envelope fields are populated.

## Test plan
- [x] New unit test `test_engine_envelope_signed_heartbeat_verifies` with `bootstrap_tofu = false` confirms an engine-signed heartbeat round-trips through `verify_validator_message`
- [x] `cargo test -p lib-consensus --lib` — 183 pass / 4 fail (KI-01..04 baseline preserved)
- [x] `cargo build --workspace` — clean