### PR TITLE
refactor(consensus): CONS-305b route commit quorum through FSM transition (closes #2342)

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/mod.rs
+++ b/lib-consensus/src/engines/consensus_engine/mod.rs
@@ -462,6 +462,13 @@ pub struct ConsensusEngine {
     validator_manager: ValidatorManager,
     /// Current consensus round
     current_round: ConsensusRound,
+    /// FSM control state (CONS-301..305).  Mirrors `current_round.step`
+    /// during the handler-by-handler migration; kept in sync via
+    /// `enter_fsm_state()` whenever the round step changes.  When the
+    /// migration completes (CONS-305f) `current_round.step` and the
+    /// `enter_*_step` helpers go away and this becomes the single
+    /// source of truth.
+    fsm_state: lib_consensus_core::fsm::ValidatorState,
     /// Consensus configuration
     config: ConsensusConfig,
     /// Pending proposals queue
@@ -612,6 +619,10 @@ impl ConsensusEngine {
             validator_identity: None,
             validator_manager,
             current_round,
+            // Engine starts at step=Propose (see initial ConsensusRound
+            // above) — keep the FSM mirror aligned. The consensus loop
+            // promotes to other states via `enter_fsm_state()`.
+            fsm_state: lib_consensus_core::fsm::ValidatorState::Proposing,
             config,
             pending_proposals: VecDeque::new(),
             vote_pool: HashMap::new(), // Composite key prevents equivocation

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1916,15 +1916,115 @@ impl ConsensusEngine {
         Ok(())
     }
 
+    /// Map the legacy `ConsensusStep` to the FSM's `ValidatorState`.
+    /// Used during the CONS-305 handler-by-handler migration to keep
+    /// `fsm_state` in sync with `current_round.step` at the
+    /// translation boundary. CONS-305f deletes `current_round.step`
+    /// once all handlers route through `transition()`.
+    fn step_to_fsm_state(&self, step: ConsensusStep) -> lib_consensus_core::fsm::ValidatorState {
+        use lib_consensus_core::fsm::ValidatorState as V;
+        match step {
+            ConsensusStep::Propose => V::Proposing,
+            ConsensusStep::PreVote => V::Prevoting,
+            ConsensusStep::PreCommit => V::Precommitting,
+            ConsensusStep::Commit => {
+                // The wire-level Commit step maps to Committed in the
+                // FSM where `block_hash`/`height` describe the block
+                // being committed.  Use `locked_proposal` if present;
+                // otherwise placeholder zeros (the hash isn't load-
+                // bearing in the FSM yet — runtime tracks targets).
+                let block_hash = self
+                    .current_round
+                    .locked_proposal
+                    .as_ref()
+                    .or(self.current_round.valid_proposal.as_ref())
+                    .map(|h| h.0)
+                    .unwrap_or([0u8; 32]);
+                V::Committed {
+                    block_hash,
+                    height: self.current_round.height,
+                }
+            }
+            ConsensusStep::NewRound => V::Idle,
+        }
+    }
+
+    /// Single point that transitions the FSM and keeps the legacy
+    /// `current_round.step` mirror in sync. Per CONS-305 spec: every
+    /// state mutation goes through `enter()`.
+    fn enter_fsm_state(&mut self, new_state: lib_consensus_core::fsm::ValidatorState) {
+        use lib_consensus_core::fsm::ValidatorState as V;
+        let new_step = match &new_state {
+            V::Proposing | V::Idle => ConsensusStep::Propose,
+            V::Prevoting => ConsensusStep::PreVote,
+            V::Precommitting => ConsensusStep::PreCommit,
+            V::Committed { .. } => ConsensusStep::Commit,
+            V::Rejected { .. } => ConsensusStep::NewRound,
+            // Lifecycle / failure states have no mirror — the engine
+            // can't represent them in the legacy enum. Keep
+            // `current_round.step` at NewRound for those (the runtime
+            // halts/recovers via the new FSM only).
+            _ => ConsensusStep::NewRound,
+        };
+        self.fsm_state = new_state;
+        self.current_round.step = new_step;
+    }
+
+    /// Dispatch a single FSM `Action` to the engine. CONS-305 stages
+    /// these per-action handlers progressively; for CONS-305a only
+    /// `Timeout`-driven actions need handling, the rest are no-ops or
+    /// pass through to the existing engine machinery.
+    async fn dispatch_action(&mut self, action: lib_consensus_core::fsm::Action) {
+        use lib_consensus_core::fsm::Action as A;
+        match action {
+            A::ResetWatchdog => {
+                // CONS-309 introduces the watchdog; for now this is a
+                // no-op observability hook.  We simply mark the
+                // round as not timed out so the next deadline is fresh.
+                self.current_round.timed_out = false;
+            }
+            // Other actions handled by later CONS-305x stages or by
+            // the existing handlers.  Logging the unhandled ones at
+            // debug level — never panic, never silently drop.
+            other => {
+                tracing::debug!(
+                    fsm_action = ?other,
+                    "FSM emitted action with no engine handler yet (CONS-305 in progress)"
+                );
+            }
+        }
+    }
+
     pub(super) async fn on_round_timeout(&mut self) -> ConsensusResult<()> {
+        use lib_consensus_core::fsm::{transition, Event};
+
         tracing::debug!(
-            "Round timeout at height {} round {} step {:?}",
+            "Round timeout at height {} round {} step {:?} fsm {:?}",
             self.current_round.height,
             self.current_round.round,
-            self.current_round.step
+            self.current_round.step,
+            self.fsm_state.kind(),
         );
 
-        match self.current_round.step {
+        // CONS-305a: route the timeout through the FSM. The FSM
+        // computes the next state and any actions; the runtime
+        // dispatches the actions and does the per-state-entry work
+        // (e.g. casting the next-phase vote) via the existing
+        // `enter_*_step` helpers below.  CONS-305f will fold those
+        // helpers into the action handlers and delete this dual path.
+        let prior_step = self.current_round.step.clone();
+        let prior_fsm = self.step_to_fsm_state(prior_step.clone());
+        let (next_fsm, actions) = transition(prior_fsm, Event::Timeout);
+        self.fsm_state = next_fsm;
+        for action in actions {
+            self.dispatch_action(action).await;
+        }
+
+        // Engine state-entry hooks. These will move into per-Action
+        // handlers in CONS-305f. Until then they keep the engine's
+        // existing semantics intact (cast next-phase vote, broadcast,
+        // advance round on Commit timeout).
+        match prior_step {
             ConsensusStep::Propose => {
                 self.enter_prevote_step().await?;
             }

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -2456,6 +2456,35 @@ impl ConsensusEngine {
             // guarantees we're committing the right block, and process_committed_block is
             // idempotent if the block was already applied.
             if self.current_round.height == height {
+                // CONS-305b: route the commit-quorum event through the
+                // FSM so the canonical state transitions to Committed
+                // alongside the legacy step bump below.  The FSM
+                // emits `[CommitBlock, ResetWatchdog]`; the actual
+                // finalization (process_committed_block) is called
+                // directly here for now, with the action handler
+                // staging in `dispatch_action()` for CONS-305f cleanup.
+                let bft_quorum = lib_types::consensus::BftQuorumProof {
+                    height,
+                    proposal_id: proposal_id.0,
+                    total_validators: total_validators as u32,
+                    // Attestations are aggregated by `process_committed_block`
+                    // when it builds the block's proof; for the FSM hook
+                    // we pass the empty list — the FSM only needs the
+                    // height/proposal_id metadata to track state.
+                    attestations: Vec::new(),
+                };
+                let (next_fsm, actions) = lib_consensus_core::fsm::transition(
+                    self.fsm_state.clone(),
+                    lib_consensus_core::fsm::Event::CommitQuorumReached {
+                        block_id: proposal_id.clone(),
+                        quorum: bft_quorum,
+                    },
+                );
+                self.fsm_state = next_fsm;
+                for action in actions {
+                    self.dispatch_action(action).await;
+                }
+
                 // Transition to Commit step if not already there
                 if self.current_round.step < ConsensusStep::Commit {
                     self.current_round.step = ConsensusStep::Commit;


### PR DESCRIPTION
## Summary
Second handler in the CONS-305 migration. The actual FSM event for the commit path is \`CommitQuorumReached\`, fired from \`maybe_finalize\` once 2/3+1 commit votes accumulate (\`on_commit_vote\` itself only inserts into the vote pool). This PR threads the FSM through that quorum point.

## Flow
After \`check_supermajority\` succeeds in \`maybe_finalize\`:
- Build a \`BftQuorumProof\` with height/proposal_id metadata (full attestation aggregation happens later in \`process_committed_block\`; FSM only tracks shape).
- Fire \`Event::CommitQuorumReached { block_id, quorum }\` → \`transition()\` returns \`(Committed, [CommitBlock, ResetWatchdog])\`.
- Update \`fsm_state\`, dispatch the actions.
- Existing legacy step bump and \`process_committed_block\` continue to do the actual finalization work.

Closes #2342.

## Stacked on
This branch stacks on [#2396 (CONS-305a)](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/pull/2396). After #2396 merges to development, GitHub will retarget this PR's base.

## Test plan
- [x] \`cargo test -p lib-consensus --lib\` — 183 pass / 4 fail (KI-01..04 baseline preserved)
- [x] \`cargo build --workspace\` — clean

No behavior change — FSM observes; engine still does finalization work via \`process_committed_block\`.