### PR TITLE
refactor(consensus): CONS-305e route admitted proposal through FSM (closes #2345)

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1524,8 +1524,11 @@ impl ConsensusEngine {
         let proposal_round = proposal.round;
         self.pending_proposals.push_back(proposal);
 
+        // Prior state derived from legacy step (source of truth
+        // during the migration) per #2398 review.
+        let prior_fsm = self.step_to_fsm_state(self.current_round.step.clone());
         let (next_fsm, actions) = lib_consensus_core::fsm::transition(
-            self.fsm_state.clone(),
+            prior_fsm,
             lib_consensus_core::fsm::Event::ProposalAdmitted {
                 id: proposal_id.clone(),
                 height: proposal_height,

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1513,7 +1513,29 @@ impl ConsensusEngine {
             tracing::debug!("Proposal relay failed (non-critical): {}", e);
         }
 
+        // CONS-305e: route admitted proposal through the FSM. The
+        // proposal has passed every gate (no-fork, signature, proposer
+        // election, payload validity); the FSM advances Proposing →
+        // Prevoting and emits `[BroadcastProposal, SendPrevote,
+        // ResetWatchdog]`. The existing relay above + the
+        // `enter_prevote_step()` call below continue to do that work
+        // until CONS-305f folds them into the action handlers.
+        let proposal_height = proposal.height;
+        let proposal_round = proposal.round;
         self.pending_proposals.push_back(proposal);
+
+        let (next_fsm, actions) = lib_consensus_core::fsm::transition(
+            self.fsm_state.clone(),
+            lib_consensus_core::fsm::Event::ProposalAdmitted {
+                id: proposal_id.clone(),
+                height: proposal_height,
+                round: proposal_round,
+            },
+        );
+        self.fsm_state = next_fsm;
+        for action in actions {
+            self.dispatch_action(action).await;
+        }
 
         match self.current_round.step {
             ConsensusStep::Propose => {


### PR DESCRIPTION
## Summary
Fifth and final handler in CONS-305 migration. After \`on_proposal\` passes every admission gate (no-fork, signature, proposer election, payload validity), fire \`Event::ProposalAdmitted { id, height, round }\` → \`transition()\` returns \`(Prevoting, [BroadcastProposal, SendPrevote, ResetWatchdog])\`. Existing relay and \`enter_prevote_step()\` continue to do the work.

After this PR, **all five engine handlers route through the FSM**:
- on_round_timeout (#2396, CONS-305a)
- on_commit_vote / maybe_finalize (#2397, CONS-305b)
- on_precommit (#2398, CONS-305c)
- on_prevote (#2399, CONS-305d)
- on_proposal (this PR, CONS-305e)

CONS-305f deletes the legacy \`current_round.step\` mirror and folds engine helpers into action handlers.

Closes #2345.

Stacked on [#2399 (CONS-305d)](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/pull/2399).

## Test plan
- [x] \`cargo test -p lib-consensus --lib\` — 183 pass / 4 fail (KI-01..04 baseline preserved)

No behavior change.