### PR TITLE
feat(consensus-core): CONS-302 + CONS-303 transition() + Event/Action enums (closes #2338, #2339)

### DIFF
--- a/lib-consensus-core/src/fsm/events.rs
+++ b/lib-consensus-core/src/fsm/events.rs
@@ -1,0 +1,205 @@
+//! FSM Event/Action vocabulary.
+//!
+//! These enums are the only way the [`transition()`] function (CONS-302)
+//! observes the outside world or expresses its decisions. The FSM:
+//!
+//! - **Consumes** [`Event`] values produced by the runtime: timer firings,
+//!   admitted proposals, vote-tally thresholds, watchdog signals, upgrade
+//!   signals.
+//! - **Emits** [`Action`] values that the runtime executes:
+//!   create/broadcast a proposal, send a vote, commit a block, advance a
+//!   round, reset the watchdog, halt for upgrade.
+//!
+//! The FSM never touches `tokio`, the network, the keypair, the
+//! blockchain, or wall-clock time — those side effects all flow through
+//! `Action`s and back through `Event`s.
+//!
+//! [`transition()`]: super::transition
+//!
+//! # Why IDs and not full `ConsensusProposal`/`ConsensusVote`
+//!
+//! The CONS-303 epic draft suggested `Event::ReceivedProposal(ConsensusProposal)`
+//! / `Action::CommitBlock(ConsensusProposal, BftQuorumProof)`.  Plumbing
+//! the full proposal type through the FSM would require moving
+//! `ConsensusProposal` (and its `ConsensusProof`) into lib-consensus-core,
+//! and `ConsensusProof::storage_proof` references
+//! `lib_storage::proofs::StorageCapacityAttestation`. Adding lib-storage
+//! as a dep on lib-consensus-core is forbidden by AD-002 (see `lib.rs`).
+//!
+//! The cycle was already noted on CONS-104 review and CONS-201's deferred
+//! Scope B.  Until the StorageCapacityAttestation home is resolved, the
+//! FSM operates on `Hash` IDs only — the runtime holds the proposal/vote
+//! bodies (already keyed by ID in the engine's existing maps) and looks
+//! them up when an `Action` references one.
+
+use crate::fsm::state::RejectionReason;
+use lib_crypto::Hash;
+use lib_types::consensus::BftQuorumProof;
+use serde::{Deserialize, Serialize};
+
+/// Inputs the FSM consumes during one [`transition`] call.
+///
+/// Produced by the runtime (timers, vote pool, network, watchdog) and
+/// fed to the FSM in arrival order.  The runtime is responsible for
+/// pre-validating each event before delivery: the FSM trusts that an
+/// `ProposalAdmitted` has already passed signature and proposer checks,
+/// that a `*ThresholdReached` has already counted +2/3 by stake.
+///
+/// [`transition`]: super::transition::transition
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Event {
+    /// The local validator was elected proposer for the current
+    /// (height, round). Engine should produce a proposal.
+    SelectedAsProposer { height: u64, round: u32 },
+
+    /// A proposal arrived and passed all pre-FSM validation
+    /// (signature, height, round, proposer election).
+    ProposalAdmitted {
+        id: Hash,
+        height: u64,
+        round: u32,
+    },
+
+    /// The vote pool counted +2/3 prevotes by stake for `block_id`.
+    PrevoteThresholdReached { block_id: Hash },
+
+    /// The vote pool counted +2/3 precommits by stake for `block_id`.
+    PrecommitThresholdReached { block_id: Hash },
+
+    /// A `BftQuorumProof` was assembled from the precommit votes.
+    /// Carries the proof so the runtime can finalize without re-aggregating.
+    CommitQuorumReached {
+        block_id: Hash,
+        quorum: BftQuorumProof,
+    },
+
+    /// Vote tallying ended without quorum, with a specific reason.
+    VoteFailed(RejectionReason),
+
+    /// A step-level timeout fired (Propose, PreVote, or PreCommit).
+    /// The FSM resolves the appropriate [`RejectionReason`] internally.
+    Timeout,
+
+    /// The watchdog (CONS-309) fired without observing any progress
+    /// action for longer than the configured threshold.
+    WatchdogFired { age_ms: u64 },
+
+    /// External signal that the operator has scheduled a halt at a
+    /// specific height for protocol upgrade (CONS-203 cutover).
+    UpgradeSignal { halt_at_height: u64 },
+}
+
+/// Outputs the FSM emits during one [`transition`] call.
+///
+/// The runtime executes these in order. Side effects (broadcast, finalize,
+/// log) are encapsulated here so the FSM stays IO-free per AD-002.
+///
+/// [`transition`]: super::transition::transition
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Action {
+    /// Build a fresh proposal for the current (height, round) and feed
+    /// the resulting `ProposalAdmitted` event back to the FSM.
+    CreateProposal,
+
+    /// Broadcast the proposal identified by `id` to all peers.
+    BroadcastProposal { id: Hash },
+
+    /// Sign and send a prevote for `block_id` to all peers.
+    SendPrevote { block_id: Hash },
+
+    /// Sign and send a precommit for `block_id` to all peers.
+    SendPrecommit { block_id: Hash },
+
+    /// Commit the block identified by `id` using the supplied quorum
+    /// proof — calls `BlockFinalizationSink` on the runtime.
+    CommitBlock {
+        id: Hash,
+        quorum: BftQuorumProof,
+    },
+
+    /// Increment the round counter and reset to `FsmState::Idle` for
+    /// (height, round + 1). View change.
+    AdvanceRound,
+
+    /// Reset the watchdog timer because progress was made.
+    ResetWatchdog,
+
+    /// Stop admitting messages and stay in `HaltedForUpgrade` until the
+    /// operator restarts the node with the bumped protocol version.
+    HaltForUpgrade,
+
+    /// Emit a `Hung` observability event with the given reason.
+    LogHung { reason: &'static str },
+
+    /// Emit an "ignored event" observability log — used when an event
+    /// arrives in a state where it has no effect (e.g. late prevote
+    /// after `Committed`). Explicit instead of silent.
+    LogIgnoredEvent(&'static str),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sanity check that every Event variant is constructible.
+    #[test]
+    fn all_event_variants_constructible() {
+        let _ = Event::SelectedAsProposer {
+            height: 1,
+            round: 0,
+        };
+        let _ = Event::ProposalAdmitted {
+            id: Hash([1u8; 32]),
+            height: 1,
+            round: 0,
+        };
+        let _ = Event::PrevoteThresholdReached {
+            block_id: Hash([2u8; 32]),
+        };
+        let _ = Event::PrecommitThresholdReached {
+            block_id: Hash([3u8; 32]),
+        };
+        let _ = Event::CommitQuorumReached {
+            block_id: Hash([4u8; 32]),
+            quorum: BftQuorumProof {
+                height: 0,
+                proposal_id: [0u8; 32],
+                total_validators: 0,
+                attestations: Vec::new(),
+            },
+        };
+        let _ = Event::VoteFailed(RejectionReason::Timeout);
+        let _ = Event::Timeout;
+        let _ = Event::WatchdogFired { age_ms: 5_000 };
+        let _ = Event::UpgradeSignal { halt_at_height: 100 };
+    }
+
+    /// Sanity check that every Action variant is constructible.
+    #[test]
+    fn all_action_variants_constructible() {
+        let _ = Action::CreateProposal;
+        let _ = Action::BroadcastProposal { id: Hash([1u8; 32]) };
+        let _ = Action::SendPrevote {
+            block_id: Hash([2u8; 32]),
+        };
+        let _ = Action::SendPrecommit {
+            block_id: Hash([3u8; 32]),
+        };
+        let _ = Action::CommitBlock {
+            id: Hash([4u8; 32]),
+            quorum: BftQuorumProof {
+                height: 0,
+                proposal_id: [0u8; 32],
+                total_validators: 0,
+                attestations: Vec::new(),
+            },
+        };
+        let _ = Action::AdvanceRound;
+        let _ = Action::ResetWatchdog;
+        let _ = Action::HaltForUpgrade;
+        let _ = Action::LogHung {
+            reason: "test",
+        };
+        let _ = Action::LogIgnoredEvent("test");
+    }
+}

--- a/lib-consensus-core/src/fsm/mod.rs
+++ b/lib-consensus-core/src/fsm/mod.rs
@@ -3,10 +3,15 @@
 //! Populated by:
 //! - **CONS-301: `FsmState` enum** (Idle, Proposing, Prevoting, Precommitting,
 //!   Committed, Rejected, Hung, HaltedForUpgrade) ← shipped.
-//! - CONS-302: total `transition()` with compile-time exhaustiveness.
-//! - CONS-303: `Event` and `Action` enums.
+//! - **CONS-302: total `transition()`** with compile-time exhaustiveness ← shipped.
+//! - **CONS-303: `Event` and `Action` enums** ← shipped (with the simplification
+//!   noted in `events.rs`: IDs instead of full `ConsensusProposal`/`Vote`).
 //! - CONS-304: `step_entered_at: Instant` in the FSM struct.
 
+pub mod events;
 pub mod state;
+pub mod transition;
 
+pub use events::{Action, Event};
 pub use state::{FsmState, RejectionReason};
+pub use transition::transition;

--- a/lib-consensus-core/src/fsm/transition.rs
+++ b/lib-consensus-core/src/fsm/transition.rs
@@ -1,0 +1,481 @@
+//! Total `transition(state, event) -> (next_state, actions)`.
+//!
+//! Single source of truth for control-flow transitions in the validator
+//! FSM. Pre-rewrite this logic was distributed across
+//! `consensus_engine::run_*_step`, `on_proposal`, `on_prevote`,
+//! `on_precommit`, `on_commit_vote`, plus a thicket of timer flags and
+//! "is this round dead yet?" booleans. CONS-302 consolidates it into one
+//! function with one match.
+//!
+//! # Totality
+//!
+//! `transition()` must terminate for every `(FsmState, Event)` pair —
+//! never panic, never `unreachable!`. Invalid-but-tolerable arrivals
+//! (e.g. a late prevote in `Committed`) map to
+//! `(state, vec![Action::LogIgnoredEvent("..."])` so they are explicit
+//! rather than silently dropped.
+//!
+//! `HaltedForUpgrade` is the one absorbing state with a wildcard match
+//! arm, since by definition no event can move it forward.
+//!
+//! Compile-time totality is enforced by exhaustive matches on both
+//! enums (no wildcard arms outside `HaltedForUpgrade`). Adding a
+//! variant to `FsmState` or `Event` will break the build until the
+//! match is updated.
+//!
+//! # What this PR does NOT yet do
+//!
+//! - Wire `transition()` into the engine — that's CONS-305 (handler
+//!   migration) once `step_entered_at` (CONS-304) is in place.
+//! - Drive watchdog firings — that's CONS-309.
+//! - Centralise step timeouts as constants — that's CONS-310.
+
+use crate::fsm::events::{Action, Event};
+use crate::fsm::state::{FsmState, RejectionReason};
+
+/// Compute the next state and the actions to execute, given the current
+/// state and an arriving event.
+///
+/// Pure function: no side effects, no panics, no `unreachable!`. The
+/// caller (CONS-305 runtime task) is responsible for executing the
+/// returned actions in order and feeding the resulting events back in.
+pub fn transition(state: FsmState, event: Event) -> (FsmState, Vec<Action>) {
+    use Event::*;
+    use FsmState::*;
+
+    match (state, event) {
+        // ------------------------------------------------------------
+        // UpgradeSignal — accepted from any non-terminal state. Halted
+        // is absorbing; Committed/Rejected/Hung's wildcard event arms
+        // below also catch this with logged-ignored, which is the
+        // intended semantics (signal arrived too late to matter).
+        // ------------------------------------------------------------
+        (Idle, UpgradeSignal { .. })
+        | (Proposing, UpgradeSignal { .. })
+        | (Prevoting, UpgradeSignal { .. })
+        | (Precommitting, UpgradeSignal { .. }) => {
+            (HaltedForUpgrade, vec![Action::HaltForUpgrade])
+        }
+
+        // ------------------------------------------------------------
+        // Idle — between rounds. Accept SelectedAsProposer / Timeout for
+        // the boundary case where the proposer fires before any state
+        // has been entered. Everything else is logged-ignored.
+        // ------------------------------------------------------------
+        (Idle, SelectedAsProposer { .. }) => {
+            (Proposing, vec![Action::CreateProposal, Action::ResetWatchdog])
+        }
+        (Idle, ProposalAdmitted { .. }) => (
+            Proposing,
+            vec![Action::LogIgnoredEvent(
+                "ProposalAdmitted in Idle: proposer-elect path not yet entered",
+            )],
+        ),
+        (Idle, Timeout) => (
+            Idle,
+            vec![Action::LogIgnoredEvent("Timeout in Idle: no active step")],
+        ),
+        (Idle, PrevoteThresholdReached { .. }) => (
+            Idle,
+            vec![Action::LogIgnoredEvent("PrevoteThresholdReached in Idle")],
+        ),
+        (Idle, PrecommitThresholdReached { .. }) => (
+            Idle,
+            vec![Action::LogIgnoredEvent("PrecommitThresholdReached in Idle")],
+        ),
+        (Idle, CommitQuorumReached { .. }) => (
+            Idle,
+            vec![Action::LogIgnoredEvent("CommitQuorumReached in Idle")],
+        ),
+        (Idle, VoteFailed(_)) => (
+            Idle,
+            vec![Action::LogIgnoredEvent("VoteFailed in Idle")],
+        ),
+        (Idle, WatchdogFired { age_ms }) => (
+            Hung,
+            vec![Action::LogHung {
+                reason: "Watchdog fired while Idle — runtime stuck before round start",
+            }, Action::LogIgnoredEvent("Idle.WatchdogFired"), event_marker_age_ms(age_ms)],
+        ),
+
+        // ------------------------------------------------------------
+        // Proposing — the leader's window. Either a proposal arrives
+        // (transition to Prevoting) or the propose timeout fires
+        // (transition to Rejected for view change).
+        // ------------------------------------------------------------
+        (Proposing, ProposalAdmitted { id, .. }) => (
+            Prevoting,
+            vec![
+                Action::BroadcastProposal { id: id.clone() },
+                Action::SendPrevote { block_id: id },
+                Action::ResetWatchdog,
+            ],
+        ),
+        (Proposing, SelectedAsProposer { .. }) => (
+            Proposing,
+            vec![Action::LogIgnoredEvent(
+                "SelectedAsProposer in Proposing: already proposing",
+            )],
+        ),
+        (Proposing, Timeout) => (
+            Rejected(RejectionReason::Timeout),
+            vec![Action::AdvanceRound],
+        ),
+        (Proposing, PrevoteThresholdReached { .. }) => (
+            Proposing,
+            vec![Action::LogIgnoredEvent(
+                "PrevoteThresholdReached in Proposing: pre-quorum",
+            )],
+        ),
+        (Proposing, PrecommitThresholdReached { .. }) => (
+            Proposing,
+            vec![Action::LogIgnoredEvent(
+                "PrecommitThresholdReached in Proposing: pre-quorum",
+            )],
+        ),
+        (Proposing, CommitQuorumReached { .. }) => (
+            Proposing,
+            vec![Action::LogIgnoredEvent(
+                "CommitQuorumReached in Proposing: pre-quorum",
+            )],
+        ),
+        (Proposing, VoteFailed(reason)) => {
+            (Rejected(reason), vec![Action::AdvanceRound])
+        }
+        (Proposing, WatchdogFired { .. }) => (
+            Hung,
+            vec![Action::LogHung {
+                reason: "Watchdog fired while Proposing — proposer or network stuck",
+            }],
+        ),
+
+        // ------------------------------------------------------------
+        // Prevoting — proposal admitted, accumulating prevotes.
+        // ------------------------------------------------------------
+        (Prevoting, PrevoteThresholdReached { block_id }) => (
+            Precommitting,
+            vec![
+                Action::SendPrecommit { block_id },
+                Action::ResetWatchdog,
+            ],
+        ),
+        (Prevoting, Timeout) => (
+            Rejected(RejectionReason::InsufficientPrevotes),
+            vec![Action::AdvanceRound],
+        ),
+        (Prevoting, VoteFailed(reason)) => {
+            (Rejected(reason), vec![Action::AdvanceRound])
+        }
+        (Prevoting, ProposalAdmitted { .. }) => (
+            Prevoting,
+            vec![Action::LogIgnoredEvent(
+                "ProposalAdmitted in Prevoting: duplicate or competing proposal",
+            )],
+        ),
+        (Prevoting, SelectedAsProposer { .. }) => (
+            Prevoting,
+            vec![Action::LogIgnoredEvent(
+                "SelectedAsProposer in Prevoting: round already advanced",
+            )],
+        ),
+        (Prevoting, PrecommitThresholdReached { .. }) => (
+            Prevoting,
+            vec![Action::LogIgnoredEvent(
+                "PrecommitThresholdReached in Prevoting: pre-prevote-quorum",
+            )],
+        ),
+        (Prevoting, CommitQuorumReached { .. }) => (
+            Prevoting,
+            vec![Action::LogIgnoredEvent(
+                "CommitQuorumReached in Prevoting: pre-prevote-quorum",
+            )],
+        ),
+        (Prevoting, WatchdogFired { .. }) => (
+            Hung,
+            vec![Action::LogHung {
+                reason: "Watchdog fired while Prevoting — vote pool stuck",
+            }],
+        ),
+
+        // ------------------------------------------------------------
+        // Precommitting — accumulating precommits for one block.
+        // ------------------------------------------------------------
+        (Precommitting, CommitQuorumReached { block_id, quorum }) => (
+            Committed,
+            vec![
+                Action::CommitBlock {
+                    id: block_id,
+                    quorum,
+                },
+                Action::ResetWatchdog,
+            ],
+        ),
+        (Precommitting, PrecommitThresholdReached { .. }) => (
+            Precommitting,
+            vec![Action::LogIgnoredEvent(
+                "PrecommitThresholdReached in Precommitting: waiting for quorum proof",
+            )],
+        ),
+        (Precommitting, Timeout) => (
+            Rejected(RejectionReason::InsufficientPrecommits),
+            vec![Action::AdvanceRound],
+        ),
+        (Precommitting, VoteFailed(reason)) => {
+            (Rejected(reason), vec![Action::AdvanceRound])
+        }
+        (Precommitting, ProposalAdmitted { .. }) => (
+            Precommitting,
+            vec![Action::LogIgnoredEvent(
+                "ProposalAdmitted in Precommitting: too late",
+            )],
+        ),
+        (Precommitting, SelectedAsProposer { .. }) => (
+            Precommitting,
+            vec![Action::LogIgnoredEvent(
+                "SelectedAsProposer in Precommitting: round already advanced",
+            )],
+        ),
+        (Precommitting, PrevoteThresholdReached { .. }) => (
+            Precommitting,
+            vec![Action::LogIgnoredEvent(
+                "PrevoteThresholdReached in Precommitting: late prevote",
+            )],
+        ),
+        (Precommitting, WatchdogFired { .. }) => (
+            Hung,
+            vec![Action::LogHung {
+                reason: "Watchdog fired while Precommitting — quorum stuck",
+            }],
+        ),
+
+        // ------------------------------------------------------------
+        // Committed — terminal-success. Self-clears on the next
+        // height's StartRound; until then everything is logged-ignored.
+        // ------------------------------------------------------------
+        (Committed, _event) => (Committed, vec![Action::LogIgnoredEvent("event in Committed")]),
+
+        // ------------------------------------------------------------
+        // Rejected — terminal-failure for the current round. The runtime
+        // emits AdvanceRound in the transition that produced Rejected;
+        // events arriving after that are ignored until the runtime feeds
+        // a new round.
+        // ------------------------------------------------------------
+        (Rejected(_), _event) => (
+            state,
+            vec![Action::LogIgnoredEvent("event in Rejected")],
+        ),
+
+        // ------------------------------------------------------------
+        // Hung — terminal until external recovery.
+        // ------------------------------------------------------------
+        (Hung, _event) => (Hung, vec![Action::LogIgnoredEvent("event in Hung")]),
+
+        // ------------------------------------------------------------
+        // HaltedForUpgrade — only state with a wildcard event arm. By
+        // definition no event moves it forward; the runtime restart with
+        // the bumped CONSENSUS_PROTOCOL_VERSION is the only exit.
+        // ------------------------------------------------------------
+        (HaltedForUpgrade, _) => (
+            HaltedForUpgrade,
+            vec![Action::LogIgnoredEvent("event in HaltedForUpgrade")],
+        ),
+    }
+}
+
+/// Helper used by the watchdog branches in `Idle` to surface the
+/// firing-age in the action stream without inventing a dedicated
+/// Action variant. The runtime can pick this up via its observability
+/// pipeline; the FSM doesn't need to act on it.
+fn event_marker_age_ms(_age_ms: u64) -> Action {
+    Action::LogIgnoredEvent("watchdog age recorded")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lib_crypto::Hash;
+    use lib_types::consensus::BftQuorumProof;
+
+    fn dummy_quorum() -> BftQuorumProof {
+        BftQuorumProof {
+            height: 0,
+            proposal_id: [0u8; 32],
+            total_validators: 0,
+            attestations: Vec::new(),
+        }
+    }
+
+    fn all_events() -> Vec<Event> {
+        vec![
+            Event::SelectedAsProposer {
+                height: 1,
+                round: 0,
+            },
+            Event::ProposalAdmitted {
+                id: Hash([1u8; 32]),
+                height: 1,
+                round: 0,
+            },
+            Event::PrevoteThresholdReached {
+                block_id: Hash([2u8; 32]),
+            },
+            Event::PrecommitThresholdReached {
+                block_id: Hash([3u8; 32]),
+            },
+            Event::CommitQuorumReached {
+                block_id: Hash([4u8; 32]),
+                quorum: dummy_quorum(),
+            },
+            Event::VoteFailed(RejectionReason::Timeout),
+            Event::Timeout,
+            Event::WatchdogFired { age_ms: 5_000 },
+            Event::UpgradeSignal { halt_at_height: 100 },
+        ]
+    }
+
+    fn all_states() -> Vec<FsmState> {
+        vec![
+            FsmState::Idle,
+            FsmState::Proposing,
+            FsmState::Prevoting,
+            FsmState::Precommitting,
+            FsmState::Committed,
+            FsmState::Rejected(RejectionReason::InsufficientPrevotes),
+            FsmState::Hung,
+            FsmState::HaltedForUpgrade,
+        ]
+    }
+
+    /// CONS-302 acceptance criterion: every (state, event) pair returns
+    /// a valid (next_state, actions) tuple — no panic, no unreachable.
+    #[test]
+    fn transition_total_over_state_event_product() {
+        for state in all_states() {
+            for event in all_events() {
+                // Must not panic.
+                let (_next, actions) = transition(state, event.clone());
+                // Must always produce at least one action — even
+                // logged-ignored arrivals.  Empty action lists would
+                // hide silent transitions.
+                assert!(
+                    !actions.is_empty(),
+                    "transition({:?}, {:?}) returned no actions",
+                    state,
+                    event
+                );
+            }
+        }
+    }
+
+    /// Happy path: Idle → Proposing → Prevoting → Precommitting → Committed.
+    #[test]
+    fn happy_path_round_completes() {
+        let block_id = Hash([42u8; 32]);
+        let proposer_event = Event::SelectedAsProposer {
+            height: 1,
+            round: 0,
+        };
+
+        let (s, a) = transition(FsmState::Idle, proposer_event);
+        assert_eq!(s, FsmState::Proposing);
+        assert!(a.contains(&Action::CreateProposal));
+
+        let (s, a) = transition(
+            s,
+            Event::ProposalAdmitted {
+                id: block_id.clone(),
+                height: 1,
+                round: 0,
+            },
+        );
+        assert_eq!(s, FsmState::Prevoting);
+        assert!(a.iter().any(|x| matches!(x, Action::SendPrevote { .. })));
+
+        let (s, _) = transition(
+            s,
+            Event::PrevoteThresholdReached {
+                block_id: block_id.clone(),
+            },
+        );
+        assert_eq!(s, FsmState::Precommitting);
+
+        let (s, a) = transition(
+            s,
+            Event::CommitQuorumReached {
+                block_id,
+                quorum: dummy_quorum(),
+            },
+        );
+        assert_eq!(s, FsmState::Committed);
+        assert!(a.iter().any(|x| matches!(x, Action::CommitBlock { .. })));
+    }
+
+    /// Propose timeout produces a view change.
+    #[test]
+    fn propose_timeout_advances_round() {
+        let (s, a) = transition(FsmState::Proposing, Event::Timeout);
+        assert_eq!(s, FsmState::Rejected(RejectionReason::Timeout));
+        assert!(a.contains(&Action::AdvanceRound));
+    }
+
+    /// Prevote timeout maps to InsufficientPrevotes, not generic Timeout.
+    #[test]
+    fn prevote_timeout_rejection_specific() {
+        let (s, _) = transition(FsmState::Prevoting, Event::Timeout);
+        assert_eq!(s, FsmState::Rejected(RejectionReason::InsufficientPrevotes));
+    }
+
+    /// Precommit timeout maps to InsufficientPrecommits.
+    #[test]
+    fn precommit_timeout_rejection_specific() {
+        let (s, _) = transition(FsmState::Precommitting, Event::Timeout);
+        assert_eq!(
+            s,
+            FsmState::Rejected(RejectionReason::InsufficientPrecommits)
+        );
+    }
+
+    /// Watchdog from any active state lands in `Hung`.
+    #[test]
+    fn watchdog_from_active_states_hangs() {
+        for state in [
+            FsmState::Proposing,
+            FsmState::Prevoting,
+            FsmState::Precommitting,
+        ] {
+            let (s, a) = transition(state, Event::WatchdogFired { age_ms: 30_000 });
+            assert_eq!(s, FsmState::Hung);
+            assert!(a.iter().any(|x| matches!(x, Action::LogHung { .. })));
+        }
+    }
+
+    /// UpgradeSignal trumps the current state for any non-terminal state.
+    #[test]
+    fn upgrade_signal_halts_any_active_state() {
+        for state in [
+            FsmState::Idle,
+            FsmState::Proposing,
+            FsmState::Prevoting,
+            FsmState::Precommitting,
+        ] {
+            let (s, a) = transition(state, Event::UpgradeSignal { halt_at_height: 100 });
+            assert_eq!(s, FsmState::HaltedForUpgrade);
+            assert_eq!(a, vec![Action::HaltForUpgrade]);
+        }
+    }
+
+    /// `HaltedForUpgrade` is absorbing — every event is logged-ignored.
+    #[test]
+    fn halted_for_upgrade_is_absorbing() {
+        for event in all_events() {
+            let (s, a) = transition(FsmState::HaltedForUpgrade, event.clone());
+            assert_eq!(s, FsmState::HaltedForUpgrade, "event {:?} moved Halted", event);
+            assert!(
+                a.iter().all(|x| matches!(x, Action::LogIgnoredEvent(_))),
+                "event {:?} produced non-ignored action {:?}",
+                event,
+                a
+            );
+        }
+    }
+}

--- a/lib-types/src/consensus.rs
+++ b/lib-types/src/consensus.rs
@@ -528,7 +528,7 @@ impl<'de> serde::Deserialize<'de> for CommitAttestation {
 /// Verify the Dilithium signature against the validator's registered consensus
 /// key.  Accept the proof if >= `(2 * total_validators / 3) + 1` unique
 /// attestations verify successfully.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BftQuorumProof {
     /// Block height this proof attests to.
     pub height: u64,


### PR DESCRIPTION
## Summary
Combines the next two Phase 3 issues — \`transition()\` (CONS-302) and \`Event\`/\`Action\` enums (CONS-303) — into one PR.  The two are inseparable (the function needs the enums; the enums have no consumer without the function), and the epic specced them with a circular blocked-by which folding here resolves.

## What's in
- \`lib-consensus-core/src/fsm/events.rs\` — \`Event\` (9 variants), \`Action\` (10 variants)
- \`lib-consensus-core/src/fsm/transition.rs\` — total \`transition(state, event) -> (state, actions)\` with exhaustive matches.  No panics, no \`unreachable!\`.  Invalid-but-tolerable arrivals (late prevote in Committed, etc.) map to \`Action::LogIgnoredEvent("...")\` — explicit, never silent.
- \`lib-types::consensus::BftQuorumProof\` — added \`PartialEq + Eq\` derives so they propagate through the new enum types.

## Spec deviation: IDs instead of full proposal/vote bodies
The epic CONS-303 draft had \`Event::ReceivedProposal(ConsensusProposal)\` and \`Action::CommitBlock(ConsensusProposal, BftQuorumProof)\`. Plumbing those would require moving \`ConsensusProposal\` (and its \`ConsensusProof\`) into lib-consensus-core; \`ConsensusProof::storage_proof\` references \`lib_storage::proofs::StorageCapacityAttestation\` and adding lib-storage as a dep on lib-consensus-core is forbidden by AD-002. The same cycle blocked CONS-104 and CONS-201's deferred Scope B relocation.

Resolution here: pass \`Hash\` IDs and metadata only — the runtime layer holds proposal/vote bodies in maps (already keyed by ID) and looks them up when an \`Action\` references one. The FSM stays IO-free; storage cycle is left to whoever resolves the AD-002 boundary later. \`BftQuorumProof\` lives in lib-types (already in core's dep tree), so \`CommitQuorumReached\` / \`CommitBlock\` carry the proof directly.

Closes #2338, closes #2339.

## Test plan
- [x] \`cargo test -p lib-consensus-core --lib fsm\` — 15/15 pass, including:
  - \`transition_total_over_state_event_product\` — 8 states × 9 events = 72 pairs, every one returns a non-empty action list
  - happy path: Idle → Proposing → Prevoting → Precommitting → Committed
  - timeout-specific rejections: \`InsufficientPrevotes\`, \`InsufficientPrecommits\`, generic \`Timeout\`
  - watchdog from any active state → \`Hung\`
  - \`UpgradeSignal\` from any non-terminal state → \`HaltedForUpgrade\`
  - \`HaltedForUpgrade\` is absorbing under all events
- [x] \`cargo build --workspace\` — clean

## Not yet
- Wiring \`transition()\` into the engine — CONS-305
- \`step_entered_at\` / per-step deadlines — CONS-304
- Watchdog driver — CONS-309