### PR TITLE
chore(ci): skip workspace build on doc-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,22 @@ name: CI
 on:
   push:
     branches: [development, main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/**/*.md'
   pull_request:
     branches: [development, main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/**/*.md'
   workflow_dispatch:
     inputs:
       deploy:


### PR DESCRIPTION
## Summary

Adds \`paths-ignore\` filter to the CI workflow's \`push\` + \`pull_request\` triggers so doc-only changes skip the ~5-min workspace build:

- \`**/*.md\`
- \`docs/**\`
- \`.docs/**\`
- \`LICENSE\`
- \`.gitignore\`
- \`.github/**/*.md\`

Code PRs (Rust, configs, scripts, deploy) continue to run CI as before.

## Why

Doc-only PRs (typo fixes, review comment responses, docstring changes) currently consume ~5 min of CI wall-clock per push. The filter wins that back without affecting the safety net for actual code changes.

## Test plan

- [x] Workflow YAML still parses (the diff is purely declarative — adds two \`paths-ignore\` blocks).
- [ ] First doc-only PR after merge will demonstrate the skip (will show as no checks queued).