### PR TITLE
feat(consensus): CONS-502b — engine event-injection channel + watchdog spawn task (CONS-309 FSM closed-loop)

### DIFF
--- a/lib-consensus-runtime/Cargo.toml
+++ b/lib-consensus-runtime/Cargo.toml
@@ -32,4 +32,4 @@ tokio              = { version = "1.0", features = ["full"] }
 bincode            = "1.3"
 
 [dev-dependencies]
-tokio              = { version = "1.0", features = ["full"] }
+tokio              = { version = "1.0", features = ["full", "test-util"] }

--- a/lib-consensus-runtime/src/runtime.rs
+++ b/lib-consensus-runtime/src/runtime.rs
@@ -1,21 +1,25 @@
 //! `ConsensusRuntime` — single owner of the consensus loop and side-effect
 //! dispatch.
 //!
-//! ## Status (CONS-502 scaffold)
+//! ## Status (CONS-502 + CONS-502b)
 //!
-//! This first cut wraps the existing `lib_consensus::ConsensusEngine` and
-//! does **just two things**:
+//! This cut wraps the existing `lib_consensus::ConsensusEngine` and does:
 //!
 //! 1. Runs the **startup transport-compatibility check** documented in
 //!    `lib_consensus_core::budget` (CONS-310 / CONS-403). If the transport's
 //!    `idle_timeout()` exceeds `MAX_BROADCAST_BUDGET_MS * 100`, runtime
 //!    construction fails with [`RuntimeError::TransportIdleTooLong`] —
 //!    surfacing the misconfiguration before any consensus rounds run.
-//! 2. Delegates `run()` to `ConsensusEngine::run_consensus_loop()`.
+//! 2. **Spawns the watchdog task (CONS-309/CONS-502b)** that polls a
+//!    shared "last `ResetWatchdog`" clock and fires
+//!    `Event::WatchdogFired` into the engine's runtime-event channel
+//!    when the engine has been idle longer than
+//!    `WATCHDOG_THRESHOLD_MULTIPLIER × max(propose_timeout,
+//!    prevote_timeout, precommit_timeout)`. The engine's FSM transitions
+//!    Idle/Proposing/Prevoting/Precommitting → Hung on receipt.
+//! 3. Drives the engine via `ConsensusEngine::run_consensus_loop()`.
 //!
-//! Follow-up PRs add (in order):
-//! - **CONS-502b**: engine event-injection channel + watchdog spawn
-//!   (closes CONS-309 fully).
+//! Follow-up PRs:
 //! - **CONS-502c**: `Action` executor task driven by the action channel
 //!   from CONS-306/307.
 //! - **CONS-502d**: zhtp swap from `engine.run_consensus_loop()` to
@@ -25,10 +29,21 @@
 //! crate is **opt-in** and changes nothing in production.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use lib_consensus::{ConsensusEngine, ConsensusError};
-use lib_consensus_core::budget::MAX_BROADCAST_BUDGET_MS;
+use lib_consensus_core::budget::{MAX_BROADCAST_BUDGET_MS, WATCHDOG_THRESHOLD_MULTIPLIER};
+use lib_consensus_core::fsm::Event;
 use lib_consensus_core::ports::TransportInfo;
+use tokio::sync::{mpsc, RwLock};
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+
+/// CONS-309: how often the watchdog task wakes up to compare
+/// `Instant::now() - last_reset` against the threshold. 500 ms matches
+/// the spec sketch and is far below any realistic per-phase timeout, so
+/// the latency between hang and fire is bounded by this value.
+const WATCHDOG_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Errors surfaced by [`ConsensusRuntime::new`] — all configuration errors
 /// caught at startup, never during a round.
@@ -60,19 +75,31 @@ fn transport_idle_ceiling_ms() -> u128 {
     u128::from(MAX_BROADCAST_BUDGET_MS) * 100
 }
 
-/// Owns the `ConsensusEngine` and the future orchestration glue. See the
-/// module docs for the staged build-out.
+/// Owns the `ConsensusEngine` plus the watchdog task. CONS-502c will
+/// add the action executor; CONS-502d wires this from zhtp.
 pub struct ConsensusRuntime {
     engine: ConsensusEngine,
     transport_name: String,
+    watchdog_threshold: Duration,
+    watchdog_clock: Arc<RwLock<Instant>>,
+    /// Receiver retained until `run()` consumes it to spawn the watchdog
+    /// task; the matching sender is already installed on the engine via
+    /// `set_runtime_event_receiver`.
+    runtime_event_tx_for_watchdog: mpsc::UnboundedSender<Event>,
 }
 
 impl ConsensusRuntime {
     /// Build a runtime around `engine`, asserting the transport is
-    /// compatible with the consensus budget. The transport is consulted
-    /// only at construction; the runtime never holds it after that.
+    /// compatible with the consensus budget and installing the
+    /// runtime-event channel + watchdog clock on the engine.
+    ///
+    /// The watchdog threshold is computed from the engine's config as
+    /// `WATCHDOG_THRESHOLD_MULTIPLIER × max(propose_timeout,
+    /// prevote_timeout, precommit_timeout)`. Override with
+    /// [`Self::with_watchdog_threshold`] when an integration test
+    /// needs a tighter bound.
     pub fn new(
-        engine: ConsensusEngine,
+        mut engine: ConsensusEngine,
         transport: &dyn TransportInfo,
     ) -> Result<Self, RuntimeError> {
         let ceiling_ms = transport_idle_ceiling_ms();
@@ -84,9 +111,20 @@ impl ConsensusRuntime {
                 ceiling_ms,
             });
         }
+
+        let watchdog_threshold = derive_watchdog_threshold(engine.config());
+        let watchdog_clock = Arc::new(RwLock::new(Instant::now()));
+        let (event_tx, event_rx) = mpsc::unbounded_channel::<Event>();
+
+        engine.set_watchdog_clock(watchdog_clock.clone());
+        engine.set_runtime_event_receiver(event_rx);
+
         Ok(Self {
             engine,
             transport_name: transport.name().to_string(),
+            watchdog_threshold,
+            watchdog_clock,
+            runtime_event_tx_for_watchdog: event_tx,
         })
     }
 
@@ -99,23 +137,109 @@ impl ConsensusRuntime {
         Self::new(engine, transport.as_ref())
     }
 
+    /// Override the watchdog threshold. Default is derived from
+    /// `engine.config()`; tests use this to make the threshold trip
+    /// in <1 s instead of waiting on real phase timeouts.
+    pub fn with_watchdog_threshold(mut self, threshold: Duration) -> Self {
+        self.watchdog_threshold = threshold;
+        self
+    }
+
     /// Operator-facing transport name captured at startup. Useful in
     /// dashboards alongside engine diagnostics.
     pub fn transport_name(&self) -> &str {
         &self.transport_name
     }
 
-    /// Drive the consensus loop. Today this is a thin delegate to
-    /// `ConsensusEngine::run_consensus_loop()`. CONS-502b/c add the
-    /// watchdog and action-executor tasks alongside, in a single
-    /// `tokio::select!` per AD-006.
+    /// Effective watchdog threshold (post any
+    /// [`Self::with_watchdog_threshold`] override). Surfaced for
+    /// diagnostics + tests.
+    pub fn watchdog_threshold(&self) -> Duration {
+        self.watchdog_threshold
+    }
+
+    /// Drive the consensus loop with the watchdog spawned alongside.
+    /// On engine exit (graceful or error) the watchdog is aborted.
     pub async fn run(mut self) -> Result<(), ConsensusError> {
         tracing::info!(
-            "ConsensusRuntime starting (transport={})",
-            self.transport_name
+            "ConsensusRuntime starting (transport={}, watchdog_threshold={:?})",
+            self.transport_name,
+            self.watchdog_threshold
         );
-        self.engine.run_consensus_loop().await
+        let watchdog_handle = spawn_watchdog(
+            self.watchdog_clock.clone(),
+            self.watchdog_threshold,
+            self.runtime_event_tx_for_watchdog.clone(),
+            WATCHDOG_POLL_INTERVAL,
+        );
+        let result = self.engine.run_consensus_loop().await;
+        watchdog_handle.abort();
+        result
     }
+}
+
+/// Derive the watchdog threshold from the engine's per-phase timeouts.
+/// `WATCHDOG_THRESHOLD_MULTIPLIER` is centralized in
+/// `lib_consensus_core::budget` per AD-011.
+fn derive_watchdog_threshold(config: &lib_types::consensus::ConsensusConfig) -> Duration {
+    let max_phase_ms = config
+        .propose_timeout
+        .max(config.prevote_timeout)
+        .max(config.precommit_timeout);
+    Duration::from_millis(max_phase_ms.saturating_mul(u64::from(WATCHDOG_THRESHOLD_MULTIPLIER)))
+}
+
+/// Spawn the watchdog task. Visible to integration tests so they can
+/// exercise the latch + fire behaviour without a real `ConsensusEngine`.
+pub(crate) fn spawn_watchdog(
+    clock: Arc<RwLock<Instant>>,
+    threshold: Duration,
+    tx: mpsc::UnboundedSender<Event>,
+    poll_interval: Duration,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(poll_interval);
+        // Latch: fire exactly once per `Hung` episode so we don't spam
+        // the engine with WatchdogFired while it's already in `Hung`.
+        // Re-arms once the engine resets the clock (i.e. Hung exits via
+        // external recovery and `ResetWatchdog` runs again).
+        let mut already_fired_for_current_idle = false;
+        loop {
+            tick.tick().await;
+            let last_reset = *clock.read().await;
+            let age = last_reset.elapsed();
+            if age <= threshold {
+                already_fired_for_current_idle = false;
+                continue;
+            }
+            if already_fired_for_current_idle {
+                continue;
+            }
+            let event = Event::WatchdogFired {
+                age_ms: age.as_millis() as u64,
+                // The FSM event uses `std::time::Instant`; tokio's
+                // wrapper converts cleanly. With a paused tokio clock,
+                // both reflect the virtual time consistently.
+                fired_at: Instant::now().into_std(),
+            };
+            match tx.send(event) {
+                Ok(()) => {
+                    tracing::warn!(
+                        age_ms = age.as_millis() as u64,
+                        threshold_ms = threshold.as_millis() as u64,
+                        "Consensus watchdog fired — engine idle past threshold"
+                    );
+                    already_fired_for_current_idle = true;
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        "Watchdog task exiting — engine event receiver closed"
+                    );
+                    break;
+                }
+            }
+        }
+    })
 }
 
 #[cfg(test)]
@@ -231,5 +355,189 @@ mod tests {
         let msg = format!("{}", classify_transport(&t).unwrap_err());
         assert!(msg.contains("MAX_BROADCAST_BUDGET_MS"), "msg = {}", msg);
         assert!(msg.contains("AD-011"), "msg = {}", msg);
+    }
+
+    // ---------------- watchdog (CONS-309 / CONS-502b) ----------------
+
+    fn fixture_config() -> lib_types::consensus::ConsensusConfig {
+        // Default values; what matters here is that the per-phase
+        // timeouts get multiplied by WATCHDOG_THRESHOLD_MULTIPLIER.
+        let mut c = lib_types::consensus::ConsensusConfig::default();
+        c.propose_timeout = 200;
+        c.prevote_timeout = 300;
+        c.precommit_timeout = 250;
+        c
+    }
+
+    #[test]
+    fn derived_threshold_uses_max_phase_times_multiplier() {
+        let cfg = fixture_config();
+        let t = derive_watchdog_threshold(&cfg);
+        // max(200, 300, 250) = 300; × 5 = 1500 ms.
+        assert_eq!(t, Duration::from_millis(1500));
+    }
+
+    #[test]
+    fn derived_threshold_handles_overflow_safely() {
+        let mut cfg = lib_types::consensus::ConsensusConfig::default();
+        cfg.propose_timeout = u64::MAX;
+        cfg.prevote_timeout = 1;
+        cfg.precommit_timeout = 1;
+        // saturating_mul keeps the threshold finite instead of panicking
+        // — operator misconfiguration shouldn't take down the runtime
+        // before consensus has a chance to start.
+        let t = derive_watchdog_threshold(&cfg);
+        assert_eq!(t, Duration::from_millis(u64::MAX));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn watchdog_fires_after_threshold_elapses() {
+        // Pause the tokio clock so we can advance virtual time without
+        // sleeping — keeps the test deterministic and fast.
+        let clock = Arc::new(RwLock::new(Instant::now()));
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let handle = spawn_watchdog(
+            clock.clone(),
+            Duration::from_millis(100),
+            tx,
+            Duration::from_millis(20),
+        );
+
+        tokio::time::advance(Duration::from_millis(150)).await;
+        // Yield enough for the spawned task's interval to tick + the
+        // send to land in the rx buffer.
+        let event = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("watchdog did not fire within 1 s of virtual time")
+            .expect("rx closed unexpectedly");
+        match event {
+            Event::WatchdogFired { age_ms, .. } => {
+                assert!(age_ms >= 100, "age_ms = {}", age_ms);
+            }
+            other => panic!("expected WatchdogFired, got {:?}", other),
+        }
+        handle.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn watchdog_does_not_fire_when_clock_keeps_resetting() {
+        let clock = Arc::new(RwLock::new(Instant::now()));
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let handle = spawn_watchdog(
+            clock.clone(),
+            Duration::from_millis(100),
+            tx,
+            Duration::from_millis(20),
+        );
+
+        // Reset every 30 ms for 200 ms. With threshold = 100 ms and
+        // resets at 30 ms intervals, age never crosses 100 ms.
+        for _ in 0..6 {
+            tokio::time::advance(Duration::from_millis(30)).await;
+            *clock.write().await = Instant::now();
+        }
+
+        // Sample the channel — should be empty.
+        match tokio::time::timeout(Duration::from_millis(50), rx.recv()).await {
+            Err(_) => { /* expected: timeout means no event */ }
+            Ok(Some(e)) => panic!("watchdog fired despite resets: {:?}", e),
+            Ok(None) => panic!("rx closed unexpectedly"),
+        }
+        handle.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn watchdog_latches_to_one_fire_per_idle_episode() {
+        // While clock stays stale, the watchdog must fire exactly once
+        // until a reset. This prevents flooding the engine's event
+        // channel with redundant `WatchdogFired` events while it sits
+        // in `Hung`.
+        let clock = Arc::new(RwLock::new(Instant::now()));
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let handle = spawn_watchdog(
+            clock.clone(),
+            Duration::from_millis(50),
+            tx,
+            Duration::from_millis(10),
+        );
+
+        tokio::time::advance(Duration::from_millis(500)).await;
+
+        // Drain whatever has arrived; expect exactly one event.
+        let first = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("first fire never arrived")
+            .expect("rx closed");
+        assert!(matches!(first, Event::WatchdogFired { .. }));
+
+        // No further events should arrive while clock stays stale.
+        match tokio::time::timeout(Duration::from_millis(100), rx.recv()).await {
+            Err(_) => { /* expected: latch held */ }
+            Ok(Some(e)) => panic!("watchdog double-fired: {:?}", e),
+            Ok(None) => panic!("rx closed unexpectedly"),
+        }
+        handle.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn watchdog_re_arms_after_clock_reset() {
+        // After the first fire, a reset should re-enable a second fire
+        // once the clock goes stale again. This mirrors the "Hung →
+        // Idle via external recovery → Hung again" episode shape.
+        let clock = Arc::new(RwLock::new(Instant::now()));
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let handle = spawn_watchdog(
+            clock.clone(),
+            Duration::from_millis(50),
+            tx,
+            Duration::from_millis(10),
+        );
+
+        // Episode 1: let it fire.
+        tokio::time::advance(Duration::from_millis(200)).await;
+        let first = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("first fire never arrived")
+            .expect("rx closed");
+        assert!(matches!(first, Event::WatchdogFired { .. }));
+
+        // Reset the clock as the engine would after Hung exits, then
+        // sleep a sub-threshold interval to give the watchdog a chance
+        // to observe `age <= threshold` and clear its latch. With a
+        // paused clock, sleep yields to the spawned task and advances
+        // virtual time together.
+        *clock.write().await = Instant::now();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Episode 2: another stale period → another fire.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let second = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("second fire never arrived")
+            .expect("rx closed");
+        assert!(matches!(second, Event::WatchdogFired { .. }));
+        handle.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn watchdog_exits_when_engine_event_channel_closes() {
+        // If the engine drops its receiver (e.g. clean shutdown), the
+        // watchdog task should exit on its next attempt-to-send rather
+        // than spin forever.
+        let clock = Arc::new(RwLock::new(Instant::now()));
+        let (tx, rx) = mpsc::unbounded_channel::<Event>();
+        let handle = spawn_watchdog(
+            clock.clone(),
+            Duration::from_millis(50),
+            tx,
+            Duration::from_millis(10),
+        );
+
+        drop(rx);
+        tokio::time::advance(Duration::from_millis(200)).await;
+
+        // Give the task a tick to observe the closed channel.
+        let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
+        // If we got here without panicking the join completed.
     }
 }

--- a/lib-consensus/src/engines/consensus_engine/mod.rs
+++ b/lib-consensus/src/engines/consensus_engine/mod.rs
@@ -559,6 +559,20 @@ pub struct ConsensusEngine {
     /// Catch-up sync reads this to avoid writing blocks that BFT will finalize.
     /// Updated at the start of each consensus round.
     bft_active_height: Option<Arc<std::sync::atomic::AtomicU64>>,
+    /// CONS-309 / CONS-502b: receiver for FSM events injected by the
+    /// runtime layer (today: `Event::WatchdogFired` from
+    /// `lib_consensus_runtime::ConsensusRuntime`'s watchdog task).
+    /// `None` until `set_runtime_event_receiver` is called — running the
+    /// engine without it just means no watchdog, no harm.
+    runtime_event_rx:
+        Option<tokio::sync::mpsc::UnboundedReceiver<lib_consensus_core::fsm::Event>>,
+    /// CONS-309 / CONS-502b: shared "last reset" instant the runtime's
+    /// watchdog task reads each tick. Updated by `dispatch_action` when
+    /// the FSM emits `Action::ResetWatchdog`. `None` when no runtime is
+    /// attached (the engine still works; the watchdog just doesn't run).
+    /// Uses `tokio::time::Instant` so paused-clock unit tests in the
+    /// runtime can advance virtual time and still observe correct ages.
+    watchdog_clock: Option<Arc<tokio::sync::RwLock<tokio::time::Instant>>>,
 }
 
 /// Validator set update message sent from the runtime to the consensus loop.
@@ -653,12 +667,38 @@ impl ConsensusEngine {
             engine_start_time,
             validator_update_rx: None,
             bft_active_height: None,
+            runtime_event_rx: None,
+            watchdog_clock: None,
         })
     }
 
     /// Set the message receiver (from network layer)
     pub fn set_message_receiver(&mut self, rx: mpsc::Receiver<ValidatorMessage>) {
         self.message_rx = Some(rx);
+    }
+
+    /// CONS-309 / CONS-502b: install the runtime's FSM-event channel.
+    /// The `run_consensus_loop` `tokio::select!` then drains it, feeding
+    /// each event into `transition()` exactly like a network message.
+    /// Without this set the engine still runs — just nobody can inject
+    /// `WatchdogFired` etc.
+    pub fn set_runtime_event_receiver(
+        &mut self,
+        rx: tokio::sync::mpsc::UnboundedReceiver<lib_consensus_core::fsm::Event>,
+    ) {
+        self.runtime_event_rx = Some(rx);
+    }
+
+    /// CONS-309 / CONS-502b: install the shared "last reset" clock.
+    /// `dispatch_action` updates this on every `Action::ResetWatchdog`;
+    /// the runtime's watchdog task reads it each poll tick. Must be set
+    /// alongside `set_runtime_event_receiver` to make the watchdog
+    /// loop closed.
+    pub fn set_watchdog_clock(
+        &mut self,
+        clock: Arc<tokio::sync::RwLock<tokio::time::Instant>>,
+    ) {
+        self.watchdog_clock = Some(clock);
     }
 
     /// Set the validator update receiver. The consensus loop processes updates

--- a/lib-consensus/src/engines/consensus_engine/network.rs
+++ b/lib-consensus/src/engines/consensus_engine/network.rs
@@ -25,6 +25,10 @@ impl ConsensusEngine {
             ConsensusError::ValidatorError("Message receiver not set".to_string())
         })?;
         let mut validator_update_rx = self.validator_update_rx.take();
+        // CONS-309 / CONS-502b: receiver for runtime-injected FSM events
+        // (today: `WatchdogFired`). Optional — when `None`, the matching
+        // select branch never resolves and the engine behaves as before.
+        let mut runtime_event_rx = self.runtime_event_rx.take();
 
         // Sync consensus height with blockchain before starting
         // This ensures we start at the correct height after bootstrap mode
@@ -492,6 +496,22 @@ impl ConsensusEngine {
                     // height hasn't been sealed yet (e.g. bootstrap startup).
                     self.snapshot_validator_set(self.current_round.height);
                 }
+
+                // CONS-309 / CONS-502b: drain runtime-injected FSM events
+                // (today: `WatchdogFired` from the runtime's watchdog
+                // task). Each event flows through `transition()` exactly
+                // like a network message would, so the FSM stays the
+                // single source of truth and the runtime never mutates
+                // engine state directly.
+                Some(event) = recv_runtime_event(&mut runtime_event_rx) => {
+                    let prior = self.fsm_state.clone();
+                    let (next, actions) =
+                        lib_consensus_core::fsm::transition(prior, event);
+                    self.enter_fsm_state(next).await;
+                    for action in actions {
+                        self.dispatch_action(action).await;
+                    }
+                }
             }
         }
 
@@ -608,6 +628,19 @@ impl ConsensusEngine {
 async fn recv_validator_update(
     rx: &mut Option<tokio::sync::mpsc::Receiver<super::ValidatorSetUpdate>>,
 ) -> Option<super::ValidatorSetUpdate> {
+    match rx.as_mut() {
+        Some(rx) => rx.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Helper for `tokio::select!`: receives from the runtime FSM-event channel
+/// if present, or pends forever if the runtime hasn't installed one.
+/// Pending-forever keeps the channel branch dormant in the legacy zhtp path
+/// where `run_consensus_loop` is called directly without a runtime wrapper.
+async fn recv_runtime_event(
+    rx: &mut Option<tokio::sync::mpsc::UnboundedReceiver<lib_consensus_core::fsm::Event>>,
+) -> Option<lib_consensus_core::fsm::Event> {
     match rx.as_mut() {
         Some(rx) => rx.recv().await,
         None => std::future::pending().await,

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1923,7 +1923,10 @@ impl ConsensusEngine {
     /// without it the recursion `dispatch_action(SendCommit) →
     /// enter_commit_step → maybe_finalize → transition() →
     /// dispatch_action(CommitBlock)` would resurface (E0733).
-    async fn enter_fsm_state(&mut self, new_state: lib_consensus_core::fsm::ValidatorState) {
+    pub(super) async fn enter_fsm_state(
+        &mut self,
+        new_state: lib_consensus_core::fsm::ValidatorState,
+    ) {
         use lib_consensus_core::fsm::ValidatorState as V;
         let prior_kind = self.fsm_state.kind();
         let new_kind = new_state.kind();
@@ -1977,11 +1980,19 @@ impl ConsensusEngine {
     /// finalization runs separately at the handler level
     /// (on_commit_vote / on_precommit / on_round_timeout's PreCommit
     /// branch / run_commit_step).
-    async fn dispatch_action(&mut self, action: lib_consensus_core::fsm::Action) {
+    pub(super) async fn dispatch_action(&mut self, action: lib_consensus_core::fsm::Action) {
         use lib_consensus_core::fsm::Action as A;
         match action {
             A::ResetWatchdog => {
                 self.current_round.timed_out = false;
+                // CONS-309 / CONS-502b: stamp the shared clock so the
+                // runtime's watchdog task sees fresh activity. No-op
+                // when the runtime hasn't installed a clock (e.g. tests
+                // and the legacy zhtp path that calls
+                // `run_consensus_loop` directly).
+                if let Some(clock) = &self.watchdog_clock {
+                    *clock.write().await = tokio::time::Instant::now();
+                }
             }
 
             A::CreateProposal => {


### PR DESCRIPTION
## Summary

Closes the consensus watchdog loop end-to-end:

1. \`ConsensusEngine\` gets a new \`runtime_event_rx\` channel + \`watchdog_clock\`. \`dispatch_action\` updates the clock on \`Action::ResetWatchdog\`. \`run_consensus_loop\`'s \`tokio::select!\` drains the new channel, feeding events through \`transition()\` like any other input.
2. \`ConsensusRuntime\` derives the watchdog threshold from \`engine.config()\` as \`WATCHDOG_THRESHOLD_MULTIPLIER × max(propose, prevote, precommit)\` ms, spawns a polling task that reads the shared clock, and injects \`Event::WatchdogFired\` when the engine has been idle past threshold. The engine's existing FSM arms transition Idle/Proposing/Prevoting/Precommitting → Hung.
3. The watchdog uses a **latch** (one fire per idle episode) so the engine isn't flooded with redundant \`WatchdogFired\` while it sits in Hung. The latch re-arms when the clock observes a reset.

## Why this matters

CONS-309 has had the FSM-side machinery (Hung state, WatchdogFired event, transition arms) for several PRs but no actual spawned task firing the event. This PR closes that loop. With CONS-502d landing the zhtp swap, the watchdog goes live.

## Engine surface

- New optional fields on \`ConsensusEngine\`. Both \`None\` by default — the legacy zhtp path is unchanged until CONS-502d.
- New setters: \`set_runtime_event_receiver\`, \`set_watchdog_clock\`. \`ConsensusRuntime::new\` calls both.
- \`enter_fsm_state\` and \`dispatch_action\` promoted from \`async fn\` to \`pub(super) async fn\` so the new \`network.rs\` branch can call them.

## Tests

- 6 new tokio paused-clock tests in \`lib-consensus-runtime\`: fires after threshold, doesn't fire while resetting, latch behaviour (one-fire-per-episode), re-arms after reset, clean exit on receiver-closed, threshold-derivation (incl. saturating overflow).
- 7 existing startup-check tests still pass.
- \`cargo test -p lib-consensus-runtime --lib\` — **13/13**.
- \`cargo test -p lib-consensus --lib\` — **187/187**.
- \`cargo build --workspace\` — clean.

## What's still owed for #2345 to fully close

- **CONS-502d**: zhtp swap from \`engine.run_consensus_loop()\` to \`ConsensusRuntime::run()\` — that's where the watchdog goes live in production. The CONS-309 integration test ("simulate stuck FSM, assert Hung reached within threshold + 1 s") belongs there alongside the swap.

Refs #2345.