### PR TITLE
refactor(consensus): CONS-305d route prevote threshold through FSM (closes #2344)

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1682,8 +1682,12 @@ impl ConsensusEngine {
             // (Precommitting, [SendPrecommit, ResetWatchdog])`.  The
             // existing `enter_precommit_step()` does the casting and
             // broadcast; the FSM observes the state advance.
+            //
+            // Prior state derived from legacy step (source of truth
+            // during the migration) per #2398 review.
+            let prior_fsm = self.step_to_fsm_state(self.current_round.step.clone());
             let (next_fsm, actions) = lib_consensus_core::fsm::transition(
-                self.fsm_state.clone(),
+                prior_fsm,
                 lib_consensus_core::fsm::Event::PrevoteThresholdReached {
                     block_id: proposal_id.clone(),
                 },

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1676,6 +1676,23 @@ impl ConsensusEngine {
                 // First proposal to reach quorum in this round
                 self.current_round.valid_proposal = Some(proposal_id.clone());
             }
+
+            // CONS-305d: route the prevote-quorum threshold through
+            // the FSM. `(Prevoting, PrevoteThresholdReached) →
+            // (Precommitting, [SendPrecommit, ResetWatchdog])`.  The
+            // existing `enter_precommit_step()` does the casting and
+            // broadcast; the FSM observes the state advance.
+            let (next_fsm, actions) = lib_consensus_core::fsm::transition(
+                self.fsm_state.clone(),
+                lib_consensus_core::fsm::Event::PrevoteThresholdReached {
+                    block_id: proposal_id.clone(),
+                },
+            );
+            self.fsm_state = next_fsm;
+            for action in actions {
+                self.dispatch_action(action).await;
+            }
+
             // Allow late prevote quorum to still trigger precommit casting even if the
             // prevote timeout already fired and step advanced to PreCommit. enter_precommit_step
             // is idempotent for the step transition (guards against double-entry) but we bypass


### PR DESCRIPTION
## Summary
Re-opens CONS-305d after the previous PR (#2399) was auto-closed when its base branch (#2398) was deleted on merge. Same content + the drift-resistance fix from #2398 review applied at the prevote threshold site.

When \`on_prevote\` observes +2/3 prevotes (and \`valid_proposal\` is unset or matches), fire \`Event::PrevoteThresholdReached { block_id }\` → \`transition()\` returns \`(Precommitting, [SendPrecommit, ResetWatchdog])\`. Existing \`enter_precommit_step()\` continues to cast the precommit and broadcast.

Closes #2344.

## Test plan
- [x] \`cargo test -p lib-consensus --lib\` — 183 pass / 4 fail (KI-01..04 baseline preserved)