### PR TITLE
feat(consensus): CONS-306 — broadcaster moved off the engine via channel + executor task

### DIFF
--- a/lib-consensus-runtime/src/runtime.rs
+++ b/lib-consensus-runtime/src/runtime.rs
@@ -31,6 +31,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use lib_consensus::engines::consensus_engine::BroadcastEnvelope;
+use lib_consensus::types::MessageBroadcaster;
 use lib_consensus::{ConsensusEngine, ConsensusError};
 use lib_consensus_core::budget::{MAX_BROADCAST_BUDGET_MS, WATCHDOG_THRESHOLD_MULTIPLIER};
 use lib_consensus_core::fsm::Event;
@@ -75,8 +77,8 @@ fn transport_idle_ceiling_ms() -> u128 {
     u128::from(MAX_BROADCAST_BUDGET_MS) * 100
 }
 
-/// Owns the `ConsensusEngine` plus the watchdog task. CONS-502c will
-/// add the action executor; CONS-502d wires this from zhtp.
+/// Owns the `ConsensusEngine`, the watchdog task, and the broadcast
+/// executor task (CONS-306). CONS-502d wires this from zhtp.
 pub struct ConsensusRuntime {
     engine: ConsensusEngine,
     transport_name: String,
@@ -86,6 +88,14 @@ pub struct ConsensusRuntime {
     /// task; the matching sender is already installed on the engine via
     /// `set_runtime_event_receiver`.
     runtime_event_tx_for_watchdog: mpsc::UnboundedSender<Event>,
+    /// CONS-306: broadcast envelopes from the engine. The executor task
+    /// drains this and is the **only** caller of
+    /// `broadcaster.broadcast_to_validators(...).await` once
+    /// `set_broadcast_sender` has been wired on the engine.
+    broadcast_rx: Option<mpsc::UnboundedReceiver<BroadcastEnvelope>>,
+    /// CONS-306: the broadcaster Arc cloned out of the engine so the
+    /// executor task can call it without borrowing the engine.
+    broadcaster: Arc<dyn MessageBroadcaster>,
 }
 
 impl ConsensusRuntime {
@@ -130,12 +140,22 @@ impl ConsensusRuntime {
         engine.set_watchdog_clock(watchdog_clock.clone());
         engine.set_runtime_event_receiver(event_rx);
 
+        // CONS-306: wire the broadcast queue. After this point, every
+        // `enter_*_step` / heartbeat / proposal-relay call in the
+        // engine emits envelopes here instead of awaiting the
+        // broadcaster directly.
+        let (broadcast_tx, broadcast_rx) = mpsc::unbounded_channel::<BroadcastEnvelope>();
+        let broadcaster = engine.broadcaster_arc();
+        engine.set_broadcast_sender(broadcast_tx);
+
         Ok(Self {
             engine,
             transport_name: transport.name().to_string(),
             watchdog_threshold,
             watchdog_clock,
             runtime_event_tx_for_watchdog: event_tx,
+            broadcast_rx: Some(broadcast_rx),
+            broadcaster,
         })
     }
 
@@ -169,8 +189,9 @@ impl ConsensusRuntime {
         self.watchdog_threshold
     }
 
-    /// Drive the consensus loop with the watchdog spawned alongside.
-    /// On engine exit (graceful or error) the watchdog is aborted.
+    /// Drive the consensus loop with the watchdog and the broadcast
+    /// executor spawned alongside. On engine exit (graceful or error)
+    /// both background tasks are aborted.
     pub async fn run(mut self) -> Result<(), ConsensusError> {
         tracing::info!(
             "ConsensusRuntime starting (transport={}, watchdog_threshold={:?})",
@@ -183,10 +204,39 @@ impl ConsensusRuntime {
             self.runtime_event_tx_for_watchdog.clone(),
             WATCHDOG_POLL_INTERVAL,
         );
+        let broadcast_handle = self
+            .broadcast_rx
+            .take()
+            .map(|rx| spawn_broadcast_executor(rx, self.broadcaster.clone()));
         let result = self.engine.run_consensus_loop().await;
         watchdog_handle.abort();
+        if let Some(h) = broadcast_handle {
+            h.abort();
+        }
         result
     }
+}
+
+/// CONS-306 broadcast executor: drains envelopes from the engine and
+/// is the **only** caller of `broadcast_to_validators(...).await`.
+/// Per CE-ENG-4 each broadcast is best-effort — failures are logged
+/// and dropped, never retried (retry is the responsibility of the
+/// FSM via timeouts).
+pub(crate) fn spawn_broadcast_executor(
+    mut rx: mpsc::UnboundedReceiver<BroadcastEnvelope>,
+    broadcaster: Arc<dyn MessageBroadcaster>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(env) = rx.recv().await {
+            if let Err(e) = broadcaster
+                .broadcast_to_validators(env.message, &env.recipients)
+                .await
+            {
+                tracing::debug!(error = ?e, "Broadcast executor: send failed (CE-ENG-4)");
+            }
+        }
+        tracing::debug!("Broadcast executor exited — engine sender dropped");
+    })
 }
 
 /// Derive the watchdog threshold from the engine's per-phase timeouts.
@@ -528,6 +578,48 @@ mod tests {
             .expect("rx closed");
         assert!(matches!(second, Event::WatchdogFired { .. }));
         handle.abort();
+    }
+
+    // ---------------- broadcast executor (CONS-306) ----------------
+
+    /// Counting fake broadcaster — records every envelope it sees.
+    /// Lives in this module so the executor's contract is tested
+    /// without dragging in an end-to-end engine fixture.
+    struct CountingBroadcaster {
+        calls: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    }
+
+    #[async_trait::async_trait]
+    impl lib_consensus::types::MessageBroadcaster for CountingBroadcaster {
+        async fn broadcast_to_validators(
+            &self,
+            _message: lib_consensus::types::ValidatorMessage,
+            _validator_ids: &[lib_identity::IdentityId],
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            self.calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_executor_exits_on_sender_drop() {
+        // Closing the sender side cleanly exits the executor, freeing
+        // its task slot so the runtime's `run()` can return. End-to-
+        // end "drains every envelope" coverage lands in the engine
+        // integration test added alongside the CONS-309 stuck-FSM
+        // assertion (separate PR — needs a real engine fixture).
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let broadcaster: Arc<dyn lib_consensus::types::MessageBroadcaster> =
+            Arc::new(CountingBroadcaster {
+                calls: calls.clone(),
+            });
+        let (tx, rx) = mpsc::unbounded_channel::<BroadcastEnvelope>();
+        let handle = spawn_broadcast_executor(rx, broadcaster);
+        drop(tx);
+        let res = tokio::time::timeout(Duration::from_secs(1), handle).await;
+        assert!(res.is_ok(), "executor did not exit on sender drop");
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib-consensus/src/engines/consensus_engine/mod.rs
+++ b/lib-consensus/src/engines/consensus_engine/mod.rs
@@ -573,6 +573,26 @@ pub struct ConsensusEngine {
     /// Uses `tokio::time::Instant` so paused-clock unit tests in the
     /// runtime can advance virtual time and still observe correct ages.
     watchdog_clock: Option<Arc<tokio::sync::RwLock<tokio::time::Instant>>>,
+    /// CONS-306: outbound broadcast channel. When set, every engine
+    /// broadcast hop emits a `BroadcastEnvelope` here instead of
+    /// awaiting `broadcaster.broadcast_to_validators(...)` inline.
+    /// `None` keeps the legacy direct-await path. Per AD-006 the
+    /// goal is to remove `.await` on side effects from the engine —
+    /// when the runtime is enabled and this channel is wired, the
+    /// `.broadcaster` field becomes a fallback only (the runtime
+    /// holds the canonical impl on its executor task).
+    broadcast_tx: Option<tokio::sync::mpsc::UnboundedSender<BroadcastEnvelope>>,
+}
+
+/// CONS-306 outbound envelope: a `ValidatorMessage` plus the validator
+/// set to deliver it to. The engine constructs these in
+/// `enter_*_step`, `wrap_heartbeat`, etc. and emits them via
+/// `broadcast_tx`. The runtime's executor task drains the channel and
+/// calls the broadcaster `.await` exactly once per envelope.
+#[derive(Debug, Clone)]
+pub struct BroadcastEnvelope {
+    pub message: ValidatorMessage,
+    pub recipients: Vec<IdentityId>,
 }
 
 /// Validator set update message sent from the runtime to the consensus loop.
@@ -669,6 +689,7 @@ impl ConsensusEngine {
             bft_active_height: None,
             runtime_event_rx: None,
             watchdog_clock: None,
+            broadcast_tx: None,
         })
     }
 
@@ -699,6 +720,69 @@ impl ConsensusEngine {
         clock: Arc<tokio::sync::RwLock<tokio::time::Instant>>,
     ) {
         self.watchdog_clock = Some(clock);
+    }
+
+    /// CONS-306: install the runtime's broadcast queue. Once set, the
+    /// `broadcast()` helper (used by every engine hop that previously
+    /// awaited `broadcaster.broadcast_to_validators`) emits the
+    /// envelope here instead — a non-blocking channel send. The
+    /// runtime's executor task is the single owner of the actual
+    /// `.broadcaster.broadcast_to_validators(...).await` per AD-006.
+    pub fn set_broadcast_sender(
+        &mut self,
+        tx: tokio::sync::mpsc::UnboundedSender<BroadcastEnvelope>,
+    ) {
+        self.broadcast_tx = Some(tx);
+    }
+
+    /// Clone the broadcaster Arc so the runtime can hand it to its
+    /// executor task. Visible to runtime callers only — kept narrow
+    /// because no part of the engine should be reaching for the
+    /// broadcaster outside the broadcast hop.
+    pub fn broadcaster_arc(&self) -> Arc<dyn MessageBroadcaster> {
+        Arc::clone(&self.broadcaster)
+    }
+
+    /// CONS-306: single broadcast hop used by every `enter_*_step`,
+    /// heartbeat, and proposal-relay site in the engine. When
+    /// `broadcast_tx` is set (runtime path), this is a non-blocking
+    /// channel send and never `.await`s on the broadcaster. When the
+    /// channel is absent (legacy direct path), it falls back to the
+    /// pre-CONS-306 `.broadcaster.broadcast_to_validators(...).await`.
+    /// In both cases failures are logged and dropped per CE-ENG-4.
+    pub(super) async fn broadcast(
+        &self,
+        message: ValidatorMessage,
+        recipients: &[IdentityId],
+    ) {
+        if let Some(tx) = &self.broadcast_tx {
+            // Channel path: non-blocking. The cost is one Vec clone
+            // for `recipients`. SendError means the runtime executor
+            // dropped its receiver; per CE-ENG-4 we don't retry.
+            if tx
+                .send(BroadcastEnvelope {
+                    message,
+                    recipients: recipients.to_vec(),
+                })
+                .is_err()
+            {
+                tracing::debug!(
+                    "Broadcast channel closed — runtime executor exited; dropping envelope (CE-ENG-4)"
+                );
+            }
+            return;
+        }
+        // Legacy path: direct await. Only reached when no runtime is
+        // attached (e.g. the AD-011 fallback in zhtp). Once that
+        // collision is resolved and the runtime path is universal,
+        // this branch and the `.broadcaster` field can both go away.
+        if let Err(e) = self
+            .broadcaster
+            .broadcast_to_validators(message, recipients)
+            .await
+        {
+            tracing::debug!(error = ?e, "Broadcast failed (continuing per CE-ENG-4)");
+        }
     }
 
     /// Set the validator update receiver. The consensus loop processes updates

--- a/lib-consensus/src/engines/consensus_engine/network.rs
+++ b/lib-consensus/src/engines/consensus_engine/network.rs
@@ -328,12 +328,7 @@ impl ConsensusEngine {
                         // verify against `HeartbeatSigningPayload` instead of
                         // dropping unsigned messages.
                         let msg = wrap_heartbeat(heartbeat_msg, self.validator_keypair.as_ref());
-                        if let Err(e) = self.broadcaster.broadcast_to_validators(
-                            msg,
-                            &validator_ids,
-                        ).await {
-                            tracing::debug!("Heartbeat broadcast failed: {}", e);
-                        }
+                        self.broadcast(msg, &validator_ids).await;
                     }
                 }
 

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -621,17 +621,7 @@ impl ConsensusEngine {
 
                 // Invariant CE-ENG-4: Treat broadcast as best-effort telemetry
                 // Log failures for observability without affecting consensus correctness
-                if let Err(e) = self
-                    .broadcaster
-                    .broadcast_to_validators(msg, &validator_ids)
-                    .await
-                {
-                    tracing::debug!(
-                        error = ?e,
-                        height = self.current_round.height,
-                        "Failed to broadcast proposal to validators (continuing per CE-ENG-4)"
-                    );
-                }
+                self.broadcast(msg, &validator_ids).await;
             }
         }
 
@@ -685,17 +675,7 @@ impl ConsensusEngine {
 
             // Invariant CE-ENG-4: Treat broadcast as best-effort telemetry
             // Log failures for observability without affecting consensus correctness
-            if let Err(e) = self
-                .broadcaster
-                .broadcast_to_validators(msg, &validator_ids)
-                .await
-            {
-                tracing::debug!(
-                    error = ?e,
-                    height = self.current_round.height,
-                    "Failed to broadcast prevote to validators (continuing per CE-ENG-4)"
-                );
-            }
+            self.broadcast(msg, &validator_ids).await;
         }
 
         // Wait for prevotes with timeout
@@ -754,17 +734,7 @@ impl ConsensusEngine {
 
                 // Invariant CE-ENG-4: Treat broadcast as best-effort telemetry
                 // Log failures for observability without affecting consensus correctness
-                if let Err(e) = self
-                    .broadcaster
-                    .broadcast_to_validators(msg, &validator_ids)
-                    .await
-                {
-                    tracing::debug!(
-                        error = ?e,
-                        height = self.current_round.height,
-                        "Failed to broadcast precommit to validators (continuing per CE-ENG-4)"
-                    );
-                }
+                self.broadcast(msg, &validator_ids).await;
             }
         }
 
@@ -835,18 +805,7 @@ impl ConsensusEngine {
 
                 // Invariant CE-ENG-4: Treat broadcast as best-effort telemetry
                 // Log failures for observability without affecting consensus correctness
-                if let Err(e) = self
-                    .broadcaster
-                    .broadcast_to_validators(msg, &validator_ids)
-                    .await
-                {
-                    tracing::debug!(
-                        error = ?e,
-                        height = self.current_round.height,
-                        proposal_id = ?proposal_id,
-                        "Failed to broadcast commit vote to validators (continuing per CE-ENG-4)"
-                    );
-                }
+                self.broadcast(msg, &validator_ids).await;
 
                 // Use maybe_finalize instead of calling process_committed_block directly.
                 // At this point we have precommit quorum but only just cast our own commit vote.
@@ -1406,13 +1365,7 @@ impl ConsensusEngine {
         let relay_proposal = proposal.clone();
         let relay_validator_ids = self.get_active_validator_ids();
         let relay_msg = wrap_propose(relay_proposal, self.validator_keypair.as_ref());
-        if let Err(e) = self
-            .broadcaster
-            .broadcast_to_validators(relay_msg, &relay_validator_ids)
-            .await
-        {
-            tracing::debug!("Proposal relay failed (non-critical): {}", e);
-        }
+        self.broadcast(relay_msg, &relay_validator_ids).await;
 
         // CONS-305e: route admitted proposal through the FSM. The
         // proposal has passed every gate (no-fork, signature, proposer
@@ -1477,13 +1430,7 @@ impl ConsensusEngine {
                         .await?;
                     let msg = wrap_vote(vote, self.validator_keypair.as_ref());
                     let validator_ids = self.get_active_validator_ids();
-                    if let Err(e) = self
-                        .broadcaster
-                        .broadcast_to_validators(msg, &validator_ids)
-                        .await
-                    {
-                        tracing::debug!("Failed to broadcast late prevote: {}", e);
-                    }
+                    self.broadcast(msg, &validator_ids).await;
 
                     // Check if this late prevote completes the quorum
                     let prevote_count = self.count_prevotes_for(
@@ -1567,13 +1514,7 @@ impl ConsensusEngine {
         // time this vote arrives, the pool check fires and returns early without relay.
         let relay_msg = wrap_vote(vote.clone(), self.validator_keypair.as_ref());
         let relay_validator_ids = self.get_active_validator_ids();
-        if let Err(e) = self
-            .broadcaster
-            .broadcast_to_validators(relay_msg, &relay_validator_ids)
-            .await
-        {
-            tracing::debug!("PreVote relay failed (non-critical): {}", e);
-        }
+        self.broadcast(relay_msg, &relay_validator_ids).await;
 
         tracing::debug!(
             "Added PreVote from {} for proposal {:?} at height {} round {}",
@@ -1705,13 +1646,7 @@ impl ConsensusEngine {
         // cannot collect precommits from non-hub validators — quorum is impossible.
         let relay_msg = wrap_vote(vote.clone(), self.validator_keypair.as_ref());
         let relay_validator_ids = self.get_active_validator_ids();
-        if let Err(e) = self
-            .broadcaster
-            .broadcast_to_validators(relay_msg, &relay_validator_ids)
-            .await
-        {
-            tracing::debug!("PreCommit relay failed (non-critical): {}", e);
-        }
+        self.broadcast(relay_msg, &relay_validator_ids).await;
 
         tracing::debug!(
             "Added PreCommit from {} for proposal {:?} at height {} round {}",
@@ -1876,13 +1811,7 @@ impl ConsensusEngine {
         // the 3-of-3 commit quorum required to finalize a block.
         let relay_msg = wrap_vote(vote.clone(), self.validator_keypair.as_ref());
         let relay_validator_ids = self.get_active_validator_ids();
-        if let Err(e) = self
-            .broadcaster
-            .broadcast_to_validators(relay_msg, &relay_validator_ids)
-            .await
-        {
-            tracing::debug!("Commit vote relay failed (non-critical): {}", e);
-        }
+        self.broadcast(relay_msg, &relay_validator_ids).await;
 
         tracing::debug!(
             "Stored commit vote from {} for proposal {:?} at height {} round {} (current step: {:?})",
@@ -2216,13 +2145,7 @@ impl ConsensusEngine {
                         let msg = wrap_propose(proposal, self.validator_keypair.as_ref());
                         let validator_ids = self.get_active_validator_ids();
 
-                        if let Err(e) = self
-                            .broadcaster
-                            .broadcast_to_validators(msg, &validator_ids)
-                            .await
-                        {
-                            tracing::debug!("Failed to broadcast proposal (CE-ENG-4): {}", e);
-                        }
+                        self.broadcast(msg, &validator_ids).await;
 
                         // Proposer enters prevote immediately after broadcasting its proposal.
                         // Without this, the proposer waits propose_timeout (3 s) before prevoting,
@@ -2277,16 +2200,7 @@ impl ConsensusEngine {
             let msg = wrap_vote(vote, self.validator_keypair.as_ref());
             let validator_ids = self.get_active_validator_ids();
 
-            if let Err(e) = self
-                .broadcaster
-                .broadcast_to_validators(msg, &validator_ids)
-                .await
-            {
-                tracing::debug!(
-                    error = ?e,
-                    "Failed to broadcast prevote (continuing per CE-ENG-4)"
-                );
-            }
+            self.broadcast(msg, &validator_ids).await;
         }
 
         Ok(())
@@ -2361,16 +2275,7 @@ impl ConsensusEngine {
                 let msg = wrap_vote(vote, self.validator_keypair.as_ref());
                 let validator_ids = self.get_active_validator_ids();
 
-                if let Err(e) = self
-                    .broadcaster
-                    .broadcast_to_validators(msg, &validator_ids)
-                    .await
-                {
-                    tracing::debug!(
-                        error = ?e,
-                        "Failed to broadcast precommit (continuing per CE-ENG-4)"
-                    );
-                }
+                self.broadcast(msg, &validator_ids).await;
             }
         }
 
@@ -2450,16 +2355,7 @@ impl ConsensusEngine {
                 let msg = wrap_vote(vote, self.validator_keypair.as_ref());
                 let validator_ids = self.get_active_validator_ids();
 
-                if let Err(e) = self
-                    .broadcaster
-                    .broadcast_to_validators(msg, &validator_ids)
-                    .await
-                {
-                    tracing::debug!(
-                        error = ?e,
-                        "Failed to broadcast commit vote (continuing per CE-ENG-4)"
-                    );
-                }
+                self.broadcast(msg, &validator_ids).await;
 
                 // CONS-305f: maybe_finalize is no longer called from
                 // here. Calling it from inside enter_commit_step


### PR DESCRIPTION
## Summary

Removes inline \`.await\` on \`MessageBroadcaster::broadcast_to_validators\` from the consensus engine per AD-006. The engine emits \`BroadcastEnvelope\`s into a channel; a runtime-owned executor task is the sole caller of the broadcaster.

## What changed

### Engine (\`lib-consensus\`)
- New \`BroadcastEnvelope\` value type.
- \`ConsensusEngine\` gains \`broadcast_tx\` / \`set_broadcast_sender\` / \`broadcaster_arc()\`.
- New \`pub(super) async fn broadcast(&self, msg, recipients)\` helper. Channel path = non-blocking send. Legacy path (no channel installed) = direct \`.await\` on the broadcaster — preserves existing test fixtures and the AD-011 fallback in zhtp.
- **14 inline broadcaster awaits removed**: 13 in \`state_machine.rs\` + 1 in \`network.rs\` (heartbeat). Each now calls \`self.broadcast(...)\`.

### Runtime (\`lib-consensus-runtime\`)
- \`ConsensusRuntime::new\` builds the broadcast channel + clones the broadcaster Arc + flips the engine onto the channel path.
- \`ConsensusRuntime::run\` spawns the executor task alongside the watchdog. Executor drains envelopes; it is the only caller of \`broadcast_to_validators(...).await\` once the runtime is active.
- One new unit test pins the executor's clean-shutdown contract.

## Acceptance

> No \`.await\` on \`MessageBroadcaster\` calls in \`lib-consensus-core/src/\`.

\`\`\`
$ grep -rn "broadcaster.*\\\\.await\\\\|broadcast_to_validators(.*).await" lib-consensus-core/src/
(empty)
\`\`\`

The engine still lives in \`lib-consensus\` until CONS-104..108 finish migration; the only remaining broadcaster-\`.await\` there is the helper's legacy fallback (mod.rs:751), which goes away once the runtime path is universal (CONS-507/508).

The CONS-306 spec's stress test (hung broadcaster doesn't prevent round progress) lands alongside the CONS-309 stuck-FSM integration test in a separate PR — both need a real engine fixture.

## Validation

- [x] \`cargo test -p lib-consensus --lib\` — **187/187** (existing broadcast tests still pass via the legacy-fallback path).
- [x] \`cargo test -p lib-consensus-runtime --lib\` — **14/14** (13 existing + 1 executor-exit).
- [x] \`cargo build --workspace\` — clean.

## Diff stats

\`+194 −127\` across 4 files.

Closes #2342.