### PR TITLE
feat(consensus): CONS-403 — TransportInfo port + zhtp QUIC adapter impl

### DIFF
--- a/lib-consensus-core/src/ports/mod.rs
+++ b/lib-consensus-core/src/ports/mod.rs
@@ -19,6 +19,8 @@
 
 pub mod governance;
 pub mod rewards;
+pub mod transport;
 
 pub use governance::{GovernanceCallback, NoOpGovernanceCallback};
 pub use rewards::{NoOpRewardCallback, RewardCallback, ValidatorRewardInput};
+pub use transport::{NoOpTransportInfo, TransportInfo};

--- a/lib-consensus-core/src/ports/transport.rs
+++ b/lib-consensus-core/src/ports/transport.rs
@@ -1,0 +1,88 @@
+//! Transport introspection port (CONS-403).
+//!
+//! Per AD-002, the consensus engine never reaches into the transport for
+//! configuration. But the *runtime* needs a narrow read-only handle to
+//! detect transport misconfigurations that would silently break the
+//! broadcast watchdog (CONS-309) before it ever fires.
+//!
+//! The runtime startup check (planned in `lib-consensus-runtime`)
+//! refuses to start whenever the transport's reported idle timeout
+//! exceeds `lib_consensus_core::budget::MAX_BROADCAST_BUDGET_MS * 100`.
+//! See `crate::budget` for the rationale and the test that pins the
+//! ceiling at 75 s.
+//!
+//! This trait is intentionally tiny: just enough surface for that
+//! startup assertion plus a name for diagnostics. Anything richer
+//! belongs in a runtime-side trait (CONS-501..504 territory).
+//!
+//! ## Implementations
+//!
+//! - `lib-consensus-runtime`'s zhtp QUIC adapter returns the QUIC
+//!   `max_idle_timeout` configured in
+//!   `lib-network/src/protocols/quic_mesh.rs`.
+//! - `NoOpTransportInfo` here is a test/benchmark double that returns
+//!   a budget-respecting timeout so consensus tests don't have to wire
+//!   a real transport.
+
+use std::time::Duration;
+
+/// Read-only introspection of the transport that delivers
+/// `ValidatorMessage`s. Implementations must be cheap to call — the
+/// runtime calls them at startup and may surface them in diagnostics.
+pub trait TransportInfo: Send + Sync {
+    /// The transport's idle timeout. The runtime startup check
+    /// compares this against `budget::MAX_BROADCAST_BUDGET_MS * 100`.
+    /// A timeout longer than the ceiling means stuck broadcasts
+    /// disappear into the transport instead of surfacing to the
+    /// watchdog.
+    fn idle_timeout(&self) -> Duration;
+
+    /// Short, stable name used in operator-facing error messages and
+    /// dashboards (e.g. `"zhtp-quic-mesh"`). MUST NOT depend on
+    /// runtime state — the runtime startup check needs to print it
+    /// before the transport is fully wired.
+    fn name(&self) -> &str;
+}
+
+/// In-memory test double. Returns the largest idle timeout that still
+/// passes the startup check at `MAX_BROADCAST_BUDGET_MS = 750` ms,
+/// keeping unit tests on the safe side of the budget.
+pub struct NoOpTransportInfo;
+
+impl TransportInfo for NoOpTransportInfo {
+    fn idle_timeout(&self) -> Duration {
+        // Exactly the runtime ceiling — passes the `<= ceiling` check
+        // by one millisecond's worth of margin in any realistic
+        // implementation. Tests that need a *failing* transport should
+        // construct their own with an explicit, larger timeout.
+        Duration::from_millis(crate::budget::MAX_BROADCAST_BUDGET_MS * 100 - 1)
+    }
+
+    fn name(&self) -> &str {
+        "noop-transport"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_transport_passes_runtime_ceiling() {
+        // Guard the contract for `NoOpTransportInfo`: idle timeout
+        // must be strictly under the runtime's startup ceiling so
+        // tests that depend on it are never the canary.
+        let ceiling = Duration::from_millis(crate::budget::MAX_BROADCAST_BUDGET_MS * 100);
+        assert!(
+            NoOpTransportInfo.idle_timeout() < ceiling,
+            "NoOpTransportInfo.idle_timeout() must be strictly below the runtime ceiling"
+        );
+    }
+
+    #[test]
+    fn noop_transport_name_is_stable() {
+        // Name is operator-facing — pin it so a future rename forces
+        // a runbook update.
+        assert_eq!(NoOpTransportInfo.name(), "noop-transport");
+    }
+}

--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -13,6 +13,7 @@ use crate::server::mesh::core::MeshRouter;
 use lib_blockchain::Blockchain;
 use lib_consensus::types::{MessageBroadcaster as ConsensusMessageBroadcaster, ValidatorMessage};
 use lib_consensus_core::budget::WRONG_CHAIN_HALT_THRESHOLD;
+use lib_consensus_core::ports::TransportInfo;
 use lib_consensus::validators::{
     ValidatorAnnouncement, ValidatorDiscoveryProtocol, ValidatorEndpoint,
     ValidatorNetworkTransport, ValidatorProtocol, ValidatorStatus,
@@ -31,6 +32,17 @@ pub struct ConsensusMeshBroadcaster {
 }
 
 impl ConsensusMeshBroadcaster {
+    /// Idle timeout reported to the consensus runtime for the broadcast
+    /// startup check (CONS-403). Mirrors the QUIC server/client config in
+    /// `lib-network/src/protocols/quic_mesh.rs:1706` and `:1760`. If those
+    /// constants change, update this value too — the runtime startup check
+    /// surfaces the divergence as a configuration error.
+    const QUIC_MESH_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+    /// Operator-facing transport name (CONS-403). Used in startup-check
+    /// errors and dashboards.
+    const TRANSPORT_NAME: &'static str = "zhtp-quic-mesh";
+
     pub fn new(mesh_router: Arc<MeshRouter>) -> Self {
         Self { mesh_router }
     }
@@ -139,6 +151,24 @@ impl ConsensusMessageBroadcaster for ConsensusMeshBroadcaster {
         } else {
             Ok(())
         }
+    }
+}
+
+/// CONS-403: expose the QUIC mesh's idle timeout to the consensus runtime
+/// startup check so a misconfigured transport (idle > budget × 100) is
+/// caught before it can silently swallow stuck broadcasts.
+///
+/// We do **not** read the value out of `quinn::TransportConfig` at runtime —
+/// the config is built inside `lib-network` and isn't exposed. We mirror the
+/// constant instead. If the QUIC config is ever made tunable, this adapter
+/// must learn to read it (and the runtime check will catch any drift).
+impl TransportInfo for ConsensusMeshBroadcaster {
+    fn idle_timeout(&self) -> std::time::Duration {
+        Self::QUIC_MESH_IDLE_TIMEOUT
+    }
+
+    fn name(&self) -> &str {
+        Self::TRANSPORT_NAME
     }
 }
 


### PR DESCRIPTION
## Summary

- New `TransportInfo` trait in `lib-consensus-core/src/ports/transport.rs` (idle_timeout + name) for the consensus runtime startup check from CONS-310.
- `NoOpTransportInfo` test double that's pinned strictly under `MAX_BROADCAST_BUDGET_MS * 100` so consensus tests never accidentally trip the runtime ceiling.
- `ConsensusMeshBroadcaster` in zhtp implements `TransportInfo` returning the 300 s value mirrored from `lib-network/src/protocols/quic_mesh.rs` (raised from 30 s in issue #907).

Closes #2349.

## Stacked PR — base is #2410 (CONS-310)

GitHub will auto-retarget this PR to \`development\` when #2410 merges.

## Known design tension (intentional, surfaced now)

300 s (current QUIC idle) > 75 s (\`MAX_BROADCAST_BUDGET_MS * 100\` ceiling). The runtime startup check planned in \`lib-consensus-runtime\` (CONS-502) will refuse to start under this combo. This is exactly the cross-cutting visibility AD-011 is meant to provide: the resolution is either lower QUIC idle (revisit issue #907) or grow the broadcast budget. Will file a tracking issue against CONS-502 when the runtime crate exists.

## Test plan

- [x] \`cargo test -p lib-consensus-core --lib transport\` — 2/2 pass
- [x] \`cargo test -p lib-consensus-core --lib\` — 38/38 pass (was 36, +2 new)
- [x] \`cargo build -p zhtp --lib\` — clean
- [ ] Reviewer: confirm the 300 s mirror in \`ConsensusMeshBroadcaster::QUIC_MESH_IDLE_TIMEOUT\` matches both call sites in \`quic_mesh.rs:1706\` and \`:1760\`. If those constants ever differ, this adapter needs to learn how to read the actual value.