### PR TITLE
feat(consensus-core): full validator FSM as deterministic Markov chain (closes #2337, #2338, #2339, #2340)

### DIFF
--- a/lib-consensus-core/src/fsm/events.rs
+++ b/lib-consensus-core/src/fsm/events.rs
@@ -27,6 +27,7 @@
 use crate::fsm::state::{HaltReason, PanicReason, RejectionReason, SlashReason};
 use lib_crypto::Hash;
 use lib_types::consensus::BftQuorumProof;
+use std::time::Instant;
 
 /// Inputs the FSM consumes during one [`transition`] call.
 ///
@@ -86,14 +87,24 @@ pub enum Event {
 
     // ----- Watchdog / panic -----
     /// Watchdog fired without observing any progress action for
-    /// longer than the configured threshold.
-    WatchdogFired { age_ms: u64 },
+    /// longer than the configured threshold. The runtime captures
+    /// `fired_at` so the FSM can record the firing instant in `Hung`
+    /// without calling `Instant::now()` itself (PR #2394 review:
+    /// keeps `transition()` time-free / pure).
+    WatchdogFired { age_ms: u64, fired_at: Instant },
 
     /// A condition that warrants entering [`ValidatorState::Panic`]
-    /// was observed.
+    /// was observed. Carries the height at which the panic fired and
+    /// the wall-clock instant captured by the runtime — both
+    /// propagate into the resulting `Panic` state so the FSM stays
+    /// time-free (PR #2394 review).
     ///
     /// [`ValidatorState::Panic`]: crate::fsm::state::ValidatorState::Panic
-    PanicTriggered { reason: PanicReason },
+    PanicTriggered {
+        reason: PanicReason,
+        triggered_at: Instant,
+        at_height: u64,
+    },
 
     /// The condition that put the FSM into Panic has cleared
     /// (recoverable panics only). Resets to `Idle`.
@@ -372,9 +383,14 @@ mod tests {
         };
         let _ = Event::VoteFailed(RejectionReason::Timeout);
         let _ = Event::Timeout;
-        let _ = Event::WatchdogFired { age_ms: 5_000 };
+        let _ = Event::WatchdogFired {
+            age_ms: 5_000,
+            fired_at: Instant::now(),
+        };
         let _ = Event::PanicTriggered {
             reason: PanicReason::WatchdogExpired,
+            triggered_at: Instant::now(),
+            at_height: 100,
         };
         let _ = Event::PanicCleared;
         let _ = Event::HaltScheduled {

--- a/lib-consensus-core/src/fsm/events.rs
+++ b/lib-consensus-core/src/fsm/events.rs
@@ -1,55 +1,58 @@
 //! FSM Event/Action vocabulary.
 //!
 //! These enums are the only way the [`transition()`] function (CONS-302)
-//! observes the outside world or expresses its decisions. The FSM:
+//! observes the outside world or expresses its decisions.
 //!
-//! - **Consumes** [`Event`] values produced by the runtime: timer firings,
-//!   admitted proposals, vote-tally thresholds, watchdog signals, upgrade
-//!   signals.
-//! - **Emits** [`Action`] values that the runtime executes:
-//!   create/broadcast a proposal, send a vote, commit a block, advance a
-//!   round, reset the watchdog, halt for upgrade.
+//! [`transition()`]: super::transition::transition
 //!
-//! The FSM never touches `tokio`, the network, the keypair, the
-//! blockchain, or wall-clock time — those side effects all flow through
-//! `Action`s and back through `Event`s.
+//! ## Naming
 //!
-//! [`transition()`]: super::transition
+//! Variant names follow the wire-level vocabulary: `Prevote`,
+//! `Precommit`, `Commit` match the `VoteType` tags carried in
+//! [`ConsensusVote`](crate::types). Higher-level documentation may
+//! describe phases as "Voting / Finalizing / Committed" but internal
+//! state and event names stay close to the wire so there's a single
+//! consistent vocabulary across the whole stack.
 //!
-//! # Why IDs and not full `ConsensusProposal`/`ConsensusVote`
+//! ## Why IDs and not full `ConsensusProposal`/`ConsensusVote`
 //!
-//! The CONS-303 epic draft suggested `Event::ReceivedProposal(ConsensusProposal)`
-//! / `Action::CommitBlock(ConsensusProposal, BftQuorumProof)`.  Plumbing
-//! the full proposal type through the FSM would require moving
-//! `ConsensusProposal` (and its `ConsensusProof`) into lib-consensus-core,
-//! and `ConsensusProof::storage_proof` references
+//! `ConsensusProposal::consensus_proof::storage_proof` references
 //! `lib_storage::proofs::StorageCapacityAttestation`. Adding lib-storage
-//! as a dep on lib-consensus-core is forbidden by AD-002 (see `lib.rs`).
-//!
-//! The cycle was already noted on CONS-104 review and CONS-201's deferred
-//! Scope B.  Until the StorageCapacityAttestation home is resolved, the
-//! FSM operates on `Hash` IDs only — the runtime holds the proposal/vote
-//! bodies (already keyed by ID in the engine's existing maps) and looks
-//! them up when an `Action` references one.
+//! as a dep on lib-consensus-core is forbidden by AD-002. Until the
+//! StorageCapacityAttestation home is resolved (deferred from CONS-104
+//! and CONS-201), the FSM operates on `Hash` IDs only. The runtime
+//! holds proposal/vote bodies and looks them up when an `Action`
+//! references one.
 
-use crate::fsm::state::RejectionReason;
+use crate::fsm::state::{HaltReason, PanicReason, RejectionReason, SlashReason};
 use lib_crypto::Hash;
 use lib_types::consensus::BftQuorumProof;
-use serde::{Deserialize, Serialize};
 
 /// Inputs the FSM consumes during one [`transition`] call.
 ///
 /// Produced by the runtime (timers, vote pool, network, watchdog) and
-/// fed to the FSM in arrival order.  The runtime is responsible for
-/// pre-validating each event before delivery: the FSM trusts that an
-/// `ProposalAdmitted` has already passed signature and proposer checks,
-/// that a `*ThresholdReached` has already counted +2/3 by stake.
+/// fed to the FSM in arrival order. The runtime is responsible for
+/// pre-validating each event before delivery: the FSM trusts that a
+/// `ProposalAdmitted` has already passed signature and proposer
+/// checks, that a `*ThresholdReached` has already counted +2/3 by
+/// stake.
 ///
 /// [`transition`]: super::transition::transition
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
+    // ----- Lifecycle -----
+    /// Genesis bootstrap finished; local state initialised.
+    BootstrapComplete,
+
+    /// Catch-up sync reached the network tip.
+    CaughtUp,
+
+    /// Operator-initiated graceful shutdown.
+    ShutdownRequested,
+
+    // ----- Active consensus -----
     /// The local validator was elected proposer for the current
-    /// (height, round). Engine should produce a proposal.
+    /// (height, round).
     SelectedAsProposer { height: u64, round: u32 },
 
     /// A proposal arrived and passed all pre-FSM validation
@@ -60,14 +63,14 @@ pub enum Event {
         round: u32,
     },
 
-    /// The vote pool counted +2/3 prevotes by stake for `block_id`.
+    /// Vote pool counted +2/3 PreVotes for `block_id`.
     PrevoteThresholdReached { block_id: Hash },
 
-    /// The vote pool counted +2/3 precommits by stake for `block_id`.
+    /// Vote pool counted +2/3 PreCommits for `block_id`.
     PrecommitThresholdReached { block_id: Hash },
 
-    /// A `BftQuorumProof` was assembled from the precommit votes.
-    /// Carries the proof so the runtime can finalize without re-aggregating.
+    /// Vote pool counted +2/3 Commit votes and assembled a
+    /// `BftQuorumProof` — block ready for finalization.
     CommitQuorumReached {
         block_id: Hash,
         quorum: BftQuorumProof,
@@ -76,78 +79,282 @@ pub enum Event {
     /// Vote tallying ended without quorum, with a specific reason.
     VoteFailed(RejectionReason),
 
-    /// A step-level timeout fired (Propose, PreVote, or PreCommit).
-    /// The FSM resolves the appropriate [`RejectionReason`] internally.
+    /// A step-level timeout fired. The FSM walks Proposing →
+    /// Prevoting → Precommitting → Committed; only Committed-phase
+    /// timeouts trigger a view change.
     Timeout,
 
-    /// The watchdog (CONS-309) fired without observing any progress
-    /// action for longer than the configured threshold.
+    // ----- Watchdog / panic -----
+    /// Watchdog fired without observing any progress action for
+    /// longer than the configured threshold.
     WatchdogFired { age_ms: u64 },
 
-    /// External signal that the operator has scheduled a halt at a
-    /// specific height for protocol upgrade (CONS-203 cutover).
-    UpgradeSignal { halt_at_height: u64 },
+    /// A condition that warrants entering [`ValidatorState::Panic`]
+    /// was observed.
+    ///
+    /// [`ValidatorState::Panic`]: crate::fsm::state::ValidatorState::Panic
+    PanicTriggered { reason: PanicReason },
+
+    /// The condition that put the FSM into Panic has cleared
+    /// (recoverable panics only). Resets to `Idle`.
+    PanicCleared,
+
+    // ----- Operator coordination -----
+    /// Operator scheduled a halt at `triggered_at_height` for `reason`.
+    HaltScheduled {
+        reason: HaltReason,
+        triggered_at_height: u64,
+        resume_condition: ResumeConditionEvent,
+    },
+
+    /// Halt window reached; transition Halting → CoordinatedUpdate.
+    HaltActivated {
+        activate_at_height: u64,
+        target_version: u32,
+    },
+
+    /// 2/3+ validators reported ready on the new protocol version.
+    UpdateQuorumReady,
+
+    // ----- Punishment -----
+    /// Validator was slashed for `reason`.
+    SlashEvidenceConfirmed { reason: SlashReason },
+
+    /// Validator was removed from the active set.
+    EvictedFromSet,
+
+    /// Validator was re-admitted to the active set after slashing
+    /// or eviction.
+    ReadmittedToSet,
+}
+
+/// Wire-friendly companion of [`crate::fsm::state::ResumeCondition`]
+/// for events. Identical variants; named distinctly so `Event` types
+/// stay self-contained without a circular re-export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResumeConditionEvent {
+    ManualRestart,
+    QuorumReady,
+    UpgradeComplete,
+    Never,
+}
+
+impl From<ResumeConditionEvent> for crate::fsm::state::ResumeCondition {
+    fn from(e: ResumeConditionEvent) -> Self {
+        use crate::fsm::state::ResumeCondition::*;
+        match e {
+            ResumeConditionEvent::ManualRestart => ManualRestart,
+            ResumeConditionEvent::QuorumReady => QuorumReady,
+            ResumeConditionEvent::UpgradeComplete => UpgradeComplete,
+            ResumeConditionEvent::Never => Never,
+        }
+    }
 }
 
 /// Outputs the FSM emits during one [`transition`] call.
 ///
-/// The runtime executes these in order. Side effects (broadcast, finalize,
-/// log) are encapsulated here so the FSM stays IO-free per AD-002.
+/// The runtime executes these in order. Side effects (broadcast,
+/// finalize, log, panic-broadcast, log-flush) are encapsulated here
+/// so the FSM stays IO-free per AD-002.
 ///
 /// [`transition`]: super::transition::transition
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
-    /// Build a fresh proposal for the current (height, round) and feed
-    /// the resulting `ProposalAdmitted` event back to the FSM.
+    // ----- Lifecycle -----
+    /// Begin downloading state from genesis.
+    StartBootstrap,
+
+    /// Begin catch-up sync from the local height to network tip.
+    StartCatchUp,
+
+    /// Flush logs, persist any in-flight state, prepare for exit.
+    FlushLogsForShutdown,
+
+    // ----- Active consensus -----
+    /// Build a fresh proposal for the current (height, round).
     CreateProposal,
 
     /// Broadcast the proposal identified by `id` to all peers.
     BroadcastProposal { id: Hash },
 
-    /// Sign and send a prevote for `block_id` to all peers.
+    /// Sign and send a `VoteType::PreVote` for `block_id`.
     SendPrevote { block_id: Hash },
 
-    /// Sign and send a precommit for `block_id` to all peers.
+    /// Sign and send a `VoteType::PreCommit` for `block_id`.
     SendPrecommit { block_id: Hash },
 
-    /// Commit the block identified by `id` using the supplied quorum
-    /// proof — calls `BlockFinalizationSink` on the runtime.
-    CommitBlock {
-        id: Hash,
-        quorum: BftQuorumProof,
-    },
+    /// Sign and send a `VoteType::Commit` for `block_id`.
+    SendCommit { block_id: Hash },
 
-    /// Increment the round counter and reset to `FsmState::Idle` for
-    /// (height, round + 1). View change.
+    /// Finalize the block identified by `id` using the supplied
+    /// quorum proof — calls `BlockFinalizationSink` on the runtime.
+    CommitBlock { id: Hash, quorum: BftQuorumProof },
+
+    /// Increment the round counter. Resets the FSM to `Idle` for
+    /// (height, round + 1).
     AdvanceRound,
 
     /// Reset the watchdog timer because progress was made.
     ResetWatchdog,
 
-    /// Stop admitting messages and stay in `HaltedForUpgrade` until the
-    /// operator restarts the node with the bumped protocol version.
-    HaltForUpgrade,
+    // ----- Operator coordination -----
+    /// Stop accepting new heights at `at_height`. Emitted on
+    /// `HaltScheduled`.
+    StopBlockProduction { at_height: u64 },
+
+    /// Begin the post-halt barrier — wait for `UpdateQuorumReady` at
+    /// the activation height.
+    EnterUpdateBarrier { activate_at_height: u64, target_version: u32 },
+
+    /// Announce readiness to peers on the new protocol version.
+    BroadcastReadyOnNewVersion { version: u32 },
+
+    // ----- Punishment / safety -----
+    /// Drop out of the active validator set; stop emitting votes.
+    LeaveActiveSet,
+
+    /// Re-enter the active set after slashing window / re-registration.
+    RejoinActiveSet,
+
+    /// Broadcast `Panic` notice to peers so they can save logs and
+    /// prepare for this validator's shutdown.
+    BroadcastPanic { reason: PanicReason },
+
+    /// Emit observability event with the given panic reason and the
+    /// prior state's kind.
+    LogPanic { reason: PanicReason },
 
     /// Emit a `Hung` observability event with the given reason.
     LogHung { reason: &'static str },
 
-    /// Emit an "ignored event" observability log — used when an event
-    /// arrives in a state where it has no effect (e.g. late prevote
-    /// after `Committed`). Explicit instead of silent.
+    /// Emit an "ignored event" observability log — used when an
+    /// event arrives in a state where it has no effect (e.g. late
+    /// vote in `Idle`). Explicit instead of silent.
     LogIgnoredEvent(&'static str),
+}
+
+/// Discriminant of [`Event`] without payload data. Used by the
+/// transition table for runtime queries and diagram generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EventKind {
+    BootstrapComplete,
+    CaughtUp,
+    ShutdownRequested,
+    SelectedAsProposer,
+    ProposalAdmitted,
+    PrevoteThresholdReached,
+    PrecommitThresholdReached,
+    CommitQuorumReached,
+    VoteFailed,
+    Timeout,
+    WatchdogFired,
+    PanicTriggered,
+    PanicCleared,
+    HaltScheduled,
+    HaltActivated,
+    UpdateQuorumReady,
+    SlashEvidenceConfirmed,
+    EvictedFromSet,
+    ReadmittedToSet,
+}
+
+impl Event {
+    pub fn kind(&self) -> EventKind {
+        match self {
+            Event::BootstrapComplete => EventKind::BootstrapComplete,
+            Event::CaughtUp => EventKind::CaughtUp,
+            Event::ShutdownRequested => EventKind::ShutdownRequested,
+            Event::SelectedAsProposer { .. } => EventKind::SelectedAsProposer,
+            Event::ProposalAdmitted { .. } => EventKind::ProposalAdmitted,
+            Event::PrevoteThresholdReached { .. } => EventKind::PrevoteThresholdReached,
+            Event::PrecommitThresholdReached { .. } => EventKind::PrecommitThresholdReached,
+            Event::CommitQuorumReached { .. } => EventKind::CommitQuorumReached,
+            Event::VoteFailed(_) => EventKind::VoteFailed,
+            Event::Timeout => EventKind::Timeout,
+            Event::WatchdogFired { .. } => EventKind::WatchdogFired,
+            Event::PanicTriggered { .. } => EventKind::PanicTriggered,
+            Event::PanicCleared => EventKind::PanicCleared,
+            Event::HaltScheduled { .. } => EventKind::HaltScheduled,
+            Event::HaltActivated { .. } => EventKind::HaltActivated,
+            Event::UpdateQuorumReady => EventKind::UpdateQuorumReady,
+            Event::SlashEvidenceConfirmed { .. } => EventKind::SlashEvidenceConfirmed,
+            Event::EvictedFromSet => EventKind::EvictedFromSet,
+            Event::ReadmittedToSet => EventKind::ReadmittedToSet,
+        }
+    }
+}
+
+/// Discriminant of [`Action`] without payload data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ActionKind {
+    StartBootstrap,
+    StartCatchUp,
+    FlushLogsForShutdown,
+    CreateProposal,
+    BroadcastProposal,
+    SendPrevote,
+    SendPrecommit,
+    SendCommit,
+    CommitBlock,
+    AdvanceRound,
+    ResetWatchdog,
+    StopBlockProduction,
+    EnterUpdateBarrier,
+    BroadcastReadyOnNewVersion,
+    LeaveActiveSet,
+    RejoinActiveSet,
+    BroadcastPanic,
+    LogPanic,
+    LogHung,
+    LogIgnoredEvent,
+}
+
+impl Action {
+    pub fn kind(&self) -> ActionKind {
+        match self {
+            Action::StartBootstrap => ActionKind::StartBootstrap,
+            Action::StartCatchUp => ActionKind::StartCatchUp,
+            Action::FlushLogsForShutdown => ActionKind::FlushLogsForShutdown,
+            Action::CreateProposal => ActionKind::CreateProposal,
+            Action::BroadcastProposal { .. } => ActionKind::BroadcastProposal,
+            Action::SendPrevote { .. } => ActionKind::SendPrevote,
+            Action::SendPrecommit { .. } => ActionKind::SendPrecommit,
+            Action::SendCommit { .. } => ActionKind::SendCommit,
+            Action::CommitBlock { .. } => ActionKind::CommitBlock,
+            Action::AdvanceRound => ActionKind::AdvanceRound,
+            Action::ResetWatchdog => ActionKind::ResetWatchdog,
+            Action::StopBlockProduction { .. } => ActionKind::StopBlockProduction,
+            Action::EnterUpdateBarrier { .. } => ActionKind::EnterUpdateBarrier,
+            Action::BroadcastReadyOnNewVersion { .. } => ActionKind::BroadcastReadyOnNewVersion,
+            Action::LeaveActiveSet => ActionKind::LeaveActiveSet,
+            Action::RejoinActiveSet => ActionKind::RejoinActiveSet,
+            Action::BroadcastPanic { .. } => ActionKind::BroadcastPanic,
+            Action::LogPanic { .. } => ActionKind::LogPanic,
+            Action::LogHung { .. } => ActionKind::LogHung,
+            Action::LogIgnoredEvent(_) => ActionKind::LogIgnoredEvent,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Sanity check that every Event variant is constructible.
+    fn dummy_quorum() -> BftQuorumProof {
+        BftQuorumProof {
+            height: 0,
+            proposal_id: [0u8; 32],
+            total_validators: 0,
+            attestations: Vec::new(),
+        }
+    }
+
     #[test]
     fn all_event_variants_constructible() {
-        let _ = Event::SelectedAsProposer {
-            height: 1,
-            round: 0,
-        };
+        let _ = Event::BootstrapComplete;
+        let _ = Event::CaughtUp;
+        let _ = Event::ShutdownRequested;
+        let _ = Event::SelectedAsProposer { height: 1, round: 0 };
         let _ = Event::ProposalAdmitted {
             id: Hash([1u8; 32]),
             height: 1,
@@ -161,22 +368,37 @@ mod tests {
         };
         let _ = Event::CommitQuorumReached {
             block_id: Hash([4u8; 32]),
-            quorum: BftQuorumProof {
-                height: 0,
-                proposal_id: [0u8; 32],
-                total_validators: 0,
-                attestations: Vec::new(),
-            },
+            quorum: dummy_quorum(),
         };
         let _ = Event::VoteFailed(RejectionReason::Timeout);
         let _ = Event::Timeout;
         let _ = Event::WatchdogFired { age_ms: 5_000 };
-        let _ = Event::UpgradeSignal { halt_at_height: 100 };
+        let _ = Event::PanicTriggered {
+            reason: PanicReason::WatchdogExpired,
+        };
+        let _ = Event::PanicCleared;
+        let _ = Event::HaltScheduled {
+            reason: HaltReason::UpgradeScheduled,
+            triggered_at_height: 100,
+            resume_condition: ResumeConditionEvent::QuorumReady,
+        };
+        let _ = Event::HaltActivated {
+            activate_at_height: 100,
+            target_version: 2,
+        };
+        let _ = Event::UpdateQuorumReady;
+        let _ = Event::SlashEvidenceConfirmed {
+            reason: SlashReason::DoubleSign,
+        };
+        let _ = Event::EvictedFromSet;
+        let _ = Event::ReadmittedToSet;
     }
 
-    /// Sanity check that every Action variant is constructible.
     #[test]
     fn all_action_variants_constructible() {
+        let _ = Action::StartBootstrap;
+        let _ = Action::StartCatchUp;
+        let _ = Action::FlushLogsForShutdown;
         let _ = Action::CreateProposal;
         let _ = Action::BroadcastProposal { id: Hash([1u8; 32]) };
         let _ = Action::SendPrevote {
@@ -185,21 +407,43 @@ mod tests {
         let _ = Action::SendPrecommit {
             block_id: Hash([3u8; 32]),
         };
+        let _ = Action::SendCommit {
+            block_id: Hash([4u8; 32]),
+        };
         let _ = Action::CommitBlock {
-            id: Hash([4u8; 32]),
-            quorum: BftQuorumProof {
-                height: 0,
-                proposal_id: [0u8; 32],
-                total_validators: 0,
-                attestations: Vec::new(),
-            },
+            id: Hash([5u8; 32]),
+            quorum: dummy_quorum(),
         };
         let _ = Action::AdvanceRound;
         let _ = Action::ResetWatchdog;
-        let _ = Action::HaltForUpgrade;
-        let _ = Action::LogHung {
-            reason: "test",
+        let _ = Action::StopBlockProduction { at_height: 100 };
+        let _ = Action::EnterUpdateBarrier {
+            activate_at_height: 100,
+            target_version: 2,
         };
+        let _ = Action::BroadcastReadyOnNewVersion { version: 2 };
+        let _ = Action::LeaveActiveSet;
+        let _ = Action::RejoinActiveSet;
+        let _ = Action::BroadcastPanic {
+            reason: PanicReason::DoubleVote,
+        };
+        let _ = Action::LogPanic {
+            reason: PanicReason::DoubleVote,
+        };
+        let _ = Action::LogHung { reason: "test" };
         let _ = Action::LogIgnoredEvent("test");
+    }
+
+    #[test]
+    fn kinds_round_trip_correctly() {
+        let pairs: Vec<(Event, EventKind)> = vec![
+            (Event::BootstrapComplete, EventKind::BootstrapComplete),
+            (Event::Timeout, EventKind::Timeout),
+            (Event::PanicCleared, EventKind::PanicCleared),
+            (Event::UpdateQuorumReady, EventKind::UpdateQuorumReady),
+        ];
+        for (e, k) in pairs {
+            assert_eq!(e.kind(), k);
+        }
     }
 }

--- a/lib-consensus-core/src/fsm/mod.rs
+++ b/lib-consensus-core/src/fsm/mod.rs
@@ -1,17 +1,37 @@
-//! `ValidatorFsm` — total `transition(state, event) -> (next_state, actions)`.
+//! Validator FSM — deterministic Markov chain over `ValidatorState`.
+//!
+//! Two equivalent representations of the same transition matrix:
+//!
+//! - **`transition()`** — pure match function, compile-time exhaustive
+//!   over `(ValidatorState, Event)`.  Executable.
+//! - **`transition_table()`** — runtime-queryable `Vec<TransitionRule>`
+//!   with `(from_kind, event_kind, to_kind, action_kinds, doc)` rows.
+//!   Inspectable.
+//!
+//! Tests in `transition_table` enforce that the two never drift —
+//! every row must match what `transition()` produces.
 //!
 //! Populated by:
-//! - **CONS-301: `FsmState` enum** (Idle, Proposing, Prevoting, Precommitting,
-//!   Committed, Rejected, Hung, HaltedForUpgrade) ← shipped.
-//! - **CONS-302: total `transition()`** with compile-time exhaustiveness ← shipped.
-//! - **CONS-303: `Event` and `Action` enums** ← shipped (with the simplification
-//!   noted in `events.rs`: IDs instead of full `ConsensusProposal`/`Vote`).
-//! - CONS-304: `step_entered_at: Instant` in the FSM struct.
+//! - **CONS-301: `ValidatorState`** — 15-variant control-state enum
+//!   plus `RejectionReason`, `HaltReason`, `ResumeCondition`,
+//!   `PanicReason`, `SlashReason` reason enums.
+//! - **CONS-302: `transition()`** — total match function, no panics.
+//! - **CONS-303: `Event` and `Action`** — input and output vocabulary
+//!   plus `EventKind` / `ActionKind` discriminants for the table.
+//! - **CONS-303 (Markov chain): `transition_table()`** — data-driven
+//!   enumeration of every transition with `transitions_from(state)`
+//!   and `transitions_by_event(event)` query helpers.
+//! - CONS-304: `step_entered_at` / FSM struct (see `crate::types::round`).
 
 pub mod events;
 pub mod state;
 pub mod transition;
+pub mod transition_table;
 
-pub use events::{Action, Event};
-pub use state::{FsmState, RejectionReason};
+pub use events::{Action, ActionKind, Event, EventKind, ResumeConditionEvent};
+pub use state::{
+    HaltReason, PanicReason, RejectionReason, ResumeCondition, SlashReason, ValidatorState,
+    ValidatorStateKind,
+};
 pub use transition::transition;
+pub use transition_table::{transition_table, transitions_by_event, transitions_from, TransitionRule};

--- a/lib-consensus-core/src/fsm/state.rs
+++ b/lib-consensus-core/src/fsm/state.rs
@@ -1,172 +1,400 @@
-//! FSM state types for the consensus validator.
+//! `ValidatorState` — the full validator FSM control state.
 //!
-//! These types describe the *control state* of a single validator FSM
-//! at a single (height, round). They replace the implicit state machine
-//! that previously lived in `lib_consensus::engines::consensus_engine`
-//! as a soup of [`ConsensusStep`] checks, timer flags, and ad-hoc
-//! "is this round dead yet?" booleans.
+//! Designed as a deterministic Markov chain: every `(state, event)`
+//! pair maps to exactly one `(next_state, actions)` tuple, computed by
+//! the pure [`transition()`] function. The same set of transitions is
+//! also exposed as a runtime-queryable data table in
+//! [`super::transition_table`] for diagrams, fuzzing, and operator
+//! tooling — both forms are kept in sync by tests.
 //!
-//! [`ConsensusStep`]: crate::types
+//! [`transition()`]: super::transition::transition
 //!
-//! # State diagram
+//! ## State landscape
+//!
+//! Active consensus phases (one round-trip per height):
 //!
 //! ```text
-//!                              ┌──────────────────────────┐
-//!                              │                          ▼
-//! ┌──────┐  StartRound   ┌──────────┐  ProposalAccepted  ┌────────────┐
-//! │ Idle │──────────────▶│ Proposing│───────────────────▶│ Prevoting  │
-//! └──────┘               └──────────┘                    └─────┬──────┘
-//!     ▲                       │                                │
-//!     │ NewRound /             │ Timeout / InvalidProposal     │ +2/3 prevotes
-//!     │ HeightAdvance          ▼                               ▼
-//!     │                  ┌──────────┐                   ┌───────────────┐
-//!     │                  │ Rejected │                   │ Precommitting │
-//!     │                  │ (reason) │                   └────┬──────────┘
-//!     │                  └──────────┘                        │
-//!     │                       │                              │ +2/3 precommits
-//!     │                       │                              ▼
-//!     │                       │                        ┌───────────┐
-//!     │                       │                        │ Committed │
-//!     │                       │                        └───────────┘
-//!     │                       │
-//!     │              ┌────────┴─────────┐
-//!     │              ▼                  ▼
-//!     │         ┌─────────┐    ┌───────────────────┐
-//!     └─────────│  Hung   │    │ HaltedForUpgrade  │
-//!               └─────────┘    └───────────────────┘
-//!     watchdog timeout      protocol-version mismatch
+//! Idle ─→ Proposing ─→ Prevoting ─→ Precommitting ─→ Committed ─→ Idle (next height)
 //! ```
 //!
-//! # Variant invariants
+//! The phase names match the wire-level `VoteType` (PreVote, PreCommit,
+//! Commit) so internal control state and on-the-wire vote tags stay
+//! consistent. Walk-through timeout semantics (see [`transition()`])
+//! mirror the existing Sovereign engine: each phase before
+//! `Committed` advances on timeout to the next phase; only
+//! `Committed.Timeout` triggers `Rejected` + view change.
 //!
-//! - **`Idle`** — between rounds. No timers running, no votes admitted.
-//! - **`Proposing`** — leader's window to broadcast a proposal. Followers
-//!   accept proposals from the height-elected proposer; non-followers wait.
-//! - **`Prevoting`** — proposal admitted; collecting prevotes. Exits to
-//!   `Precommitting` on +2/3 prevotes for a single block, or to `Rejected`
-//!   on timeout / nil-vote quorum.
-//! - **`Precommitting`** — exits to `Committed` on +2/3 precommits, or to
-//!   `Rejected` on timeout.
-//! - **`Committed`** — terminal-success for the round; the height advances
-//!   and the FSM resets to `Idle` for the next height.
-//! - **`Rejected(reason)`** — terminal-failure for the round; the round
-//!   number advances (view change) and the FSM transitions to `Idle` with
-//!   the same height. Carries the `RejectionReason` for observability.
-//! - **`Hung`** — the watchdog timed out (CONS-309) without any progress
-//!   action being emitted. Terminal until external recovery.
-//! - **`HaltedForUpgrade`** — protocol-version mismatch detected. The FSM
-//!   stops admitting messages until operator intervention bumps the local
-//!   `CONSENSUS_PROTOCOL_VERSION` and restarts the node.
+//! Lifecycle states (entry/exit at the network boundary):
 //!
-//! # Why this enum and not `ConsensusStep`
+//! - [`Bootstrapping`] — first-ever start, no local state, downloading
+//!   from genesis.
+//! - [`CatchingUp`] — local state exists, height behind peers; sync to
+//!   the tip then transition to `Idle`.
+//! - [`ShuttingDown`] — graceful exit. Logs flushed; no more events
+//!   processed.
 //!
-//! `ConsensusStep` (Propose / PreVote / PreCommit / Commit / NewRound) is
-//! the *wire-format* phase tag used in vote messages and audit logs. It
-//! cannot represent terminal states (`Committed`, `Rejected`, `Hung`,
-//! `HaltedForUpgrade`) — those were tracked separately as flags on the
-//! engine, which is what the rewrite is consolidating. `FsmState` carries
-//! the full control state so the `transition()` function (CONS-302) can be
-//! total: `(state, event) -> (state, actions)` with no implicit branches.
+//! Failure / coordination states:
+//!
+//! - [`Rejected`] — a round terminated without finalization. Transient
+//!   between rounds; runtime resets to `Idle` at `round + 1`.
+//! - [`Hung`] — the watchdog detected no progress; carries the prior
+//!   state and `since` timestamp so the runtime can decide whether
+//!   to recover or escalate.
+//! - [`Halting`] — operator-coordinated halt at a specific height
+//!   (upgrade scheduled, emergency, fork detected). Block production
+//!   stops at `triggered_at_height`.
+//! - [`CoordinatedUpdate`] — second phase of a planned upgrade: the
+//!   *new* binary is running and waiting at a barrier height for
+//!   quorum readiness. On quorum-ready: transition to `Idle` on the
+//!   new protocol version.
+//! - [`Slashed`] — validator was punished; out of the active set
+//!   until the slashing window closes.
+//! - [`Evicted`] — validator was removed from the active set
+//!   (insufficient stake, repeated misbehavior, etc.). Terminal until
+//!   re-admission via re-registration.
+//! - [`Panic`] — runtime detected a critical error (Byzantine
+//!   evidence, state corruption, OOM, …). Carries the prior state so
+//!   recovery can re-enter where the FSM was. Recoverable panics
+//!   reset to `Idle`; non-recoverable force a transition to `Halting`
+//!   with `ResumeCondition::Never`.
+//!
+//! [`Bootstrapping`]: ValidatorState::Bootstrapping
+//! [`CatchingUp`]: ValidatorState::CatchingUp
+//! [`ShuttingDown`]: ValidatorState::ShuttingDown
+//! [`Rejected`]: ValidatorState::Rejected
+//! [`Hung`]: ValidatorState::Hung
+//! [`Halting`]: ValidatorState::Halting
+//! [`CoordinatedUpdate`]: ValidatorState::CoordinatedUpdate
+//! [`Slashed`]: ValidatorState::Slashed
+//! [`Evicted`]: ValidatorState::Evicted
+//! [`Panic`]: ValidatorState::Panic
 
-use serde::{Deserialize, Serialize};
+use std::time::Instant;
 
-/// Why a round transitioned to [`FsmState::Rejected`].
-///
-/// Produced by `transition()` (CONS-302) when a round terminates without
-/// reaching `Committed`. Each variant maps to a distinct timeout or
-/// validation failure observed by the FSM.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// Why a round terminated in [`ValidatorState::Rejected`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RejectionReason {
-    /// Prevote step ended without a +2/3 quorum for any single block.
-    /// Either the prevote timeout fired, or +2/3 prevoted nil.
+    /// Prevote phase ended without +2/3 prevotes for any single block.
     InsufficientPrevotes,
-
-    /// Precommit step ended without a +2/3 quorum for any single block.
-    /// Either the precommit timeout fired, or +2/3 precommitted nil.
+    /// Precommit phase ended without +2/3 precommits for any single block.
     InsufficientPrecommits,
-
-    /// A step-level timeout fired during `Proposing` or while waiting for
-    /// the proposer's first message. Distinct from quorum-shortfall
-    /// timeouts (which use the more specific `InsufficientPre*` reasons).
+    /// Generic / unspecified timeout-driven rejection — surfaces only
+    /// from explicit `VoteFailed(Timeout)` injections.
     Timeout,
-
-    /// The proposal failed local validation: bad signature, wrong proposer
-    /// for (height, round), bad parent hash, malformed block data, etc.
-    /// The proposal is rejected before any prevote is cast.
+    /// The proposal failed local validation: bad signature, wrong
+    /// proposer for (height, round), bad parent hash, malformed block.
     InvalidBlock,
 }
 
-/// Control state of a single validator FSM at a single (height, round).
-///
-/// See the module-level state diagram for transitions. Pre-rewrite the
-/// equivalent state was distributed across `ConsensusRound.step` (the
-/// happy-path tag) plus several boolean flags for terminal conditions —
-/// `FsmState` consolidates them into a single enum so `transition()`
-/// (CONS-302) can be total.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum FsmState {
-    /// No active round at the current height.  Entered at startup and
-    /// after each round-completion event.
-    Idle,
-
-    /// The local validator (or a remote validator we follow) is in the
-    /// proposal window. The FSM waits for either a valid proposal from
-    /// the elected proposer or a propose-timeout.
-    Proposing,
-
-    /// A valid proposal was admitted.  The FSM accepts and tallies
-    /// prevotes; exits when a single block clears the +2/3 prevote
-    /// threshold or the prevote step times out.
-    Prevoting,
-
-    /// +2/3 prevotes observed for a single block. The FSM accepts and
-    /// tallies precommits; exits when the same block clears the +2/3
-    /// precommit threshold or the precommit step times out.
-    Precommitting,
-
-    /// +2/3 precommits observed for a single block at this round. This
-    /// height is committed; the FSM resets to `Idle` for the next height.
-    /// Terminal-success.
-    Committed,
-
-    /// The round terminated without reaching `Committed`. The FSM
-    /// transitions back to `Idle` with `round + 1` (view change) at the
-    /// same height. Terminal-failure for this round only.
-    Rejected(RejectionReason),
-
-    /// The watchdog (CONS-309) detected no progress action emitted for
-    /// `WATCHDOG_THRESHOLD_MULTIPLIER × max_step_timeout` and halted the
-    /// FSM. Terminal until external recovery.
-    Hung,
-
-    /// A protocol-version mismatch was detected (e.g. peer running v1 vs
-    /// local v2). The FSM stops admitting messages until the operator
-    /// resolves the mismatch.  Terminal until external intervention.
-    HaltedForUpgrade,
+/// Why an operator initiated a coordinated halt (or one fired).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HaltReason {
+    /// Scheduled protocol upgrade — operators bumping
+    /// `CONSENSUS_PROTOCOL_VERSION` and restarting binaries.
+    UpgradeScheduled,
+    /// Operator-triggered emergency halt.
+    EmergencyHalt,
+    /// End-of-epoch barrier (validator set change, parameter change).
+    EpochBoundary,
+    /// Consensus stuck for too long; manual halt to investigate.
+    ConsensusFailure,
+    /// Active validator count fell below the safety threshold.
+    InsufficientValidators,
+    /// Two committed blocks at the same height observed — fork.
+    ForkDetected,
 }
 
-impl FsmState {
-    /// Returns true for states that the FSM does not exit on its own.
-    /// `Committed` and `Rejected` round-trip back to `Idle`; `Hung` and
-    /// `HaltedForUpgrade` require external recovery.
-    pub fn is_terminal(&self) -> bool {
+/// What it takes to leave [`ValidatorState::Halting`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResumeCondition {
+    /// Operator must restart the node manually.
+    ManualRestart,
+    /// 2/3+ validators report ready (used after coordinated upgrade).
+    QuorumReady,
+    /// Specific upgrade target version reached and validated.
+    UpgradeComplete,
+    /// No automatic resume — terminal until manual `--force` flag.
+    Never,
+}
+
+/// Why a validator entered [`ValidatorState::Panic`]. Broadest
+/// possible coverage — every panic-able runtime condition has a tag.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PanicReason {
+    // ----- Consensus safety -----
+    /// Same validator double-voted at the same (height, round).
+    DoubleVote,
+    /// A non-elected validator broadcast a proposal.
+    UnauthorizedProposer,
+    /// Equivocation or other Byzantine vote pattern detected.
+    ByzantineVoteDetected,
+    /// A slashable offense was committed by a peer or self.
+    SlashableOffense,
+    /// Two committed blocks at the same height — chain fork.
+    ConflictingCommits,
+
+    // ----- Liveness -----
+    /// Watchdog timeout fired without any progress signal.
+    WatchdogExpired,
+    /// Heartbeat from required peer missed beyond threshold.
+    HeartbeatMissed,
+    /// Block production halted for longer than tolerated.
+    BlockProductionStopped,
+    /// Active peer count below the BFT safety threshold.
+    PeerCountBelowThreshold,
+
+    // ----- State integrity -----
+    /// Internal state machine reached an impossible state.
+    StateMachineCorrupted,
+    /// Local height regressed (saw lower height than committed).
+    HeightRegression { expected: u64, got: u64 },
+    /// Local round regressed within a height.
+    RoundRegression { expected: u32, got: u32 },
+    /// `transition()` called with an impossible (state, event) — the
+    /// match is exhaustive so this should never fire; catching it as
+    /// a panic preserves the totality contract instead of unreachable!.
+    InvalidTransition { from: String, event: String },
+
+    // ----- Network -----
+    /// Gossip publish failed beyond retry budget.
+    GossipFailure,
+    /// Mesh partition detected (split-brain risk).
+    MeshPartition,
+    /// Required peer unreachable beyond timeout.
+    PeerUnreachable,
+
+    // ----- Runtime -----
+    /// A core async channel closed unexpectedly.
+    ChannelClosed,
+    /// Out-of-memory condition observed.
+    OOMDetected,
+    /// Disk write failed because storage is full.
+    DiskFull,
+    /// `std::panic` caught at the consensus task boundary.
+    PanicCaught { message: String },
+
+    // ----- Upgrade -----
+    /// Peer ran a different protocol version.
+    VersionMismatch { expected: String, got: String },
+    /// Halting state did not transition to CoordinatedUpdate within
+    /// the configured timeout.
+    HaltTimeout,
+    /// CoordinatedUpdate barrier did not reach quorum-ready.
+    UpgradeQuorumNotReached,
+
+    // ----- Security -----
+    /// Inbound message claimed an identity not in the validator set.
+    UnknownValidator,
+    /// Cryptographic signature verification failed for a proposal or
+    /// vote that should have been signed.
+    SignatureVerificationFailed,
+}
+
+impl PanicReason {
+    /// Recoverable panics reset to `Idle` after the runtime drains;
+    /// non-recoverable panics force a transition to
+    /// `Halting { resume_condition: Never }`.
+    ///
+    /// Per the design table: only network/liveness flutters are
+    /// recoverable. Anything that touched safety, state integrity,
+    /// or security forces an unrecoverable halt.
+    pub fn is_recoverable(&self) -> bool {
         matches!(
             self,
-            FsmState::Committed
-                | FsmState::Rejected(_)
-                | FsmState::Hung
-                | FsmState::HaltedForUpgrade
+            PanicReason::HeartbeatMissed
+                | PanicReason::PeerUnreachable
+                | PanicReason::GossipFailure
+                | PanicReason::MeshPartition
         )
     }
+}
 
-    /// Returns true for states reachable via external recovery only.
-    /// Distinct from [`is_terminal`]: `Committed` and `Rejected` are
-    /// terminal but self-clearing on the next round; `Hung` and
-    /// `HaltedForUpgrade` are not.
-    ///
-    /// [`is_terminal`]: Self::is_terminal
+/// Why a validator entered [`ValidatorState::Slashed`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SlashReason {
+    /// Double-signed two votes at the same (height, round).
+    DoubleSign,
+    /// Equivocation evidence accepted by 2/3+.
+    Equivocation,
+    /// Repeated consensus inactivity beyond threshold.
+    Liveness,
+    /// Byzantine behavior reported by peers and validated.
+    Byzantine,
+}
+
+/// Full validator FSM control state.
+///
+/// Designed to be a node in a deterministic Markov chain — every
+/// `(state, event)` produces exactly one `(next_state, actions)` per
+/// [`transition()`]. Variants carry the minimum data needed to make
+/// each terminal state self-describing for observability (e.g.
+/// `Committed` carries `block_hash + height`, `Hung` carries the
+/// prior state for resume).
+///
+/// [`transition()`]: super::transition::transition
+///
+/// `Instant` fields (`Hung.since`, `Panic.triggered_at`) intentionally
+/// prevent automatic `Serialize / Deserialize` derives; wall-clock data
+/// shouldn't appear in audit logs or block bodies. For wire/log
+/// purposes use [`ValidatorStateKind`] and the structured data fields
+/// directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidatorState {
+    // ----- Lifecycle -----
+    /// First-ever start, no local state, downloading from genesis.
+    Bootstrapping,
+
+    /// Local state exists but height is behind peers. Sync from
+    /// `from_height` to `to_height`, then transition to `Idle`.
+    CatchingUp {
+        from_height: u64,
+        to_height: u64,
+    },
+
+    // ----- Active consensus -----
+    /// Between rounds. Awaiting `SelectedAsProposer` or `ProposalAdmitted`.
+    Idle,
+
+    /// Propose phase: leader's window. Either build the proposal
+    /// (local validator is proposer) or wait for one.
+    Proposing,
+
+    /// Prevote phase (engine's `PreVote` step): cast and gather
+    /// `VoteType::PreVote`s.
+    Prevoting,
+
+    /// Precommit phase (engine's `PreCommit` + `Commit` steps): cast
+    /// and gather `VoteType::PreCommit`s, then `VoteType::Commit`s.
+    Precommitting,
+
+    /// Block finalized at this height. Carries the finalized block's
+    /// hash and height for observability. Transitions to `Idle` for
+    /// the next height on the next round-entry signal.
+    Committed {
+        block_hash: [u8; 32],
+        height: u64,
+    },
+
+    // ----- Failure / recovery -----
+    /// Round terminated without finalization. The runtime has emitted
+    /// `AdvanceRound`; this state self-clears to `Idle` at `round + 1`.
+    Rejected {
+        reason: RejectionReason,
+        round: u32,
+    },
+
+    /// Watchdog detected no progress action. Carries the prior state
+    /// for diagnostic resume.
+    Hung {
+        since: Instant,
+        prior_state: Box<ValidatorState>,
+    },
+
+    // ----- Operator coordination -----
+    /// Operator-coordinated halt at a specific height. Block
+    /// production stops at `triggered_at_height`. Resume governed by
+    /// `resume_condition`.
+    Halting {
+        reason: HaltReason,
+        triggered_at_height: u64,
+        last_block_hash: Option<[u8; 32]>,
+        resume_condition: ResumeCondition,
+    },
+
+    /// Second phase of a coordinated upgrade: the *new* binary is
+    /// running, waiting at the barrier height. On quorum-ready,
+    /// transition to `Idle` on the new protocol version.
+    CoordinatedUpdate {
+        activate_at_height: u64,
+        target_version: u32,
+    },
+
+    // ----- Punishment -----
+    /// Validator was punished and removed from the active set for
+    /// the slashing window. May re-enter via re-staking.
+    Slashed {
+        reason: SlashReason,
+    },
+
+    /// Validator was removed from the active set (insufficient stake,
+    /// repeated misbehavior). Terminal until re-admission via
+    /// re-registration.
+    Evicted,
+
+    // ----- Critical -----
+    /// Runtime detected a critical error. Carries prior state for
+    /// diagnostic resume; recoverable reasons (per
+    /// [`PanicReason::is_recoverable`]) reset to `Idle`, non-
+    /// recoverable transition to `Halting{Never}`.
+    Panic {
+        reason: PanicReason,
+        triggered_at: Instant,
+        prior_state: Box<ValidatorState>,
+    },
+
+    /// Graceful exit. Logs flushed; no more events processed.
+    /// Terminal — process exits after this state.
+    ShuttingDown,
+}
+
+/// Discriminant of [`ValidatorState`] without the data fields.
+///
+/// Used by the runtime-queryable transition table
+/// (`super::transition_table`) and by audit logs / metrics where
+/// only the state name is meaningful. Implements all the derive
+/// traits the full enum can't because of `Instant` and `Box<Self>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ValidatorStateKind {
+    Bootstrapping,
+    CatchingUp,
+    Idle,
+    Proposing,
+    Prevoting,
+    Precommitting,
+    Committed,
+    Rejected,
+    Hung,
+    Halting,
+    CoordinatedUpdate,
+    Slashed,
+    Evicted,
+    Panic,
+    ShuttingDown,
+}
+
+impl ValidatorState {
+    /// Project to the data-free discriminant.
+    pub fn kind(&self) -> ValidatorStateKind {
+        match self {
+            ValidatorState::Bootstrapping => ValidatorStateKind::Bootstrapping,
+            ValidatorState::CatchingUp { .. } => ValidatorStateKind::CatchingUp,
+            ValidatorState::Idle => ValidatorStateKind::Idle,
+            ValidatorState::Proposing => ValidatorStateKind::Proposing,
+            ValidatorState::Prevoting => ValidatorStateKind::Prevoting,
+            ValidatorState::Precommitting => ValidatorStateKind::Precommitting,
+            ValidatorState::Committed { .. } => ValidatorStateKind::Committed,
+            ValidatorState::Rejected { .. } => ValidatorStateKind::Rejected,
+            ValidatorState::Hung { .. } => ValidatorStateKind::Hung,
+            ValidatorState::Halting { .. } => ValidatorStateKind::Halting,
+            ValidatorState::CoordinatedUpdate { .. } => ValidatorStateKind::CoordinatedUpdate,
+            ValidatorState::Slashed { .. } => ValidatorStateKind::Slashed,
+            ValidatorState::Evicted => ValidatorStateKind::Evicted,
+            ValidatorState::Panic { .. } => ValidatorStateKind::Panic,
+            ValidatorState::ShuttingDown => ValidatorStateKind::ShuttingDown,
+        }
+    }
+
+    /// True for states that the FSM does not exit on its own without
+    /// external recovery (operator restart, re-registration, etc.).
     pub fn requires_external_recovery(&self) -> bool {
-        matches!(self, FsmState::Hung | FsmState::HaltedForUpgrade)
+        matches!(
+            self,
+            ValidatorState::Halting {
+                resume_condition: ResumeCondition::Never | ResumeCondition::ManualRestart,
+                ..
+            } | ValidatorState::Evicted
+                | ValidatorState::ShuttingDown
+        )
     }
 }
 
@@ -174,83 +402,145 @@ impl FsmState {
 mod tests {
     use super::*;
 
-    /// CONS-301 acceptance criterion: all 8 variants reachable in tests.
-    /// Constructs each variant once and exercises a small property on it
-    /// so future enum changes break the test, not just the build.
-    #[test]
-    fn all_variants_constructible_and_distinct() {
-        let states = [
-            FsmState::Idle,
-            FsmState::Proposing,
-            FsmState::Prevoting,
-            FsmState::Precommitting,
-            FsmState::Committed,
-            FsmState::Rejected(RejectionReason::InsufficientPrevotes),
-            FsmState::Hung,
-            FsmState::HaltedForUpgrade,
-        ];
-        // Every variant is distinct under PartialEq.
-        for (i, a) in states.iter().enumerate() {
-            for (j, b) in states.iter().enumerate() {
-                assert_eq!(a == b, i == j, "{:?} vs {:?}", a, b);
-            }
-        }
+    fn all_kinds() -> Vec<ValidatorStateKind> {
+        vec![
+            ValidatorStateKind::Bootstrapping,
+            ValidatorStateKind::CatchingUp,
+            ValidatorStateKind::Idle,
+            ValidatorStateKind::Proposing,
+            ValidatorStateKind::Prevoting,
+            ValidatorStateKind::Precommitting,
+            ValidatorStateKind::Committed,
+            ValidatorStateKind::Rejected,
+            ValidatorStateKind::Hung,
+            ValidatorStateKind::Halting,
+            ValidatorStateKind::CoordinatedUpdate,
+            ValidatorStateKind::Slashed,
+            ValidatorStateKind::Evicted,
+            ValidatorStateKind::Panic,
+            ValidatorStateKind::ShuttingDown,
+        ]
     }
 
+    /// Construct one instance of every variant; verify .kind() is
+    /// correct and all 15 kinds are distinct.
     #[test]
-    fn rejected_carries_distinct_reasons() {
-        let reasons = [
-            RejectionReason::InsufficientPrevotes,
-            RejectionReason::InsufficientPrecommits,
-            RejectionReason::Timeout,
-            RejectionReason::InvalidBlock,
+    fn all_variants_constructible_with_correct_kind() {
+        let states = vec![
+            ValidatorState::Bootstrapping,
+            ValidatorState::CatchingUp {
+                from_height: 0,
+                to_height: 100,
+            },
+            ValidatorState::Idle,
+            ValidatorState::Proposing,
+            ValidatorState::Prevoting,
+            ValidatorState::Precommitting,
+            ValidatorState::Committed {
+                block_hash: [0u8; 32],
+                height: 1,
+            },
+            ValidatorState::Rejected {
+                reason: RejectionReason::InsufficientPrevotes,
+                round: 0,
+            },
+            ValidatorState::Hung {
+                since: Instant::now(),
+                prior_state: Box::new(ValidatorState::Idle),
+            },
+            ValidatorState::Halting {
+                reason: HaltReason::UpgradeScheduled,
+                triggered_at_height: 100,
+                last_block_hash: None,
+                resume_condition: ResumeCondition::QuorumReady,
+            },
+            ValidatorState::CoordinatedUpdate {
+                activate_at_height: 100,
+                target_version: 2,
+            },
+            ValidatorState::Slashed {
+                reason: SlashReason::DoubleSign,
+            },
+            ValidatorState::Evicted,
+            ValidatorState::Panic {
+                reason: PanicReason::WatchdogExpired,
+                triggered_at: Instant::now(),
+                prior_state: Box::new(ValidatorState::Idle),
+            },
+            ValidatorState::ShuttingDown,
         ];
-        // All 4 reasons distinct.
-        for (i, a) in reasons.iter().enumerate() {
-            for (j, b) in reasons.iter().enumerate() {
+        let kinds: Vec<_> = states.iter().map(|s| s.kind()).collect();
+        assert_eq!(kinds, all_kinds());
+
+        // All 15 kinds distinct under PartialEq.
+        for (i, a) in kinds.iter().enumerate() {
+            for (j, b) in kinds.iter().enumerate() {
                 assert_eq!(a == b, i == j);
             }
         }
-        // `Rejected` discriminates on the inner reason.
-        assert_ne!(
-            FsmState::Rejected(RejectionReason::Timeout),
-            FsmState::Rejected(RejectionReason::InvalidBlock)
-        );
     }
 
     #[test]
-    fn is_terminal_classifies_correctly() {
-        assert!(!FsmState::Idle.is_terminal());
-        assert!(!FsmState::Proposing.is_terminal());
-        assert!(!FsmState::Prevoting.is_terminal());
-        assert!(!FsmState::Precommitting.is_terminal());
-
-        assert!(FsmState::Committed.is_terminal());
-        assert!(FsmState::Rejected(RejectionReason::Timeout).is_terminal());
-        assert!(FsmState::Hung.is_terminal());
-        assert!(FsmState::HaltedForUpgrade.is_terminal());
+    fn panic_recoverability_classifies_per_design_table() {
+        // Recoverable per the design table.
+        for r in [
+            PanicReason::HeartbeatMissed,
+            PanicReason::PeerUnreachable,
+            PanicReason::GossipFailure,
+            PanicReason::MeshPartition,
+        ] {
+            assert!(r.is_recoverable(), "{:?} should be recoverable", r);
+        }
+        // Non-recoverable per the design table.
+        for r in [
+            PanicReason::DoubleVote,
+            PanicReason::ByzantineVoteDetected,
+            PanicReason::SlashableOffense,
+            PanicReason::ConflictingCommits,
+            PanicReason::StateMachineCorrupted,
+            PanicReason::SignatureVerificationFailed,
+        ] {
+            assert!(!r.is_recoverable(), "{:?} must NOT be recoverable", r);
+        }
     }
 
     #[test]
-    fn requires_external_recovery_only_for_hung_and_halted() {
-        assert!(!FsmState::Idle.requires_external_recovery());
-        assert!(!FsmState::Committed.requires_external_recovery());
-        assert!(!FsmState::Rejected(RejectionReason::Timeout).requires_external_recovery());
+    fn requires_external_recovery_is_correct() {
+        assert!(!ValidatorState::Idle.requires_external_recovery());
+        assert!(!ValidatorState::Proposing.requires_external_recovery());
+        assert!(!ValidatorState::Bootstrapping.requires_external_recovery());
+        assert!(!ValidatorState::CatchingUp {
+            from_height: 0,
+            to_height: 1,
+        }
+        .requires_external_recovery());
 
-        assert!(FsmState::Hung.requires_external_recovery());
-        assert!(FsmState::HaltedForUpgrade.requires_external_recovery());
-    }
+        assert!(ValidatorState::Halting {
+            reason: HaltReason::UpgradeScheduled,
+            triggered_at_height: 0,
+            last_block_hash: None,
+            resume_condition: ResumeCondition::Never,
+        }
+        .requires_external_recovery());
 
-    /// Compile-time check that both types implement the serde traits.
-    /// lib-consensus-core deliberately doesn't take a serde_json or bincode
-    /// dependency, so a runtime round-trip test would force a new dep just
-    /// to prove what the derive macro already does. The fn-pointer
-    /// assignment fails to compile if `Serialize`/`Deserialize` aren't on
-    /// the type — same guarantee.
-    #[test]
-    fn states_implement_serde_traits() {
-        fn assert_serializable<T: serde::Serialize + for<'de> serde::Deserialize<'de>>() {}
-        assert_serializable::<FsmState>();
-        assert_serializable::<RejectionReason>();
+        assert!(ValidatorState::Halting {
+            reason: HaltReason::EmergencyHalt,
+            triggered_at_height: 0,
+            last_block_hash: None,
+            resume_condition: ResumeCondition::ManualRestart,
+        }
+        .requires_external_recovery());
+
+        // QuorumReady / UpgradeComplete don't require external action.
+        assert!(!ValidatorState::Halting {
+            reason: HaltReason::UpgradeScheduled,
+            triggered_at_height: 0,
+            last_block_hash: None,
+            resume_condition: ResumeCondition::QuorumReady,
+        }
+        .requires_external_recovery());
+
+        assert!(ValidatorState::Evicted.requires_external_recovery());
+        assert!(ValidatorState::ShuttingDown.requires_external_recovery());
     }
 }

--- a/lib-consensus-core/src/fsm/state.rs
+++ b/lib-consensus-core/src/fsm/state.rs
@@ -325,10 +325,17 @@ pub enum ValidatorState {
     /// Runtime detected a critical error. Carries prior state for
     /// diagnostic resume; recoverable reasons (per
     /// [`PanicReason::is_recoverable`]) reset to `Idle`, non-
-    /// recoverable transition to `Halting{Never}`.
+    /// recoverable transition to `Halting{Never}` at `at_height`.
+    ///
+    /// `at_height` is captured from the runtime when the panic
+    /// fires (PR #2394 review) so the non-recoverable transition
+    /// can construct a real `Halting { triggered_at_height }` and
+    /// `StopBlockProduction { at_height }` instead of placeholder
+    /// zeros.
     Panic {
         reason: PanicReason,
         triggered_at: Instant,
+        at_height: u64,
         prior_state: Box<ValidatorState>,
     },
 
@@ -386,6 +393,10 @@ impl ValidatorState {
 
     /// True for states that the FSM does not exit on its own without
     /// external recovery (operator restart, re-registration, etc.).
+    ///
+    /// `Hung` is included per PR #2394 review (Copilot) — `transition()`
+    /// has no event arm that exits `Hung`, so it is genuinely terminal
+    /// until the operator restarts the runtime.
     pub fn requires_external_recovery(&self) -> bool {
         matches!(
             self,
@@ -394,6 +405,7 @@ impl ValidatorState {
                 ..
             } | ValidatorState::Evicted
                 | ValidatorState::ShuttingDown
+                | ValidatorState::Hung { .. }
         )
     }
 }
@@ -465,6 +477,7 @@ mod tests {
             ValidatorState::Panic {
                 reason: PanicReason::WatchdogExpired,
                 triggered_at: Instant::now(),
+                at_height: 100,
                 prior_state: Box::new(ValidatorState::Idle),
             },
             ValidatorState::ShuttingDown,

--- a/lib-consensus-core/src/fsm/transition.rs
+++ b/lib-consensus-core/src/fsm/transition.rs
@@ -6,44 +6,163 @@
 //! drops. Invalid-but-tolerable arrivals (late vote in `Idle`, etc.)
 //! map to `Action::LogIgnoredEvent("…")` so they are explicit.
 //!
+//! ## Pure function, no clock access
+//!
+//! `transition()` reads no wall clock. Timestamps that flow into
+//! `Hung.since` and `Panic.triggered_at` come from the event payload
+//! (`WatchdogFired { fired_at }`, `PanicTriggered { triggered_at }`)
+//! — the runtime captures them at firing time. PR #2394 review
+//! (Copilot) flagged the prior `Instant::now()` calls inside
+//! `transition()` as breaking the deterministic / pure contract.
+//!
 //! ## Markov chain
 //!
-//! Pair this with [`super::transition_table`], which exposes the same
-//! transitions as a runtime-queryable data structure. Tests verify
-//! the match function and the table agree, so they cannot drift.
+//! Pair this with [`super::transition_table`], which exposes the
+//! same transitions as a runtime-queryable data structure. Tests
+//! verify the match function and the table agree, so they cannot
+//! drift.
 //!
 //! ## Sovereign protocol semantics
 //!
-//! 4 active phases — Proposing → Prevoting → Precommitting → Committed
-//! — with **walk-through timeouts**: every step before `Committed`
-//! advances on timeout to the next phase. Only `Committed.Timeout`
-//! triggers `Rejected(InsufficientPrecommits)` + view change. This
-//! matches the existing engine's `on_round_timeout`.
+//! 4 active phases — Proposing → Prevoting → Precommitting →
+//! Committed — with **walk-through timeouts**: every step before
+//! `Committed` advances on timeout to the next phase. Only
+//! `Committed.Timeout` triggers `Rejected(InsufficientPrecommits)` +
+//! view change. Matches the existing engine's `on_round_timeout`.
 
 use crate::fsm::events::{Action, Event};
-use crate::fsm::state::{HaltReason, RejectionReason, ResumeCondition, ValidatorState};
-use std::time::Instant;
+use crate::fsm::state::{
+    HaltReason, RejectionReason, ResumeCondition, ValidatorState,
+};
 
 /// Compute the next state and the actions to execute.
 ///
-/// Pure function: no side effects, no panics, no `unreachable!`. The
-/// caller (CONS-305 runtime) executes the returned actions in order
-/// and feeds the resulting events back in.
+/// Pure function: no side effects, no panics, no `unreachable!`, no
+/// clock access. The caller (CONS-305 runtime) executes the returned
+/// actions in order and feeds the resulting events back in.
 pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<Action>) {
     use Event::*;
     use ValidatorState::*;
 
-    // Highest-priority cross-cutting events: panic, halt, shutdown,
-    // eviction. Handled before phase-specific arms so they win from
-    // any active state.
-    if let Some(out) = handle_universal(&state, &event) {
-        return out;
-    }
-
-    match (state.clone(), event) {
+    match (state, event) {
         // ============================================================
-        // Bootstrapping — first-ever start. Exits to Idle on
-        // BootstrapComplete; otherwise events are logged-ignored.
+        // Universal events — handled before phase-specific arms so
+        // they win from any active state. The order in this match
+        // matters: more-specific patterns (e.g. excluded states for
+        // PanicTriggered) come before catch-all bindings.
+        // ============================================================
+
+        // PanicTriggered: from already-critical states, log and ignore.
+        (
+            state @ (Panic { .. } | Halting { .. } | ShuttingDown),
+            PanicTriggered { .. },
+        ) => (
+            state,
+            vec![Action::LogIgnoredEvent(
+                "PanicTriggered while already in critical state",
+            )],
+        ),
+        // PanicTriggered from any other state: enter Panic carrying
+        // the prior state, the runtime-captured `triggered_at`, and
+        // the current `at_height` so the non-recoverable
+        // `(Panic, PanicCleared)` arm can construct a real Halting.
+        (
+            state,
+            PanicTriggered {
+                reason,
+                triggered_at,
+                at_height,
+            },
+        ) if !matches!(state, Idle | Bootstrapping | CatchingUp { .. }) // any non-trivial state
+            || matches!(state, Idle | Bootstrapping | CatchingUp { .. })
+        => {
+            // Above guard is intentionally `true` for every value of
+            // `state` — Rust requires guards on the catch-all arm
+            // when other arms with binding patterns are present.
+            (
+                Panic {
+                    reason: reason.clone(),
+                    triggered_at,
+                    at_height,
+                    prior_state: Box::new(state),
+                },
+                vec![
+                    Action::BroadcastPanic {
+                        reason: reason.clone(),
+                    },
+                    Action::LogPanic { reason },
+                ],
+            )
+        }
+
+        // HaltScheduled: from already-halted/panicked/exited, log+ignore.
+        (
+            state @ (Halting { .. } | Panic { .. } | ShuttingDown | Evicted),
+            HaltScheduled { .. },
+        ) => (
+            state,
+            vec![Action::LogIgnoredEvent(
+                "HaltScheduled while already halting/panicked/exiting",
+            )],
+        ),
+        // HaltScheduled from any other state. Capture last_block_hash
+        // from Committed (if applicable) so operators can correlate
+        // the halt with the last finalized block.
+        (
+            state,
+            HaltScheduled {
+                reason,
+                triggered_at_height,
+                resume_condition,
+            },
+        ) => {
+            let last_block_hash = if let Committed { block_hash, .. } = &state {
+                Some(*block_hash)
+            } else {
+                None
+            };
+            let _ = state; // explicitly drop the prior state
+            (
+                Halting {
+                    reason,
+                    triggered_at_height,
+                    last_block_hash,
+                    resume_condition: ResumeCondition::from(resume_condition),
+                },
+                vec![Action::StopBlockProduction {
+                    at_height: triggered_at_height,
+                }],
+            )
+        }
+
+        // ShutdownRequested: accepted from any state.
+        (_state, ShutdownRequested) => {
+            (ShuttingDown, vec![Action::FlushLogsForShutdown])
+        }
+
+        // SlashEvidenceConfirmed: from already-slashed/exited, log+ignore.
+        (
+            state @ (Slashed { .. } | Evicted | ShuttingDown | Panic { .. }),
+            SlashEvidenceConfirmed { .. },
+        ) => (
+            state,
+            vec![Action::LogIgnoredEvent(
+                "SlashEvidenceConfirmed while already slashed/exiting",
+            )],
+        ),
+        (_state, SlashEvidenceConfirmed { reason }) => {
+            (Slashed { reason }, vec![Action::LeaveActiveSet])
+        }
+
+        // EvictedFromSet: from already-out, log+ignore.
+        (state @ (Evicted | ShuttingDown), EvictedFromSet) => (
+            state,
+            vec![Action::LogIgnoredEvent("EvictedFromSet while already out")],
+        ),
+        (_state, EvictedFromSet) => (Evicted, vec![Action::LeaveActiveSet]),
+
+        // ============================================================
+        // Bootstrapping
         // ============================================================
         (Bootstrapping, BootstrapComplete) => (Idle, vec![Action::ResetWatchdog]),
         (Bootstrapping, _) => (
@@ -52,24 +171,28 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
         ),
 
         // ============================================================
-        // CatchingUp — local state behind peers. Exits to Idle on
-        // CaughtUp; otherwise events are logged-ignored.
+        // CatchingUp
         // ============================================================
         (CatchingUp { .. }, CaughtUp) => (Idle, vec![Action::ResetWatchdog]),
-        (CatchingUp { .. }, _) => (
-            state,
+        (catching @ CatchingUp { .. }, _) => (
+            catching,
             vec![Action::LogIgnoredEvent("event in CatchingUp")],
         ),
 
         // ============================================================
-        // Idle — between rounds. Proposer-elect → Proposing.
+        // Idle
         // ============================================================
         (Idle, SelectedAsProposer { .. }) => (
             Proposing,
             vec![Action::CreateProposal, Action::ResetWatchdog],
         ),
         (Idle, ProposalAdmitted { .. }) => (
-            Proposing,
+            // Stay Idle until the runtime drives proposer election.
+            // PR #2394 reverse-drift test caught the prior version
+            // transitioning state on a logged-ignored action — a
+            // contradiction between state change and "this event had
+            // no effect" semantics.
+            Idle,
             vec![Action::LogIgnoredEvent(
                 "ProposalAdmitted in Idle: proposer-elect path not yet entered",
             )],
@@ -78,9 +201,9 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
             Idle,
             vec![Action::LogIgnoredEvent("Timeout in Idle: no active phase")],
         ),
-        (Idle, WatchdogFired { .. }) => (
+        (Idle, WatchdogFired { fired_at, .. }) => (
             Hung {
-                since: Instant::now(),
+                since: fired_at,
                 prior_state: Box::new(Idle),
             },
             vec![Action::LogHung {
@@ -93,8 +216,7 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
         ),
 
         // ============================================================
-        // Proposing — leader's window. ProposalAdmitted → Prevoting.
-        // Timeout walks forward to Prevoting.
+        // Proposing
         // ============================================================
         (Proposing, ProposalAdmitted { id, .. }) => (
             Prevoting,
@@ -106,15 +228,12 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
         ),
         (Proposing, Timeout) => (Prevoting, vec![Action::ResetWatchdog]),
         (Proposing, VoteFailed(reason)) => (
-            Rejected {
-                reason,
-                round: 0, // runtime fills in current_round on entry
-            },
+            Rejected { reason, round: 0 }, // runtime fills round on entry
             vec![Action::AdvanceRound],
         ),
-        (Proposing, WatchdogFired { .. }) => (
+        (Proposing, WatchdogFired { fired_at, .. }) => (
             Hung {
-                since: Instant::now(),
+                since: fired_at,
                 prior_state: Box::new(Proposing),
             },
             vec![Action::LogHung {
@@ -127,24 +246,20 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
         ),
 
         // ============================================================
-        // Prevoting — gathering PreVotes. PrevoteThresholdReached →
-        // Precommitting (send precommit). Timeout walks to Precommitting.
+        // Prevoting
         // ============================================================
         (Prevoting, PrevoteThresholdReached { block_id }) => (
             Precommitting,
-            vec![
-                Action::SendPrecommit { block_id },
-                Action::ResetWatchdog,
-            ],
+            vec![Action::SendPrecommit { block_id }, Action::ResetWatchdog],
         ),
         (Prevoting, Timeout) => (Precommitting, vec![Action::ResetWatchdog]),
         (Prevoting, VoteFailed(reason)) => (
             Rejected { reason, round: 0 },
             vec![Action::AdvanceRound],
         ),
-        (Prevoting, WatchdogFired { .. }) => (
+        (Prevoting, WatchdogFired { fired_at, .. }) => (
             Hung {
-                since: Instant::now(),
+                since: fired_at,
                 prior_state: Box::new(Prevoting),
             },
             vec![Action::LogHung {
@@ -158,24 +273,12 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
 
         // ============================================================
         // Precommitting — gathering PreCommits, then Commit votes.
-        // Two events advance through this phase:
-        //   PrecommitThresholdReached → send commit vote, stay
-        //   CommitQuorumReached → finalize, transition to Committed
         // ============================================================
         (Precommitting, PrecommitThresholdReached { block_id }) => (
             Precommitting,
-            vec![
-                Action::SendCommit { block_id },
-                Action::ResetWatchdog,
-            ],
+            vec![Action::SendCommit { block_id }, Action::ResetWatchdog],
         ),
-        (
-            Precommitting,
-            CommitQuorumReached {
-                block_id,
-                quorum,
-            },
-        ) => (
+        (Precommitting, CommitQuorumReached { block_id, quorum }) => (
             Committed {
                 block_hash: block_id.0,
                 height: quorum.height,
@@ -188,17 +291,14 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
                 Action::ResetWatchdog,
             ],
         ),
-        // Walk-through Timeout. View-change happens at Committed.Timeout,
-        // not here — the existing engine progresses to "Commit step"
-        // on PreCommit timeout, gathering commit votes anyway.
         (Precommitting, Timeout) => (Precommitting, vec![Action::ResetWatchdog]),
         (Precommitting, VoteFailed(reason)) => (
             Rejected { reason, round: 0 },
             vec![Action::AdvanceRound],
         ),
-        (Precommitting, WatchdogFired { .. }) => (
+        (Precommitting, WatchdogFired { fired_at, .. }) => (
             Hung {
-                since: Instant::now(),
+                since: fired_at,
                 prior_state: Box::new(Precommitting),
             },
             vec![Action::LogHung {
@@ -207,16 +307,15 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
         ),
         (Precommitting, _) => (
             Precommitting,
-            vec![Action::LogIgnoredEvent(
-                "event in Precommitting (out-of-phase)",
-            )],
+            vec![Action::LogIgnoredEvent("event in Precommitting (out-of-phase)")],
         ),
 
         // ============================================================
         // Committed — block finalized at this height. The runtime
-        // advances to next height; further events at this height are
-        // logged-ignored. SelectedAsProposer at next height triggers
-        // the Idle path on round-entry (runtime resets to Idle).
+        // resets the FSM to Idle (next height entry) explicitly; this
+        // FSM doesn't auto-transition. PR #2394 review removed an
+        // earlier `(Committed, ProposalAdmitted) → Proposing` shortcut
+        // that bypassed runtime state-management for the height bump.
         // ============================================================
         (Committed { .. }, SelectedAsProposer { .. }) => (
             Proposing,
@@ -229,57 +328,33 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
             },
             vec![Action::AdvanceRound],
         ),
-        (
-            Committed { .. },
-            ProposalAdmitted {
-                id, height, round,
-            },
-        ) => (
-            // Next height arrived — re-enter Proposing then immediately
-            // admit. (Engine resets the round struct on its side.)
-            Proposing,
-            vec![
-                Action::BroadcastProposal { id: id.clone() },
-                Action::SendPrevote { block_id: id },
-                Action::ResetWatchdog,
-                Action::LogIgnoredEvent("auto-rolled Committed→Proposing"),
-                // height/round logged for diagnostics
-                Action::LogIgnoredEvent(if height > 0 || round > 0 {
-                    "next-height entry"
-                } else {
-                    "next-height entry (zero)"
-                }),
-            ],
-        ),
-        (Committed { .. }, _) => (
-            state,
-            vec![Action::LogIgnoredEvent("event in Committed")],
+        (committed @ Committed { .. }, _) => (
+            committed,
+            vec![Action::LogIgnoredEvent(
+                "event in Committed (runtime resets to Idle for next height)",
+            )],
         ),
 
         // ============================================================
-        // Rejected — runtime emitted AdvanceRound; events arriving
-        // before the next round entry are logged-ignored.
+        // Rejected — runtime emits AdvanceRound on entry; events
+        // arriving before next round entry are logged-ignored.
         // ============================================================
         (Rejected { .. }, SelectedAsProposer { .. }) => (
             Proposing,
             vec![Action::CreateProposal, Action::ResetWatchdog],
         ),
-        (Rejected { .. }, _) => (
-            state,
+        (rejected @ Rejected { .. }, _) => (
+            rejected,
             vec![Action::LogIgnoredEvent("event in Rejected")],
         ),
 
         // ============================================================
         // Hung — terminal until external recovery.
         // ============================================================
-        (Hung { .. }, _) => (
-            state,
-            vec![Action::LogIgnoredEvent("event in Hung")],
-        ),
+        (hung @ Hung { .. }, _) => (hung, vec![Action::LogIgnoredEvent("event in Hung")]),
 
         // ============================================================
-        // Halting — block production stopped. Exit on HaltActivated
-        // (transition to CoordinatedUpdate).
+        // Halting → CoordinatedUpdate
         // ============================================================
         (
             Halting { .. },
@@ -297,22 +372,15 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
                 target_version,
             }],
         ),
-        (Halting { .. }, _) => (
-            state,
+        (halting @ Halting { .. }, _) => (
+            halting,
             vec![Action::LogIgnoredEvent("event in Halting")],
         ),
 
         // ============================================================
-        // CoordinatedUpdate — barrier; new binary running, awaiting
-        // quorum-ready. UpdateQuorumReady → Idle (next round on the
-        // new protocol version).
+        // CoordinatedUpdate → Idle on quorum-ready
         // ============================================================
-        (
-            CoordinatedUpdate {
-                target_version, ..
-            },
-            UpdateQuorumReady,
-        ) => (
+        (CoordinatedUpdate { target_version, .. }, UpdateQuorumReady) => (
             Idle,
             vec![
                 Action::BroadcastReadyOnNewVersion {
@@ -321,178 +389,75 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
                 Action::ResetWatchdog,
             ],
         ),
-        (CoordinatedUpdate { .. }, _) => (
-            state,
+        (cu @ CoordinatedUpdate { .. }, _) => (
+            cu,
             vec![Action::LogIgnoredEvent("event in CoordinatedUpdate")],
         ),
 
         // ============================================================
-        // Slashed — out of active set. Re-enter on ReadmittedToSet.
+        // Slashed — re-enter on ReadmittedToSet.
         // ============================================================
         (Slashed { .. }, ReadmittedToSet) => (Idle, vec![Action::RejoinActiveSet]),
-        (Slashed { .. }, _) => (
-            state,
+        (slashed @ Slashed { .. }, _) => (
+            slashed,
             vec![Action::LogIgnoredEvent("event in Slashed")],
         ),
 
         // ============================================================
-        // Evicted — terminal until re-admission.
+        // Evicted — re-enter on ReadmittedToSet.
         // ============================================================
         (Evicted, ReadmittedToSet) => (Idle, vec![Action::RejoinActiveSet]),
         (Evicted, _) => (Evicted, vec![Action::LogIgnoredEvent("event in Evicted")]),
 
         // ============================================================
-        // Panic — recoverable reasons reset to Idle on PanicCleared;
-        // non-recoverable reasons force Halting{Never}. Catch the
-        // PanicCleared event here; non-recoverable transitions are
-        // emitted via PanicTriggered handling in handle_universal.
+        // Panic — recoverable resets to Idle on PanicCleared;
+        // non-recoverable forces Halting{Never} at the panic-time
+        // height, with last_block_hash recovered from prior_state if
+        // we panicked from Committed.
         // ============================================================
-        (Panic { reason, .. }, PanicCleared) => {
+        (
+            Panic {
+                reason,
+                at_height,
+                prior_state,
+                ..
+            },
+            PanicCleared,
+        ) => {
             if reason.is_recoverable() {
                 (Idle, vec![Action::ResetWatchdog])
             } else {
+                let last_block_hash = if let Committed { block_hash, .. } = prior_state.as_ref() {
+                    Some(*block_hash)
+                } else {
+                    None
+                };
                 (
                     Halting {
                         reason: HaltReason::EmergencyHalt,
-                        triggered_at_height: 0,
-                        last_block_hash: None,
+                        triggered_at_height: at_height,
+                        last_block_hash,
                         resume_condition: ResumeCondition::Never,
                     },
                     vec![
                         Action::LogPanic { reason },
-                        Action::StopBlockProduction { at_height: 0 },
+                        Action::StopBlockProduction { at_height },
                     ],
                 )
             }
         }
-        (Panic { .. }, _) => (
-            state,
+        (panic_state @ Panic { .. }, _) => (
+            panic_state,
             vec![Action::LogIgnoredEvent("event in Panic")],
         ),
 
         // ============================================================
-        // ShuttingDown — terminal. All events logged-ignored.
+        // ShuttingDown — terminal.
         // ============================================================
         (ShuttingDown, _) => (
             ShuttingDown,
             vec![Action::LogIgnoredEvent("event in ShuttingDown")],
         ),
-    }
-}
-
-/// Cross-cutting events that override phase-specific transitions.
-/// Returns `Some` if the event was handled here, `None` if the main
-/// `match` should run.
-fn handle_universal(
-    state: &ValidatorState,
-    event: &Event,
-) -> Option<(ValidatorState, Vec<Action>)> {
-    use Event::*;
-    use ValidatorState::*;
-
-    match event {
-        // PanicTriggered — recoverable: enter Panic; non-recoverable:
-        // enter Panic and the runtime should observe the reason and
-        // emit PanicCleared (which then routes to Halting{Never}).
-        PanicTriggered { reason } => {
-            // Don't re-enter Panic from Panic / Halting / ShuttingDown.
-            if matches!(state, Panic { .. } | Halting { .. } | ShuttingDown) {
-                return Some((
-                    state.clone(),
-                    vec![Action::LogIgnoredEvent(
-                        "PanicTriggered while already in critical state",
-                    )],
-                ));
-            }
-            Some((
-                Panic {
-                    reason: reason.clone(),
-                    triggered_at: Instant::now(),
-                    prior_state: Box::new(state.clone()),
-                },
-                vec![
-                    Action::BroadcastPanic {
-                        reason: reason.clone(),
-                    },
-                    Action::LogPanic {
-                        reason: reason.clone(),
-                    },
-                ],
-            ))
-        }
-
-        // HaltScheduled — accepted from any active consensus state.
-        // Already-halted / panicked / shutting-down ignore.
-        HaltScheduled {
-            reason,
-            triggered_at_height,
-            resume_condition,
-        } => {
-            if matches!(state, Halting { .. } | Panic { .. } | ShuttingDown | Evicted) {
-                return Some((
-                    state.clone(),
-                    vec![Action::LogIgnoredEvent(
-                        "HaltScheduled while already halting/panicked/exiting",
-                    )],
-                ));
-            }
-            // Capture last_block_hash if we're in Committed.
-            let last_block_hash = if let Committed { block_hash, .. } = state {
-                Some(*block_hash)
-            } else {
-                None
-            };
-            Some((
-                Halting {
-                    reason: *reason,
-                    triggered_at_height: *triggered_at_height,
-                    last_block_hash,
-                    resume_condition: ResumeCondition::from(*resume_condition),
-                },
-                vec![Action::StopBlockProduction {
-                    at_height: *triggered_at_height,
-                }],
-            ))
-        }
-
-        // ShutdownRequested — accepted from any state. Always
-        // transitions to ShuttingDown and flushes logs.
-        ShutdownRequested => Some((
-            ShuttingDown,
-            vec![Action::FlushLogsForShutdown],
-        )),
-
-        // SlashEvidenceConfirmed — accepted from any active state.
-        SlashEvidenceConfirmed { reason } => {
-            if matches!(
-                state,
-                Slashed { .. } | Evicted | ShuttingDown | Panic { .. }
-            ) {
-                return Some((
-                    state.clone(),
-                    vec![Action::LogIgnoredEvent(
-                        "SlashEvidenceConfirmed while already slashed/exiting",
-                    )],
-                ));
-            }
-            Some((
-                Slashed { reason: *reason },
-                vec![Action::LeaveActiveSet],
-            ))
-        }
-
-        // EvictedFromSet — terminal-ish.
-        EvictedFromSet => {
-            if matches!(state, Evicted | ShuttingDown) {
-                return Some((
-                    state.clone(),
-                    vec![Action::LogIgnoredEvent("EvictedFromSet while already out")],
-                ));
-            }
-            Some((Evicted, vec![Action::LeaveActiveSet]))
-        }
-
-        _ => None,
     }
 }
 
@@ -503,6 +468,7 @@ mod tests {
     use crate::fsm::state::{PanicReason, SlashReason};
     use lib_crypto::Hash;
     use lib_types::consensus::BftQuorumProof;
+    use std::time::Instant;
 
     fn dummy_quorum() -> BftQuorumProof {
         BftQuorumProof {
@@ -513,8 +479,22 @@ mod tests {
         }
     }
 
-    /// Happy path: Idle → Proposing → Prevoting → Precommitting →
-    /// Committed → (next round) Proposing.
+    fn dummy_watchdog() -> Event {
+        Event::WatchdogFired {
+            age_ms: 30_000,
+            fired_at: Instant::now(),
+        }
+    }
+
+    fn dummy_panic(reason: PanicReason) -> Event {
+        Event::PanicTriggered {
+            reason,
+            triggered_at: Instant::now(),
+            at_height: 100,
+        }
+    }
+
+    /// Happy path: Idle → Proposing → Prevoting → Precommitting → Committed.
     #[test]
     fn happy_path_round_completes() {
         let block_id = Hash([42u8; 32]);
@@ -550,7 +530,7 @@ mod tests {
                 block_id: block_id.clone(),
             },
         );
-        assert_eq!(s, ValidatorState::Precommitting); // stays for commit-vote gathering
+        assert_eq!(s, ValidatorState::Precommitting);
 
         let (s, a) = transition(
             s,
@@ -563,8 +543,6 @@ mod tests {
         assert!(a.iter().any(|x| matches!(x, Action::CommitBlock { .. })));
     }
 
-    /// Walk-through timeouts: Proposing → Prevoting → Precommitting,
-    /// each by a Timeout. Committed.Timeout view-changes.
     #[test]
     fn timeouts_walk_through_phases() {
         let (s, _) = transition(ValidatorState::Proposing, Event::Timeout);
@@ -574,8 +552,6 @@ mod tests {
         assert_eq!(s, ValidatorState::Precommitting);
 
         let (s, _) = transition(ValidatorState::Precommitting, Event::Timeout);
-        // Precommitting.Timeout is walk-forward (engine progresses to
-        // Commit step which is folded into Precommitting in this FSM).
         assert_eq!(s, ValidatorState::Precommitting);
     }
 
@@ -598,15 +574,48 @@ mod tests {
         assert!(a.contains(&Action::AdvanceRound));
     }
 
+    /// PR #2394 review: ProposalAdmitted in Committed must NOT
+    /// auto-transition to Proposing. The runtime resets to Idle for
+    /// the next height; this FSM logs and ignores.
     #[test]
-    fn watchdog_from_active_states_hangs() {
+    fn committed_proposal_admitted_is_logged_ignored() {
+        let (s, a) = transition(
+            ValidatorState::Committed {
+                block_hash: [1u8; 32],
+                height: 1,
+            },
+            Event::ProposalAdmitted {
+                id: Hash([2u8; 32]),
+                height: 2,
+                round: 0,
+            },
+        );
+        assert!(matches!(s, ValidatorState::Committed { .. }));
+        assert!(a.iter().all(|x| matches!(x, Action::LogIgnoredEvent(_))));
+    }
+
+    #[test]
+    fn watchdog_from_active_states_hangs_with_event_timestamp() {
+        let fired_at = Instant::now();
         for state in [
             ValidatorState::Proposing,
             ValidatorState::Prevoting,
             ValidatorState::Precommitting,
         ] {
-            let (s, a) = transition(state, Event::WatchdogFired { age_ms: 30_000 });
-            assert!(matches!(s, ValidatorState::Hung { .. }));
+            let (s, a) = transition(
+                state,
+                Event::WatchdogFired {
+                    age_ms: 30_000,
+                    fired_at,
+                },
+            );
+            // The Hung state's `since` came from the event payload,
+            // not Instant::now() inside transition.
+            if let ValidatorState::Hung { since, .. } = s {
+                assert_eq!(since, fired_at);
+            } else {
+                panic!("expected Hung, got {:?}", s);
+            }
             assert!(a.iter().any(|x| matches!(x, Action::LogHung { .. })));
         }
     }
@@ -615,41 +624,70 @@ mod tests {
     fn panic_recoverable_resets_to_idle_on_clear() {
         let (s, _) = transition(
             ValidatorState::Prevoting,
-            Event::PanicTriggered {
-                reason: PanicReason::HeartbeatMissed,
-            },
+            dummy_panic(PanicReason::HeartbeatMissed),
         );
         assert!(matches!(s, ValidatorState::Panic { .. }));
         let (s, _) = transition(s, Event::PanicCleared);
         assert_eq!(s, ValidatorState::Idle);
     }
 
+    /// Non-recoverable panic forces `Halting{Never}` at the panic-
+    /// time height (PR #2394 review: prior placeholder of 0 lost
+    /// height context).
     #[test]
-    fn panic_non_recoverable_forces_halting_never() {
+    fn panic_non_recoverable_forces_halting_at_correct_height() {
         let (s, _) = transition(
             ValidatorState::Prevoting,
             Event::PanicTriggered {
                 reason: PanicReason::DoubleVote,
+                triggered_at: Instant::now(),
+                at_height: 1234,
             },
         );
-        assert!(matches!(s, ValidatorState::Panic { .. }));
-        let (s, _) = transition(s, Event::PanicCleared);
-        assert!(matches!(
-            s,
+        assert!(matches!(s, ValidatorState::Panic { at_height: 1234, .. }));
+        let (s, a) = transition(s, Event::PanicCleared);
+        match s {
             ValidatorState::Halting {
                 resume_condition: ResumeCondition::Never,
+                triggered_at_height: 1234,
                 ..
-            }
-        ));
+            } => {}
+            other => panic!("expected Halting{{Never, height=1234}}, got {:?}", other),
+        }
+        assert!(a.contains(&Action::StopBlockProduction { at_height: 1234 }));
+    }
+
+    /// Non-recoverable panic from Committed state preserves the
+    /// last_block_hash via the Box<prior_state>.
+    #[test]
+    fn panic_from_committed_preserves_last_block_hash() {
+        let block_hash = [99u8; 32];
+        let (s, _) = transition(
+            ValidatorState::Committed {
+                block_hash,
+                height: 100,
+            },
+            Event::PanicTriggered {
+                reason: PanicReason::ConflictingCommits,
+                triggered_at: Instant::now(),
+                at_height: 100,
+            },
+        );
+        let (s, _) = transition(s, Event::PanicCleared);
+        match s {
+            ValidatorState::Halting {
+                last_block_hash: Some(h),
+                ..
+            } => assert_eq!(h, block_hash),
+            other => panic!("expected Halting with last_block_hash, got {:?}", other),
+        }
     }
 
     #[test]
     fn panic_broadcasts_to_peers_for_logs() {
         let (_, a) = transition(
             ValidatorState::Prevoting,
-            Event::PanicTriggered {
-                reason: PanicReason::ByzantineVoteDetected,
-            },
+            dummy_panic(PanicReason::ByzantineVoteDetected),
         );
         assert!(a.iter().any(|x| matches!(x, Action::BroadcastPanic { .. })));
     }
@@ -740,7 +778,7 @@ mod tests {
     }
 
     /// Totality: every (state_kind, event_kind) pair returns a
-    /// non-empty action list. Sample one variant per kind.
+    /// non-empty action list.
     #[test]
     fn transition_total_no_silent_drops() {
         let states = [
@@ -782,6 +820,7 @@ mod tests {
             ValidatorState::Panic {
                 reason: PanicReason::HeartbeatMissed,
                 triggered_at: Instant::now(),
+                at_height: 0,
                 prior_state: Box::new(ValidatorState::Idle),
             },
             ValidatorState::ShuttingDown,
@@ -809,10 +848,8 @@ mod tests {
             },
             Event::VoteFailed(RejectionReason::Timeout),
             Event::Timeout,
-            Event::WatchdogFired { age_ms: 1 },
-            Event::PanicTriggered {
-                reason: PanicReason::WatchdogExpired,
-            },
+            dummy_watchdog(),
+            dummy_panic(PanicReason::WatchdogExpired),
             Event::PanicCleared,
             Event::HaltScheduled {
                 reason: HaltReason::UpgradeScheduled,

--- a/lib-consensus-core/src/fsm/transition.rs
+++ b/lib-consensus-core/src/fsm/transition.rs
@@ -1,70 +1,73 @@
 //! Total `transition(state, event) -> (next_state, actions)`.
 //!
-//! Single source of truth for control-flow transitions in the validator
-//! FSM. Pre-rewrite this logic was distributed across
-//! `consensus_engine::run_*_step`, `on_proposal`, `on_prevote`,
-//! `on_precommit`, `on_commit_vote`, plus a thicket of timer flags and
-//! "is this round dead yet?" booleans. CONS-302 consolidates it into one
-//! function with one match.
+//! Single source of truth for control-flow transitions in the
+//! validator FSM. Every `(state, event)` pair maps to exactly one
+//! `(next_state, actions)` — no panics, no `unreachable!`, no silent
+//! drops. Invalid-but-tolerable arrivals (late vote in `Idle`, etc.)
+//! map to `Action::LogIgnoredEvent("…")` so they are explicit.
 //!
-//! # Totality
+//! ## Markov chain
 //!
-//! `transition()` must terminate for every `(FsmState, Event)` pair —
-//! never panic, never `unreachable!`. Invalid-but-tolerable arrivals
-//! (e.g. a late prevote in `Committed`) map to
-//! `(state, vec![Action::LogIgnoredEvent("..."])` so they are explicit
-//! rather than silently dropped.
+//! Pair this with [`super::transition_table`], which exposes the same
+//! transitions as a runtime-queryable data structure. Tests verify
+//! the match function and the table agree, so they cannot drift.
 //!
-//! `HaltedForUpgrade` is the one absorbing state with a wildcard match
-//! arm, since by definition no event can move it forward.
+//! ## Sovereign protocol semantics
 //!
-//! Compile-time totality is enforced by exhaustive matches on both
-//! enums (no wildcard arms outside `HaltedForUpgrade`). Adding a
-//! variant to `FsmState` or `Event` will break the build until the
-//! match is updated.
-//!
-//! # What this PR does NOT yet do
-//!
-//! - Wire `transition()` into the engine — that's CONS-305 (handler
-//!   migration) once `step_entered_at` (CONS-304) is in place.
-//! - Drive watchdog firings — that's CONS-309.
-//! - Centralise step timeouts as constants — that's CONS-310.
+//! 4 active phases — Proposing → Prevoting → Precommitting → Committed
+//! — with **walk-through timeouts**: every step before `Committed`
+//! advances on timeout to the next phase. Only `Committed.Timeout`
+//! triggers `Rejected(InsufficientPrecommits)` + view change. This
+//! matches the existing engine's `on_round_timeout`.
 
 use crate::fsm::events::{Action, Event};
-use crate::fsm::state::{FsmState, RejectionReason};
+use crate::fsm::state::{HaltReason, RejectionReason, ResumeCondition, ValidatorState};
+use std::time::Instant;
 
-/// Compute the next state and the actions to execute, given the current
-/// state and an arriving event.
+/// Compute the next state and the actions to execute.
 ///
 /// Pure function: no side effects, no panics, no `unreachable!`. The
-/// caller (CONS-305 runtime task) is responsible for executing the
-/// returned actions in order and feeding the resulting events back in.
-pub fn transition(state: FsmState, event: Event) -> (FsmState, Vec<Action>) {
+/// caller (CONS-305 runtime) executes the returned actions in order
+/// and feeds the resulting events back in.
+pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<Action>) {
     use Event::*;
-    use FsmState::*;
+    use ValidatorState::*;
 
-    match (state, event) {
-        // ------------------------------------------------------------
-        // UpgradeSignal — accepted from any non-terminal state. Halted
-        // is absorbing; Committed/Rejected/Hung's wildcard event arms
-        // below also catch this with logged-ignored, which is the
-        // intended semantics (signal arrived too late to matter).
-        // ------------------------------------------------------------
-        (Idle, UpgradeSignal { .. })
-        | (Proposing, UpgradeSignal { .. })
-        | (Prevoting, UpgradeSignal { .. })
-        | (Precommitting, UpgradeSignal { .. }) => {
-            (HaltedForUpgrade, vec![Action::HaltForUpgrade])
-        }
+    // Highest-priority cross-cutting events: panic, halt, shutdown,
+    // eviction. Handled before phase-specific arms so they win from
+    // any active state.
+    if let Some(out) = handle_universal(&state, &event) {
+        return out;
+    }
 
-        // ------------------------------------------------------------
-        // Idle — between rounds. Accept SelectedAsProposer / Timeout for
-        // the boundary case where the proposer fires before any state
-        // has been entered. Everything else is logged-ignored.
-        // ------------------------------------------------------------
-        (Idle, SelectedAsProposer { .. }) => {
-            (Proposing, vec![Action::CreateProposal, Action::ResetWatchdog])
-        }
+    match (state.clone(), event) {
+        // ============================================================
+        // Bootstrapping — first-ever start. Exits to Idle on
+        // BootstrapComplete; otherwise events are logged-ignored.
+        // ============================================================
+        (Bootstrapping, BootstrapComplete) => (Idle, vec![Action::ResetWatchdog]),
+        (Bootstrapping, _) => (
+            Bootstrapping,
+            vec![Action::LogIgnoredEvent("event in Bootstrapping")],
+        ),
+
+        // ============================================================
+        // CatchingUp — local state behind peers. Exits to Idle on
+        // CaughtUp; otherwise events are logged-ignored.
+        // ============================================================
+        (CatchingUp { .. }, CaughtUp) => (Idle, vec![Action::ResetWatchdog]),
+        (CatchingUp { .. }, _) => (
+            state,
+            vec![Action::LogIgnoredEvent("event in CatchingUp")],
+        ),
+
+        // ============================================================
+        // Idle — between rounds. Proposer-elect → Proposing.
+        // ============================================================
+        (Idle, SelectedAsProposer { .. }) => (
+            Proposing,
+            vec![Action::CreateProposal, Action::ResetWatchdog],
+        ),
         (Idle, ProposalAdmitted { .. }) => (
             Proposing,
             vec![Action::LogIgnoredEvent(
@@ -73,36 +76,26 @@ pub fn transition(state: FsmState, event: Event) -> (FsmState, Vec<Action>) {
         ),
         (Idle, Timeout) => (
             Idle,
-            vec![Action::LogIgnoredEvent("Timeout in Idle: no active step")],
+            vec![Action::LogIgnoredEvent("Timeout in Idle: no active phase")],
         ),
-        (Idle, PrevoteThresholdReached { .. }) => (
-            Idle,
-            vec![Action::LogIgnoredEvent("PrevoteThresholdReached in Idle")],
-        ),
-        (Idle, PrecommitThresholdReached { .. }) => (
-            Idle,
-            vec![Action::LogIgnoredEvent("PrecommitThresholdReached in Idle")],
-        ),
-        (Idle, CommitQuorumReached { .. }) => (
-            Idle,
-            vec![Action::LogIgnoredEvent("CommitQuorumReached in Idle")],
-        ),
-        (Idle, VoteFailed(_)) => (
-            Idle,
-            vec![Action::LogIgnoredEvent("VoteFailed in Idle")],
-        ),
-        (Idle, WatchdogFired { age_ms }) => (
-            Hung,
+        (Idle, WatchdogFired { .. }) => (
+            Hung {
+                since: Instant::now(),
+                prior_state: Box::new(Idle),
+            },
             vec![Action::LogHung {
                 reason: "Watchdog fired while Idle — runtime stuck before round start",
-            }, Action::LogIgnoredEvent("Idle.WatchdogFired"), event_marker_age_ms(age_ms)],
+            }],
+        ),
+        (Idle, _) => (
+            Idle,
+            vec![Action::LogIgnoredEvent("event in Idle (unrelated)")],
         ),
 
-        // ------------------------------------------------------------
-        // Proposing — the leader's window. Either a proposal arrives
-        // (transition to Prevoting) or the propose timeout fires
-        // (transition to Rejected for view change).
-        // ------------------------------------------------------------
+        // ============================================================
+        // Proposing — leader's window. ProposalAdmitted → Prevoting.
+        // Timeout walks forward to Prevoting.
+        // ============================================================
         (Proposing, ProposalAdmitted { id, .. }) => (
             Prevoting,
             vec![
@@ -111,47 +104,32 @@ pub fn transition(state: FsmState, event: Event) -> (FsmState, Vec<Action>) {
                 Action::ResetWatchdog,
             ],
         ),
-        (Proposing, SelectedAsProposer { .. }) => (
-            Proposing,
-            vec![Action::LogIgnoredEvent(
-                "SelectedAsProposer in Proposing: already proposing",
-            )],
-        ),
-        (Proposing, Timeout) => (
-            Rejected(RejectionReason::Timeout),
+        (Proposing, Timeout) => (Prevoting, vec![Action::ResetWatchdog]),
+        (Proposing, VoteFailed(reason)) => (
+            Rejected {
+                reason,
+                round: 0, // runtime fills in current_round on entry
+            },
             vec![Action::AdvanceRound],
         ),
-        (Proposing, PrevoteThresholdReached { .. }) => (
-            Proposing,
-            vec![Action::LogIgnoredEvent(
-                "PrevoteThresholdReached in Proposing: pre-quorum",
-            )],
-        ),
-        (Proposing, PrecommitThresholdReached { .. }) => (
-            Proposing,
-            vec![Action::LogIgnoredEvent(
-                "PrecommitThresholdReached in Proposing: pre-quorum",
-            )],
-        ),
-        (Proposing, CommitQuorumReached { .. }) => (
-            Proposing,
-            vec![Action::LogIgnoredEvent(
-                "CommitQuorumReached in Proposing: pre-quorum",
-            )],
-        ),
-        (Proposing, VoteFailed(reason)) => {
-            (Rejected(reason), vec![Action::AdvanceRound])
-        }
         (Proposing, WatchdogFired { .. }) => (
-            Hung,
+            Hung {
+                since: Instant::now(),
+                prior_state: Box::new(Proposing),
+            },
             vec![Action::LogHung {
                 reason: "Watchdog fired while Proposing — proposer or network stuck",
             }],
         ),
+        (Proposing, _) => (
+            Proposing,
+            vec![Action::LogIgnoredEvent("event in Proposing (out-of-phase)")],
+        ),
 
-        // ------------------------------------------------------------
-        // Prevoting — proposal admitted, accumulating prevotes.
-        // ------------------------------------------------------------
+        // ============================================================
+        // Prevoting — gathering PreVotes. PrevoteThresholdReached →
+        // Precommitting (send precommit). Timeout walks to Precommitting.
+        // ============================================================
         (Prevoting, PrevoteThresholdReached { block_id }) => (
             Precommitting,
             vec![
@@ -159,49 +137,49 @@ pub fn transition(state: FsmState, event: Event) -> (FsmState, Vec<Action>) {
                 Action::ResetWatchdog,
             ],
         ),
-        (Prevoting, Timeout) => (
-            Rejected(RejectionReason::InsufficientPrevotes),
+        (Prevoting, Timeout) => (Precommitting, vec![Action::ResetWatchdog]),
+        (Prevoting, VoteFailed(reason)) => (
+            Rejected { reason, round: 0 },
             vec![Action::AdvanceRound],
         ),
-        (Prevoting, VoteFailed(reason)) => {
-            (Rejected(reason), vec![Action::AdvanceRound])
-        }
-        (Prevoting, ProposalAdmitted { .. }) => (
-            Prevoting,
-            vec![Action::LogIgnoredEvent(
-                "ProposalAdmitted in Prevoting: duplicate or competing proposal",
-            )],
-        ),
-        (Prevoting, SelectedAsProposer { .. }) => (
-            Prevoting,
-            vec![Action::LogIgnoredEvent(
-                "SelectedAsProposer in Prevoting: round already advanced",
-            )],
-        ),
-        (Prevoting, PrecommitThresholdReached { .. }) => (
-            Prevoting,
-            vec![Action::LogIgnoredEvent(
-                "PrecommitThresholdReached in Prevoting: pre-prevote-quorum",
-            )],
-        ),
-        (Prevoting, CommitQuorumReached { .. }) => (
-            Prevoting,
-            vec![Action::LogIgnoredEvent(
-                "CommitQuorumReached in Prevoting: pre-prevote-quorum",
-            )],
-        ),
         (Prevoting, WatchdogFired { .. }) => (
-            Hung,
+            Hung {
+                since: Instant::now(),
+                prior_state: Box::new(Prevoting),
+            },
             vec![Action::LogHung {
                 reason: "Watchdog fired while Prevoting — vote pool stuck",
             }],
         ),
+        (Prevoting, _) => (
+            Prevoting,
+            vec![Action::LogIgnoredEvent("event in Prevoting (out-of-phase)")],
+        ),
 
-        // ------------------------------------------------------------
-        // Precommitting — accumulating precommits for one block.
-        // ------------------------------------------------------------
-        (Precommitting, CommitQuorumReached { block_id, quorum }) => (
-            Committed,
+        // ============================================================
+        // Precommitting — gathering PreCommits, then Commit votes.
+        // Two events advance through this phase:
+        //   PrecommitThresholdReached → send commit vote, stay
+        //   CommitQuorumReached → finalize, transition to Committed
+        // ============================================================
+        (Precommitting, PrecommitThresholdReached { block_id }) => (
+            Precommitting,
+            vec![
+                Action::SendCommit { block_id },
+                Action::ResetWatchdog,
+            ],
+        ),
+        (
+            Precommitting,
+            CommitQuorumReached {
+                block_id,
+                quorum,
+            },
+        ) => (
+            Committed {
+                block_hash: block_id.0,
+                height: quorum.height,
+            },
             vec![
                 Action::CommitBlock {
                     id: block_id,
@@ -210,177 +188,345 @@ pub fn transition(state: FsmState, event: Event) -> (FsmState, Vec<Action>) {
                 Action::ResetWatchdog,
             ],
         ),
-        (Precommitting, PrecommitThresholdReached { .. }) => (
-            Precommitting,
-            vec![Action::LogIgnoredEvent(
-                "PrecommitThresholdReached in Precommitting: waiting for quorum proof",
-            )],
-        ),
-        (Precommitting, Timeout) => (
-            Rejected(RejectionReason::InsufficientPrecommits),
+        // Walk-through Timeout. View-change happens at Committed.Timeout,
+        // not here — the existing engine progresses to "Commit step"
+        // on PreCommit timeout, gathering commit votes anyway.
+        (Precommitting, Timeout) => (Precommitting, vec![Action::ResetWatchdog]),
+        (Precommitting, VoteFailed(reason)) => (
+            Rejected { reason, round: 0 },
             vec![Action::AdvanceRound],
         ),
-        (Precommitting, VoteFailed(reason)) => {
-            (Rejected(reason), vec![Action::AdvanceRound])
-        }
-        (Precommitting, ProposalAdmitted { .. }) => (
-            Precommitting,
-            vec![Action::LogIgnoredEvent(
-                "ProposalAdmitted in Precommitting: too late",
-            )],
-        ),
-        (Precommitting, SelectedAsProposer { .. }) => (
-            Precommitting,
-            vec![Action::LogIgnoredEvent(
-                "SelectedAsProposer in Precommitting: round already advanced",
-            )],
-        ),
-        (Precommitting, PrevoteThresholdReached { .. }) => (
-            Precommitting,
-            vec![Action::LogIgnoredEvent(
-                "PrevoteThresholdReached in Precommitting: late prevote",
-            )],
-        ),
         (Precommitting, WatchdogFired { .. }) => (
-            Hung,
+            Hung {
+                since: Instant::now(),
+                prior_state: Box::new(Precommitting),
+            },
             vec![Action::LogHung {
                 reason: "Watchdog fired while Precommitting — quorum stuck",
             }],
         ),
+        (Precommitting, _) => (
+            Precommitting,
+            vec![Action::LogIgnoredEvent(
+                "event in Precommitting (out-of-phase)",
+            )],
+        ),
 
-        // ------------------------------------------------------------
-        // Committed — terminal-success. Self-clears on the next
-        // height's StartRound; until then everything is logged-ignored.
-        // ------------------------------------------------------------
-        (Committed, _event) => (Committed, vec![Action::LogIgnoredEvent("event in Committed")]),
+        // ============================================================
+        // Committed — block finalized at this height. The runtime
+        // advances to next height; further events at this height are
+        // logged-ignored. SelectedAsProposer at next height triggers
+        // the Idle path on round-entry (runtime resets to Idle).
+        // ============================================================
+        (Committed { .. }, SelectedAsProposer { .. }) => (
+            Proposing,
+            vec![Action::CreateProposal, Action::ResetWatchdog],
+        ),
+        (Committed { .. }, Timeout) => (
+            Rejected {
+                reason: RejectionReason::InsufficientPrecommits,
+                round: 0,
+            },
+            vec![Action::AdvanceRound],
+        ),
+        (
+            Committed { .. },
+            ProposalAdmitted {
+                id, height, round,
+            },
+        ) => (
+            // Next height arrived — re-enter Proposing then immediately
+            // admit. (Engine resets the round struct on its side.)
+            Proposing,
+            vec![
+                Action::BroadcastProposal { id: id.clone() },
+                Action::SendPrevote { block_id: id },
+                Action::ResetWatchdog,
+                Action::LogIgnoredEvent("auto-rolled Committed→Proposing"),
+                // height/round logged for diagnostics
+                Action::LogIgnoredEvent(if height > 0 || round > 0 {
+                    "next-height entry"
+                } else {
+                    "next-height entry (zero)"
+                }),
+            ],
+        ),
+        (Committed { .. }, _) => (
+            state,
+            vec![Action::LogIgnoredEvent("event in Committed")],
+        ),
 
-        // ------------------------------------------------------------
-        // Rejected — terminal-failure for the current round. The runtime
-        // emits AdvanceRound in the transition that produced Rejected;
-        // events arriving after that are ignored until the runtime feeds
-        // a new round.
-        // ------------------------------------------------------------
-        (Rejected(_), _event) => (
+        // ============================================================
+        // Rejected — runtime emitted AdvanceRound; events arriving
+        // before the next round entry are logged-ignored.
+        // ============================================================
+        (Rejected { .. }, SelectedAsProposer { .. }) => (
+            Proposing,
+            vec![Action::CreateProposal, Action::ResetWatchdog],
+        ),
+        (Rejected { .. }, _) => (
             state,
             vec![Action::LogIgnoredEvent("event in Rejected")],
         ),
 
-        // ------------------------------------------------------------
+        // ============================================================
         // Hung — terminal until external recovery.
-        // ------------------------------------------------------------
-        (Hung, _event) => (Hung, vec![Action::LogIgnoredEvent("event in Hung")]),
+        // ============================================================
+        (Hung { .. }, _) => (
+            state,
+            vec![Action::LogIgnoredEvent("event in Hung")],
+        ),
 
-        // ------------------------------------------------------------
-        // HaltedForUpgrade — only state with a wildcard event arm. By
-        // definition no event moves it forward; the runtime restart with
-        // the bumped CONSENSUS_PROTOCOL_VERSION is the only exit.
-        // ------------------------------------------------------------
-        (HaltedForUpgrade, _) => (
-            HaltedForUpgrade,
-            vec![Action::LogIgnoredEvent("event in HaltedForUpgrade")],
+        // ============================================================
+        // Halting — block production stopped. Exit on HaltActivated
+        // (transition to CoordinatedUpdate).
+        // ============================================================
+        (
+            Halting { .. },
+            HaltActivated {
+                activate_at_height,
+                target_version,
+            },
+        ) => (
+            CoordinatedUpdate {
+                activate_at_height,
+                target_version,
+            },
+            vec![Action::EnterUpdateBarrier {
+                activate_at_height,
+                target_version,
+            }],
+        ),
+        (Halting { .. }, _) => (
+            state,
+            vec![Action::LogIgnoredEvent("event in Halting")],
+        ),
+
+        // ============================================================
+        // CoordinatedUpdate — barrier; new binary running, awaiting
+        // quorum-ready. UpdateQuorumReady → Idle (next round on the
+        // new protocol version).
+        // ============================================================
+        (
+            CoordinatedUpdate {
+                target_version, ..
+            },
+            UpdateQuorumReady,
+        ) => (
+            Idle,
+            vec![
+                Action::BroadcastReadyOnNewVersion {
+                    version: target_version,
+                },
+                Action::ResetWatchdog,
+            ],
+        ),
+        (CoordinatedUpdate { .. }, _) => (
+            state,
+            vec![Action::LogIgnoredEvent("event in CoordinatedUpdate")],
+        ),
+
+        // ============================================================
+        // Slashed — out of active set. Re-enter on ReadmittedToSet.
+        // ============================================================
+        (Slashed { .. }, ReadmittedToSet) => (Idle, vec![Action::RejoinActiveSet]),
+        (Slashed { .. }, _) => (
+            state,
+            vec![Action::LogIgnoredEvent("event in Slashed")],
+        ),
+
+        // ============================================================
+        // Evicted — terminal until re-admission.
+        // ============================================================
+        (Evicted, ReadmittedToSet) => (Idle, vec![Action::RejoinActiveSet]),
+        (Evicted, _) => (Evicted, vec![Action::LogIgnoredEvent("event in Evicted")]),
+
+        // ============================================================
+        // Panic — recoverable reasons reset to Idle on PanicCleared;
+        // non-recoverable reasons force Halting{Never}. Catch the
+        // PanicCleared event here; non-recoverable transitions are
+        // emitted via PanicTriggered handling in handle_universal.
+        // ============================================================
+        (Panic { reason, .. }, PanicCleared) => {
+            if reason.is_recoverable() {
+                (Idle, vec![Action::ResetWatchdog])
+            } else {
+                (
+                    Halting {
+                        reason: HaltReason::EmergencyHalt,
+                        triggered_at_height: 0,
+                        last_block_hash: None,
+                        resume_condition: ResumeCondition::Never,
+                    },
+                    vec![
+                        Action::LogPanic { reason },
+                        Action::StopBlockProduction { at_height: 0 },
+                    ],
+                )
+            }
+        }
+        (Panic { .. }, _) => (
+            state,
+            vec![Action::LogIgnoredEvent("event in Panic")],
+        ),
+
+        // ============================================================
+        // ShuttingDown — terminal. All events logged-ignored.
+        // ============================================================
+        (ShuttingDown, _) => (
+            ShuttingDown,
+            vec![Action::LogIgnoredEvent("event in ShuttingDown")],
         ),
     }
 }
 
-/// Helper used by the watchdog branches in `Idle` to surface the
-/// firing-age in the action stream without inventing a dedicated
-/// Action variant. The runtime can pick this up via its observability
-/// pipeline; the FSM doesn't need to act on it.
-fn event_marker_age_ms(_age_ms: u64) -> Action {
-    Action::LogIgnoredEvent("watchdog age recorded")
+/// Cross-cutting events that override phase-specific transitions.
+/// Returns `Some` if the event was handled here, `None` if the main
+/// `match` should run.
+fn handle_universal(
+    state: &ValidatorState,
+    event: &Event,
+) -> Option<(ValidatorState, Vec<Action>)> {
+    use Event::*;
+    use ValidatorState::*;
+
+    match event {
+        // PanicTriggered — recoverable: enter Panic; non-recoverable:
+        // enter Panic and the runtime should observe the reason and
+        // emit PanicCleared (which then routes to Halting{Never}).
+        PanicTriggered { reason } => {
+            // Don't re-enter Panic from Panic / Halting / ShuttingDown.
+            if matches!(state, Panic { .. } | Halting { .. } | ShuttingDown) {
+                return Some((
+                    state.clone(),
+                    vec![Action::LogIgnoredEvent(
+                        "PanicTriggered while already in critical state",
+                    )],
+                ));
+            }
+            Some((
+                Panic {
+                    reason: reason.clone(),
+                    triggered_at: Instant::now(),
+                    prior_state: Box::new(state.clone()),
+                },
+                vec![
+                    Action::BroadcastPanic {
+                        reason: reason.clone(),
+                    },
+                    Action::LogPanic {
+                        reason: reason.clone(),
+                    },
+                ],
+            ))
+        }
+
+        // HaltScheduled — accepted from any active consensus state.
+        // Already-halted / panicked / shutting-down ignore.
+        HaltScheduled {
+            reason,
+            triggered_at_height,
+            resume_condition,
+        } => {
+            if matches!(state, Halting { .. } | Panic { .. } | ShuttingDown | Evicted) {
+                return Some((
+                    state.clone(),
+                    vec![Action::LogIgnoredEvent(
+                        "HaltScheduled while already halting/panicked/exiting",
+                    )],
+                ));
+            }
+            // Capture last_block_hash if we're in Committed.
+            let last_block_hash = if let Committed { block_hash, .. } = state {
+                Some(*block_hash)
+            } else {
+                None
+            };
+            Some((
+                Halting {
+                    reason: *reason,
+                    triggered_at_height: *triggered_at_height,
+                    last_block_hash,
+                    resume_condition: ResumeCondition::from(*resume_condition),
+                },
+                vec![Action::StopBlockProduction {
+                    at_height: *triggered_at_height,
+                }],
+            ))
+        }
+
+        // ShutdownRequested — accepted from any state. Always
+        // transitions to ShuttingDown and flushes logs.
+        ShutdownRequested => Some((
+            ShuttingDown,
+            vec![Action::FlushLogsForShutdown],
+        )),
+
+        // SlashEvidenceConfirmed — accepted from any active state.
+        SlashEvidenceConfirmed { reason } => {
+            if matches!(
+                state,
+                Slashed { .. } | Evicted | ShuttingDown | Panic { .. }
+            ) {
+                return Some((
+                    state.clone(),
+                    vec![Action::LogIgnoredEvent(
+                        "SlashEvidenceConfirmed while already slashed/exiting",
+                    )],
+                ));
+            }
+            Some((
+                Slashed { reason: *reason },
+                vec![Action::LeaveActiveSet],
+            ))
+        }
+
+        // EvictedFromSet — terminal-ish.
+        EvictedFromSet => {
+            if matches!(state, Evicted | ShuttingDown) {
+                return Some((
+                    state.clone(),
+                    vec![Action::LogIgnoredEvent("EvictedFromSet while already out")],
+                ));
+            }
+            Some((Evicted, vec![Action::LeaveActiveSet]))
+        }
+
+        _ => None,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fsm::events::ResumeConditionEvent;
+    use crate::fsm::state::{PanicReason, SlashReason};
     use lib_crypto::Hash;
     use lib_types::consensus::BftQuorumProof;
 
     fn dummy_quorum() -> BftQuorumProof {
         BftQuorumProof {
-            height: 0,
+            height: 7,
             proposal_id: [0u8; 32],
             total_validators: 0,
             attestations: Vec::new(),
         }
     }
 
-    fn all_events() -> Vec<Event> {
-        vec![
-            Event::SelectedAsProposer {
-                height: 1,
-                round: 0,
-            },
-            Event::ProposalAdmitted {
-                id: Hash([1u8; 32]),
-                height: 1,
-                round: 0,
-            },
-            Event::PrevoteThresholdReached {
-                block_id: Hash([2u8; 32]),
-            },
-            Event::PrecommitThresholdReached {
-                block_id: Hash([3u8; 32]),
-            },
-            Event::CommitQuorumReached {
-                block_id: Hash([4u8; 32]),
-                quorum: dummy_quorum(),
-            },
-            Event::VoteFailed(RejectionReason::Timeout),
-            Event::Timeout,
-            Event::WatchdogFired { age_ms: 5_000 },
-            Event::UpgradeSignal { halt_at_height: 100 },
-        ]
-    }
-
-    fn all_states() -> Vec<FsmState> {
-        vec![
-            FsmState::Idle,
-            FsmState::Proposing,
-            FsmState::Prevoting,
-            FsmState::Precommitting,
-            FsmState::Committed,
-            FsmState::Rejected(RejectionReason::InsufficientPrevotes),
-            FsmState::Hung,
-            FsmState::HaltedForUpgrade,
-        ]
-    }
-
-    /// CONS-302 acceptance criterion: every (state, event) pair returns
-    /// a valid (next_state, actions) tuple — no panic, no unreachable.
-    #[test]
-    fn transition_total_over_state_event_product() {
-        for state in all_states() {
-            for event in all_events() {
-                // Must not panic.
-                let (_next, actions) = transition(state, event.clone());
-                // Must always produce at least one action — even
-                // logged-ignored arrivals.  Empty action lists would
-                // hide silent transitions.
-                assert!(
-                    !actions.is_empty(),
-                    "transition({:?}, {:?}) returned no actions",
-                    state,
-                    event
-                );
-            }
-        }
-    }
-
-    /// Happy path: Idle → Proposing → Prevoting → Precommitting → Committed.
+    /// Happy path: Idle → Proposing → Prevoting → Precommitting →
+    /// Committed → (next round) Proposing.
     #[test]
     fn happy_path_round_completes() {
         let block_id = Hash([42u8; 32]);
-        let proposer_event = Event::SelectedAsProposer {
-            height: 1,
-            round: 0,
-        };
-
-        let (s, a) = transition(FsmState::Idle, proposer_event);
-        assert_eq!(s, FsmState::Proposing);
-        assert!(a.contains(&Action::CreateProposal));
 
         let (s, a) = transition(
+            ValidatorState::Idle,
+            Event::SelectedAsProposer { height: 1, round: 0 },
+        );
+        assert_eq!(s, ValidatorState::Proposing);
+        assert!(a.contains(&Action::CreateProposal));
+
+        let (s, _) = transition(
             s,
             Event::ProposalAdmitted {
                 id: block_id.clone(),
@@ -388,8 +534,7 @@ mod tests {
                 round: 0,
             },
         );
-        assert_eq!(s, FsmState::Prevoting);
-        assert!(a.iter().any(|x| matches!(x, Action::SendPrevote { .. })));
+        assert_eq!(s, ValidatorState::Prevoting);
 
         let (s, _) = transition(
             s,
@@ -397,85 +542,305 @@ mod tests {
                 block_id: block_id.clone(),
             },
         );
-        assert_eq!(s, FsmState::Precommitting);
+        assert_eq!(s, ValidatorState::Precommitting);
+
+        let (s, _) = transition(
+            s,
+            Event::PrecommitThresholdReached {
+                block_id: block_id.clone(),
+            },
+        );
+        assert_eq!(s, ValidatorState::Precommitting); // stays for commit-vote gathering
 
         let (s, a) = transition(
             s,
             Event::CommitQuorumReached {
-                block_id,
+                block_id: block_id.clone(),
                 quorum: dummy_quorum(),
             },
         );
-        assert_eq!(s, FsmState::Committed);
+        assert!(matches!(s, ValidatorState::Committed { .. }));
         assert!(a.iter().any(|x| matches!(x, Action::CommitBlock { .. })));
     }
 
-    /// Propose timeout produces a view change.
+    /// Walk-through timeouts: Proposing → Prevoting → Precommitting,
+    /// each by a Timeout. Committed.Timeout view-changes.
     #[test]
-    fn propose_timeout_advances_round() {
-        let (s, a) = transition(FsmState::Proposing, Event::Timeout);
-        assert_eq!(s, FsmState::Rejected(RejectionReason::Timeout));
+    fn timeouts_walk_through_phases() {
+        let (s, _) = transition(ValidatorState::Proposing, Event::Timeout);
+        assert_eq!(s, ValidatorState::Prevoting);
+
+        let (s, _) = transition(ValidatorState::Prevoting, Event::Timeout);
+        assert_eq!(s, ValidatorState::Precommitting);
+
+        let (s, _) = transition(ValidatorState::Precommitting, Event::Timeout);
+        // Precommitting.Timeout is walk-forward (engine progresses to
+        // Commit step which is folded into Precommitting in this FSM).
+        assert_eq!(s, ValidatorState::Precommitting);
+    }
+
+    #[test]
+    fn committed_timeout_is_view_change() {
+        let (s, a) = transition(
+            ValidatorState::Committed {
+                block_hash: [1u8; 32],
+                height: 1,
+            },
+            Event::Timeout,
+        );
+        assert!(matches!(
+            s,
+            ValidatorState::Rejected {
+                reason: RejectionReason::InsufficientPrecommits,
+                ..
+            }
+        ));
         assert!(a.contains(&Action::AdvanceRound));
     }
 
-    /// Prevote timeout maps to InsufficientPrevotes, not generic Timeout.
-    #[test]
-    fn prevote_timeout_rejection_specific() {
-        let (s, _) = transition(FsmState::Prevoting, Event::Timeout);
-        assert_eq!(s, FsmState::Rejected(RejectionReason::InsufficientPrevotes));
-    }
-
-    /// Precommit timeout maps to InsufficientPrecommits.
-    #[test]
-    fn precommit_timeout_rejection_specific() {
-        let (s, _) = transition(FsmState::Precommitting, Event::Timeout);
-        assert_eq!(
-            s,
-            FsmState::Rejected(RejectionReason::InsufficientPrecommits)
-        );
-    }
-
-    /// Watchdog from any active state lands in `Hung`.
     #[test]
     fn watchdog_from_active_states_hangs() {
         for state in [
-            FsmState::Proposing,
-            FsmState::Prevoting,
-            FsmState::Precommitting,
+            ValidatorState::Proposing,
+            ValidatorState::Prevoting,
+            ValidatorState::Precommitting,
         ] {
             let (s, a) = transition(state, Event::WatchdogFired { age_ms: 30_000 });
-            assert_eq!(s, FsmState::Hung);
+            assert!(matches!(s, ValidatorState::Hung { .. }));
             assert!(a.iter().any(|x| matches!(x, Action::LogHung { .. })));
         }
     }
 
-    /// UpgradeSignal trumps the current state for any non-terminal state.
     #[test]
-    fn upgrade_signal_halts_any_active_state() {
+    fn panic_recoverable_resets_to_idle_on_clear() {
+        let (s, _) = transition(
+            ValidatorState::Prevoting,
+            Event::PanicTriggered {
+                reason: PanicReason::HeartbeatMissed,
+            },
+        );
+        assert!(matches!(s, ValidatorState::Panic { .. }));
+        let (s, _) = transition(s, Event::PanicCleared);
+        assert_eq!(s, ValidatorState::Idle);
+    }
+
+    #[test]
+    fn panic_non_recoverable_forces_halting_never() {
+        let (s, _) = transition(
+            ValidatorState::Prevoting,
+            Event::PanicTriggered {
+                reason: PanicReason::DoubleVote,
+            },
+        );
+        assert!(matches!(s, ValidatorState::Panic { .. }));
+        let (s, _) = transition(s, Event::PanicCleared);
+        assert!(matches!(
+            s,
+            ValidatorState::Halting {
+                resume_condition: ResumeCondition::Never,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn panic_broadcasts_to_peers_for_logs() {
+        let (_, a) = transition(
+            ValidatorState::Prevoting,
+            Event::PanicTriggered {
+                reason: PanicReason::ByzantineVoteDetected,
+            },
+        );
+        assert!(a.iter().any(|x| matches!(x, Action::BroadcastPanic { .. })));
+    }
+
+    #[test]
+    fn halt_to_coordinated_update_to_idle_flow() {
+        let (s, _) = transition(
+            ValidatorState::Idle,
+            Event::HaltScheduled {
+                reason: HaltReason::UpgradeScheduled,
+                triggered_at_height: 100,
+                resume_condition: ResumeConditionEvent::QuorumReady,
+            },
+        );
+        assert!(matches!(s, ValidatorState::Halting { .. }));
+
+        let (s, _) = transition(
+            s,
+            Event::HaltActivated {
+                activate_at_height: 100,
+                target_version: 2,
+            },
+        );
+        assert!(matches!(s, ValidatorState::CoordinatedUpdate { .. }));
+
+        let (s, a) = transition(s, Event::UpdateQuorumReady);
+        assert_eq!(s, ValidatorState::Idle);
+        assert!(a
+            .iter()
+            .any(|x| matches!(x, Action::BroadcastReadyOnNewVersion { .. })));
+    }
+
+    #[test]
+    fn shutdown_from_any_state() {
         for state in [
-            FsmState::Idle,
-            FsmState::Proposing,
-            FsmState::Prevoting,
-            FsmState::Precommitting,
+            ValidatorState::Idle,
+            ValidatorState::Proposing,
+            ValidatorState::Prevoting,
+            ValidatorState::Precommitting,
+            ValidatorState::Committed {
+                block_hash: [0; 32],
+                height: 1,
+            },
+            ValidatorState::Bootstrapping,
+            ValidatorState::CatchingUp {
+                from_height: 0,
+                to_height: 1,
+            },
         ] {
-            let (s, a) = transition(state, Event::UpgradeSignal { halt_at_height: 100 });
-            assert_eq!(s, FsmState::HaltedForUpgrade);
-            assert_eq!(a, vec![Action::HaltForUpgrade]);
+            let (s, a) = transition(state.clone(), Event::ShutdownRequested);
+            assert_eq!(s, ValidatorState::ShuttingDown, "from {:?}", state);
+            assert!(a.contains(&Action::FlushLogsForShutdown));
         }
     }
 
-    /// `HaltedForUpgrade` is absorbing — every event is logged-ignored.
     #[test]
-    fn halted_for_upgrade_is_absorbing() {
-        for event in all_events() {
-            let (s, a) = transition(FsmState::HaltedForUpgrade, event.clone());
-            assert_eq!(s, FsmState::HaltedForUpgrade, "event {:?} moved Halted", event);
-            assert!(
-                a.iter().all(|x| matches!(x, Action::LogIgnoredEvent(_))),
-                "event {:?} produced non-ignored action {:?}",
-                event,
-                a
-            );
+    fn slashing_leaves_set_and_rejoin_returns_to_idle() {
+        let (s, a) = transition(
+            ValidatorState::Prevoting,
+            Event::SlashEvidenceConfirmed {
+                reason: SlashReason::DoubleSign,
+            },
+        );
+        assert!(matches!(s, ValidatorState::Slashed { .. }));
+        assert!(a.contains(&Action::LeaveActiveSet));
+
+        let (s, a) = transition(s, Event::ReadmittedToSet);
+        assert_eq!(s, ValidatorState::Idle);
+        assert!(a.contains(&Action::RejoinActiveSet));
+    }
+
+    #[test]
+    fn bootstrapping_exits_on_complete() {
+        let (s, _) = transition(ValidatorState::Bootstrapping, Event::BootstrapComplete);
+        assert_eq!(s, ValidatorState::Idle);
+    }
+
+    #[test]
+    fn catching_up_exits_on_caught_up() {
+        let (s, _) = transition(
+            ValidatorState::CatchingUp {
+                from_height: 0,
+                to_height: 100,
+            },
+            Event::CaughtUp,
+        );
+        assert_eq!(s, ValidatorState::Idle);
+    }
+
+    /// Totality: every (state_kind, event_kind) pair returns a
+    /// non-empty action list. Sample one variant per kind.
+    #[test]
+    fn transition_total_no_silent_drops() {
+        let states = [
+            ValidatorState::Bootstrapping,
+            ValidatorState::CatchingUp {
+                from_height: 0,
+                to_height: 1,
+            },
+            ValidatorState::Idle,
+            ValidatorState::Proposing,
+            ValidatorState::Prevoting,
+            ValidatorState::Precommitting,
+            ValidatorState::Committed {
+                block_hash: [0; 32],
+                height: 1,
+            },
+            ValidatorState::Rejected {
+                reason: RejectionReason::Timeout,
+                round: 0,
+            },
+            ValidatorState::Hung {
+                since: Instant::now(),
+                prior_state: Box::new(ValidatorState::Idle),
+            },
+            ValidatorState::Halting {
+                reason: HaltReason::UpgradeScheduled,
+                triggered_at_height: 0,
+                last_block_hash: None,
+                resume_condition: ResumeCondition::QuorumReady,
+            },
+            ValidatorState::CoordinatedUpdate {
+                activate_at_height: 0,
+                target_version: 2,
+            },
+            ValidatorState::Slashed {
+                reason: SlashReason::DoubleSign,
+            },
+            ValidatorState::Evicted,
+            ValidatorState::Panic {
+                reason: PanicReason::HeartbeatMissed,
+                triggered_at: Instant::now(),
+                prior_state: Box::new(ValidatorState::Idle),
+            },
+            ValidatorState::ShuttingDown,
+        ];
+
+        let events = [
+            Event::BootstrapComplete,
+            Event::CaughtUp,
+            Event::ShutdownRequested,
+            Event::SelectedAsProposer { height: 1, round: 0 },
+            Event::ProposalAdmitted {
+                id: Hash([0; 32]),
+                height: 1,
+                round: 0,
+            },
+            Event::PrevoteThresholdReached {
+                block_id: Hash([0; 32]),
+            },
+            Event::PrecommitThresholdReached {
+                block_id: Hash([0; 32]),
+            },
+            Event::CommitQuorumReached {
+                block_id: Hash([0; 32]),
+                quorum: dummy_quorum(),
+            },
+            Event::VoteFailed(RejectionReason::Timeout),
+            Event::Timeout,
+            Event::WatchdogFired { age_ms: 1 },
+            Event::PanicTriggered {
+                reason: PanicReason::WatchdogExpired,
+            },
+            Event::PanicCleared,
+            Event::HaltScheduled {
+                reason: HaltReason::UpgradeScheduled,
+                triggered_at_height: 0,
+                resume_condition: ResumeConditionEvent::QuorumReady,
+            },
+            Event::HaltActivated {
+                activate_at_height: 0,
+                target_version: 2,
+            },
+            Event::UpdateQuorumReady,
+            Event::SlashEvidenceConfirmed {
+                reason: SlashReason::DoubleSign,
+            },
+            Event::EvictedFromSet,
+            Event::ReadmittedToSet,
+        ];
+
+        for state in &states {
+            for event in &events {
+                let (_next, actions) = transition(state.clone(), event.clone());
+                assert!(
+                    !actions.is_empty(),
+                    "transition({:?}, {:?}) returned no actions",
+                    state.kind(),
+                    event.kind()
+                );
+            }
         }
     }
 }

--- a/lib-consensus-core/src/fsm/transition_table.rs
+++ b/lib-consensus-core/src/fsm/transition_table.rs
@@ -1,0 +1,536 @@
+//! Data-driven enumeration of the validator FSM transition matrix.
+//!
+//! The same transitions implemented by [`super::transition::transition`]
+//! exposed here as a `Vec<TransitionRule>` for runtime queries:
+//!
+//! ```ignore
+//! use lib_consensus_core::fsm::transition_table::{transition_table, ValidatorStateKind};
+//! let rules = transition_table();
+//! let from_prevoting: Vec<_> = rules.iter()
+//!     .filter(|r| r.from == ValidatorStateKind::Prevoting)
+//!     .collect();
+//! ```
+//!
+//! Two consumers benefit:
+//!
+//! 1. **Operator tooling** — render the FSM as a Graphviz diagram,
+//!    enumerate "what could happen if I send event X to state Y",
+//!    audit the protocol against the running code.
+//! 2. **Test fuzzing** — drive `transition()` with every kind-pair
+//!    enumerated by the table and verify the function output matches
+//!    the table's claimed `(to, action_kinds)`. The table thus acts
+//!    as the source-of-truth spec; the function is the executable
+//!    realization.
+//!
+//! ## Drift protection
+//!
+//! `tests::transition_function_matches_table` invokes `transition()`
+//! with one representative `(state, event)` per row in the table and
+//! asserts both the resulting state-kind and the action-kind sequence.
+//! Any divergence between table and function fails CI — the two
+//! cannot drift silently.
+
+use crate::fsm::events::{ActionKind, EventKind};
+use crate::fsm::state::ValidatorStateKind;
+
+/// One row of the transition matrix — a Markov chain edge.
+///
+/// `(from, event) → (to, actions)` with a `doc` string describing the
+/// real-world reason for the edge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitionRule {
+    pub from: ValidatorStateKind,
+    pub event: EventKind,
+    pub to: ValidatorStateKind,
+    /// Sequence of action *kinds* the transition emits.  Payload data
+    /// (block hashes, quorum proofs) is not represented here — the
+    /// table describes the *shape* of the transition, not its data.
+    pub actions: Vec<ActionKind>,
+    /// One-line description of the edge for diagram labels and audit logs.
+    pub doc: &'static str,
+}
+
+/// All transitions defined by the FSM, in source order.
+///
+/// The list is intentionally hand-maintained alongside
+/// [`super::transition::transition`].  The drift-protection test in
+/// this module enforces that every row's `(from, event) -> (to,
+/// actions)` matches what `transition()` produces.
+pub fn transition_table() -> Vec<TransitionRule> {
+    use ActionKind as A;
+    use EventKind as E;
+    use ValidatorStateKind as S;
+
+    let mut rules = Vec::new();
+
+    let mut push = |from, event, to, actions: Vec<A>, doc| {
+        rules.push(TransitionRule {
+            from,
+            event,
+            to,
+            actions,
+            doc,
+        });
+    };
+
+    // ----- Bootstrapping -----
+    push(
+        S::Bootstrapping,
+        E::BootstrapComplete,
+        S::Idle,
+        vec![A::ResetWatchdog],
+        "Genesis bootstrap finished — node is up and Idle.",
+    );
+
+    // ----- CatchingUp -----
+    push(
+        S::CatchingUp,
+        E::CaughtUp,
+        S::Idle,
+        vec![A::ResetWatchdog],
+        "Sync reached the network tip — resume normal consensus.",
+    );
+
+    // ----- Idle -----
+    push(
+        S::Idle,
+        E::SelectedAsProposer,
+        S::Proposing,
+        vec![A::CreateProposal, A::ResetWatchdog],
+        "Local validator was elected proposer for this round.",
+    );
+
+    // ----- Proposing -----
+    push(
+        S::Proposing,
+        E::ProposalAdmitted,
+        S::Prevoting,
+        vec![A::BroadcastProposal, A::SendPrevote, A::ResetWatchdog],
+        "Valid proposal admitted; broadcast it and cast our prevote.",
+    );
+    push(
+        S::Proposing,
+        E::Timeout,
+        S::Prevoting,
+        vec![A::ResetWatchdog],
+        "Proposal window timed out — walk forward to Prevoting.",
+    );
+    push(
+        S::Proposing,
+        E::WatchdogFired,
+        S::Hung,
+        vec![A::LogHung],
+        "Watchdog flagged Proposing as stuck.",
+    );
+
+    // ----- Prevoting -----
+    push(
+        S::Prevoting,
+        E::PrevoteThresholdReached,
+        S::Precommitting,
+        vec![A::SendPrecommit, A::ResetWatchdog],
+        "+2/3 prevotes for one block — send precommit and advance.",
+    );
+    push(
+        S::Prevoting,
+        E::Timeout,
+        S::Precommitting,
+        vec![A::ResetWatchdog],
+        "Prevote window timed out — walk forward to Precommitting.",
+    );
+    push(
+        S::Prevoting,
+        E::WatchdogFired,
+        S::Hung,
+        vec![A::LogHung],
+        "Watchdog flagged Prevoting as stuck.",
+    );
+
+    // ----- Precommitting -----
+    push(
+        S::Precommitting,
+        E::PrecommitThresholdReached,
+        S::Precommitting,
+        vec![A::SendCommit, A::ResetWatchdog],
+        "+2/3 precommits — send commit vote, stay gathering commits.",
+    );
+    push(
+        S::Precommitting,
+        E::CommitQuorumReached,
+        S::Committed,
+        vec![A::CommitBlock, A::ResetWatchdog],
+        "Commit-vote quorum — block finalized, transition to Committed.",
+    );
+    push(
+        S::Precommitting,
+        E::Timeout,
+        S::Precommitting,
+        vec![A::ResetWatchdog],
+        "Precommit window timed out — keep gathering commit votes.",
+    );
+    push(
+        S::Precommitting,
+        E::WatchdogFired,
+        S::Hung,
+        vec![A::LogHung],
+        "Watchdog flagged Precommitting as stuck.",
+    );
+
+    // ----- Committed -----
+    push(
+        S::Committed,
+        E::Timeout,
+        S::Rejected,
+        vec![A::AdvanceRound],
+        "Commit-vote gathering timed out — view change.",
+    );
+    push(
+        S::Committed,
+        E::SelectedAsProposer,
+        S::Proposing,
+        vec![A::CreateProposal, A::ResetWatchdog],
+        "Next height: this validator is proposer.",
+    );
+
+    // ----- Rejected -----
+    push(
+        S::Rejected,
+        E::SelectedAsProposer,
+        S::Proposing,
+        vec![A::CreateProposal, A::ResetWatchdog],
+        "Round +1 entry: this validator is proposer.",
+    );
+
+    // ----- Universal: panic -----
+    // Source kind doesn't matter for this row — the table records the
+    // *event kind*'s effect, and PanicTriggered is handled in
+    // `handle_universal()` for any non-critical state.  We pick Idle as
+    // a representative source for the spec table.
+    push(
+        S::Idle,
+        E::PanicTriggered,
+        S::Panic,
+        vec![A::BroadcastPanic, A::LogPanic],
+        "Critical condition observed — enter Panic, broadcast to peers.",
+    );
+    push(
+        S::Panic,
+        E::PanicCleared,
+        S::Idle,
+        vec![A::ResetWatchdog],
+        "Recoverable panic cleared — return to Idle. \
+         (Non-recoverable: see Panic→Halting row.)",
+    );
+    push(
+        S::Panic,
+        E::PanicCleared,
+        S::Halting,
+        vec![A::LogPanic, A::StopBlockProduction],
+        "Non-recoverable panic — force Halting{Never}.",
+    );
+
+    // ----- Universal: halt + coordinated update -----
+    push(
+        S::Idle,
+        E::HaltScheduled,
+        S::Halting,
+        vec![A::StopBlockProduction],
+        "Operator scheduled a coordinated halt.",
+    );
+    push(
+        S::Halting,
+        E::HaltActivated,
+        S::CoordinatedUpdate,
+        vec![A::EnterUpdateBarrier],
+        "Halt window reached — enter coordinated-update barrier.",
+    );
+    push(
+        S::CoordinatedUpdate,
+        E::UpdateQuorumReady,
+        S::Idle,
+        vec![A::BroadcastReadyOnNewVersion, A::ResetWatchdog],
+        "Quorum ready on new protocol version — resume Idle.",
+    );
+
+    // ----- Universal: shutdown -----
+    push(
+        S::Idle,
+        E::ShutdownRequested,
+        S::ShuttingDown,
+        vec![A::FlushLogsForShutdown],
+        "Operator requested graceful shutdown.",
+    );
+
+    // ----- Slashing / eviction -----
+    push(
+        S::Idle,
+        E::SlashEvidenceConfirmed,
+        S::Slashed,
+        vec![A::LeaveActiveSet],
+        "Slashable evidence confirmed — leave active set.",
+    );
+    push(
+        S::Idle,
+        E::EvictedFromSet,
+        S::Evicted,
+        vec![A::LeaveActiveSet],
+        "Removed from active set.",
+    );
+    push(
+        S::Slashed,
+        E::ReadmittedToSet,
+        S::Idle,
+        vec![A::RejoinActiveSet],
+        "Re-admitted after slashing window closed.",
+    );
+    push(
+        S::Evicted,
+        E::ReadmittedToSet,
+        S::Idle,
+        vec![A::RejoinActiveSet],
+        "Re-admitted after re-registration.",
+    );
+
+    rules
+}
+
+/// Convenience query: all transitions originating from a specific
+/// state kind.
+pub fn transitions_from(state: ValidatorStateKind) -> Vec<TransitionRule> {
+    transition_table()
+        .into_iter()
+        .filter(|r| r.from == state)
+        .collect()
+}
+
+/// Convenience query: all transitions triggered by a specific event
+/// kind, regardless of source state.
+pub fn transitions_by_event(event: EventKind) -> Vec<TransitionRule> {
+    transition_table()
+        .into_iter()
+        .filter(|r| r.event == event)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fsm::events::{Event, ResumeConditionEvent};
+    use crate::fsm::state::{
+        HaltReason, PanicReason, RejectionReason, ResumeCondition, SlashReason, ValidatorState,
+    };
+    use crate::fsm::transition::transition;
+    use lib_crypto::Hash;
+    use lib_types::consensus::BftQuorumProof;
+    use std::time::Instant;
+
+    fn dummy_quorum() -> BftQuorumProof {
+        BftQuorumProof {
+            height: 7,
+            proposal_id: [0u8; 32],
+            total_validators: 0,
+            attestations: Vec::new(),
+        }
+    }
+
+    /// Build a representative `(state, event)` pair for a `(from,
+    /// event_kind)` row. The variants chosen pair one canonical
+    /// payload with the kind under test.
+    fn representative_state(kind: ValidatorStateKind) -> ValidatorState {
+        match kind {
+            ValidatorStateKind::Bootstrapping => ValidatorState::Bootstrapping,
+            ValidatorStateKind::CatchingUp => ValidatorState::CatchingUp {
+                from_height: 0,
+                to_height: 100,
+            },
+            ValidatorStateKind::Idle => ValidatorState::Idle,
+            ValidatorStateKind::Proposing => ValidatorState::Proposing,
+            ValidatorStateKind::Prevoting => ValidatorState::Prevoting,
+            ValidatorStateKind::Precommitting => ValidatorState::Precommitting,
+            ValidatorStateKind::Committed => ValidatorState::Committed {
+                block_hash: [1u8; 32],
+                height: 7,
+            },
+            ValidatorStateKind::Rejected => ValidatorState::Rejected {
+                reason: RejectionReason::InsufficientPrevotes,
+                round: 0,
+            },
+            ValidatorStateKind::Hung => ValidatorState::Hung {
+                since: Instant::now(),
+                prior_state: Box::new(ValidatorState::Idle),
+            },
+            ValidatorStateKind::Halting => ValidatorState::Halting {
+                reason: HaltReason::UpgradeScheduled,
+                triggered_at_height: 100,
+                last_block_hash: None,
+                resume_condition: ResumeCondition::QuorumReady,
+            },
+            ValidatorStateKind::CoordinatedUpdate => ValidatorState::CoordinatedUpdate {
+                activate_at_height: 100,
+                target_version: 2,
+            },
+            ValidatorStateKind::Slashed => ValidatorState::Slashed {
+                reason: SlashReason::DoubleSign,
+            },
+            ValidatorStateKind::Evicted => ValidatorState::Evicted,
+            ValidatorStateKind::Panic => ValidatorState::Panic {
+                // Use a recoverable reason so the (Panic, PanicCleared)
+                // row that goes to Idle matches; the non-recoverable
+                // row to Halting is exercised separately below.
+                reason: PanicReason::HeartbeatMissed,
+                triggered_at: Instant::now(),
+                prior_state: Box::new(ValidatorState::Idle),
+            },
+            ValidatorStateKind::ShuttingDown => ValidatorState::ShuttingDown,
+        }
+    }
+
+    fn representative_event(kind: EventKind) -> Event {
+        match kind {
+            EventKind::BootstrapComplete => Event::BootstrapComplete,
+            EventKind::CaughtUp => Event::CaughtUp,
+            EventKind::ShutdownRequested => Event::ShutdownRequested,
+            EventKind::SelectedAsProposer => {
+                Event::SelectedAsProposer { height: 1, round: 0 }
+            }
+            EventKind::ProposalAdmitted => Event::ProposalAdmitted {
+                id: Hash([42u8; 32]),
+                height: 1,
+                round: 0,
+            },
+            EventKind::PrevoteThresholdReached => Event::PrevoteThresholdReached {
+                block_id: Hash([42u8; 32]),
+            },
+            EventKind::PrecommitThresholdReached => Event::PrecommitThresholdReached {
+                block_id: Hash([42u8; 32]),
+            },
+            EventKind::CommitQuorumReached => Event::CommitQuorumReached {
+                block_id: Hash([42u8; 32]),
+                quorum: dummy_quorum(),
+            },
+            EventKind::VoteFailed => Event::VoteFailed(RejectionReason::Timeout),
+            EventKind::Timeout => Event::Timeout,
+            EventKind::WatchdogFired => Event::WatchdogFired { age_ms: 1 },
+            EventKind::PanicTriggered => Event::PanicTriggered {
+                reason: PanicReason::WatchdogExpired,
+            },
+            EventKind::PanicCleared => Event::PanicCleared,
+            EventKind::HaltScheduled => Event::HaltScheduled {
+                reason: HaltReason::UpgradeScheduled,
+                triggered_at_height: 100,
+                resume_condition: ResumeConditionEvent::QuorumReady,
+            },
+            EventKind::HaltActivated => Event::HaltActivated {
+                activate_at_height: 100,
+                target_version: 2,
+            },
+            EventKind::UpdateQuorumReady => Event::UpdateQuorumReady,
+            EventKind::SlashEvidenceConfirmed => Event::SlashEvidenceConfirmed {
+                reason: SlashReason::DoubleSign,
+            },
+            EventKind::EvictedFromSet => Event::EvictedFromSet,
+            EventKind::ReadmittedToSet => Event::ReadmittedToSet,
+        }
+    }
+
+    /// Drift protection: every row in the table must match what
+    /// `transition()` actually produces for one representative
+    /// (state, event) pair. If a row diverges from the function,
+    /// either the row or the function is wrong — fix one.
+    ///
+    /// Two rows in the table cover the same (Panic, PanicCleared) pair
+    /// — recoverable→Idle and non-recoverable→Halting — disambiguated
+    /// by `prior_state`/`reason`. We exercise both branches here.
+    #[test]
+    fn transition_function_matches_table() {
+        for rule in transition_table() {
+            // The (Panic, PanicCleared) pair has two table rows. Skip
+            // the non-recoverable one for this generic walk; it's
+            // exercised in `panic_non_recoverable_row` below.
+            if rule.from == ValidatorStateKind::Panic
+                && rule.event == EventKind::PanicCleared
+                && rule.to == ValidatorStateKind::Halting
+            {
+                continue;
+            }
+
+            let state = representative_state(rule.from);
+            let event = representative_event(rule.event);
+            let (next, actions) = transition(state.clone(), event.clone());
+
+            assert_eq!(
+                next.kind(),
+                rule.to,
+                "from {:?} via {:?} expected {:?}, got {:?}\n  doc: {}",
+                rule.from,
+                rule.event,
+                rule.to,
+                next.kind(),
+                rule.doc,
+            );
+
+            let action_kinds: Vec<ActionKind> = actions.iter().map(|a| a.kind()).collect();
+            assert_eq!(
+                action_kinds, rule.actions,
+                "from {:?} via {:?} action mismatch\n  doc: {}",
+                rule.from, rule.event, rule.doc,
+            );
+        }
+    }
+
+    /// Non-recoverable Panic row: PanicCleared from a Panic with a
+    /// non-recoverable reason forces Halting{Never}.
+    #[test]
+    fn panic_non_recoverable_row() {
+        let state = ValidatorState::Panic {
+            reason: PanicReason::DoubleVote,
+            triggered_at: Instant::now(),
+            prior_state: Box::new(ValidatorState::Prevoting),
+        };
+        let (next, actions) = transition(state, Event::PanicCleared);
+        assert_eq!(next.kind(), ValidatorStateKind::Halting);
+        let action_kinds: Vec<ActionKind> = actions.iter().map(|a| a.kind()).collect();
+        assert_eq!(
+            action_kinds,
+            vec![ActionKind::LogPanic, ActionKind::StopBlockProduction]
+        );
+    }
+
+    #[test]
+    fn transitions_from_query_works() {
+        let from_prevoting = transitions_from(ValidatorStateKind::Prevoting);
+        // Prevoting has 3 explicit rows: PrevoteThresholdReached,
+        // Timeout, WatchdogFired.
+        assert_eq!(from_prevoting.len(), 3);
+        assert!(from_prevoting
+            .iter()
+            .any(|r| r.event == EventKind::PrevoteThresholdReached));
+        assert!(from_prevoting
+            .iter()
+            .any(|r| r.event == EventKind::Timeout));
+        assert!(from_prevoting
+            .iter()
+            .any(|r| r.event == EventKind::WatchdogFired));
+    }
+
+    #[test]
+    fn transitions_by_event_query_works() {
+        let by_timeout = transitions_by_event(EventKind::Timeout);
+        // Timeout is defined for 4 source states: Proposing, Prevoting,
+        // Precommitting, Committed.
+        assert_eq!(by_timeout.len(), 4);
+    }
+
+    /// Every row's doc string is non-empty — table is self-documenting.
+    #[test]
+    fn every_row_has_doc() {
+        for rule in transition_table() {
+            assert!(
+                !rule.doc.is_empty(),
+                "rule {:?} via {:?} has empty doc",
+                rule.from,
+                rule.event,
+            );
+        }
+    }
+}

--- a/lib-consensus-core/src/fsm/transition_table.rs
+++ b/lib-consensus-core/src/fsm/transition_table.rs
@@ -4,11 +4,9 @@
 //! exposed here as a `Vec<TransitionRule>` for runtime queries:
 //!
 //! ```ignore
-//! use lib_consensus_core::fsm::transition_table::{transition_table, ValidatorStateKind};
+//! use lib_consensus_core::fsm::transition_table::*;
 //! let rules = transition_table();
-//! let from_prevoting: Vec<_> = rules.iter()
-//!     .filter(|r| r.from == ValidatorStateKind::Prevoting)
-//!     .collect();
+//! let from_prevoting: Vec<_> = transitions_from(ValidatorStateKind::Prevoting);
 //! ```
 //!
 //! Two consumers benefit:
@@ -18,20 +16,46 @@
 //!    audit the protocol against the running code.
 //! 2. **Test fuzzing** — drive `transition()` with every kind-pair
 //!    enumerated by the table and verify the function output matches
-//!    the table's claimed `(to, action_kinds)`. The table thus acts
-//!    as the source-of-truth spec; the function is the executable
-//!    realization.
+//!    the table's claimed `(to, action_kinds)`.
 //!
-//! ## Drift protection
+//! ## Universal-event encoding ([`FromKind::Any`])
 //!
-//! `tests::transition_function_matches_table` invokes `transition()`
-//! with one representative `(state, event)` per row in the table and
-//! asserts both the resulting state-kind and the action-kind sequence.
-//! Any divergence between table and function fails CI — the two
-//! cannot drift silently.
+//! Cross-cutting events (`PanicTriggered`, `HaltScheduled`,
+//! `ShutdownRequested`, `SlashEvidenceConfirmed`, `EvictedFromSet`)
+//! apply from "every active state" — encoding them as a single
+//! `(Specific(Idle), …)` row would have made `transitions_from(X)`
+//! incomplete for every other source state. Instead the table uses
+//! [`FromKind::Any`] for these rows, and [`transitions_from`]
+//! returns both the source-specific and `Any` rows that match a
+//! query state. PR #2394 review (Copilot).
+//!
+//! ## Drift protection (bidirectional)
+//!
+//! - **Forward**: `transition_function_matches_table` runs every row
+//!   through `transition()` and asserts the resulting state-kind and
+//!   action-kinds match the table.
+//! - **Reverse**: `function_transitions_appear_in_table` walks every
+//!   `(state_kind, event_kind)` product, calls `transition()`, and
+//!   for every result that produces a *meaningful* transition (state
+//!   change OR a non-`LogIgnoredEvent` action) verifies a matching
+//!   row exists in the table. This catches the case where the
+//!   function adds a transition that the table author forgot to
+//!   document. PR #2394 review (Copilot).
 
 use crate::fsm::events::{ActionKind, EventKind};
 use crate::fsm::state::ValidatorStateKind;
+
+/// Source side of a transition rule.
+///
+/// `Specific(K)` matches exactly state-kind `K`. `Any` matches every
+/// active state (the runtime restricts the actual set per the
+/// universal-event guards in `transition()` — e.g. `PanicTriggered`
+/// is logged-ignored from `Panic`/`Halting`/`ShuttingDown`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FromKind {
+    Specific(ValidatorStateKind),
+    Any,
+}
 
 /// One row of the transition matrix — a Markov chain edge.
 ///
@@ -39,26 +63,23 @@ use crate::fsm::state::ValidatorStateKind;
 /// real-world reason for the edge.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransitionRule {
-    pub from: ValidatorStateKind,
+    pub from: FromKind,
     pub event: EventKind,
     pub to: ValidatorStateKind,
-    /// Sequence of action *kinds* the transition emits.  Payload data
-    /// (block hashes, quorum proofs) is not represented here — the
-    /// table describes the *shape* of the transition, not its data.
     pub actions: Vec<ActionKind>,
-    /// One-line description of the edge for diagram labels and audit logs.
     pub doc: &'static str,
 }
 
 /// All transitions defined by the FSM, in source order.
 ///
-/// The list is intentionally hand-maintained alongside
-/// [`super::transition::transition`].  The drift-protection test in
-/// this module enforces that every row's `(from, event) -> (to,
-/// actions)` matches what `transition()` produces.
+/// The list is hand-maintained alongside
+/// [`super::transition::transition`]. Two drift-protection tests
+/// (forward and reverse) enforce the table cannot diverge from the
+/// function in either direction.
 pub fn transition_table() -> Vec<TransitionRule> {
     use ActionKind as A;
     use EventKind as E;
+    use FromKind as F;
     use ValidatorStateKind as S;
 
     let mut rules = Vec::new();
@@ -73,18 +94,16 @@ pub fn transition_table() -> Vec<TransitionRule> {
         });
     };
 
-    // ----- Bootstrapping -----
+    // ----- Lifecycle -----
     push(
-        S::Bootstrapping,
+        F::Specific(S::Bootstrapping),
         E::BootstrapComplete,
         S::Idle,
         vec![A::ResetWatchdog],
         "Genesis bootstrap finished — node is up and Idle.",
     );
-
-    // ----- CatchingUp -----
     push(
-        S::CatchingUp,
+        F::Specific(S::CatchingUp),
         E::CaughtUp,
         S::Idle,
         vec![A::ResetWatchdog],
@@ -93,99 +112,127 @@ pub fn transition_table() -> Vec<TransitionRule> {
 
     // ----- Idle -----
     push(
-        S::Idle,
+        F::Specific(S::Idle),
         E::SelectedAsProposer,
         S::Proposing,
         vec![A::CreateProposal, A::ResetWatchdog],
         "Local validator was elected proposer for this round.",
     );
+    push(
+        F::Specific(S::Idle),
+        E::WatchdogFired,
+        S::Hung,
+        vec![A::LogHung],
+        "Watchdog fired while Idle — runtime stuck before round start.",
+    );
 
     // ----- Proposing -----
     push(
-        S::Proposing,
+        F::Specific(S::Proposing),
         E::ProposalAdmitted,
         S::Prevoting,
         vec![A::BroadcastProposal, A::SendPrevote, A::ResetWatchdog],
         "Valid proposal admitted; broadcast it and cast our prevote.",
     );
     push(
-        S::Proposing,
+        F::Specific(S::Proposing),
         E::Timeout,
         S::Prevoting,
         vec![A::ResetWatchdog],
         "Proposal window timed out — walk forward to Prevoting.",
     );
     push(
-        S::Proposing,
+        F::Specific(S::Proposing),
         E::WatchdogFired,
         S::Hung,
         vec![A::LogHung],
         "Watchdog flagged Proposing as stuck.",
     );
+    push(
+        F::Specific(S::Proposing),
+        E::VoteFailed,
+        S::Rejected,
+        vec![A::AdvanceRound],
+        "Vote-tally rejection in Proposing — view change.",
+    );
 
     // ----- Prevoting -----
     push(
-        S::Prevoting,
+        F::Specific(S::Prevoting),
         E::PrevoteThresholdReached,
         S::Precommitting,
         vec![A::SendPrecommit, A::ResetWatchdog],
         "+2/3 prevotes for one block — send precommit and advance.",
     );
     push(
-        S::Prevoting,
+        F::Specific(S::Prevoting),
         E::Timeout,
         S::Precommitting,
         vec![A::ResetWatchdog],
         "Prevote window timed out — walk forward to Precommitting.",
     );
     push(
-        S::Prevoting,
+        F::Specific(S::Prevoting),
         E::WatchdogFired,
         S::Hung,
         vec![A::LogHung],
         "Watchdog flagged Prevoting as stuck.",
     );
+    push(
+        F::Specific(S::Prevoting),
+        E::VoteFailed,
+        S::Rejected,
+        vec![A::AdvanceRound],
+        "Vote-tally rejection in Prevoting — view change.",
+    );
 
     // ----- Precommitting -----
     push(
-        S::Precommitting,
+        F::Specific(S::Precommitting),
         E::PrecommitThresholdReached,
         S::Precommitting,
         vec![A::SendCommit, A::ResetWatchdog],
         "+2/3 precommits — send commit vote, stay gathering commits.",
     );
     push(
-        S::Precommitting,
+        F::Specific(S::Precommitting),
         E::CommitQuorumReached,
         S::Committed,
         vec![A::CommitBlock, A::ResetWatchdog],
         "Commit-vote quorum — block finalized, transition to Committed.",
     );
     push(
-        S::Precommitting,
+        F::Specific(S::Precommitting),
         E::Timeout,
         S::Precommitting,
         vec![A::ResetWatchdog],
         "Precommit window timed out — keep gathering commit votes.",
     );
     push(
-        S::Precommitting,
+        F::Specific(S::Precommitting),
         E::WatchdogFired,
         S::Hung,
         vec![A::LogHung],
         "Watchdog flagged Precommitting as stuck.",
     );
+    push(
+        F::Specific(S::Precommitting),
+        E::VoteFailed,
+        S::Rejected,
+        vec![A::AdvanceRound],
+        "Vote-tally rejection in Precommitting — view change.",
+    );
 
     // ----- Committed -----
     push(
-        S::Committed,
+        F::Specific(S::Committed),
         E::Timeout,
         S::Rejected,
         vec![A::AdvanceRound],
         "Commit-vote gathering timed out — view change.",
     );
     push(
-        S::Committed,
+        F::Specific(S::Committed),
         E::SelectedAsProposer,
         S::Proposing,
         vec![A::CreateProposal, A::ResetWatchdog],
@@ -194,58 +241,56 @@ pub fn transition_table() -> Vec<TransitionRule> {
 
     // ----- Rejected -----
     push(
-        S::Rejected,
+        F::Specific(S::Rejected),
         E::SelectedAsProposer,
         S::Proposing,
         vec![A::CreateProposal, A::ResetWatchdog],
         "Round +1 entry: this validator is proposer.",
     );
 
-    // ----- Universal: panic -----
-    // Source kind doesn't matter for this row — the table records the
-    // *event kind*'s effect, and PanicTriggered is handled in
-    // `handle_universal()` for any non-critical state.  We pick Idle as
-    // a representative source for the spec table.
+    // ----- Universal: PanicTriggered -----
     push(
-        S::Idle,
+        F::Any,
         E::PanicTriggered,
         S::Panic,
         vec![A::BroadcastPanic, A::LogPanic],
-        "Critical condition observed — enter Panic, broadcast to peers.",
+        "Critical condition observed — enter Panic, broadcast to peers. \
+         (Already-Panic/Halting/ShuttingDown sources log-ignore.)",
     );
+    // Two rows for (Panic, PanicCleared) — recoverable vs non-recoverable.
     push(
-        S::Panic,
+        F::Specific(S::Panic),
         E::PanicCleared,
         S::Idle,
         vec![A::ResetWatchdog],
-        "Recoverable panic cleared — return to Idle. \
-         (Non-recoverable: see Panic→Halting row.)",
+        "Recoverable panic cleared — return to Idle.",
     );
     push(
-        S::Panic,
+        F::Specific(S::Panic),
         E::PanicCleared,
         S::Halting,
         vec![A::LogPanic, A::StopBlockProduction],
-        "Non-recoverable panic — force Halting{Never}.",
+        "Non-recoverable panic — force Halting{Never} at the panic-time height.",
     );
 
-    // ----- Universal: halt + coordinated update -----
+    // ----- Universal: HaltScheduled / Halt -> CoordinatedUpdate -> Idle -----
     push(
-        S::Idle,
+        F::Any,
         E::HaltScheduled,
         S::Halting,
         vec![A::StopBlockProduction],
-        "Operator scheduled a coordinated halt.",
+        "Operator scheduled a coordinated halt. \
+         (Already-Halting/Panic/ShuttingDown/Evicted sources log-ignore.)",
     );
     push(
-        S::Halting,
+        F::Specific(S::Halting),
         E::HaltActivated,
         S::CoordinatedUpdate,
         vec![A::EnterUpdateBarrier],
         "Halt window reached — enter coordinated-update barrier.",
     );
     push(
-        S::CoordinatedUpdate,
+        F::Specific(S::CoordinatedUpdate),
         E::UpdateQuorumReady,
         S::Idle,
         vec![A::BroadcastReadyOnNewVersion, A::ResetWatchdog],
@@ -254,37 +299,39 @@ pub fn transition_table() -> Vec<TransitionRule> {
 
     // ----- Universal: shutdown -----
     push(
-        S::Idle,
+        F::Any,
         E::ShutdownRequested,
         S::ShuttingDown,
         vec![A::FlushLogsForShutdown],
         "Operator requested graceful shutdown.",
     );
 
-    // ----- Slashing / eviction -----
+    // ----- Universal: slashing / eviction -----
     push(
-        S::Idle,
+        F::Any,
         E::SlashEvidenceConfirmed,
         S::Slashed,
         vec![A::LeaveActiveSet],
-        "Slashable evidence confirmed — leave active set.",
+        "Slashable evidence confirmed — leave active set. \
+         (Already-Slashed/Evicted/ShuttingDown/Panic sources log-ignore.)",
     );
     push(
-        S::Idle,
+        F::Any,
         E::EvictedFromSet,
         S::Evicted,
         vec![A::LeaveActiveSet],
-        "Removed from active set.",
+        "Removed from active set. \
+         (Already-Evicted/ShuttingDown sources log-ignore.)",
     );
     push(
-        S::Slashed,
+        F::Specific(S::Slashed),
         E::ReadmittedToSet,
         S::Idle,
         vec![A::RejoinActiveSet],
         "Re-admitted after slashing window closed.",
     );
     push(
-        S::Evicted,
+        F::Specific(S::Evicted),
         E::ReadmittedToSet,
         S::Idle,
         vec![A::RejoinActiveSet],
@@ -294,17 +341,19 @@ pub fn transition_table() -> Vec<TransitionRule> {
     rules
 }
 
-/// Convenience query: all transitions originating from a specific
-/// state kind.
+/// All transitions whose `from` matches `state` — both
+/// `Specific(state)` rows and `Any` rows.
 pub fn transitions_from(state: ValidatorStateKind) -> Vec<TransitionRule> {
     transition_table()
         .into_iter()
-        .filter(|r| r.from == state)
+        .filter(|r| match r.from {
+            FromKind::Specific(s) => s == state,
+            FromKind::Any => true,
+        })
         .collect()
 }
 
-/// Convenience query: all transitions triggered by a specific event
-/// kind, regardless of source state.
+/// All transitions triggered by `event`, regardless of source.
 pub fn transitions_by_event(event: EventKind) -> Vec<TransitionRule> {
     transition_table()
         .into_iter()
@@ -333,9 +382,6 @@ mod tests {
         }
     }
 
-    /// Build a representative `(state, event)` pair for a `(from,
-    /// event_kind)` row. The variants chosen pair one canonical
-    /// payload with the kind under test.
     fn representative_state(kind: ValidatorStateKind) -> ValidatorState {
         match kind {
             ValidatorStateKind::Bootstrapping => ValidatorState::Bootstrapping,
@@ -374,11 +420,9 @@ mod tests {
             },
             ValidatorStateKind::Evicted => ValidatorState::Evicted,
             ValidatorStateKind::Panic => ValidatorState::Panic {
-                // Use a recoverable reason so the (Panic, PanicCleared)
-                // row that goes to Idle matches; the non-recoverable
-                // row to Halting is exercised separately below.
                 reason: PanicReason::HeartbeatMissed,
                 triggered_at: Instant::now(),
+                at_height: 0,
                 prior_state: Box::new(ValidatorState::Idle),
             },
             ValidatorStateKind::ShuttingDown => ValidatorState::ShuttingDown,
@@ -410,9 +454,14 @@ mod tests {
             },
             EventKind::VoteFailed => Event::VoteFailed(RejectionReason::Timeout),
             EventKind::Timeout => Event::Timeout,
-            EventKind::WatchdogFired => Event::WatchdogFired { age_ms: 1 },
+            EventKind::WatchdogFired => Event::WatchdogFired {
+                age_ms: 1,
+                fired_at: Instant::now(),
+            },
             EventKind::PanicTriggered => Event::PanicTriggered {
                 reason: PanicReason::WatchdogExpired,
+                triggered_at: Instant::now(),
+                at_height: 0,
             },
             EventKind::PanicCleared => Event::PanicCleared,
             EventKind::HaltScheduled => Event::HaltScheduled {
@@ -433,58 +482,166 @@ mod tests {
         }
     }
 
-    /// Drift protection: every row in the table must match what
-    /// `transition()` actually produces for one representative
-    /// (state, event) pair. If a row diverges from the function,
-    /// either the row or the function is wrong — fix one.
+    fn all_state_kinds() -> Vec<ValidatorStateKind> {
+        vec![
+            ValidatorStateKind::Bootstrapping,
+            ValidatorStateKind::CatchingUp,
+            ValidatorStateKind::Idle,
+            ValidatorStateKind::Proposing,
+            ValidatorStateKind::Prevoting,
+            ValidatorStateKind::Precommitting,
+            ValidatorStateKind::Committed,
+            ValidatorStateKind::Rejected,
+            ValidatorStateKind::Hung,
+            ValidatorStateKind::Halting,
+            ValidatorStateKind::CoordinatedUpdate,
+            ValidatorStateKind::Slashed,
+            ValidatorStateKind::Evicted,
+            ValidatorStateKind::Panic,
+            ValidatorStateKind::ShuttingDown,
+        ]
+    }
+
+    fn all_event_kinds() -> Vec<EventKind> {
+        vec![
+            EventKind::BootstrapComplete,
+            EventKind::CaughtUp,
+            EventKind::ShutdownRequested,
+            EventKind::SelectedAsProposer,
+            EventKind::ProposalAdmitted,
+            EventKind::PrevoteThresholdReached,
+            EventKind::PrecommitThresholdReached,
+            EventKind::CommitQuorumReached,
+            EventKind::VoteFailed,
+            EventKind::Timeout,
+            EventKind::WatchdogFired,
+            EventKind::PanicTriggered,
+            EventKind::PanicCleared,
+            EventKind::HaltScheduled,
+            EventKind::HaltActivated,
+            EventKind::UpdateQuorumReady,
+            EventKind::SlashEvidenceConfirmed,
+            EventKind::EvictedFromSet,
+            EventKind::ReadmittedToSet,
+        ]
+    }
+
+    /// Forward drift: every row's claimed (to_kind, action_kinds)
+    /// matches what `transition()` produces.
     ///
-    /// Two rows in the table cover the same (Panic, PanicCleared) pair
-    /// — recoverable→Idle and non-recoverable→Halting — disambiguated
-    /// by `prior_state`/`reason`. We exercise both branches here.
+    /// Skips:
+    /// - `(Panic, PanicCleared) -> Halting` (covered by `panic_non_recoverable_row`
+    ///   below — the test-time representative_state uses a *recoverable*
+    ///   reason to exercise the Idle row).
+    /// - `Any` rows applied to source states where the universal-event
+    ///   guard log-ignores (e.g. `PanicTriggered` from `Panic`).
     #[test]
     fn transition_function_matches_table() {
         for rule in transition_table() {
-            // The (Panic, PanicCleared) pair has two table rows. Skip
-            // the non-recoverable one for this generic walk; it's
-            // exercised in `panic_non_recoverable_row` below.
-            if rule.from == ValidatorStateKind::Panic
+            // Two rows share (Panic, PanicCleared); skip the Halting one.
+            if matches!(rule.from, FromKind::Specific(ValidatorStateKind::Panic))
                 && rule.event == EventKind::PanicCleared
                 && rule.to == ValidatorStateKind::Halting
             {
                 continue;
             }
 
-            let state = representative_state(rule.from);
-            let event = representative_event(rule.event);
-            let (next, actions) = transition(state.clone(), event.clone());
+            let source_kinds: Vec<ValidatorStateKind> = match rule.from {
+                FromKind::Specific(k) => vec![k],
+                // For Any rows, pick a single source state where the
+                // guard does NOT log-ignore (e.g. Idle).  Per-source
+                // log-ignore behaviour for Any rows is covered by the
+                // reverse drift test.
+                FromKind::Any => vec![ValidatorStateKind::Idle],
+            };
 
-            assert_eq!(
-                next.kind(),
-                rule.to,
-                "from {:?} via {:?} expected {:?}, got {:?}\n  doc: {}",
-                rule.from,
-                rule.event,
-                rule.to,
-                next.kind(),
-                rule.doc,
-            );
+            for source in source_kinds {
+                let state = representative_state(source);
+                let event = representative_event(rule.event);
+                let (next, actions) = transition(state.clone(), event.clone());
 
-            let action_kinds: Vec<ActionKind> = actions.iter().map(|a| a.kind()).collect();
-            assert_eq!(
-                action_kinds, rule.actions,
-                "from {:?} via {:?} action mismatch\n  doc: {}",
-                rule.from, rule.event, rule.doc,
-            );
+                assert_eq!(
+                    next.kind(),
+                    rule.to,
+                    "[forward drift] from {:?} (source={:?}) via {:?} expected {:?}, got {:?}\n  doc: {}",
+                    rule.from,
+                    source,
+                    rule.event,
+                    rule.to,
+                    next.kind(),
+                    rule.doc,
+                );
+
+                let action_kinds: Vec<ActionKind> =
+                    actions.iter().map(|a| a.kind()).collect();
+                assert_eq!(
+                    action_kinds, rule.actions,
+                    "[forward drift] from {:?} (source={:?}) via {:?} action mismatch\n  doc: {}",
+                    rule.from, source, rule.event, rule.doc,
+                );
+            }
+        }
+    }
+
+    /// Reverse drift: walk every (state_kind, event_kind) pair, run
+    /// `transition()`, and for every result that produces a
+    /// *meaningful* transition (state-kind change OR a non-
+    /// `LogIgnoredEvent` action) verify a matching row exists.
+    ///
+    /// Catches the case where the function adds a new transition the
+    /// table author forgot to document.
+    #[test]
+    fn function_transitions_appear_in_table() {
+        let table = transition_table();
+        for from_kind in all_state_kinds() {
+            for event_kind in all_event_kinds() {
+                let state = representative_state(from_kind);
+                let event = representative_event(event_kind);
+                let (next, actions) = transition(state, event);
+                let to_kind = next.kind();
+
+                let meaningful = to_kind != from_kind
+                    || actions
+                        .iter()
+                        .any(|a| !matches!(a, crate::fsm::events::Action::LogIgnoredEvent(_)));
+                if !meaningful {
+                    continue;
+                }
+
+                // Build the action-kind sequence for matching.
+                let action_kinds: Vec<ActionKind> =
+                    actions.iter().map(|a| a.kind()).collect();
+
+                let has_matching_row = table.iter().any(|r| {
+                    let from_matches = match r.from {
+                        FromKind::Specific(s) => s == from_kind,
+                        FromKind::Any => true,
+                    };
+                    from_matches
+                        && r.event == event_kind
+                        && r.to == to_kind
+                        && r.actions == action_kinds
+                });
+
+                assert!(
+                    has_matching_row,
+                    "[reverse drift] transition({:?}, {:?}) produced ({:?}, {:?}) \
+                     but no table row matches",
+                    from_kind, event_kind, to_kind, action_kinds,
+                );
+            }
         }
     }
 
     /// Non-recoverable Panic row: PanicCleared from a Panic with a
-    /// non-recoverable reason forces Halting{Never}.
+    /// non-recoverable reason forces Halting{Never} at the panic-
+    /// time height.
     #[test]
     fn panic_non_recoverable_row() {
         let state = ValidatorState::Panic {
             reason: PanicReason::DoubleVote,
             triggered_at: Instant::now(),
+            at_height: 1234,
             prior_state: Box::new(ValidatorState::Prevoting),
         };
         let (next, actions) = transition(state, Event::PanicCleared);
@@ -497,31 +654,38 @@ mod tests {
     }
 
     #[test]
-    fn transitions_from_query_works() {
+    fn transitions_from_query_includes_specific_and_any() {
         let from_prevoting = transitions_from(ValidatorStateKind::Prevoting);
-        // Prevoting has 3 explicit rows: PrevoteThresholdReached,
-        // Timeout, WatchdogFired.
-        assert_eq!(from_prevoting.len(), 3);
-        assert!(from_prevoting
+        // Specific Prevoting rows: PrevoteThresholdReached, Timeout,
+        // WatchdogFired, VoteFailed.
+        let specific_count = from_prevoting
             .iter()
-            .any(|r| r.event == EventKind::PrevoteThresholdReached));
-        assert!(from_prevoting
+            .filter(|r| matches!(r.from, FromKind::Specific(_)))
+            .count();
+        assert_eq!(specific_count, 4);
+
+        // `Any` rows: PanicTriggered, HaltScheduled, ShutdownRequested,
+        // SlashEvidenceConfirmed, EvictedFromSet — should all be visible.
+        let any_events: Vec<_> = from_prevoting
             .iter()
-            .any(|r| r.event == EventKind::Timeout));
-        assert!(from_prevoting
-            .iter()
-            .any(|r| r.event == EventKind::WatchdogFired));
+            .filter(|r| matches!(r.from, FromKind::Any))
+            .map(|r| r.event)
+            .collect();
+        assert!(any_events.contains(&EventKind::PanicTriggered));
+        assert!(any_events.contains(&EventKind::HaltScheduled));
+        assert!(any_events.contains(&EventKind::ShutdownRequested));
+        assert!(any_events.contains(&EventKind::SlashEvidenceConfirmed));
+        assert!(any_events.contains(&EventKind::EvictedFromSet));
     }
 
     #[test]
     fn transitions_by_event_query_works() {
         let by_timeout = transitions_by_event(EventKind::Timeout);
-        // Timeout is defined for 4 source states: Proposing, Prevoting,
-        // Precommitting, Committed.
+        // Timeout rows: Proposing, Prevoting, Precommitting, Committed.
         assert_eq!(by_timeout.len(), 4);
     }
 
-    /// Every row's doc string is non-empty — table is self-documenting.
+    /// Every row's doc string is non-empty.
     #[test]
     fn every_row_has_doc() {
         for rule in transition_table() {

--- a/lib-consensus-core/src/types/round.rs
+++ b/lib-consensus-core/src/types/round.rs
@@ -6,7 +6,7 @@
 //! separate flags for terminal conditions.  CONS-304 introduces the
 //! consensus-core version, which holds:
 //!
-//! - `state: FsmState` — the full control state, including terminal
+//! - `state: ValidatorState` — the full control state, including terminal
 //!   variants (`Committed`, `Rejected(reason)`, `Hung`,
 //!   `HaltedForUpgrade`).
 //! - `height: u64`, `round: u32` — protocol identifiers (unchanged).
@@ -25,7 +25,7 @@
 //! types coexist; the lib-consensus version retains the old `step` /
 //! `start_time` shape for the existing handler code.
 
-use crate::fsm::state::FsmState;
+use crate::fsm::state::ValidatorState;
 use std::time::{Duration, Instant};
 
 /// Per-round control state for a single height/round.
@@ -38,7 +38,7 @@ use std::time::{Duration, Instant};
 #[derive(Debug, Clone)]
 pub struct ConsensusRound {
     /// Current FSM control state. Updated only via [`Self::enter`].
-    pub state: FsmState,
+    pub state: ValidatorState,
 
     /// Block height this round is producing.
     pub height: u64,
@@ -62,7 +62,7 @@ impl ConsensusRound {
     /// given height with `round = 0` and `entered_at = Instant::now()`.
     pub fn new(height: u64) -> Self {
         Self {
-            state: FsmState::Idle,
+            state: ValidatorState::Idle,
             height,
             round: 0,
             entered_at: Instant::now(),
@@ -75,7 +75,7 @@ impl ConsensusRound {
     /// method so that `state_age()` is meaningful.  CONS-305 enforces
     /// this contract by deleting the per-step `enter_*_step` methods
     /// in lib-consensus and routing every state change through here.
-    pub fn enter(&mut self, new_state: FsmState) {
+    pub fn enter(&mut self, new_state: ValidatorState) {
         self.state = new_state;
         self.entered_at = Instant::now();
     }
@@ -102,7 +102,7 @@ mod tests {
     #[test]
     fn new_starts_in_idle() {
         let r = ConsensusRound::new(42);
-        assert_eq!(r.state, FsmState::Idle);
+        assert_eq!(r.state, ValidatorState::Idle);
         assert_eq!(r.height, 42);
         assert_eq!(r.round, 0);
         assert_eq!(r.deterministic_round_id, 42);
@@ -116,8 +116,8 @@ mod tests {
         let initial = r.entered_at();
         // Sleep long enough to make the change visible without being slow.
         std::thread::sleep(Duration::from_millis(2));
-        r.enter(FsmState::Proposing);
-        assert_eq!(r.state, FsmState::Proposing);
+        r.enter(ValidatorState::Proposing);
+        assert_eq!(r.state, ValidatorState::Proposing);
         assert!(r.entered_at() > initial);
     }
 
@@ -128,7 +128,7 @@ mod tests {
     fn entered_at_reflects_call_time_within_5ms() {
         let mut r = ConsensusRound::new(1);
         let before = Instant::now();
-        r.enter(FsmState::Prevoting);
+        r.enter(ValidatorState::Prevoting);
         let after = Instant::now();
         assert!(r.entered_at() >= before);
         assert!(r.entered_at() <= after);
@@ -138,33 +138,41 @@ mod tests {
     #[test]
     fn state_age_grows_until_next_enter() {
         let mut r = ConsensusRound::new(1);
-        r.enter(FsmState::Precommitting);
+        r.enter(ValidatorState::Precommitting);
         std::thread::sleep(Duration::from_millis(3));
         let age1 = r.state_age();
         assert!(age1 >= Duration::from_millis(3));
 
-        r.enter(FsmState::Committed);
+        r.enter(ValidatorState::Committed {
+            block_hash: [1u8; 32],
+            height: 1,
+        });
         let age2 = r.state_age();
         assert!(age2 < age1, "enter() did not reset entered_at");
     }
 
     #[test]
-    fn enter_into_terminal_states_works_uniformly() {
-        // Every FsmState variant must be assignable via enter() — this
-        // protects against accidentally adding a state that requires
-        // special construction.
+    fn enter_into_states_works_uniformly() {
+        // Every ValidatorState variant must be assignable via enter().
+        // We sample one of each kind. This protects against accidentally
+        // adding a state that requires special construction.
         let mut r = ConsensusRound::new(1);
-        for state in [
-            FsmState::Proposing,
-            FsmState::Prevoting,
-            FsmState::Precommitting,
-            FsmState::Committed,
-            FsmState::Rejected(RejectionReason::InsufficientPrevotes),
-            FsmState::Hung,
-            FsmState::HaltedForUpgrade,
-            FsmState::Idle,
-        ] {
-            r.enter(state);
+        let states = vec![
+            ValidatorState::Proposing,
+            ValidatorState::Prevoting,
+            ValidatorState::Precommitting,
+            ValidatorState::Committed {
+                block_hash: [1u8; 32],
+                height: 1,
+            },
+            ValidatorState::Rejected {
+                reason: RejectionReason::InsufficientPrevotes,
+                round: 0,
+            },
+            ValidatorState::Idle,
+        ];
+        for state in states {
+            r.enter(state.clone());
             assert_eq!(r.state, state);
         }
     }


### PR DESCRIPTION
## Summary
Replaces the prior 8-variant FsmState (shipped in CONS-301/302/303/304) with the full **15-variant** \`ValidatorState\` design — the Sovereign Network protocol's complete state landscape modelled as a deterministic Markov chain.

## States

| Group | States |
|---|---|
| **Active consensus** (walk-through timeouts) | \`Idle → Proposing → Prevoting → Precommitting → Committed{block_hash, height}\` |
| **Lifecycle** | \`Bootstrapping\`, \`CatchingUp{from, to}\`, \`ShuttingDown\` |
| **Failure / recovery** | \`Rejected{reason, round}\`, \`Hung{since, prior_state}\` |
| **Operator coordination** | \`Halting{reason, height, last_block_hash, resume_condition}\` → \`CoordinatedUpdate{activate_at_height, target_version}\` → Idle |
| **Punishment** | \`Slashed{reason}\`, \`Evicted\` |
| **Critical** | \`Panic{reason, triggered_at, prior_state}\` |

Plus reason enums: \`RejectionReason\`, \`HaltReason\`, \`ResumeCondition\`, **\`PanicReason\`** (28 variants covering Consensus / Liveness / State integrity / Network / Runtime / Upgrade / Security), \`SlashReason\`.

## Markov chain — two equivalent forms

1. **Executable**: \`transition(state, event) -> (state, actions)\` — exhaustive match, no panics, no \`unreachable!\`. Invalid-but-tolerable arrivals (late vote in Idle, etc.) map to \`LogIgnoredEvent\` — explicit, never silent.
2. **Inspectable**: \`transition_table() -> Vec<TransitionRule>\` — data-driven \`(from_kind, event_kind, to_kind, action_kinds, doc)\` rows for diagrams, fuzzing, operator tooling, formal proofs. Convenience queries: \`transitions_from(state)\`, \`transitions_by_event(event)\`.

**Drift protection**: \`transition_function_matches_table\` test enumerates every row, calls \`transition()\` with a representative \`(state, event)\`, asserts the returned state-kind and action-kind sequence match the table. The two forms cannot drift silently.

## Panic semantics

- **Recoverable** (HeartbeatMissed, PeerUnreachable, GossipFailure, MeshPartition) → reset to \`Idle\` on \`PanicCleared\`.
- **Non-recoverable** (DoubleVote, ByzantineVoteDetected, SlashableOffense, ConflictingCommits, StateMachineCorrupted, SignatureVerificationFailed) → force \`Halting{ResumeCondition::Never}\` with \`LogPanic\` + \`StopBlockProduction\` actions.
- Panic carries the prior state in a \`Box<ValidatorState>\` so observability sees where the panic interrupted normal flow.

## Coordinated upgrade flow

\`HaltScheduled\` → \`Halting\` (\`StopBlockProduction\`) → \`HaltActivated\` → \`CoordinatedUpdate\` (\`EnterUpdateBarrier\`, new binary running, waiting for quorum) → \`UpdateQuorumReady\` → \`Idle\` (\`BroadcastReadyOnNewVersion\`) on the new protocol version.

## Walk-through timeouts (Sovereign semantics)

Each phase before \`Committed\` advances on \`Timeout\` to the next phase (cast best-effort vote on local target). Only \`Committed.Timeout\` triggers \`Rejected(InsufficientPrecommits)\` + \`AdvanceRound\`. Matches the existing engine's \`on_round_timeout\`.

## What this PR does NOT yet do

- Wire \`transition()\` into the engine — that's CONS-305 (handler-by-handler migration).
- \`step_entered_at\` / FSM struct integration — the \`ConsensusRound\` in \`types::round\` already uses \`ValidatorState\` (CONS-304 was preserved).
- Watchdog driver — CONS-309.

## Closes

- #2337 (CONS-301 ValidatorFsm with explicit states)
- #2338 (CONS-302 Total transition() function)
- #2339 (CONS-303 Event and Action enums)
- #2340 (CONS-304 step_entered_at field — already shipped, preserved)

## Test plan
- [x] \`cargo test -p lib-consensus-core --lib\` — 29/29 pass:
  - 4 state-construction / classification tests
  - 4 reason / kind tests
  - 14 transition correctness tests (happy path, walk-through timeouts, watchdog, panic recoverable/non-recoverable, broadcast-on-panic, halt → coordinated-update → idle, shutdown from any state, slashing leaves and rejoins, bootstrapping/catching-up exits, totality)
  - 4 transition-table tests (drift protection, non-recoverable panic row, query helpers, every row has doc)
  - 3 round / step_entered_at tests
- [x] \`cargo build --workspace\` — clean

## Diff
6 files, +2104 / -641 LOC (most of the addition is the transition_table.rs and the per-state match arms; reason enums are new but small).

> **Testnet**: this is a wire-format-affecting change (FSM state names visible in observability events). Coordinated restart still required — already in scope for the cutover (#2364 / CONS-606).