### PR TITLE
refactor(consensus): CONS-305c route precommit threshold through FSM (closes #2343)

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1796,8 +1796,13 @@ impl ConsensusEngine {
             // commit-vote quorum that maybe_finalize handles); the
             // SendCommit action is the work that `enter_commit_step`
             // already does.
+            // Derive the prior state from the legacy step (the
+            // source of truth during the migration) rather than
+            // `self.fsm_state` to avoid silent action drops if the
+            // mirror has drifted — PR #2398 review.
+            let prior_fsm = self.step_to_fsm_state(self.current_round.step.clone());
             let (next_fsm, actions) = lib_consensus_core::fsm::transition(
-                self.fsm_state.clone(),
+                prior_fsm,
                 lib_consensus_core::fsm::Event::PrecommitThresholdReached {
                     block_id: proposal_id.clone(),
                 },
@@ -2002,13 +2007,38 @@ impl ConsensusEngine {
                 // round as not timed out so the next deadline is fresh.
                 self.current_round.timed_out = false;
             }
-            // Other actions handled by later CONS-305x stages or by
-            // the existing handlers.  Logging the unhandled ones at
-            // debug level — never panic, never silently drop.
+
+            // CONS-305x staging: these actions are emitted by the FSM
+            // but the work is currently done by the existing engine
+            // helpers (`enter_prevote_step`, `enter_precommit_step`,
+            // `enter_commit_step`, `process_committed_block`, the
+            // proposal relay in `on_proposal`).  CONS-305f folds the
+            // helpers into per-action handlers and removes this
+            // branch.  Until then they are deliberate no-ops — NOT
+            // missing-handler debug logs (which would fire on every
+            // round and mislead operators per PR #2398 review).
+            A::CreateProposal
+            | A::BroadcastProposal { .. }
+            | A::SendPrevote { .. }
+            | A::SendPrecommit { .. }
+            | A::SendCommit { .. }
+            | A::CommitBlock { .. }
+            | A::AdvanceRound => {
+                // engine still does the work.
+            }
+
+            // Logged-ignored arrivals (state didn't change, just
+            // observability).  Drop silently — the FSM's own
+            // observability hooks handle these.
+            A::LogIgnoredEvent(_) | A::LogHung { .. } | A::LogPanic { .. } => {}
+
+            // Operator/lifecycle actions wired in later CONS-305x
+            // stages.  Log at debug for visibility; engine code
+            // continues to handle them via existing paths.
             other => {
                 tracing::debug!(
                     fsm_action = ?other,
-                    "FSM emitted action with no engine handler yet (CONS-305 in progress)"
+                    "FSM emitted lifecycle action with no engine handler yet (CONS-305 in progress)"
                 );
             }
         }
@@ -2492,8 +2522,12 @@ impl ConsensusEngine {
                     // height/proposal_id metadata to track state.
                     attestations: Vec::new(),
                 };
+                // Derive prior state from legacy step (source of
+                // truth during the migration) to avoid silent action
+                // drops on mirror drift — PR #2398 review.
+                let prior_fsm = self.step_to_fsm_state(self.current_round.step.clone());
                 let (next_fsm, actions) = lib_consensus_core::fsm::transition(
-                    self.fsm_state.clone(),
+                    prior_fsm,
                     lib_consensus_core::fsm::Event::CommitQuorumReached {
                         block_id: proposal_id.clone(),
                         quorum: bft_quorum,

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1788,6 +1788,25 @@ impl ConsensusEngine {
                 // First proposal to reach precommit quorum in this round
                 self.current_round.locked_proposal = Some(proposal_id.clone());
             }
+
+            // CONS-305c: route the precommit-quorum threshold through
+            // the FSM. `(Precommitting, PrecommitThresholdReached) →
+            // (Precommitting, [SendCommit, ResetWatchdog])` — state
+            // stays Precommitting (we are now waiting for the
+            // commit-vote quorum that maybe_finalize handles); the
+            // SendCommit action is the work that `enter_commit_step`
+            // already does.
+            let (next_fsm, actions) = lib_consensus_core::fsm::transition(
+                self.fsm_state.clone(),
+                lib_consensus_core::fsm::Event::PrecommitThresholdReached {
+                    block_id: proposal_id.clone(),
+                },
+            );
+            self.fsm_state = next_fsm;
+            for action in actions {
+                self.dispatch_action(action).await;
+            }
+
             // Allow late precommit quorum to still trigger commit vote casting even if the
             // precommit timeout already fired and step advanced to Commit. enter_commit_step
             // is idempotent for the step transition but we bypass that guard to cast the vote.


### PR DESCRIPTION
## Summary
Third handler in CONS-305 migration. When \`on_precommit\` observes +2/3 precommits, fire \`Event::PrecommitThresholdReached { block_id }\` → \`transition()\` returns \`(Precommitting, [SendCommit, ResetWatchdog])\`.  State stays \`Precommitting\` (gathering commit votes); \`SendCommit\` action is staged for CONS-305f cleanup. Existing \`enter_commit_step()\` continues to cast the commit vote and broadcast.

Closes #2343.

## Test plan
- [x] \`cargo test -p lib-consensus --lib\` — 183 pass / 4 fail (KI-01..04 baseline preserved)
- [x] \`cargo build --workspace\` — clean

No behavior change.