### PR TITLE
refactor(consensus): CONS-305f step 2 — enter_fsm_state drives phase-entry (#2341)

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1535,7 +1535,7 @@ impl ConsensusEngine {
                 round: proposal_round,
             },
         );
-        self.fsm_state = next_fsm;
+        self.enter_fsm_state(next_fsm).await;
         for action in actions {
             self.dispatch_action(action).await;
         }
@@ -1722,7 +1722,7 @@ impl ConsensusEngine {
                     block_id: proposal_id.clone(),
                 },
             );
-            self.fsm_state = next_fsm;
+            self.enter_fsm_state(next_fsm).await;
             for action in actions {
                 self.dispatch_action(action).await;
             }
@@ -1732,14 +1732,16 @@ impl ConsensusEngine {
             // prevote quorum after timeout** path. When the local
             // step has already advanced to PreCommit via the
             // PreVote-step timeout, `prior_fsm = Precommitting`
-            // and the FSM treats this `PrevoteThresholdReached` as
-            // logged-ignored (it doesn't emit SendPrecommit from
-            // an already-Precommitting state). Without this call
-            // we'd never cast our precommit on a late prevote
-            // quorum. The helper is idempotent w.r.t. its own
-            // re-entry guard, so the ON-TIME quorum case (FSM
-            // dispatched SendPrecommit and dispatch_action ran
-            // enter_precommit_step) still works.
+            // and the FSM treats `PrevoteThresholdReached` as
+            // logged-ignored (no SendPrecommit emitted from an
+            // already-Precommitting state). Without this call we'd
+            // never cast our precommit on a late prevote quorum.
+            //
+            // The on-TIME quorum path (Prevoting→Precommitting) is
+            // covered by step 2's phase-entry hook in
+            // `enter_fsm_state`; the helper is idempotent w.r.t.
+            // its own re-entry guard so the second call here is a
+            // no-op in that case.
             self.enter_precommit_step().await?;
         }
 
@@ -1867,7 +1869,7 @@ impl ConsensusEngine {
                     block_id: proposal_id.clone(),
                 },
             );
-            self.fsm_state = next_fsm;
+            self.enter_fsm_state(next_fsm).await;
             for action in actions {
                 self.dispatch_action(action).await;
             }
@@ -2040,25 +2042,71 @@ impl ConsensusEngine {
         }
     }
 
-    /// Single point that transitions the FSM and keeps the legacy
-    /// `current_round.step` mirror in sync. Per CONS-305 spec: every
-    /// state mutation goes through `enter()`.
-    fn enter_fsm_state(&mut self, new_state: lib_consensus_core::fsm::ValidatorState) {
+    /// Single point that transitions the FSM, keeps the legacy
+    /// `current_round.step` mirror in sync, and runs the phase-entry
+    /// hook on state-kind change. Per CONS-305 spec: every state
+    /// mutation goes through `enter()`.
+    ///
+    /// **Phase-entry hook** (CONS-305f staging step 2): when the FSM
+    /// transitions to a different state kind
+    /// (Proposing / Prevoting / Precommitting / Committed), the
+    /// corresponding `enter_*_step` helper runs to do the per-phase
+    /// work (proposer election, cast vote, broadcast). This covers
+    /// BOTH the explicit quorum-driven transitions (e.g.
+    /// PrevoteThresholdReached → Precommitting) AND walk-through
+    /// timeouts (e.g. Proposing.Timeout → Prevoting) uniformly — the
+    /// runtime no longer needs the legacy match-step block in
+    /// `on_round_timeout`. Errors from the helper are logged at
+    /// warn level (best-effort, CE-ENG-4); the FSM transition is
+    /// unconditional.
+    ///
+    /// **Recursion-free invariant**: `enter_*_step` MUST NOT call
+    /// `maybe_finalize` (which calls `transition()` which can
+    /// re-enter dispatch). CONS-305f staging step 1 moved
+    /// `maybe_finalize` out of `enter_commit_step` to its callers;
+    /// that invariant is what makes this safe.
+    async fn enter_fsm_state(&mut self, new_state: lib_consensus_core::fsm::ValidatorState) {
         use lib_consensus_core::fsm::ValidatorState as V;
-        let new_step = match &new_state {
-            V::Proposing | V::Idle => ConsensusStep::Propose,
-            V::Prevoting => ConsensusStep::PreVote,
-            V::Precommitting => ConsensusStep::PreCommit,
-            V::Committed { .. } => ConsensusStep::Commit,
-            V::Rejected { .. } => ConsensusStep::NewRound,
-            // Lifecycle / failure states have no mirror — the engine
-            // can't represent them in the legacy enum. Keep
-            // `current_round.step` at NewRound for those (the runtime
-            // halts/recovers via the new FSM only).
-            _ => ConsensusStep::NewRound,
-        };
-        self.fsm_state = new_state;
-        self.current_round.step = new_step;
+        let prior_kind = self.fsm_state.kind();
+        let new_kind = new_state.kind();
+        self.fsm_state = new_state.clone();
+
+        // Phase-entry runs only on state-kind change so intra-kind
+        // transitions (e.g. Precommitting → Precommitting on
+        // PrecommitThresholdReached, or wire-level PreCommit→Commit
+        // step within the FSM Precommitting kind) don't re-run
+        // proposer election or double-cast votes. The phase-entry
+        // helpers (`enter_*_step`) update `current_round.step`
+        // themselves; intra-kind step changes (e.g. PreCommit →
+        // Commit) stay under engine control via the existing
+        // helpers.
+        if new_kind != prior_kind {
+            let entry_result = match &new_state {
+                V::Proposing => Some(self.enter_propose_step().await),
+                V::Prevoting => Some(self.enter_prevote_step().await),
+                V::Precommitting => Some(self.enter_precommit_step().await),
+                V::Committed { .. } => Some(self.enter_commit_step().await),
+                _ => None,
+            };
+            if let Some(Err(e)) = entry_result {
+                tracing::warn!(
+                    error = ?e,
+                    new_kind = ?new_kind,
+                    "Phase-entry hook failed (continuing per CE-ENG-4)"
+                );
+            }
+        }
+
+        // For terminal/operational states with no phase-entry
+        // (`Idle`, `Rejected`, `Hung`, `Halting`, etc.), align the
+        // legacy step mirror so observability stays consistent.
+        // Active-phase states leave `step` to their phase-entry hook.
+        match &new_state {
+            V::Idle | V::Rejected { .. } => {
+                self.current_round.step = ConsensusStep::NewRound;
+            }
+            _ => {}
+        }
     }
 
     /// Dispatch one FSM `Action` to the engine.
@@ -2083,26 +2131,15 @@ impl ConsensusEngine {
                 self.current_round.timed_out = false;
             }
 
-            A::CreateProposal => {
-                if let Err(e) = self.enter_propose_step().await {
-                    tracing::warn!(error = ?e, "CreateProposal action failed");
-                }
-            }
-            A::SendPrevote { .. } => {
-                if let Err(e) = self.enter_prevote_step().await {
-                    tracing::warn!(error = ?e, "SendPrevote action failed");
-                }
-            }
-            A::SendPrecommit { .. } => {
-                if let Err(e) = self.enter_precommit_step().await {
-                    tracing::warn!(error = ?e, "SendPrecommit action failed");
-                }
-            }
-            A::SendCommit { .. } => {
-                if let Err(e) = self.enter_commit_step().await {
-                    tracing::warn!(error = ?e, "SendCommit action failed");
-                }
-            }
+            // CONS-305f step 2: state-kind-change phase entry runs
+            // in `enter_fsm_state` (canonical mutation point).  These
+            // FSM actions are emitted alongside state-kind changes
+            // so the work has already happened by the time we get
+            // here. No-op deliberately.
+            A::CreateProposal
+            | A::SendPrevote { .. }
+            | A::SendPrecommit { .. }
+            | A::SendCommit { .. } => {}
 
             // BroadcastProposal — proposal relay needs ownership of
             // the proposal struct, which the FSM action carries only
@@ -2152,21 +2189,26 @@ impl ConsensusEngine {
         let prior_step = self.current_round.step.clone();
         let prior_fsm = self.step_to_fsm_state(prior_step.clone());
         let (next_fsm, actions) = transition(prior_fsm, Event::Timeout);
-        self.fsm_state = next_fsm;
+        // CONS-305f step 2: enter_fsm_state runs the phase-entry
+        // hook on state-kind change, replacing the legacy
+        // Propose→PreVote and PreVote→PreCommit walk-through arms
+        // below.
+        self.enter_fsm_state(next_fsm).await;
         for action in actions {
             self.dispatch_action(action).await;
         }
 
-        // Engine state-entry hooks. These will move into per-Action
-        // handlers in CONS-305f. Until then they keep the engine's
-        // existing semantics intact (cast next-phase vote, broadcast,
-        // advance round on Commit timeout).
+        // Wire-level step transitions that the FSM doesn't model
+        // (PreCommit→Commit within the Precommitting kind, plus the
+        // round-reset on Commit-step timeout).
         match prior_step {
             ConsensusStep::Propose => {
-                self.enter_prevote_step().await?;
+                // Handled by enter_fsm_state above (Proposing →
+                // Prevoting kind change → enter_prevote_step).
             }
             ConsensusStep::PreVote => {
-                self.enter_precommit_step().await?;
+                // Handled by enter_fsm_state above (Prevoting →
+                // Precommitting kind change → enter_precommit_step).
             }
             ConsensusStep::PreCommit => {
                 self.enter_commit_step().await?;
@@ -2640,7 +2682,7 @@ impl ConsensusEngine {
                         quorum: bft_quorum,
                     },
                 );
-                self.fsm_state = next_fsm;
+                self.enter_fsm_state(next_fsm).await;
                 for action in actions {
                     self.dispatch_action(action).await;
                 }

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1540,9 +1540,14 @@ impl ConsensusEngine {
             self.dispatch_action(action).await;
         }
 
+        // CONS-305f: the per-step branch is reduced to the late-
+        // proposal case below. The Propose-step path used to call
+        // `enter_prevote_step` here; that work is now dispatched by
+        // the FSM `SendPrevote` action above (see the loop over
+        // `actions` returned by `transition()`).
         match self.current_round.step {
             ConsensusStep::Propose => {
-                self.enter_prevote_step().await?;
+                // Handled by FSM action dispatch above.
             }
             ConsensusStep::PreVote => {
                 // Proposal arrived after the local prevote timer already fired.
@@ -1722,11 +1727,12 @@ impl ConsensusEngine {
                 self.dispatch_action(action).await;
             }
 
-            // Allow late prevote quorum to still trigger precommit casting even if the
-            // prevote timeout already fired and step advanced to PreCommit. enter_precommit_step
-            // is idempotent for the step transition (guards against double-entry) but we bypass
-            // that guard here only if we haven't yet cast a precommit for this round.
-            self.enter_precommit_step().await?;
+            // CONS-305f: removed the direct `enter_precommit_step()`
+            // call here.  The FSM's `SendPrecommit` action dispatched
+            // above already calls `enter_precommit_step` via
+            // `dispatch_action` — keeping this redundant call meant
+            // the helper ran twice (idempotent re re-entry guards,
+            // but wasteful).
         }
 
         // **CE-L1, CE-L2**: Always check if commit quorum is reached, even in PreVote step
@@ -1858,10 +1864,9 @@ impl ConsensusEngine {
                 self.dispatch_action(action).await;
             }
 
-            // Allow late precommit quorum to still trigger commit vote casting even if the
-            // precommit timeout already fired and step advanced to Commit. enter_commit_step
-            // is idempotent for the step transition but we bypass that guard to cast the vote.
-            self.enter_commit_step().await?;
+            // CONS-305f: removed the direct `enter_commit_step()`
+            // call here. The FSM's `SendCommit` action dispatched
+            // above calls it via `dispatch_action`.
         }
 
         // **CE-L1, CE-L2**: Always check if commit quorum is reached, even in PreCommit step
@@ -2044,47 +2049,72 @@ impl ConsensusEngine {
     /// these per-action handlers progressively; for CONS-305a only
     /// `Timeout`-driven actions need handling, the rest are no-ops or
     /// pass through to the existing engine machinery.
+    /// Dispatch one FSM `Action` to the engine.
+    ///
+    /// CONS-305f cutover: dispatch_action is the canonical entry
+    /// point for state-entry side effects. Errors from the engine
+    /// helpers are logged at warn level and not propagated — actions
+    /// are best-effort (CE-ENG-4).
+    ///
+    /// **Recursion-free invariant**: the helpers called from here
+    /// (`enter_propose_step`, `enter_prevote_step`,
+    /// `enter_precommit_step`, `enter_commit_step`) MUST NOT call
+    /// `maybe_finalize` (which would re-enter dispatch_action via
+    /// `transition()` + `CommitBlock` action). Quorum-trigger
+    /// finalization runs separately at the handler level
+    /// (on_commit_vote / on_precommit / on_round_timeout's PreCommit
+    /// branch / run_commit_step).
     async fn dispatch_action(&mut self, action: lib_consensus_core::fsm::Action) {
         use lib_consensus_core::fsm::Action as A;
         match action {
             A::ResetWatchdog => {
-                // CONS-309 introduces the watchdog; for now this is a
-                // no-op observability hook.  We simply mark the
-                // round as not timed out so the next deadline is fresh.
                 self.current_round.timed_out = false;
             }
 
-            // CONS-305x staging: these actions are emitted by the FSM
-            // but the work is currently done by the existing engine
-            // helpers (`enter_prevote_step`, `enter_precommit_step`,
-            // `enter_commit_step`, `process_committed_block`, the
-            // proposal relay in `on_proposal`).  CONS-305f folds the
-            // helpers into per-action handlers and removes this
-            // branch.  Until then they are deliberate no-ops — NOT
-            // missing-handler debug logs (which would fire on every
-            // round and mislead operators per PR #2398 review).
-            A::CreateProposal
-            | A::BroadcastProposal { .. }
-            | A::SendPrevote { .. }
-            | A::SendPrecommit { .. }
-            | A::SendCommit { .. }
-            | A::CommitBlock { .. }
-            | A::AdvanceRound => {
-                // engine still does the work.
+            A::CreateProposal => {
+                if let Err(e) = self.enter_propose_step().await {
+                    tracing::warn!(error = ?e, "CreateProposal action failed");
+                }
+            }
+            A::SendPrevote { .. } => {
+                if let Err(e) = self.enter_prevote_step().await {
+                    tracing::warn!(error = ?e, "SendPrevote action failed");
+                }
+            }
+            A::SendPrecommit { .. } => {
+                if let Err(e) = self.enter_precommit_step().await {
+                    tracing::warn!(error = ?e, "SendPrecommit action failed");
+                }
+            }
+            A::SendCommit { .. } => {
+                if let Err(e) = self.enter_commit_step().await {
+                    tracing::warn!(error = ?e, "SendCommit action failed");
+                }
             }
 
-            // Logged-ignored arrivals (state didn't change, just
-            // observability).  Drop silently — the FSM's own
-            // observability hooks handle these.
+            // BroadcastProposal — proposal relay needs ownership of
+            // the proposal struct, which the FSM action carries only
+            // by Hash. Done at the call site in on_proposal.
+            A::BroadcastProposal { .. } => {}
+
+            // CommitBlock — process_committed_block is invoked from
+            // maybe_finalize when commit-vote quorum is detected. No-
+            // op here so the recursion invariant above holds.
+            A::CommitBlock { .. } => {}
+
+            // AdvanceRound — round-bump on view change. Done at the
+            // call site (on_round_timeout's Committed branch) where
+            // we have full sync_height context.
+            A::AdvanceRound => {}
+
+            // Observability — silent drop; FSM's own hooks log.
             A::LogIgnoredEvent(_) | A::LogHung { .. } | A::LogPanic { .. } => {}
 
-            // Operator/lifecycle actions wired in later CONS-305x
-            // stages.  Log at debug for visibility; engine code
-            // continues to handle them via existing paths.
+            // Lifecycle — log at debug for visibility.
             other => {
                 tracing::debug!(
                     fsm_action = ?other,
-                    "FSM emitted lifecycle action with no engine handler yet (CONS-305 in progress)"
+                    "FSM emitted lifecycle action with no engine handler yet"
                 );
             }
         }
@@ -2128,6 +2158,23 @@ impl ConsensusEngine {
             }
             ConsensusStep::PreCommit => {
                 self.enter_commit_step().await?;
+                // CONS-305f: maybe_finalize was previously called from
+                // inside enter_commit_step. Moved here so dispatch_action
+                // can call enter_commit_step without recursing through
+                // maybe_finalize → transition() → dispatch_action.
+                let target = self
+                    .current_round
+                    .valid_proposal
+                    .clone()
+                    .or(self.current_round.locked_proposal.clone());
+                if let Some(proposal_id) = target {
+                    self.maybe_finalize(
+                        self.current_round.height,
+                        self.current_round.round,
+                        &proposal_id,
+                    )
+                    .await?;
+                }
             }
             ConsensusStep::Commit => {
                 // Sync height with blockchain before advancing. This prevents the consensus
@@ -2490,17 +2537,19 @@ impl ConsensusEngine {
                     );
                 }
 
-                // Do NOT call process_committed_block directly here.
-                // We just cast our own commit vote (1 vote in pool) but may not yet have
-                // quorum. Let maybe_finalize decide: if other nodes' commit votes are already
-                // in the pool we commit immediately; otherwise on_commit_vote will trigger
-                // maybe_finalize again when the remaining votes arrive.
-                self.maybe_finalize(
-                    self.current_round.height,
-                    self.current_round.round,
-                    &proposal_id,
-                )
-                .await?;
+                // CONS-305f: maybe_finalize is no longer called from
+                // here. Calling it from inside enter_commit_step
+                // creates a `dispatch_action → enter_commit_step →
+                // maybe_finalize → transition() → dispatch_action`
+                // recursion that rustc rejects (E0733) once
+                // dispatch_action invokes enter_commit_step itself.
+                // Instead, callers that need an immediate
+                // post-cast-commit-vote quorum check call
+                // `maybe_finalize` themselves AFTER
+                // `enter_commit_step` returns. The two existing
+                // production callers (on_precommit, run_commit_step)
+                // already do this; on_round_timeout's PreCommit
+                // branch was updated to do the same.
             }
         }
 

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1727,12 +1727,20 @@ impl ConsensusEngine {
                 self.dispatch_action(action).await;
             }
 
-            // CONS-305f: removed the direct `enter_precommit_step()`
-            // call here.  The FSM's `SendPrecommit` action dispatched
-            // above already calls `enter_precommit_step` via
-            // `dispatch_action` — keeping this redundant call meant
-            // the helper ran twice (idempotent re re-entry guards,
-            // but wasteful).
+            // CONS-305f / PR #2403 review: keep the explicit
+            // `enter_precommit_step()` call here for the **late
+            // prevote quorum after timeout** path. When the local
+            // step has already advanced to PreCommit via the
+            // PreVote-step timeout, `prior_fsm = Precommitting`
+            // and the FSM treats this `PrevoteThresholdReached` as
+            // logged-ignored (it doesn't emit SendPrecommit from
+            // an already-Precommitting state). Without this call
+            // we'd never cast our precommit on a late prevote
+            // quorum. The helper is idempotent w.r.t. its own
+            // re-entry guard, so the ON-TIME quorum case (FSM
+            // dispatched SendPrecommit and dispatch_action ran
+            // enter_precommit_step) still works.
+            self.enter_precommit_step().await?;
         }
 
         // **CE-L1, CE-L2**: Always check if commit quorum is reached, even in PreVote step
@@ -1864,9 +1872,17 @@ impl ConsensusEngine {
                 self.dispatch_action(action).await;
             }
 
-            // CONS-305f: removed the direct `enter_commit_step()`
-            // call here. The FSM's `SendCommit` action dispatched
-            // above calls it via `dispatch_action`.
+            // CONS-305f / PR #2403 review: keep the explicit
+            // `enter_commit_step()` call here for the **late
+            // precommit quorum after timeout** path.  Same shape
+            // as the on_prevote case above: when the local step
+            // has already advanced to Commit via the PreCommit-
+            // step timeout, the FSM is `Committed { ... }` and
+            // treats `PrecommitThresholdReached` as logged-
+            // ignored.  Without this call we'd never cast our
+            // commit vote on a late precommit quorum.  Helper is
+            // idempotent.
+            self.enter_commit_step().await?;
         }
 
         // **CE-L1, CE-L2**: Always check if commit quorum is reached, even in PreCommit step
@@ -2045,10 +2061,6 @@ impl ConsensusEngine {
         self.current_round.step = new_step;
     }
 
-    /// Dispatch a single FSM `Action` to the engine. CONS-305 stages
-    /// these per-action handlers progressively; for CONS-305a only
-    /// `Timeout`-driven actions need handling, the rest are no-ops or
-    /// pass through to the existing engine machinery.
     /// Dispatch one FSM `Action` to the engine.
     ///
     /// CONS-305f cutover: dispatch_action is the canonical entry


### PR DESCRIPTION
## Summary
Step 2 of CONS-305f cleanup, stacked on [#2403](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/pull/2403). Every FSM transition now goes through \`enter_fsm_state\` (now async), which runs the appropriate \`enter_*_step\` helper on state-kind change.

## What changes
1. **\`enter_fsm_state\` is the canonical FSM mutation**, replacing every direct \`self.fsm_state = next_fsm\` write in handlers + \`maybe_finalize\`. On state-kind change, it dispatches the phase-entry hook (\`enter_*_step\`).
2. **Recursion-free**. Step 1 had moved \`maybe_finalize\` out of \`enter_commit_step\`, so the async-recursion (E0733) doesn't bite.
3. **dispatch_action's Send* / CreateProposal arms are no-ops**. Phase-entry work has already happened in \`enter_fsm_state\` by the time actions iterate.
4. **\`on_round_timeout\` walk-through reduced**. The match-step block no longer needs Propose→Prevote and PreVote→Precommit arms — \`enter_fsm_state\` on Timeout-driven kind changes runs the right helper. PreCommit→Commit arm stays (FSM kind doesn't change between wire-level PreCommit and Commit; engine still drives that intra-kind step transition). Commit-step round-reset arm stays (engine-specific).

## Test plan
- [x] \`cargo test -p lib-consensus --lib\` — 183 pass / 4 fail (KI-01..04 baseline preserved)
- [x] \`cargo build --workspace\` — clean

No behavior change.

## Still left in CONS-305f (step 3)
- Delete \`enter_*_step\` methods themselves (inline into phase-entry dispatch in \`enter_fsm_state\`).
- Audit ~6 production \`current_round.step = X\` writes that bypass \`enter_fsm_state\`.