### PR TITLE
refactor(consensus): CONS-203 bump CONSENSUS_PROTOCOL_VERSION to 2 (closes #2336)

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/mod.rs
+++ b/lib-consensus/src/engines/consensus_engine/mod.rs
@@ -249,7 +249,15 @@ mod tests;
 /// History:
 ///   1 — initial: proposal ID/signature include round + domain tags
 ///       `ZHTP/PROPOSAL/ID/v1` and `ZHTP/PROPOSAL/SIG/v1`
-pub const CONSENSUS_PROTOCOL_VERSION: u32 = 1;
+///   2 — CONS-201: `ValidatorMessage` collapsed from 5 variants to 3
+///       (deleted `Commit` and `RoundChange` variants); single canonical
+///       enum at `lib_consensus::validators::ValidatorMessage`. Old v1
+///       nodes encode/decode `Commit`/`RoundChange` variants that v2
+///       nodes cannot decode and would silently mis-route otherwise.
+///       Bumping enforces a hard cutover boundary — mixed-version nodes
+///       reject each other's proposals at admission time instead of
+///       silently mis-decoding the wire format.
+pub const CONSENSUS_PROTOCOL_VERSION: u32 = 2;
 
 /// Human-readable name of the consensus algorithm variant implemented here.
 ///

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -2425,7 +2425,7 @@ mod state_machine_tests {
             proposer: lib_crypto::Hash([0u8; 32]),
             height: 42,
             round: 0,
-            protocol_version: 1,
+            protocol_version: super::CONSENSUS_PROTOCOL_VERSION,
             previous_hash: lib_crypto::Hash([0u8; 32]),
             block_data: vec![],
             timestamp: 0,

--- a/lib-consensus/src/network/codec.rs
+++ b/lib-consensus/src/network/codec.rs
@@ -431,7 +431,7 @@ mod tests {
             proposer: IdentityId::from_bytes(b"test-proposer-id-1234567890123"),
             height: 100,
             round: 1,
-            protocol_version: 1,
+            protocol_version: crate::engines::consensus_engine::CONSENSUS_PROTOCOL_VERSION,
             previous_hash: Hash::from_bytes(b"prev-hash-123456789012345678901"),
             block_data: vec![1, 2, 3, 4, 5],
             timestamp: 1234567890,


### PR DESCRIPTION
## Summary
Aligns `CONSENSUS_PROTOCOL_VERSION` with the wire-format break that already shipped in CONS-201 (PR #2387). v1 nodes encode `Commit`/`RoundChange` variants that v2 cannot decode; v2 nodes never produce them. Bumping makes the boundary explicit — the admission check at `validation.rs:486` rejects mismatched versions instead of silently mis-decoding.

Coordinated testnet restart is **still required** to actually run a v2 network (separate cutover step, CONS-606). This PR only aligns the constant with code reality.

Also cleans up 2 hardcoded `protocol_version: 1` literals that should always have referenced the constant (`network/codec.rs::create_test_proposal`, reward-callback test in `state_machine.rs`).

Closes #2336.

## Test plan
- [x] `cargo build --workspace` — OK
- [x] `cargo test -p lib-consensus --lib` — 183 pass / 4 fail (KI-01..04 baseline preserved)