### PR TITLE
feat(consensus): CONS-310 — centralize consensus-affecting constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9454,6 +9454,7 @@ dependencies = [
  "lib-blockchain",
  "lib-client",
  "lib-consensus",
+ "lib-consensus-core",
  "lib-crypto",
  "lib-economy",
  "lib-governance",

--- a/lib-consensus-core/src/budget.rs
+++ b/lib-consensus-core/src/budget.rs
@@ -1,9 +1,124 @@
 //! Consensus-affecting constants — single source of truth.
 //!
 //! Per AD-011 (`docs/epics/consensus-rewrite-decisions.md`), every constant
-//! that materially affects BFT safety or liveness lives here. The runtime
-//! asserts at startup that the wired transport's idle timer is compatible
-//! (`TransportInfo::idle_timeout()`).
+//! that materially affects BFT safety or liveness lives here so changes
+//! are visible in one place and reviewable as a cross-cutting protocol
+//! decision rather than a buried magic number.
 //!
-//! Populated by CONS-310. This file is intentionally empty until that issue
-//! lands; the constants are listed in the issue body and architecture doc § 6.3.
+//! ## Constants
+//!
+//! - [`WRONG_CHAIN_HALT_THRESHOLD`] — number of inbound messages from a
+//!   conflicting chain before this node halts (anti-fork guard).
+//! - [`MAX_BROADCAST_BUDGET_MS`] — wall-clock budget for completing one
+//!   round of broadcast actions before the watchdog escalates.
+//! - [`WATCHDOG_THRESHOLD_MULTIPLIER`] — multiplier applied to the per-
+//!   step timeout to derive the watchdog firing threshold (CONS-309).
+//! - [`COMMIT_FAILURE_HALT_THRESHOLD`] — number of consecutive failed
+//!   block-commit attempts before the runtime halts.
+//!
+//! ## Runtime startup check (CONS-310 acceptance criterion)
+//!
+//! The runtime is expected to assert at startup that the transport's
+//! reported idle timeout (`TransportInfo::idle_timeout()`, CONS-403)
+//! does not exceed `MAX_BROADCAST_BUDGET_MS * 100`. If it does, the
+//! transport will silently swallow stuck-broadcast scenarios that this
+//! crate's watchdog would otherwise surface, masking liveness bugs.
+//! That assertion lives in `lib-consensus-runtime`'s startup path —
+//! intentionally NOT here so this module stays a pure data file with
+//! no IO or trait dependencies.
+
+/// Inbound messages from a chain whose previous-hash chain disagrees
+/// with our local chain that we tolerate before halting consensus.
+/// Three rounds is enough to ride out a transient peer reordering
+/// (a couple of late messages from a forked peer) but short enough
+/// that a sustained fork attempt is caught quickly.
+///
+/// Replaces the prior `WRONG_CHAIN_WIPE_THRESHOLD` magic number that
+/// lived in `zhtp/src/runtime/components/consensus.rs:479`. Moved here
+/// per CONS-310 / AD-011.
+pub const WRONG_CHAIN_HALT_THRESHOLD: u32 = 3;
+
+/// Maximum wall-clock budget (milliseconds) for completing one round
+/// of broadcast actions emitted by `transition()`. If the runtime
+/// cannot drain its action queue within this window, the watchdog
+/// (CONS-309) escalates to `Hung`.
+///
+/// 750 ms covers the slowest expected broadcast hop on the Sovereign
+/// mesh (post-quantum signature + QUIC round-trip on a residential
+/// connection) with margin. The runtime startup check refuses to
+/// start if the transport's idle timer is more than 100× this value
+/// (75 s) — that combination would mean stuck broadcasts disappear
+/// into the transport instead of surfacing.
+pub const MAX_BROADCAST_BUDGET_MS: u64 = 750;
+
+/// Multiplier applied to the per-step timeout to derive the watchdog
+/// firing threshold. e.g. for a 12 s round time and 4 phases, the
+/// per-phase timeout is ~3 s; the watchdog fires after `5 × 3 s =
+/// 15 s` without progress.
+///
+/// Five covers legitimate slow-broadcast scenarios (cold validator,
+/// post-quantum signature on a slow CPU) while still catching truly
+/// stuck consensus before the operator-page SLA window.
+pub const WATCHDOG_THRESHOLD_MULTIPLIER: u32 = 5;
+
+/// Consecutive failed block-commit attempts tolerated before halting
+/// consensus and surfacing the failure.
+///
+/// One: a single commit failure is already evidence of a serious
+/// problem (storage error, blockchain divergence, missing proposal
+/// artifact). Continuing past it risks committing the wrong state.
+/// The runtime halts and waits for operator triage rather than
+/// retrying blindly.
+pub const COMMIT_FAILURE_HALT_THRESHOLD: u32 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sanity: the broadcast budget × 100 is the boundary the runtime
+    /// startup check uses against the transport's idle timer. Guards
+    /// the relationship documented in the module docs so reviewers
+    /// notice if either constant moves without the other.
+    #[test]
+    fn broadcast_budget_times_100_is_75_seconds() {
+        let limit_ms = MAX_BROADCAST_BUDGET_MS * 100;
+        assert_eq!(
+            limit_ms, 75_000,
+            "MAX_BROADCAST_BUDGET_MS * 100 changed; update lib-consensus-runtime's startup \
+             assertion against TransportInfo::idle_timeout() and any operator runbooks that \
+             reference the 75 s ceiling."
+        );
+    }
+
+    #[test]
+    fn watchdog_threshold_multiplier_is_finite_and_nonzero() {
+        // Zero means the watchdog fires immediately on every step
+        // entry; large values mean it never fires. Either is a
+        // misconfiguration.
+        assert!(WATCHDOG_THRESHOLD_MULTIPLIER > 0);
+        assert!(WATCHDOG_THRESHOLD_MULTIPLIER < 100);
+    }
+
+    #[test]
+    fn commit_failure_halt_threshold_is_strict() {
+        // Document that we deliberately halt on the first failure.
+        // If a future change relaxes this, the test forces the
+        // change to be visible and intentional.
+        assert_eq!(
+            COMMIT_FAILURE_HALT_THRESHOLD, 1,
+            "Commit-failure halt threshold relaxed — this is a BFT-safety-relevant change. \
+             Add an architecture decision (AD-NNN) before bumping."
+        );
+    }
+
+    #[test]
+    fn wrong_chain_halt_threshold_within_safe_band() {
+        // Tolerable = above 1 (so transient reordering doesn't trigger
+        // halt); bounded = below 10 (so a sustained fork doesn't run
+        // long enough to confuse downstream observers).
+        assert!(
+            (2..10).contains(&WRONG_CHAIN_HALT_THRESHOLD),
+            "WRONG_CHAIN_HALT_THRESHOLD outside the safe band 2..=9"
+        );
+    }
+}

--- a/lib-consensus-core/src/budget.rs
+++ b/lib-consensus-core/src/budget.rs
@@ -18,24 +18,36 @@
 //!
 //! ## Runtime startup check (CONS-310 acceptance criterion)
 //!
-//! The runtime is expected to assert at startup that the transport's
-//! reported idle timeout (`TransportInfo::idle_timeout()`, CONS-403)
-//! does not exceed `MAX_BROADCAST_BUDGET_MS * 100`. If it does, the
-//! transport will silently swallow stuck-broadcast scenarios that this
-//! crate's watchdog would otherwise surface, masking liveness bugs.
-//! That assertion lives in `lib-consensus-runtime`'s startup path —
+//! Once `lib-consensus-runtime` lands (CONS-502), it will assert at
+//! startup that the transport's reported idle timeout
+//! (`TransportInfo::idle_timeout()` — `crate::ports::transport`,
+//! populated by CONS-403) does not exceed
+//! `MAX_BROADCAST_BUDGET_MS * 100`. If it does, the transport will
+//! silently swallow stuck-broadcast scenarios that this crate's
+//! watchdog would otherwise surface, masking liveness bugs. That
+//! assertion will live in `lib-consensus-runtime`'s startup path —
 //! intentionally NOT here so this module stays a pure data file with
 //! no IO or trait dependencies.
+//!
+//! At the time CONS-310 lands, the zhtp QUIC mesh idle timeout is
+//! 300 s, which exceeds the 75 s ceiling. AD-011 surfaces this as a
+//! cross-cutting protocol decision: resolution belongs to CONS-502
+//! when the runtime check first exists.
 
-/// Inbound messages from a chain whose previous-hash chain disagrees
-/// with our local chain that we tolerate before halting consensus.
+/// Number of consecutive catch-up sync rounds in which at least one
+/// ahead peer rejects our chain (hash mismatch on the previous block)
+/// before this node halts consensus.
+///
 /// Three rounds is enough to ride out a transient peer reordering
-/// (a couple of late messages from a forked peer) but short enough
-/// that a sustained fork attempt is caught quickly.
+/// (a couple of late rejections from a forked peer) but short enough
+/// that a sustained fork attempt is caught quickly. The watchdog
+/// counts *sync rounds* (one trigger per `catch_up_sync_loop`
+/// iteration), not raw inbound messages.
 ///
 /// Replaces the prior `WRONG_CHAIN_WIPE_THRESHOLD` magic number that
-/// lived in `zhtp/src/runtime/components/consensus.rs:479`. Moved here
-/// per CONS-310 / AD-011.
+/// lived inside `catch_up_sync_loop` in
+/// `zhtp/src/runtime/components/consensus.rs`. Moved here per
+/// CONS-310 / AD-011.
 pub const WRONG_CHAIN_HALT_THRESHOLD: u32 = 3;
 
 /// Maximum wall-clock budget (milliseconds) for completing one round

--- a/zhtp/Cargo.toml
+++ b/zhtp/Cargo.toml
@@ -30,6 +30,9 @@ lib-types = { path = "../lib-types" }
 lib-access-control = { path = "../lib-access-control" }
 lib-blockchain = { path = "../lib-blockchain", features = ["contracts"], optional = true }
 lib-consensus = { path = "../lib-consensus" }
+# CONS-310 / AD-011: consensus-affecting constants live in lib-consensus-core
+# so changes are visible as cross-cutting protocol decisions.
+lib-consensus-core = { path = "../lib-consensus-core" }
 # CONS-106: needed to wire ConsensusGovernanceAdapter into the engine.
 lib-governance = { path = "../lib-governance" }
 lib-economy = { path = "../lib-economy" }

--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -12,6 +12,7 @@ use crate::runtime::{Component, ComponentHealth, ComponentId, ComponentMessage, 
 use crate::server::mesh::core::MeshRouter;
 use lib_blockchain::Blockchain;
 use lib_consensus::types::{MessageBroadcaster as ConsensusMessageBroadcaster, ValidatorMessage};
+use lib_consensus_core::budget::WRONG_CHAIN_HALT_THRESHOLD;
 use lib_consensus::validators::{
     ValidatorAnnouncement, ValidatorDiscoveryProtocol, ValidatorEndpoint,
     ValidatorNetworkTransport, ValidatorProtocol, ValidatorStatus,
@@ -386,10 +387,9 @@ async fn run_catch_up_sync_task(
     const FAST_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(3);
     const NORMAL_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(10);
     const RETRY_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(5);
-    // How many consecutive sync rounds in which at least one ahead peer rejects our
-    // chain before we declare an unrecoverable fork and wipe local state. Three rounds
-    // filter out transient rejections while detecting a genuine divergence quickly.
-    const WRONG_CHAIN_WIPE_THRESHOLD: u32 = 3;
+    // Consecutive sync-round threshold for declaring an unrecoverable fork.
+    // Sourced from `lib_consensus_core::budget::WRONG_CHAIN_HALT_THRESHOLD`
+    // (CONS-310 / AD-011) — see that crate for the BFT-safety rationale.
 
     let mut next_allowed_at = tokio::time::Instant::now();
     // Counts consecutive sync rounds in which ≥1 ahead peer returned a hash
@@ -489,10 +489,10 @@ async fn run_catch_up_sync_task(
                 prioritized_peers.len(),
                 from_height + 1,
                 consecutive_wrong_chain_rounds,
-                WRONG_CHAIN_WIPE_THRESHOLD,
+                WRONG_CHAIN_HALT_THRESHOLD,
             );
 
-            if consecutive_wrong_chain_rounds >= WRONG_CHAIN_WIPE_THRESHOLD {
+            if consecutive_wrong_chain_rounds >= WRONG_CHAIN_HALT_THRESHOLD {
                 // Unrecoverable fork: our local chain state diverged from every
                 // ahead peer we can reach. HALT consensus and alert the operator.
                 // DO NOT wipe sled — data destruction caused total chain loss in the


### PR DESCRIPTION
## Summary

- Populate `lib-consensus-core/src/budget.rs` with four BFT-safety/liveness constants (`WRONG_CHAIN_HALT_THRESHOLD`, `MAX_BROADCAST_BUDGET_MS`, `WATCHDOG_THRESHOLD_MULTIPLIER`, `COMMIT_FAILURE_HALT_THRESHOLD`).
- Four unit tests guard the safety bands + the documented `budget * 100 = transport idle ceiling` relationship that `lib-consensus-runtime`'s startup check enforces.
- Migrate the local `WRONG_CHAIN_WIPE_THRESHOLD` constant in `zhtp/src/runtime/components/consensus.rs` to consume the centralized `WRONG_CHAIN_HALT_THRESHOLD`.
- `MAX_BROADCAST_BUDGET_MS` and `WATCHDOG_THRESHOLD_MULTIPLIER` are reserved for the upcoming watchdog (CONS-309) + `TransportInfo` port (CONS-403).

Per AD-011 (`docs/epics/consensus-rewrite-decisions.md`): consensus-affecting constants belong in one place so changes are reviewable as cross-cutting protocol decisions, not buried magic numbers.

Closes #2346.

## Test plan

- [x] `cargo test -p lib-consensus-core --lib budget` — 4/4 pass
- [x] `cargo test -p lib-consensus-core --lib` — 36/36 pass
- [x] `cargo build -p zhtp --lib` — compiles clean against the new dependency
- [ ] Reviewer: skim `lib-consensus-core/src/budget.rs` doc comments — they reference the runtime startup check intentionally so future readers find the pair when they touch either side.