### PR TITLE
feat(consensus): CONS-404b/c — wire FeeCallback through ConsensusEngine + FeeRouterAdapter

### DIFF
--- a/lib-blockchain/src/contracts/economics/fee_router.rs
+++ b/lib-blockchain/src/contracts/economics/fee_router.rs
@@ -1088,6 +1088,90 @@ impl lib_consensus::types::FeeCollector for FeeRouter {
 }
 
 // ============================================================================
+// CONSENSUS PORT ADAPTER (CONS-404 / AD-005)
+// ============================================================================
+
+/// Adapter that lets the new `lib_consensus_core::ports::FeeCallback` port
+/// drive the existing `FeeRouter` contract. The engine calls
+/// `collect_and_distribute(...)` once per finalized block; this adapter
+/// owns the mutex, runs the collect + distribute pair, and surfaces any
+/// failure as a tracing event (per CE-ENG-4 the engine ignores it).
+///
+/// This is the production wiring for CONS-404. Bootstrap and tests still
+/// use `NoOpFeeCallback`.
+pub struct FeeRouterAdapter {
+    inner: std::sync::Arc<std::sync::Mutex<FeeRouter>>,
+}
+
+impl FeeRouterAdapter {
+    pub fn new(fee_router: std::sync::Arc<std::sync::Mutex<FeeRouter>>) -> Self {
+        Self { inner: fee_router }
+    }
+}
+
+impl lib_consensus_core::ports::FeeCallback for FeeRouterAdapter {
+    fn collect_and_distribute(
+        &self,
+        height: u64,
+        total_fees_collected: u64,
+        _proposer: &lib_identity::IdentityId,
+    ) {
+        if total_fees_collected == 0 {
+            tracing::debug!(
+                "💰 No fees to collect for block {} (genesis or empty block)",
+                height
+            );
+            return;
+        }
+
+        // Recover from a poisoned mutex rather than propagating; consensus
+        // does not branch on this and a panic here would silently take the
+        // engine down.
+        let mut router = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => {
+                tracing::error!("💰 FeeRouter mutex poisoned at block {}: {}", height, p);
+                p.into_inner()
+            }
+        };
+
+        if !router.initialized {
+            tracing::warn!(
+                "💰 FeeRouter not initialized — skipping fee collection for block {}",
+                height
+            );
+            return;
+        }
+
+        if let Err(e) = router.collect(total_fees_collected) {
+            tracing::warn!(
+                "💰 collect_fee failed for block {} (amount {}): {}",
+                height,
+                total_fees_collected,
+                e
+            );
+            return;
+        }
+
+        match router.distribute(height) {
+            Ok(d) => tracing::info!(
+                "💰 Fees distributed for block {}: UBI={} ConsensusDAO={} EmergencyReserve={} DevGrants={} (total={})",
+                height,
+                d.ubi_pool,
+                d.dao_pool,
+                d.emergency_reserve,
+                d.dev_grants,
+                d.ubi_pool
+                    .saturating_add(d.dao_pool)
+                    .saturating_add(d.emergency_reserve)
+                    .saturating_add(d.dev_grants),
+            ),
+            Err(e) => tracing::warn!("💰 distribute_fees failed for block {}: {}", height, e),
+        }
+    }
+}
+
+// ============================================================================
 // UNIT TESTS
 // ============================================================================
 

--- a/lib-consensus/src/engines/consensus_engine/mod.rs
+++ b/lib-consensus/src/engines/consensus_engine/mod.rs
@@ -198,7 +198,7 @@ use lib_governance::dao::DaoEngine;
 use lib_consensus_core::ports::{GovernanceCallback, NoOpGovernanceCallback};
 use crate::invariants::{check_invariant, ConsensusInvariant, ConsensusState as InvariantState};
 use crate::types::*;
-use lib_consensus_core::ports::{NoOpRewardCallback, RewardCallback};
+use lib_consensus_core::ports::{FeeCallback, NoOpFeeCallback, NoOpRewardCallback, RewardCallback};
 use crate::validators::validator_manager::ValidatorInfo as ValidatorInfoTrait;
 use crate::validators::ValidatorManager;
 use crate::{ConsensusError, ConsensusResult};
@@ -506,11 +506,12 @@ pub struct ConsensusEngine {
     /// distribution side effects. Defaults to a no-op so tests and bootstrap
     /// configurations can run without wiring rewards.
     reward_callback: Arc<dyn RewardCallback>,
-    /// Fee collector for fee collection integration
-    ///
-    /// Implements the FeeCollector trait for collecting and distributing fees
-    /// during block finalization. Uses Arc<Mutex<>> for thread-safe access.
-    fee_router: Option<std::sync::Arc<std::sync::Mutex<dyn FeeCollector>>>,
+    /// CONS-404 / AD-005: fire-and-forget fee distribution hook. The runtime
+    /// adapter (e.g. `lib_blockchain::contracts::economics::fee_router::
+    /// FeeRouterAdapter`) owns the FeeRouter mutex and the 45/30/15/10 split.
+    /// Defaults to a no-op so tests and bootstrap configurations can run
+    /// without wiring fees.
+    fee_callback: Arc<dyn FeeCallback>,
     /// Message broadcaster for network distribution
     ///
     /// Invariant CE-ENG-1: ConsensusEngine never constructs, configures, or inspects
@@ -635,7 +636,7 @@ impl ConsensusEngine {
             governance_callback: Arc::new(NoOpGovernanceCallback),
             byzantine_detector: ByzantineFaultDetector::new(),
             reward_callback: Arc::new(NoOpRewardCallback),
-            fee_router: None,
+            fee_callback: Arc::new(NoOpFeeCallback),
             broadcaster,
             message_rx: None,
             liveness_event_tx: None,
@@ -878,15 +879,13 @@ impl ConsensusEngine {
         self.validator_manager.get_active_validators().len()
     }
 
-    /// Set fee collector for fee collection integration
+    /// Inject the fee distribution hook (CONS-404 / AD-005).
     ///
-    /// Allows the consensus engine to collect and distribute fees at block finalization.
-    /// The fee collector must implement the FeeCollector trait.
-    ///
-    /// # Arguments
-    /// * `fee_collector` - Implementation of FeeCollector trait (e.g., FeeRouter from lib-blockchain)
-    pub fn set_fee_router<T: FeeCollector + 'static>(&mut self, fee_collector: T) {
-        self.fee_router = Some(std::sync::Arc::new(std::sync::Mutex::new(fee_collector)));
+    /// Default is `NoOpFeeCallback`. Production runtimes wire
+    /// `lib_blockchain::contracts::economics::fee_router::FeeRouterAdapter`
+    /// (or any other `FeeCallback` impl) here.
+    pub fn set_fee_callback(&mut self, callback: Arc<dyn FeeCallback>) {
+        self.fee_callback = callback;
     }
 
     /// Inject the reward distribution hook (CONS-103 / AD-005).

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1114,14 +1114,16 @@ impl ConsensusEngine {
             proposal.height,
         );
 
-        // Collect and distribute fees from block.
-        // Mirrors reward distribution pattern - happens at block finalization.
+        // CONS-404 / AD-005: fire-and-forget fee distribution. Adapter owns
+        // the FeeRouter mutex and the 45/30/15/10 split. Per CE-ENG-4 the
+        // engine ignores any internal failure — observability is the
+        // adapter's job.
         let block_metadata = self.extract_block_metadata(&proposal).await;
-        if let Err(e) = self.collect_and_distribute_fees(&block_metadata) {
-            tracing::warn!("Error collecting fees for block {}: {}", proposal.height, e);
-            // Non-critical: Fee collection failure does NOT block consensus
-            // See Invariant CE-ENG-4: Consensus correctness independent of fee collection
-        }
+        self.fee_callback.collect_and_distribute(
+            block_metadata.height,
+            block_metadata.total_fees_collected,
+            &block_metadata.proposer,
+        );
 
         // CONS-106 / AD-005: process any DAO proposals via the fire-and-forget
         // governance callback. Failures handled inside the adapter. Pass
@@ -1135,109 +1137,6 @@ impl ConsensusEngine {
             proposal.id,
             proposal.height
         );
-
-        Ok(())
-    }
-
-    /// Collect and distribute fees from block metadata
-    ///
-    /// Called after block finalization to trigger fee collection and distribution.
-    /// Uses BlockMetadata to track fees without requiring transaction execution.
-    /// Mirrors reward distribution pattern.
-    ///
-    /// **Invariant CE-ENG-4**: Consensus correctness does NOT depend on fee collection
-    /// success. Fee collection is a side-effect of block finalization, not a prerequisite.
-    ///
-    /// **Invariant FC-1**: Fee collection is a side-effect of block finalization
-    /// **Invariant FC-2**: Fee distribution follows the 45/30/15/10 split exactly
-    fn collect_and_distribute_fees(&self, metadata: &BlockMetadata) -> ConsensusResult<()> {
-        // Skip if no fees to collect
-        if metadata.total_fees_collected == 0 {
-            tracing::debug!(
-                "💰 No fees to collect for block {} (genesis or empty block)",
-                metadata.height
-            );
-            return Ok(());
-        }
-
-        // Log fee collection attempt
-        tracing::info!(
-            "💰 Collecting fees from block height {} (total_fees: {})",
-            metadata.height,
-            metadata.total_fees_collected
-        );
-
-        // If FeeCollector is set, collect and distribute fees
-        if let Some(ref fee_router_arc) = self.fee_router {
-            // Lock the fee router for exclusive access
-            let mut fee_router = match fee_router_arc.lock() {
-                Ok(guard) => guard,
-                Err(poisoned) => {
-                    tracing::error!(
-                        "💰 FeeCollector mutex poisoned at block {}: {}",
-                        metadata.height,
-                        poisoned
-                    );
-                    // Recover from poisoned mutex
-                    poisoned.into_inner()
-                }
-            };
-
-            // Check if fee collector is initialized
-            if !fee_router.is_initialized() {
-                tracing::warn!(
-                    "💰 FeeCollector not initialized - skipping fee collection for block {}",
-                    metadata.height
-                );
-                return Ok(());
-            }
-
-            // Step 1: Collect fees
-            if let Err(e) = fee_router.collect_fee(metadata.total_fees_collected) {
-                tracing::warn!(
-                    "💰 Failed to collect fees for block {}: {}",
-                    metadata.height,
-                    e
-                );
-                // Non-critical: Continue even if collection fails
-                return Ok(());
-            }
-
-            tracing::debug!(
-                "💰 Fees collected for block {} (amount: {}, pending: {})",
-                metadata.height,
-                metadata.total_fees_collected,
-                fee_router.pending_fees()
-            );
-
-            // Step 2: Distribute fees according to 45/30/15/10 split
-            match fee_router.distribute_fees(metadata.height) {
-                Ok(distribution) => {
-                    tracing::info!(
-                        "💰 Fees distributed for block {}: UBI={} (45%), Consensus={} (30%), Governance={} (15%), Treasury={} (10%), Total={}",
-                        metadata.height,
-                        distribution.ubi_amount,
-                        distribution.consensus_amount,
-                        distribution.governance_amount,
-                        distribution.treasury_amount,
-                        distribution.total_distributed
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "💰 Failed to distribute fees for block {}: {}",
-                        metadata.height,
-                        e
-                    );
-                    // Non-critical: Fees remain pending for next distribution
-                }
-            }
-        } else {
-            tracing::debug!(
-                "💰 No FeeCollector configured - skipping fee collection for block {}",
-                metadata.height
-            );
-        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Replaces the 100-line inline \`fee_router.lock()\` / collect / distribute block in \`state_machine.rs:1117..1244\` with a single fire-and-forget call through the new \`FeeCallback\` port from CONS-404a (#2413). Closes #2350.

### \`lib-consensus\`
- \`ConsensusEngine.fee_callback: Arc<dyn FeeCallback>\` replaces \`fee_router: Option<Arc<Mutex<dyn FeeCollector>>>\`. Defaults to \`NoOpFeeCallback\`. Mirrors the \`RewardCallback\` shape from CONS-103.
- \`set_fee_callback(Arc<dyn FeeCallback>)\` replaces \`set_fee_router<T: FeeCollector + 'static>(T)\`. The old setter was **never called** anywhere in the workspace — the wiring point moves entirely to the runtime side.
- \`process_committed_block\` drops the inline lock/collect/distribute block; emits a single \`self.fee_callback.collect_and_distribute(height, total_fees, &proposer)\` per CE-ENG-4. The 87-line private helper \`collect_and_distribute_fees\` is deleted.

### \`lib-blockchain\`
- \`FeeRouterAdapter\` in \`contracts/economics/fee_router.rs\` wraps \`Arc<Mutex<FeeRouter>>\` and implements \`FeeCallback\`. Owns the mutex, handles poison recovery, runs the existing \`collect()\` + \`distribute()\` pair, and surfaces failures as tracing events. This is the production wiring for CONS-404.

### Legacy \`FeeCollector\` trait
The old \`lib_consensus::types::FeeCollector\` trait stays — \`FeeRouter\` still implements it for any non-engine consumers (the contract's own internal tests rely on it). Retirement deferred to CONS-507/508 once we confirm no external users.

## Diff stats
\`+107 -125\` across 3 files.

## Validation
- [x] \`cargo build --workspace\` — clean (2m 02s warm).
- [x] \`cargo test -p lib-consensus-core --lib\` — 40/40.
- [x] \`cargo test -p lib-consensus --lib\` — 187/187.
- [x] \`cargo test -p lib-blockchain --lib --features contracts fee_router\` — 37/37.
- [ ] Reviewer: confirm \`FeeRouterAdapter\` is the right home (alongside the existing \`FeeCollector for FeeRouter\` impl). Alternative would be a new module under lib-economy, but lib-economy doesn't host \`FeeRouter\` today.

Closes #2350.