### PR TITLE
fix(consensus): emit Send* on late-quorum FSM arms (closes #2405)

### DIFF
--- a/lib-consensus-core/src/fsm/transition.rs
+++ b/lib-consensus-core/src/fsm/transition.rs
@@ -274,6 +274,20 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
         // ============================================================
         // Precommitting — gathering PreCommits, then Commit votes.
         // ============================================================
+        // Late prevote quorum (#2405): when the runtime walked from
+        // PreVote step to PreCommit step on timeout BEFORE the prevote
+        // quorum arrived, a subsequent late prevote completing the
+        // quorum lands here.  Emit SendPrecommit so the late case
+        // still casts a precommit. Pre-#2405 this was logged-ignored
+        // and the runtime relied on a guarded direct enter_*_step
+        // call to recover.
+        (Precommitting, PrevoteThresholdReached { block_id }) => (
+            Precommitting,
+            vec![
+                Action::SendPrecommit { block_id },
+                Action::ResetWatchdog,
+            ],
+        ),
         (Precommitting, PrecommitThresholdReached { block_id }) => (
             Precommitting,
             vec![Action::SendCommit { block_id }, Action::ResetWatchdog],
@@ -327,6 +341,19 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
                 round: 0,
             },
             vec![Action::AdvanceRound],
+        ),
+        // Late precommit quorum (#2405): symmetric to the late
+        // prevote quorum on Precommitting above. When the runtime
+        // walked to wire-level Commit step on timeout but the FSM
+        // step_to_fsm_state mapping renders that as Committed, a
+        // subsequent late precommit quorum lands here. Emit
+        // SendCommit so the late case still casts a commit vote.
+        (committed @ Committed { .. }, PrecommitThresholdReached { block_id }) => (
+            committed,
+            vec![
+                Action::SendCommit { block_id },
+                Action::ResetWatchdog,
+            ],
         ),
         (committed @ Committed { .. }, _) => (
             committed,

--- a/lib-consensus-core/src/fsm/transition_table.rs
+++ b/lib-consensus-core/src/fsm/transition_table.rs
@@ -189,6 +189,14 @@ pub fn transition_table() -> Vec<TransitionRule> {
     // ----- Precommitting -----
     push(
         F::Specific(S::Precommitting),
+        E::PrevoteThresholdReached,
+        S::Precommitting,
+        vec![A::SendPrecommit, A::ResetWatchdog],
+        "Late prevote quorum after PreVote-step timeout — still cast \
+         our precommit (#2405).",
+    );
+    push(
+        F::Specific(S::Precommitting),
         E::PrecommitThresholdReached,
         S::Precommitting,
         vec![A::SendCommit, A::ResetWatchdog],
@@ -224,6 +232,15 @@ pub fn transition_table() -> Vec<TransitionRule> {
     );
 
     // ----- Committed -----
+    push(
+        F::Specific(S::Committed),
+        E::PrecommitThresholdReached,
+        S::Committed,
+        vec![A::SendCommit, A::ResetWatchdog],
+        "Late precommit quorum after PreCommit-step timeout (which \
+         the bridge maps to FSM Committed) — still cast our commit \
+         vote (#2405).",
+    );
     push(
         F::Specific(S::Committed),
         E::Timeout,

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1727,22 +1727,14 @@ impl ConsensusEngine {
                 self.dispatch_action(action).await;
             }
 
-            // CONS-305f / PR #2403 review: keep the explicit
-            // `enter_precommit_step()` call here for the **late
-            // prevote quorum after timeout** path. When the local
-            // step has already advanced to PreCommit via the
-            // PreVote-step timeout, `prior_fsm = Precommitting`
-            // and the FSM treats `PrevoteThresholdReached` as
-            // logged-ignored (no SendPrecommit emitted from an
-            // already-Precommitting state). Without this call we'd
-            // never cast our precommit on a late prevote quorum.
-            //
-            // The on-TIME quorum path (Prevoting→Precommitting) is
-            // covered by step 2's phase-entry hook in
-            // `enter_fsm_state`; the helper is idempotent w.r.t.
-            // its own re-entry guard so the second call here is a
-            // no-op in that case.
-            self.enter_precommit_step().await?;
+            // CONS-305f / #2405: late-quorum guard removed. The
+            // FSM now emits `SendPrecommit` on `(Precommitting,
+            // PrevoteThresholdReached)` so `dispatch_action` casts
+            // the late precommit. On the on-TIME path (Prevoting →
+            // Precommitting kind change), `enter_fsm_state`'s
+            // phase-entry hook also runs `enter_precommit_step` —
+            // but since the helpers are idempotent, the action
+            // dispatch's later call is a safe no-op.
         }
 
         // **CE-L1, CE-L2**: Always check if commit quorum is reached, even in PreVote step
@@ -1874,17 +1866,13 @@ impl ConsensusEngine {
                 self.dispatch_action(action).await;
             }
 
-            // CONS-305f / PR #2403 review: keep the explicit
-            // `enter_commit_step()` call here for the **late
-            // precommit quorum after timeout** path.  Same shape
-            // as the on_prevote case above: when the local step
-            // has already advanced to Commit via the PreCommit-
-            // step timeout, the FSM is `Committed { ... }` and
-            // treats `PrecommitThresholdReached` as logged-
-            // ignored.  Without this call we'd never cast our
-            // commit vote on a late precommit quorum.  Helper is
-            // idempotent.
-            self.enter_commit_step().await?;
+            // CONS-305f / #2405: late-quorum guard removed. The
+            // FSM now emits `SendCommit` on `(Committed,
+            // PrecommitThresholdReached)` so `dispatch_action`
+            // casts the late commit vote. On the on-TIME path
+            // (Precommitting + PrecommitThresholdReached → stays
+            // Precommitting), the FSM also emits SendCommit and
+            // dispatch_action calls enter_commit_step (idempotent).
         }
 
         // **CE-L1, CE-L2**: Always check if commit quorum is reached, even in PreCommit step
@@ -2131,15 +2119,33 @@ impl ConsensusEngine {
                 self.current_round.timed_out = false;
             }
 
-            // CONS-305f step 2: state-kind-change phase entry runs
-            // in `enter_fsm_state` (canonical mutation point).  These
-            // FSM actions are emitted alongside state-kind changes
-            // so the work has already happened by the time we get
-            // here. No-op deliberately.
-            A::CreateProposal
-            | A::SendPrevote { .. }
-            | A::SendPrecommit { .. }
-            | A::SendCommit { .. } => {}
+            // Phase-entry side effects. `enter_fsm_state` ALSO calls
+            // these on state-kind change; the helpers are idempotent
+            // (re-entry guards), so the double-call on kind change is
+            // a safe no-op. Dispatching from here covers the intra-
+            // kind cases (Precommitting + PrecommitThresholdReached →
+            // stays Precommitting, casts commit vote) and the late-
+            // quorum cases now that #2405 emits Send* on those arms.
+            A::CreateProposal => {
+                if let Err(e) = self.enter_propose_step().await {
+                    tracing::warn!(error = ?e, "CreateProposal action failed");
+                }
+            }
+            A::SendPrevote { .. } => {
+                if let Err(e) = self.enter_prevote_step().await {
+                    tracing::warn!(error = ?e, "SendPrevote action failed");
+                }
+            }
+            A::SendPrecommit { .. } => {
+                if let Err(e) = self.enter_precommit_step().await {
+                    tracing::warn!(error = ?e, "SendPrecommit action failed");
+                }
+            }
+            A::SendCommit { .. } => {
+                if let Err(e) = self.enter_commit_step().await {
+                    tracing::warn!(error = ?e, "SendCommit action failed");
+                }
+            }
 
             // BroadcastProposal — proposal relay needs ownership of
             // the proposal struct, which the FSM action carries only


### PR DESCRIPTION
## Summary
Closes #2405 — the late-quorum FSM gap surfaced by PR #2403 review. Two new arms in \`transition()\`:

- \`(Precommitting, PrevoteThresholdReached) → (Precommitting, [SendPrecommit, ResetWatchdog])\`
- \`(Committed { .. }, PrecommitThresholdReached) → (state, [SendCommit, ResetWatchdog])\`

Both surfaces in \`transition_table.rs\` with new rows; bidirectional drift tests verify.

## Engine cleanup
- \`dispatch_action\` Send*/CreateProposal arms now call \`enter_*_step\` (no longer no-ops). Recursion-free invariant from CONS-305f step 1 makes this safe.
- Late-quorum runtime guards in \`on_prevote\`/\`on_precommit\` deleted — FSM now handles natively.
- \`enter_fsm_state\`'s phase-entry hook on kind change still runs. Helpers are idempotent so double-call is safe no-op.

Closes #2405.

Stacked on [#2404 (CONS-305f step 2)](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/pull/2404).

## Test plan
- [x] \`cargo test -p lib-consensus-core --lib\` — 32/32 pass (drift tests)
- [x] \`cargo test -p lib-consensus --lib\` — 183 pass / 4 fail (KI-01..04 baseline preserved)
- [x] \`cargo build --workspace\` — clean