### PR TITLE
feat(consensus-core): CONS-304 ConsensusRound with state + entered_at (closes #2340)

### DIFF
--- a/lib-consensus-core/src/types/mod.rs
+++ b/lib-consensus-core/src/types/mod.rs
@@ -1,7 +1,17 @@
 //! Core consensus value types.
 //!
-//! Populated by CONS-201: `ConsensusStep`, `VoteType`, `ConsensusVote`,
-//! `ConsensusProposal`, `ConsensusRound`, and the unified `ValidatorMessage`
-//! (3 variants — `Propose`, `Vote`, `Heartbeat` — collapsing the prior
-//! 3-variant `types::ValidatorMessage` and 5-variant
-//! `validators::ValidatorMessage` into one canonical wire type).
+//! Currently populated by:
+//! - **CONS-304: `ConsensusRound`** with `state: FsmState`, `entered_at:
+//!   Instant`, `deterministic_round_id: u64` and `state_age()` helper.
+//!
+//! Future relocations (deferred):
+//! - `ConsensusStep`, `VoteType`, `ConsensusVote`, `ConsensusProposal`,
+//!   and the unified `ValidatorMessage` are still hosted in lib-consensus
+//!   because `ConsensusProof::storage_proof` references
+//!   `lib_storage::proofs::StorageCapacityAttestation` and adding
+//!   lib-storage as a dep on lib-consensus-core is forbidden by AD-002.
+//!   The cycle was noted on CONS-104 and CONS-201's deferred Scope B.
+
+pub mod round;
+
+pub use round::ConsensusRound;

--- a/lib-consensus-core/src/types/round.rs
+++ b/lib-consensus-core/src/types/round.rs
@@ -1,0 +1,171 @@
+//! `ConsensusRound` — the FSM-bearing per-round state struct.
+//!
+//! Pre-rewrite the equivalent struct in
+//! `lib-consensus::types::mod::ConsensusRound` carried `step:
+//! ConsensusStep` (the wire-format phase tag) plus a thicket of
+//! separate flags for terminal conditions.  CONS-304 introduces the
+//! consensus-core version, which holds:
+//!
+//! - `state: FsmState` — the full control state, including terminal
+//!   variants (`Committed`, `Rejected(reason)`, `Hung`,
+//!   `HaltedForUpgrade`).
+//! - `height: u64`, `round: u32` — protocol identifiers (unchanged).
+//! - `entered_at: Instant` — wall-clock instant when the FSM last
+//!   entered its current state. Updated by every `enter()` call so the
+//!   watchdog (CONS-309) can observe step age in O(1).
+//! - `deterministic_round_id: u64` — replay-determinism token. Set
+//!   equal to `height` so simulators / replay harnesses can drive
+//!   reproducible runs without needing wall-clock alignment. Replaces
+//!   the old `start_time: SystemTime` field (which was used both for
+//!   determinism *and* for wall-clock metrics — two responsibilities
+//!   that CONS-304 splits).
+//!
+//! The lib-consensus mirror struct is **not** touched in this PR — that
+//! happens with the handler migration in CONS-305. Until then the two
+//! types coexist; the lib-consensus version retains the old `step` /
+//! `start_time` shape for the existing handler code.
+
+use crate::fsm::state::FsmState;
+use std::time::{Duration, Instant};
+
+/// Per-round control state for a single height/round.
+///
+/// Constructed at round entry by the runtime; consumed by the FSM
+/// transition function. The struct is `Clone` (for snapshots) and
+/// `Debug`. It is intentionally NOT `Serialize` — `Instant` has no
+/// stable serialization, and `entered_at` is wall-clock data that
+/// should never appear in audit logs or block bodies.
+#[derive(Debug, Clone)]
+pub struct ConsensusRound {
+    /// Current FSM control state. Updated only via [`Self::enter`].
+    pub state: FsmState,
+
+    /// Block height this round is producing.
+    pub height: u64,
+
+    /// Round number within the height. Incremented on view change.
+    pub round: u32,
+
+    /// Wall-clock instant the FSM last transitioned into `state`.
+    /// Maintained by [`Self::enter`]; never written from outside this
+    /// type so the watchdog can rely on it.
+    entered_at: Instant,
+
+    /// Deterministic round identifier for replay/simulation. Set equal
+    /// to `height` per the epic spec; replay harnesses use this to
+    /// drive reproducible runs that don't depend on wall-clock time.
+    pub deterministic_round_id: u64,
+}
+
+impl ConsensusRound {
+    /// Build a round in the canonical starting state (`Idle`) at the
+    /// given height with `round = 0` and `entered_at = Instant::now()`.
+    pub fn new(height: u64) -> Self {
+        Self {
+            state: FsmState::Idle,
+            height,
+            round: 0,
+            entered_at: Instant::now(),
+            deterministic_round_id: height,
+        }
+    }
+
+    /// Replace the current FSM state and reset `entered_at` to now.
+    /// All state mutations on a `ConsensusRound` MUST go through this
+    /// method so that `state_age()` is meaningful.  CONS-305 enforces
+    /// this contract by deleting the per-step `enter_*_step` methods
+    /// in lib-consensus and routing every state change through here.
+    pub fn enter(&mut self, new_state: FsmState) {
+        self.state = new_state;
+        self.entered_at = Instant::now();
+    }
+
+    /// Time elapsed since the FSM last entered its current state. Used
+    /// by the watchdog (CONS-309) to detect stuck steps.
+    pub fn state_age(&self) -> Duration {
+        self.entered_at.elapsed()
+    }
+
+    /// Public accessor for `entered_at` — exposed read-only so the
+    /// watchdog and observability code can record it without being
+    /// able to mutate it (only `enter()` can).
+    pub fn entered_at(&self) -> Instant {
+        self.entered_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fsm::state::RejectionReason;
+
+    #[test]
+    fn new_starts_in_idle() {
+        let r = ConsensusRound::new(42);
+        assert_eq!(r.state, FsmState::Idle);
+        assert_eq!(r.height, 42);
+        assert_eq!(r.round, 0);
+        assert_eq!(r.deterministic_round_id, 42);
+        // entered_at is recent.
+        assert!(r.state_age() < Duration::from_millis(50));
+    }
+
+    #[test]
+    fn enter_updates_state_and_entered_at() {
+        let mut r = ConsensusRound::new(1);
+        let initial = r.entered_at();
+        // Sleep long enough to make the change visible without being slow.
+        std::thread::sleep(Duration::from_millis(2));
+        r.enter(FsmState::Proposing);
+        assert_eq!(r.state, FsmState::Proposing);
+        assert!(r.entered_at() > initial);
+    }
+
+    /// Acceptance criterion: after a state mutation, `entered_at`
+    /// reflects call time within 1ms (epic spec). We use a slightly
+    /// looser bound so CI doesn't flake on slow runners.
+    #[test]
+    fn entered_at_reflects_call_time_within_5ms() {
+        let mut r = ConsensusRound::new(1);
+        let before = Instant::now();
+        r.enter(FsmState::Prevoting);
+        let after = Instant::now();
+        assert!(r.entered_at() >= before);
+        assert!(r.entered_at() <= after);
+        assert!(after - before < Duration::from_millis(5));
+    }
+
+    #[test]
+    fn state_age_grows_until_next_enter() {
+        let mut r = ConsensusRound::new(1);
+        r.enter(FsmState::Precommitting);
+        std::thread::sleep(Duration::from_millis(3));
+        let age1 = r.state_age();
+        assert!(age1 >= Duration::from_millis(3));
+
+        r.enter(FsmState::Committed);
+        let age2 = r.state_age();
+        assert!(age2 < age1, "enter() did not reset entered_at");
+    }
+
+    #[test]
+    fn enter_into_terminal_states_works_uniformly() {
+        // Every FsmState variant must be assignable via enter() — this
+        // protects against accidentally adding a state that requires
+        // special construction.
+        let mut r = ConsensusRound::new(1);
+        for state in [
+            FsmState::Proposing,
+            FsmState::Prevoting,
+            FsmState::Precommitting,
+            FsmState::Committed,
+            FsmState::Rejected(RejectionReason::InsufficientPrevotes),
+            FsmState::Hung,
+            FsmState::HaltedForUpgrade,
+            FsmState::Idle,
+        ] {
+            r.enter(state);
+            assert_eq!(r.state, state);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds the FSM-bearing per-round struct in \`lib-consensus-core/src/types/round.rs\`:

\`\`\`rust
pub struct ConsensusRound {
    pub state: FsmState,
    pub height: u64,
    pub round: u32,
    entered_at: Instant,                // private — mutated only via enter()
    pub deterministic_round_id: u64,    // = height for replay determinism
}
\`\`\`

The single mutating entry point is \`enter(new_state)\`, which replaces \`state\` and resets \`entered_at\`. Watchdog (CONS-309) reads \`state_age() = entered_at.elapsed()\` for stuck-step detection. Holding \`entered_at\` private guarantees the contract — only \`enter()\` can move time forward, so age is meaningful.

Splitting the original \`start_time\` field into \`deterministic_round_id\` (replay token) and \`entered_at\` (wall-clock metric) cleans up an overload where one field served both purposes.

The lib-consensus mirror struct (\`lib_consensus::types::ConsensusRound\`) is intentionally **not** touched — that migration is CONS-305 (handler rewrite). The two structs coexist until then.

Closes #2340.

## Test plan
- [x] \`cargo test -p lib-consensus-core --lib types\` — 5/5 pass:
  - \`new_starts_in_idle\`
  - \`enter_updates_state_and_entered_at\`
  - \`entered_at_reflects_call_time_within_5ms\` (acceptance criterion from epic)
  - \`state_age_grows_until_next_enter\`
  - \`enter_into_terminal_states_works_uniformly\`
- [x] \`cargo build --workspace\` — clean