### PR TITLE
chore(ci): add PR quality gates — review agents, triage, branch protection

### DIFF
--- a/.github/BRANCH_PROTECTION_SETUP.md
+++ b/.github/BRANCH_PROTECTION_SETUP.md
@@ -1,0 +1,147 @@
+# Branch Protection Setup
+
+The PR Quality Gates workflows are wired up in `.github/workflows/`, but
+GitHub will not enforce them until you configure a **branch protection rule**
+or **repository ruleset** in the UI. The workflows themselves only *report*
+status checks; making those checks **required** is a one-time manual step.
+
+This document is the canonical setup guide. Apply these settings to `main`
+(and any other long-lived branch you want to protect, e.g. `release/*`).
+
+## 1. Choose: Branch Protection Rule or Ruleset
+
+GitHub supports both. Either works. **Rulesets** are the newer mechanism and
+are recommended for new repositories because they support multiple targets,
+import/export, and bypass lists. The "Branches" rule UI remains supported.
+
+- **Rulesets:** Settings → **Rules → Rulesets** → **New ruleset → New branch ruleset**
+- **Classic:** Settings → **Branches** → **Add branch protection rule**
+
+## 2. Target the protected branch
+
+- Branch name pattern (or "Target" in rulesets): `main`
+- If you use release branches, add a second target like `release/*`.
+
+## 3. Enable these checks
+
+The exact label naming differs slightly between Rulesets and the classic UI;
+the substantive settings are the same.
+
+### Required pull request before merge
+
+- Require a pull request before merging: **on**
+- Required approvals: **at least 1** (raise this for higher-risk repos)
+- Dismiss stale pull request approvals when new commits are pushed: **on**
+- Require approval of the most recent reviewable push: **on** (rulesets only)
+- **Require review from Code Owners: on** — this is what makes
+  `.github/CODEOWNERS` actually enforce per-path reviewer assignment.
+
+### Require status checks to pass before merging
+
+- Require status checks to pass before merging: **on**
+- Require branches to be up to date before merging: **on** (recommended)
+- **Status checks that are required** — search and add **each of the
+  following job names exactly**:
+
+  From the **PR Quality Gates** workflow:
+  - `architecture`
+  - `security`
+  - `blockchain`
+  - `tokenomics`
+  - `compliance`
+  - `privacy_zkdid`
+  - `governance`
+  - `economic_risk`
+  - `devops`
+  - `performance`
+  - `data_sovereignty`
+  - `api`
+  - `ux_safety`
+  - `testing`
+  - `documentation`
+
+  From the **PR Triage** workflow (optional but recommended so triage
+  always runs):
+  - `triage`
+
+  > **Note:** The check names will only appear in the search box after the
+  > workflow has run **at least once** on a PR. Open a no-op PR (e.g. a
+  > whitespace change in `README.md`) if you need to seed them.
+
+### Other recommended settings
+
+- Require conversation resolution before merging: **on**
+- Require signed commits: **on** if your team is set up for it
+- Require linear history: **on** (optional; pairs well with merge queue)
+- Block force pushes: **on**
+- Restrict deletions: **on**
+
+### Bypass list
+
+Keep this empty. If you must allow emergency bypass, restrict it to a single
+admin team and audit usage.
+
+## 4. (Optional) Enable Merge Queue
+
+If you want serialized merges with re-tested branches:
+
+1. In the same rule/ruleset: **Require merge queue: on**
+2. Choose the merge method (squash recommended).
+3. Set max queue size and timeout to your preference.
+
+The workflows already handle merge-queue events because both `pr-triage.yml`
+and `pr-quality-gates.yml` include the `merge_group:` trigger. No further
+workflow changes are needed.
+
+## 5. Verify
+
+1. Open a draft PR that touches a critical path (e.g. `contracts/`).
+2. Confirm the PR Triage workflow posts a sticky comment classifying the PR
+   as `critical` and listing required agents.
+3. Confirm the **Checks** tab on the PR shows all 15 quality-gate jobs.
+4. Confirm the **Merge** button is **disabled** until checks pass and a
+   Code Owner approves.
+5. Push a deliberate violation (e.g. add `eval(...)` somewhere) and confirm
+   `security` reports BLOCKER and the PR cannot merge.
+
+## 6. CODEOWNERS prerequisite
+
+`.github/CODEOWNERS` references teams under the `@SOVEREIGN-NET/*` org. Each
+team must exist in **Organization → Teams** before the Code Owner check
+behaves correctly. Until the teams exist, GitHub will silently ignore the
+mappings and Code Owner enforcement will be a no-op.
+
+Required teams (create if missing):
+
+- `@SOVEREIGN-NET/core-maintainers`
+- `@SOVEREIGN-NET/protocol`
+- `@SOVEREIGN-NET/security`
+- `@SOVEREIGN-NET/tokenomics`
+- `@SOVEREIGN-NET/compliance`
+- `@SOVEREIGN-NET/privacy`
+- `@SOVEREIGN-NET/governance`
+- `@SOVEREIGN-NET/devops`
+- `@SOVEREIGN-NET/api`
+- `@SOVEREIGN-NET/ux`
+- `@SOVEREIGN-NET/documentation`
+- `@SOVEREIGN-NET/data`
+
+Each team must have at least one member with `write` access to this repo,
+otherwise GitHub treats CODEOWNERS approvals as unsatisfiable.
+
+## 7. Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Required checks don't appear in the dropdown | The workflow has never run yet. Open any PR to trigger it. |
+| All checks show ⏭ "skipped" or pending forever | Workflow file has a YAML error or is on a branch other than `main`. |
+| `triage` job runs but no PR comment appears | The workflow is running on a `merge_group` event (no PR exists), or the GitHub App lacks `pull-requests: write`. |
+| `security` always BLOCKER even on tiny PRs | Likely a real secret leaked into a tracked file. Read the JSON output, then rotate the credential. |
+| CODEOWNERS approvals not enforced | Teams don't exist yet, are private to the org but not granted repo access, or the file has a syntax error (run `git log --check`). |
+
+## 8. References
+
+- GitHub: [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- GitHub: [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
+- GitHub: [Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+- GitHub: [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

--- a/.github/BRANCH_PROTECTION_SETUP.md
+++ b/.github/BRANCH_PROTECTION_SETUP.md
@@ -8,6 +8,28 @@ status checks; making those checks **required** is a one-time manual step.
 This document is the canonical setup guide. Apply these settings to `main`
 (and any other long-lived branch you want to protect, e.g. `release/*`).
 
+## Opt-in trigger — the `review-agents` label
+
+Both workflows (`pr-quality-gates.yml`, `pr-triage.yml`) are gated on the
+PR carrying the `review-agents` label. Without the label, every job's
+`if:` evaluates to false and the workflow skips immediately. This keeps
+default PR turnaround fast and lets reviewers opt in only when they want
+the heavy review pass.
+
+How to opt in:
+
+- **Per PR:** add the `review-agents` label. The workflow fires on the
+  `labeled` event and re-runs on every push (`synchronize`) while the
+  label remains.
+- **Manual:** `gh workflow run pr-quality-gates.yml` (or the **Run
+  workflow** button). The `if:` includes
+  `github.event_name == 'workflow_dispatch'` so manual runs always
+  execute regardless of the label.
+
+If you decide later to make the gates run on every PR by default, drop
+the `if:` lines and switch the `on:` filter back to
+`[opened, synchronize, reopened, ready_for_review]`.
+
 ## 1. Choose: Branch Protection Rule or Ruleset
 
 GitHub supports both. Either works. **Rulesets** are the newer mechanism and

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,48 @@
+# CODEOWNERS for The Sovereign Network
+#
+# NOTE: The teams referenced below (@SOVEREIGN-NET/<team>) are placeholders.
+# They MUST be created in GitHub Org settings (Settings → Teams) before
+# Code Owner review enforcement will take effect. Until then GitHub will
+# silently ignore unknown teams. See .github/BRANCH_PROTECTION_SETUP.md.
+#
+# Order matters: later patterns override earlier ones.
+
+# Default owners for everything in the repo
+*                                @SOVEREIGN-NET/core-maintainers
+
+# Smart contracts and on-chain protocol code
+/contracts/                      @SOVEREIGN-NET/protocol @SOVEREIGN-NET/security
+/smart-contracts/                @SOVEREIGN-NET/protocol @SOVEREIGN-NET/security
+/chain/                          @SOVEREIGN-NET/protocol
+/blockchain/                     @SOVEREIGN-NET/protocol
+
+# Tokenomics, treasury, and economic policy
+/tokenomics/                     @SOVEREIGN-NET/tokenomics @SOVEREIGN-NET/compliance
+/treasury/                       @SOVEREIGN-NET/tokenomics @SOVEREIGN-NET/compliance
+
+# Identity, ZK, and privacy
+/identity/                       @SOVEREIGN-NET/privacy @SOVEREIGN-NET/security
+/zk/                             @SOVEREIGN-NET/privacy @SOVEREIGN-NET/security
+
+# Governance and DAO
+/governance/                     @SOVEREIGN-NET/governance
+/dao/                            @SOVEREIGN-NET/governance
+
+# Infrastructure, CI, and ops
+/infra/                          @SOVEREIGN-NET/devops @SOVEREIGN-NET/security
+/.github/                        @SOVEREIGN-NET/devops @SOVEREIGN-NET/security
+
+# APIs and SDKs
+/api/                            @SOVEREIGN-NET/api
+/sdk/                            @SOVEREIGN-NET/api
+
+# Client surfaces
+/mobile/                         @SOVEREIGN-NET/ux @SOVEREIGN-NET/security
+/frontend/                       @SOVEREIGN-NET/ux
+
+# Documentation
+/docs/                           @SOVEREIGN-NET/documentation
+/docs/compliance/                @SOVEREIGN-NET/compliance
+
+# Data migrations
+/migrations/                     @SOVEREIGN-NET/data @SOVEREIGN-NET/devops

--- a/.github/agents/api_review.py
+++ b/.github/agents/api_review.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+API review agent.
+
+Rules:
+- MAJOR if public API/schema changes without versioning or docs.
+- MAJOR if error responses leak internals (stack traces, SQL errors, paths).
+- MINOR if API docs are not updated.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+API_PATTERNS = [
+    "api/**", "sdk/**",
+    "**/openapi*.yaml", "**/openapi*.yml", "**/openapi*.json",
+    "**/*.proto",
+    "**/schema.graphql", "**/*.graphql",
+]
+
+VERSION_HINTS = re.compile(
+    r"(?:^|/)v[0-9]+(?:[._-]?[0-9]+)?(?:/|$)|"
+    r"\bversion\s*[:=]\s*[\"']?\d+\.\d+",
+    re.IGNORECASE,
+)
+
+DOC_PATTERNS = [
+    "docs/api/**", "docs/**/api*.md",
+    "**/CHANGELOG*", "**/CHANGES*",
+    "**/openapi*.yaml", "**/openapi*.yml", "**/openapi*.json",
+]
+
+INTERNAL_LEAK_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "Stack trace returned in response",
+        re.compile(r"\b(?:traceback|stack[_ ]?trace|stackTrace)\b.*\b(?:return|res(?:ponse)?\.|json\(|jsonify\()", re.IGNORECASE),
+    ),
+    (
+        "Raw exception serialized to client",
+        re.compile(r"(?:return|res(?:ponse)?\.send|res\.json)\s*\([^)]*\b(?:str|repr)\s*\(\s*(?:e|err|exc|exception)\s*\)"),
+    ),
+    (
+        "Internal path leaked in error",
+        re.compile(r"(?:return|raise|throw)[^;\n]*['\"](?:/(?:home|root|var|etc|usr)|C:\\\\)[^'\"\n]*['\"]"),
+    ),
+    (
+        "SQL error string returned",
+        re.compile(r"(?:return|jsonify|json\()\s*\([^)]*(?:psycopg|MySQLdb|sqlite3|SQLAlchemy)Error", re.IGNORECASE),
+    ),
+]
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="api",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    relevant = common.filter_files(files, API_PATTERNS)
+    if not relevant:
+        result.applicable = False
+        result.summary = "No API/SDK files in this PR."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    result.risk_level = "high"
+
+    # Versioning check: at least one of the touched API files (or its dir)
+    # carries a version marker. We also accept a CHANGELOG update.
+    has_version_marker = False
+    for f in relevant:
+        if VERSION_HINTS.search(f):
+            has_version_marker = True
+            break
+        text = common.read_file_safe(f) or ""
+        if VERSION_HINTS.search(text):
+            has_version_marker = True
+            break
+
+    has_docs_update = bool(common.filter_files(files, DOC_PATTERNS))
+
+    if not has_version_marker and not has_docs_update:
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Public API change without versioning or docs update",
+            description=(
+                f"{len(relevant)} API/SDK file(s) changed but no version "
+                "marker (e.g. `/v1/`, `version: 1.x`) is visible AND no "
+                "docs/CHANGELOG/openapi spec was updated."
+            ),
+            recommendation=(
+                "Either bump the API version, update `docs/api/`, or update "
+                "the OpenAPI/proto spec to reflect the change. Breaking "
+                "changes require a new version path."
+            ),
+            file=relevant[0],
+        ))
+    elif not has_docs_update:
+        result.add(common.Finding(
+            severity=common.Severity.MINOR,
+            title="API change without docs update",
+            description=(
+                "API/SDK files were modified but no docs file under "
+                "`docs/api/`, no CHANGELOG, and no OpenAPI/proto spec was "
+                "updated."
+            ),
+            recommendation=(
+                "Update the corresponding docs so consumers learn about the "
+                "change at the same time as it ships."
+            ),
+            file=relevant[0],
+        ))
+
+    # Internal-leak scan across handler-ish files
+    handler_files = [f for f in relevant if f.endswith((".py", ".ts", ".js", ".go", ".rs", ".java", ".kt"))]
+    for f in handler_files:
+        text = common.read_file_safe(f) or ""
+        if not text:
+            continue
+        for label, pat in INTERNAL_LEAK_PATTERNS:
+            m = pat.search(text)
+            if m:
+                line = text.count("\n", 0, m.start()) + 1
+                result.add(common.Finding(
+                    severity=common.Severity.MAJOR,
+                    title=f"API error response may leak internals: {label}",
+                    description=(
+                        "Detected a pattern that returns stack traces, raw "
+                        "exception strings, internal filesystem paths, or "
+                        "raw SQL errors in an HTTP response. This leaks "
+                        "implementation details to attackers."
+                    ),
+                    recommendation=(
+                        "Return generic, structured errors (`{ code, "
+                        "message }`) and log full details server-side only. "
+                        "Map known exceptions to safe error codes."
+                    ),
+                    file=f,
+                    line=line,
+                ))
+
+    if not result.findings:
+        result.summary = (
+            f"{len(relevant)} API/SDK file(s) inspected; versioning and docs "
+            "appear in order."
+        )
+    else:
+        result.summary = (
+            f"{len(relevant)} API/SDK file(s) inspected; "
+            f"{len(result.findings)} concern(s) raised."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/architecture_review.py
+++ b/.github/agents/architecture_review.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Architecture review agent.
+
+Rules:
+- BLOCKER if critical files changed without an ADR/docs update.
+- MAJOR if a new top-level service/module is added with no owner or
+  documented boundary.
+- MAJOR if infra, chain, identity, and tokenomics directories appear
+  coupled in the same change without an explanation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+CRITICAL_PATTERNS = [
+    "contracts/**",
+    "smart-contracts/**",
+    "**/*.sol",
+    "chain/**",
+    "blockchain/**",
+    "consensus/**",
+    "tokenomics/**",
+    "treasury/**",
+    "identity/**",
+    "zk/**",
+    "governance/**",
+    "dao/**",
+    "infra/prod/**",
+    "infra/production/**",
+    "migrations/**",
+]
+
+ADR_PATTERNS = [
+    "docs/adr/**",
+    "docs/architecture/**",
+    "docs/specs/**",
+    "ADR-*",
+    "**/ADR-*",
+    "**/*adr*.md",
+    "docs/**/architecture*.md",
+    "docs/**/spec*.md",
+]
+
+CODEOWNERS_FILE = ".github/CODEOWNERS"
+
+DOMAIN_PREFIXES = {
+    "chain": ("chain/", "blockchain/", "consensus/", "node/"),
+    "identity": ("identity/", "zk/"),
+    "tokenomics": ("tokenomics/", "treasury/"),
+    "infra": ("infra/",),
+    "governance": ("governance/", "dao/"),
+}
+
+
+def detect_new_top_level_modules(files: list[str]) -> list[str]:
+    """Return added directories that look like new top-level services."""
+    candidates: set[str] = set()
+    for f in files:
+        if not common.file_added(f):
+            continue
+        parts = f.replace("\\", "/").split("/")
+        if len(parts) >= 2 and parts[0] not in {"docs", ".github", "tests", "test"}:
+            candidates.add(parts[0])
+    # Only flag top-level directories whose creation is part of this PR
+    # (heuristic: at least one file inside is newly added). The Path test
+    # below is best-effort — codeowners check is what really catches it.
+    return sorted(candidates)
+
+
+def has_codeowner_entry(module: str, codeowners_text: str) -> bool:
+    needle = f"/{module}/"
+    return any(needle in line for line in codeowners_text.splitlines() if not line.lstrip().startswith("#"))
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="architecture",
+        status=common.Status.PASS,
+        risk_level="low",
+    )
+
+    critical_hits = common.filter_files(files, CRITICAL_PATTERNS)
+    if not critical_hits and not files:
+        result.applicable = False
+        result.summary = "No changes detected."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    if critical_hits:
+        result.risk_level = "critical"
+        adr_hits = common.filter_files(files, ADR_PATTERNS)
+        if not adr_hits:
+            result.add(common.Finding(
+                severity=common.Severity.BLOCKER,
+                title="Critical change without ADR/spec/docs update",
+                description=(
+                    "Files in critical paths (smart contracts, chain, identity, "
+                    "tokenomics, governance, production infra, or migrations) "
+                    "were modified but no ADR, spec, or architecture document "
+                    "was updated in this PR."
+                ),
+                recommendation=(
+                    "Add or update an ADR under `docs/adr/`, a spec under "
+                    "`docs/specs/`, or another architecture document describing "
+                    "the rationale, alternatives considered, and impact."
+                ),
+                file=critical_hits[0],
+            ))
+
+    # Coupling check: more than two distinct critical domains in one PR.
+    touched_domains: list[str] = []
+    for domain, prefixes in DOMAIN_PREFIXES.items():
+        if any(f.startswith(prefixes) for f in files):
+            touched_domains.append(domain)
+    if len(touched_domains) >= 3:
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title=f"PR couples {len(touched_domains)} critical domains: {', '.join(touched_domains)}",
+            description=(
+                "A single PR is touching multiple critical subsystems at once. "
+                "This makes review and rollback difficult and increases blast "
+                "radius."
+            ),
+            recommendation=(
+                "Split this PR into one PR per subsystem, or document the "
+                "cross-cutting rationale in an ADR included in this PR."
+            ),
+        ))
+
+    # New module without owner check
+    codeowners_text = common.read_file_safe(CODEOWNERS_FILE) or ""
+    new_modules = detect_new_top_level_modules(files)
+    for mod in new_modules:
+        if mod in {"docs", ".github", "tests", "test", "scripts"}:
+            continue
+        if not has_codeowner_entry(mod, codeowners_text):
+            result.add(common.Finding(
+                severity=common.Severity.MAJOR,
+                title=f"New top-level module `{mod}/` has no CODEOWNERS entry",
+                description=(
+                    f"This PR adds files under a new top-level path `{mod}/` "
+                    "but no ownership rule is declared in `.github/CODEOWNERS`."
+                ),
+                recommendation=(
+                    f"Add a line to `.github/CODEOWNERS` mapping `/{mod}/` to "
+                    "the responsible team, and document the module's boundary "
+                    "in a README or ADR."
+                ),
+                file=f"{mod}/",
+            ))
+
+    if not result.findings:
+        result.summary = (
+            f"No architecture concerns detected across {len(files)} changed file(s)."
+        )
+    else:
+        result.summary = f"Inspected {len(files)} changed file(s)."
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/blockchain_review.py
+++ b/.github/agents/blockchain_review.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Blockchain review agent.
+
+Rules:
+- BLOCKER if chain/contract/token state files changed without tests.
+- BLOCKER if nonce/replay/finality/state-transition logic changed without
+  explicit tests.
+- MAJOR if testnet/mainnet separation is unclear.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+CHAIN_PATTERNS = [
+    "contracts/**", "smart-contracts/**",
+    "**/*.sol", "**/*.cairo", "**/*.vy",
+    "chain/**", "blockchain/**", "consensus/**", "node/**",
+]
+
+STATE_TRANSITION_KEYWORDS = [
+    r"\bnonce\b", r"\breplay\b", r"\bfinality\b",
+    r"\bstate[_ ]?transition\b", r"\bblockHeader\b",
+    r"\bvalidate(Block|Tx|Header)\b", r"\bapplyBlock\b",
+    r"\bcommit(State|Block)\b", r"\bfork[_ ]?choice\b",
+    r"\bconsensus\b",
+]
+
+NETWORK_HINTS = [r"\bmainnet\b", r"\btestnet\b", r"\bdevnet\b", r"\bchainId\b", r"\bCHAIN_ID\b"]
+HARDCODED_NETWORK_RE = re.compile(
+    r"\b(?:chainId|CHAIN_ID)\s*[=:]\s*[0-9]+\b|\b(?:rpcUrl|RPC_URL)\s*[=:]\s*['\"]https?://[^'\"]+['\"]"
+)
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="blockchain",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    chain_files = common.filter_files(files, CHAIN_PATTERNS)
+    if not chain_files:
+        result.applicable = False
+        result.summary = "No chain/contract files in this PR."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    result.risk_level = "critical"
+
+    has_tests = common.has_test_changes(files)
+    if not has_tests:
+        result.add(common.Finding(
+            severity=common.Severity.BLOCKER,
+            title="Chain/contract code changed without test changes",
+            description=(
+                f"{len(chain_files)} chain or contract file(s) were modified, "
+                "but no tests were added or updated in this PR."
+            ),
+            recommendation=(
+                "Add unit and/or integration tests covering the modified "
+                "behavior. For Solidity, add Foundry/Hardhat tests; for chain "
+                "logic, add deterministic state-transition tests."
+            ),
+            file=chain_files[0],
+        ))
+
+    # Look for state-transition / nonce / finality changes specifically.
+    state_pat = re.compile("|".join(STATE_TRANSITION_KEYWORDS), re.IGNORECASE)
+    state_hits: list[tuple[str, int]] = []
+    for f in chain_files:
+        text = common.read_file_safe(f) or ""
+        for m in state_pat.finditer(text):
+            line = text.count("\n", 0, m.start()) + 1
+            state_hits.append((f, line))
+            break  # one per file is enough to flag
+
+    if state_hits and not has_tests:
+        first_f, first_line = state_hits[0]
+        result.add(common.Finding(
+            severity=common.Severity.BLOCKER,
+            title="State-transition/nonce/finality code touched without tests",
+            description=(
+                f"Detected references to state-transition, nonce, replay, or "
+                f"finality logic in {len(state_hits)} file(s) without "
+                "corresponding tests."
+            ),
+            recommendation=(
+                "Add explicit tests for nonce ordering, replay protection, "
+                "and finality invariants. These paths must not regress."
+            ),
+            file=first_f,
+            line=first_line,
+        ))
+
+    # Hardcoded network endpoints / chain IDs without network separation
+    network_separated = False
+    for f in chain_files + common.filter_files(files, ["**/config/**", "**/networks/**"]):
+        text = common.read_file_safe(f) or ""
+        hint_count = sum(1 for kw in NETWORK_HINTS if re.search(kw, text, re.IGNORECASE))
+        if hint_count >= 2:
+            network_separated = True
+            break
+
+    has_hardcoded = False
+    hardcoded_file: str | None = None
+    hardcoded_line: int | None = None
+    for f in chain_files:
+        text = common.read_file_safe(f) or ""
+        m = HARDCODED_NETWORK_RE.search(text)
+        if m:
+            has_hardcoded = True
+            hardcoded_file = f
+            hardcoded_line = text.count("\n", 0, m.start()) + 1
+            break
+
+    if has_hardcoded and not network_separated:
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Hardcoded network endpoint or chain ID without explicit env separation",
+            description=(
+                "Found a hardcoded RPC URL or chain ID, but no clear "
+                "mainnet/testnet/devnet separation in config files of this PR."
+            ),
+            recommendation=(
+                "Move endpoints/chain IDs into a config layer that distinguishes "
+                "mainnet vs. testnet vs. devnet, and reference them by env."
+            ),
+            file=hardcoded_file or chain_files[0],
+            line=hardcoded_line,
+        ))
+
+    if not result.findings:
+        result.summary = (
+            f"{len(chain_files)} chain/contract file(s) changed; tests are "
+            "present and no obvious blockchain risks detected."
+        )
+    else:
+        result.summary = (
+            f"{len(chain_files)} chain/contract file(s) changed; "
+            f"{len(result.findings)} concern(s) raised."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/common.py
+++ b/.github/agents/common.py
@@ -1,0 +1,592 @@
+"""
+Common helpers shared across PR triage and review agents.
+
+This module is intentionally dependency-free (stdlib only) so the agents
+can run in a minimal CI image without `pip install`. It provides:
+
+- get_changed_files()      : list of paths changed vs. base ref
+- read_file_safe()         : tolerant file reader (None on miss / decode error)
+- match_any()              : glob-pattern matcher over a list
+- load_policy()            : minimal YAML loader for review-policy.yml
+- Severity / Status enums  : ordered severity levels
+- Finding / AgentResult    : data containers
+- emit_result()            : write JSON + GITHUB_STEP_SUMMARY markdown
+- exit_for_status()        : convert AgentResult.status into a process exit code
+
+Python 3.11+. No external deps.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO_ROOT = Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd())).resolve()
+POLICY_PATH = REPO_ROOT / ".github" / "review-policy.yml"
+
+
+# --------------------------------------------------------------------------- #
+# Severity / Status
+# --------------------------------------------------------------------------- #
+
+
+class Severity(str, enum.Enum):
+    INFO = "INFO"
+    MINOR = "MINOR"
+    MAJOR = "MAJOR"
+    BLOCKER = "BLOCKER"
+
+    @property
+    def rank(self) -> int:
+        return {"INFO": 0, "MINOR": 1, "MAJOR": 2, "BLOCKER": 3}[self.value]
+
+
+class Status(str, enum.Enum):
+    PASS = "PASS"
+    INFO = "INFO"
+    MINOR = "MINOR"
+    MAJOR = "MAJOR"
+    BLOCKER = "BLOCKER"
+
+    @property
+    def rank(self) -> int:
+        return {"PASS": 0, "INFO": 1, "MINOR": 2, "MAJOR": 3, "BLOCKER": 4}[self.value]
+
+
+# --------------------------------------------------------------------------- #
+# Data containers
+# --------------------------------------------------------------------------- #
+
+
+@dataclasses.dataclass
+class Finding:
+    severity: Severity
+    title: str
+    description: str
+    recommendation: str
+    file: str | None = None
+    line: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = dataclasses.asdict(self)
+        d["severity"] = self.severity.value
+        return d
+
+
+@dataclasses.dataclass
+class AgentResult:
+    agent: str
+    status: Status
+    risk_level: str
+    findings: list[Finding] = dataclasses.field(default_factory=list)
+    summary: str = ""
+    applicable: bool = True
+
+    def add(self, finding: Finding) -> None:
+        self.findings.append(finding)
+        # Bump status to match worst finding
+        if finding.severity.rank + 1 > self.status.rank:
+            self.status = Status(finding.severity.value)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent": self.agent,
+            "status": self.status.value,
+            "risk_level": self.risk_level,
+            "applicable": self.applicable,
+            "summary": self.summary,
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Git / changed-files detection
+# --------------------------------------------------------------------------- #
+
+
+def _run(cmd: list[str]) -> tuple[int, str, str]:
+    proc = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _resolve_base_ref() -> str | None:
+    """
+    Determine the base ref to diff against.
+
+    Order of preference:
+      1. PR_BASE_SHA env var (set by workflow)
+      2. GITHUB_BASE_REF env var (pull_request events)
+      3. origin/main, origin/master fallbacks
+    """
+    base_sha = os.environ.get("PR_BASE_SHA")
+    if base_sha:
+        return base_sha
+
+    base_ref = os.environ.get("GITHUB_BASE_REF")
+    if base_ref:
+        # Make sure we have it locally
+        rc, _, _ = _run(["git", "rev-parse", "--verify", f"origin/{base_ref}"])
+        if rc == 0:
+            return f"origin/{base_ref}"
+        rc, _, _ = _run(["git", "rev-parse", "--verify", base_ref])
+        if rc == 0:
+            return base_ref
+
+    for candidate in ("origin/main", "origin/master", "main", "master"):
+        rc, _, _ = _run(["git", "rev-parse", "--verify", candidate])
+        if rc == 0:
+            return candidate
+
+    return None
+
+
+def get_changed_files() -> list[str]:
+    """
+    Return repo-relative paths changed vs. the base ref.
+
+    Falls back to an empty list (rather than raising) so agents can run
+    locally without a configured base. Use FORCE_CHANGED_FILES env var
+    (newline- or comma-separated) to override for local testing.
+    """
+    forced = os.environ.get("FORCE_CHANGED_FILES")
+    if forced:
+        sep = "\n" if "\n" in forced else ","
+        return [p.strip() for p in forced.split(sep) if p.strip()]
+
+    base = _resolve_base_ref()
+    if not base:
+        # Last-ditch: list everything tracked. Useful for first-PR scenarios.
+        rc, out, _ = _run(["git", "ls-files"])
+        if rc == 0:
+            return [line for line in out.splitlines() if line.strip()]
+        return []
+
+    rc, out, err = _run(["git", "diff", "--name-only", f"{base}...HEAD"])
+    if rc != 0:
+        # Try non-three-dot diff
+        rc, out, err = _run(["git", "diff", "--name-only", base, "HEAD"])
+    if rc != 0:
+        print(f"[common] git diff failed: {err}", file=sys.stderr)
+        return []
+
+    return [line for line in out.splitlines() if line.strip()]
+
+
+# --------------------------------------------------------------------------- #
+# File / pattern helpers
+# --------------------------------------------------------------------------- #
+
+
+def read_file_safe(path: str | Path, max_bytes: int = 2_000_000) -> str | None:
+    """Return file contents as text, or None on miss/decode error/oversize."""
+    p = (REPO_ROOT / path) if not Path(path).is_absolute() else Path(path)
+    try:
+        if not p.is_file():
+            return None
+        if p.stat().st_size > max_bytes:
+            with p.open("rb") as fh:
+                return fh.read(max_bytes).decode("utf-8", errors="replace")
+        return p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def match_any(path: str, patterns: Iterable[str]) -> bool:
+    """True if `path` matches any glob pattern."""
+    norm = path.replace("\\", "/")
+    for pat in patterns:
+        if fnmatch.fnmatch(norm, pat):
+            return True
+        # Allow bare-prefix conveniences like "contracts/" matching "contracts/x"
+        if pat.endswith("/") and norm.startswith(pat):
+            return True
+    return False
+
+
+def filter_files(files: Iterable[str], patterns: Iterable[str]) -> list[str]:
+    return [f for f in files if match_any(f, patterns)]
+
+
+# --------------------------------------------------------------------------- #
+# Minimal YAML loader for review-policy.yml
+#
+# We avoid a PyYAML dependency. The policy file is intentionally written
+# in a restricted YAML subset: mappings, sequences, strings, integers,
+# booleans, comments, and `-` list items. This loader covers that subset.
+# --------------------------------------------------------------------------- #
+
+
+def _yaml_scalar(s: str) -> Any:
+    s = s.strip()
+    if (s.startswith('"') and s.endswith('"')) or (s.startswith("'") and s.endswith("'")):
+        return s[1:-1]
+    if s in ("true", "True"):
+        return True
+    if s in ("false", "False"):
+        return False
+    if s in ("null", "~", ""):
+        return None
+    try:
+        if "." in s:
+            return float(s)
+        return int(s)
+    except ValueError:
+        return s
+
+
+def _parse_yaml(text: str) -> Any:
+    """Tiny indentation-based YAML parser for the policy subset."""
+    # Strip comments and blank lines but preserve indentation.
+    raw_lines: list[tuple[int, str]] = []
+    for line in text.splitlines():
+        stripped = line.split("#", 1)[0].rstrip()
+        if not stripped.strip():
+            continue
+        indent = len(stripped) - len(stripped.lstrip(" "))
+        raw_lines.append((indent, stripped.lstrip(" ")))
+
+    pos = 0
+
+    def parse_block(indent: int) -> Any:
+        nonlocal pos
+        # Decide whether this block is a list or mapping.
+        if pos >= len(raw_lines):
+            return None
+        cur_indent, cur = raw_lines[pos]
+        if cur_indent < indent:
+            return None
+        if cur.startswith("- "):
+            return parse_list(indent)
+        return parse_map(indent)
+
+    def parse_list(indent: int) -> list[Any]:
+        nonlocal pos
+        out: list[Any] = []
+        while pos < len(raw_lines):
+            cur_indent, cur = raw_lines[pos]
+            if cur_indent < indent or not cur.startswith("- "):
+                break
+            item_text = cur[2:].strip()
+            pos += 1
+            if ":" in item_text and not item_text.endswith(":"):
+                # Inline mapping start: "- key: value" — treat as a one-key mapping
+                # whose siblings live at indent + 2.
+                key, _, val = item_text.partition(":")
+                key = key.strip()
+                val = val.strip()
+                node: dict[str, Any] = {key: _yaml_scalar(val) if val else None}
+                # Continue collecting children for this mapping at indent+2.
+                child_indent = indent + 2
+                while pos < len(raw_lines):
+                    ni, _ = raw_lines[pos]
+                    if ni < child_indent:
+                        break
+                    sub = parse_map(child_indent)
+                    if isinstance(sub, dict):
+                        node.update(sub)
+                    else:
+                        break
+                if val == "":
+                    # The mapping's first value was empty → child block holds it.
+                    val_block = node[key]
+                    if val_block is None and key in node:
+                        # Already filled by parse_map merge; nothing to do.
+                        pass
+                out.append(node)
+            elif item_text.endswith(":"):
+                # "- key:" with mapping below
+                key = item_text[:-1].strip()
+                child_indent = indent + 2
+                node = {key: parse_block(child_indent)}
+                # Pick up siblings at indent+2 (more keys of same mapping)
+                while pos < len(raw_lines):
+                    ni, _ = raw_lines[pos]
+                    if ni < child_indent:
+                        break
+                    sub = parse_map(child_indent)
+                    if isinstance(sub, dict):
+                        node.update(sub)
+                    else:
+                        break
+                out.append(node)
+            else:
+                # Bare scalar list item
+                out.append(_yaml_scalar(item_text))
+        return out
+
+    def parse_map(indent: int) -> dict[str, Any]:
+        nonlocal pos
+        out: dict[str, Any] = {}
+        while pos < len(raw_lines):
+            cur_indent, cur = raw_lines[pos]
+            if cur_indent < indent:
+                break
+            if cur_indent > indent:
+                # Shouldn't happen at this level — skip defensively.
+                pos += 1
+                continue
+            if cur.startswith("- "):
+                break
+            if ":" not in cur:
+                pos += 1
+                continue
+            key, _, val = cur.partition(":")
+            key = key.strip()
+            val = val.strip()
+            pos += 1
+            if val == "":
+                # Child block follows
+                child_indent = indent + 2
+                # Detect the actual child indent (could be deeper)
+                if pos < len(raw_lines):
+                    child_indent = max(child_indent, raw_lines[pos][0])
+                if pos < len(raw_lines) and raw_lines[pos][0] > indent:
+                    out[key] = parse_block(raw_lines[pos][0])
+                else:
+                    out[key] = None
+            else:
+                out[key] = _yaml_scalar(val)
+        return out
+
+    if not raw_lines:
+        return {}
+    first_indent = raw_lines[0][0]
+    return parse_block(first_indent)
+
+
+def load_policy(path: Path | None = None) -> dict[str, Any]:
+    """Load .github/review-policy.yml. Returns {} if missing or unparseable."""
+    p = path or POLICY_PATH
+    txt = read_file_safe(p)
+    if txt is None:
+        return {}
+    try:
+        data = _parse_yaml(txt)
+        if isinstance(data, dict):
+            return data
+        return {}
+    except Exception as e:  # noqa: BLE001 — parser is intentionally tolerant
+        print(f"[common] policy parse failed: {e}", file=sys.stderr)
+        return {}
+
+
+def applicable_rules(files: list[str], policy: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return policy rules whose `match` patterns hit any changed file."""
+    rules = policy.get("rules") or []
+    hits: list[dict[str, Any]] = []
+    for rule in rules:
+        patterns = rule.get("match") or []
+        if not patterns:
+            continue
+        if any(match_any(f, patterns) for f in files):
+            hits.append(rule)
+    return hits
+
+
+def aggregate_risk_level(rules: list[dict[str, Any]], default: str = "low") -> str:
+    """Take the highest risk level across applicable rules."""
+    order = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+    best = default
+    for r in rules:
+        rl = (r.get("risk_level") or "low").lower()
+        if order.get(rl, 0) > order.get(best, 0):
+            best = rl
+    return best
+
+
+def required_agents_for(files: list[str], policy: dict[str, Any]) -> list[str]:
+    rules = applicable_rules(files, policy)
+    union: list[str] = []
+    seen: set[str] = set()
+    if not rules:
+        defaults = (policy.get("defaults") or {}).get("required_agents") or []
+        for a in defaults:
+            if a not in seen:
+                seen.add(a)
+                union.append(a)
+        return union
+    for r in rules:
+        for a in r.get("required_agents") or []:
+            if a not in seen:
+                seen.add(a)
+                union.append(a)
+    return union
+
+
+def recommended_reviewers_for(files: list[str], policy: dict[str, Any]) -> list[str]:
+    rules = applicable_rules(files, policy)
+    union: list[str] = []
+    seen: set[str] = set()
+    if not rules:
+        defaults = (policy.get("defaults") or {}).get("recommended_reviewers") or []
+        for r in defaults:
+            if r not in seen:
+                seen.add(r)
+                union.append(r)
+        return union
+    for r in rules:
+        for rv in r.get("recommended_reviewers") or []:
+            if rv not in seen:
+                seen.add(rv)
+                union.append(rv)
+    return union
+
+
+def requires_tests(files: list[str], policy: dict[str, Any]) -> bool:
+    for r in applicable_rules(files, policy):
+        if r.get("requires_tests"):
+            return True
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Result emission
+# --------------------------------------------------------------------------- #
+
+
+def _result_to_markdown(result: AgentResult, files: list[str]) -> str:
+    if not result.applicable:
+        return (
+            f"### ✅ {result.agent} — not applicable\n\n"
+            f"_No changed files fall under this agent's scope._\n"
+        )
+    icon = {
+        "PASS": "✅",
+        "INFO": "ℹ️",
+        "MINOR": "🟡",
+        "MAJOR": "🟠",
+        "BLOCKER": "🔴",
+    }.get(result.status.value, "•")
+
+    lines = [
+        f"### {icon} {result.agent} — {result.status.value}",
+        f"**Risk:** `{result.risk_level}`  |  **Findings:** {len(result.findings)}",
+        "",
+    ]
+    if result.summary:
+        lines += [result.summary, ""]
+    if result.findings:
+        lines.append("| Severity | Title | File |")
+        lines.append("| --- | --- | --- |")
+        for f in result.findings:
+            file_disp = f"`{f.file}`" if f.file else "—"
+            title = f.title.replace("|", "\\|")
+            lines.append(f"| **{f.severity.value}** | {title} | {file_disp} |")
+        lines.append("")
+        for i, f in enumerate(result.findings, 1):
+            lines.append(f"#### {i}. {f.severity.value}: {f.title}")
+            if f.file:
+                loc = f"`{f.file}`" + (f":{f.line}" if f.line else "")
+                lines.append(f"_Location:_ {loc}")
+            lines.append("")
+            lines.append(f.description)
+            lines.append("")
+            lines.append(f"**Recommendation:** {f.recommendation}")
+            lines.append("")
+    else:
+        lines.append("_No findings._")
+        lines.append("")
+
+    if files:
+        preview = files[:25]
+        lines.append("<details><summary>Changed files inspected</summary>\n")
+        for f in preview:
+            lines.append(f"- `{f}`")
+        if len(files) > len(preview):
+            lines.append(f"- … and {len(files) - len(preview)} more")
+        lines.append("\n</details>")
+
+    return "\n".join(lines) + "\n"
+
+
+def emit_result(result: AgentResult, files: list[str]) -> None:
+    """Print JSON to stdout, append markdown to GITHUB_STEP_SUMMARY (if set)."""
+    print(json.dumps(result.to_dict(), indent=2))
+    md = _result_to_markdown(result, files)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write(md)
+        except OSError as e:
+            print(f"[common] could not write step summary: {e}", file=sys.stderr)
+    else:
+        # Local run — print readable markdown too.
+        print("\n" + md, file=sys.stderr)
+
+
+def exit_for_status(result: AgentResult) -> int:
+    """
+    Return process exit code from result.
+      - BLOCKER or MAJOR  -> 1 (fail the job)
+      - PASS / INFO / MINOR -> 0
+      - non-applicable     -> 0
+    """
+    if not result.applicable:
+        return 0
+    if result.status in (Status.BLOCKER, Status.MAJOR):
+        return 1
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Convenience text scanners used by multiple agents
+# --------------------------------------------------------------------------- #
+
+
+def file_added(path: str) -> bool:
+    """Best-effort check that a file was newly added in this PR."""
+    base = _resolve_base_ref()
+    if not base:
+        return False
+    rc, out, _ = _run(["git", "diff", "--name-status", f"{base}...HEAD"])
+    if rc != 0:
+        return False
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0].startswith("A") and parts[-1] == path:
+            return True
+    return False
+
+
+def diff_for_file(path: str) -> str:
+    """Return the unified diff for one file, or '' on failure."""
+    base = _resolve_base_ref()
+    if not base:
+        return ""
+    rc, out, _ = _run(["git", "diff", f"{base}...HEAD", "--", path])
+    if rc != 0:
+        return ""
+    return out
+
+
+def has_test_changes(files: list[str]) -> bool:
+    test_patterns = [
+        "**/tests/**",
+        "**/test_*.py",
+        "**/*_test.go",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.test.js",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "**/*.spec.js",
+        "**/*.t.sol",
+        "**/test/**",
+    ]
+    return any(match_any(f, test_patterns) for f in files)
+
+
+def has_doc_changes(files: list[str]) -> bool:
+    return any(match_any(f, ["docs/**", "**/*.md", "README*", "**/ADR-*", "**/adr/**"]) for f in files)
+
+
+def has_migration_changes(files: list[str]) -> bool:
+    return any(match_any(f, ["migrations/**", "**/migrations/**", "**/*.migration.sql"]) for f in files)

--- a/.github/agents/compliance_review.py
+++ b/.github/agents/compliance_review.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Compliance review agent.
+
+Rules:
+- BLOCKER if KYC/AML/tax/reporting/compensation-sensitive logic changed
+  without a compliance note in this PR.
+- MAJOR if token compensation, liquidity, stablecoin, fiat off-ramp, or
+  securities-sensitive files changed without docs/compliance update.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+KYC_AML_KEYWORDS = [
+    r"\bKYC\b", r"\bAML\b", r"\bCFT\b",
+    r"\bsanctions?\b", r"\btravel[ _]rule\b",
+    r"\btax(?:[ _]report(?:ing)?)?\b", r"\b1099\b",
+    r"\bbeneficial[ _]owner\b",
+    r"\bcompensation\b", r"\bpayroll\b",
+    r"\bcustody\b", r"\bcustodian\b",
+]
+
+SECURITIES_KEYWORDS = [
+    r"\bsecurit(?:y|ies)\b", r"\bSEC\b", r"\bMiCA\b",
+    r"\binvestor[s]?\b", r"\baccredited\b",
+    r"\bstablecoin\b", r"\bUSD[CT]\b",
+    r"\bfiat\b", r"\boff[ _-]?ramp\b", r"\bon[ _-]?ramp\b",
+    r"\bliquidity\b", r"\bdividend\b",
+]
+
+COMPLIANCE_DOCS_PATTERNS = [
+    "docs/compliance/**",
+    "**/COMPLIANCE*",
+    "**/compliance.md",
+    "**/legal/**",
+    "**/regulatory/**",
+]
+
+
+def has_compliance_note(files: list[str]) -> bool:
+    return bool(common.filter_files(files, COMPLIANCE_DOCS_PATTERNS))
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="compliance",
+        status=common.Status.PASS,
+        risk_level="low",
+    )
+
+    if not files:
+        result.applicable = False
+        result.summary = "No changes detected."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    kyc_pat = re.compile("|".join(KYC_AML_KEYWORDS), re.IGNORECASE)
+    sec_pat = re.compile("|".join(SECURITIES_KEYWORDS), re.IGNORECASE)
+
+    kyc_hits: list[tuple[str, int]] = []
+    sec_hits: list[tuple[str, int]] = []
+
+    code_files = [f for f in files if not common.match_any(f, [
+        "**/*.md", "docs/**", "**/*.lock", "**/*.snap",
+    ])]
+
+    for f in code_files:
+        text = common.read_file_safe(f) or ""
+        if not text:
+            continue
+        for m in kyc_pat.finditer(text):
+            kyc_hits.append((f, text.count("\n", 0, m.start()) + 1))
+            break
+        for m in sec_pat.finditer(text):
+            sec_hits.append((f, text.count("\n", 0, m.start()) + 1))
+            break
+
+    if not kyc_hits and not sec_hits:
+        result.applicable = False
+        result.summary = "No compliance-sensitive keywords detected."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    has_note = has_compliance_note(files)
+
+    if kyc_hits:
+        result.risk_level = "critical"
+        if not has_note:
+            first_f, first_line = kyc_hits[0]
+            result.add(common.Finding(
+                severity=common.Severity.BLOCKER,
+                title="KYC/AML/tax/compensation-sensitive change without compliance note",
+                description=(
+                    f"Detected references to KYC, AML, sanctions, travel-rule, "
+                    f"tax/1099, payroll, or custody in {len(kyc_hits)} file(s), "
+                    "but this PR does not add or update any document under "
+                    "`docs/compliance/`, a `COMPLIANCE.md`, or a `legal/` path."
+                ),
+                recommendation=(
+                    "Add a compliance note under `docs/compliance/` (or update "
+                    "an existing one) describing what changed, why, and the "
+                    "regulatory context. Tag `@SOVEREIGN-NET/compliance` for "
+                    "review."
+                ),
+                file=first_f,
+                line=first_line,
+            ))
+
+    if sec_hits:
+        if result.risk_level != "critical":
+            result.risk_level = "high"
+        if not has_note:
+            first_f, first_line = sec_hits[0]
+            result.add(common.Finding(
+                severity=common.Severity.MAJOR,
+                title="Securities/stablecoin/fiat-ramp change without docs update",
+                description=(
+                    "Detected references to securities, stablecoins, fiat "
+                    "on/off-ramps, liquidity, dividends, or accredited-investor "
+                    "concepts. These often carry regulatory implications."
+                ),
+                recommendation=(
+                    "Update `docs/compliance/` with the regulatory rationale, "
+                    "and confirm with `@SOVEREIGN-NET/compliance` whether the "
+                    "change requires legal sign-off."
+                ),
+                file=first_f,
+                line=first_line,
+            ))
+
+    if not result.findings:
+        result.summary = (
+            "Compliance-sensitive keywords detected; a compliance note is "
+            "present in this PR."
+        )
+    else:
+        result.summary = (
+            f"Compliance-sensitive references found; {len(result.findings)} "
+            "concern(s) raised."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/data_sovereignty_review.py
+++ b/.github/agents/data_sovereignty_review.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Data sovereignty review agent.
+
+Rules:
+- BLOCKER if database/network config exposes internal DBs publicly.
+- MAJOR if migration lacks rollback or data-retention note.
+- MAJOR if sensitive data is stored without an encryption mention.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+CONFIG_PATTERNS = [
+    "infra/**", "**/k8s/**", "**/kubernetes/**",
+    "**/terraform/**", "**/helm/**",
+    "**/docker-compose*.yml", "**/Dockerfile*",
+    "**/*.tf", "**/*.tfvars",
+]
+
+PUBLIC_EXPOSURE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "Service exposes 0.0.0.0",
+        re.compile(r"\b0\.0\.0\.0\b"),
+    ),
+    (
+        "Kubernetes Service of type LoadBalancer with DB image",
+        re.compile(r"type:\s*LoadBalancer", re.IGNORECASE),
+    ),
+    (
+        "Security group / ingress 0.0.0.0/0",
+        re.compile(r"0\.0\.0\.0/0"),
+    ),
+    (
+        "Publicly accessible DB",
+        re.compile(r"publicly_accessible\s*=\s*true", re.IGNORECASE),
+    ),
+]
+
+DB_HINTS = re.compile(
+    r"\b(?:postgres|mysql|mariadb|mongodb|redis|elasticsearch|"
+    r"cassandra|clickhouse|cockroachdb|neo4j|influxdb)\b",
+    re.IGNORECASE,
+)
+
+MIGRATION_PATTERNS = [
+    "migrations/**", "**/migrations/**", "**/*.migration.sql",
+]
+
+ROLLBACK_HINTS = ["down(", "DOWN", "rollback", "BEGIN;", "DROP TABLE IF EXISTS"]
+RETENTION_HINTS = ["retention", "ttl", "expires_at", "retain", "purge", "GDPR"]
+
+SENSITIVE_FIELD_PATTERNS = [
+    r"\bemail\b", r"\bphone\b", r"\baddress\b",
+    r"\bdate_of_birth\b", r"\bdob\b",
+    r"\bpassword\b", r"\bpassword_hash\b",
+    r"\btoken\b", r"\bseed\b", r"\bmnemonic\b",
+    r"\bnational_id\b", r"\btax_id\b", r"\bpassport\b",
+    r"\bbiometric\b",
+]
+ENCRYPTION_HINTS = re.compile(
+    r"\b(?:encrypt(?:ed|ion)?|aes|kms|envelope[_ ]?encrypt|"
+    r"vault|hsm|argon2|bcrypt|scrypt|pbkdf2)\b",
+    re.IGNORECASE,
+)
+
+
+def is_public_exposure(path: str, text: str) -> list[tuple[str, int]]:
+    hits: list[tuple[str, int]] = []
+    if not DB_HINTS.search(text):
+        # Only flag if the same file references a database; otherwise we'd
+        # flag every public web ingress.
+        return hits
+    for label, pat in PUBLIC_EXPOSURE_PATTERNS:
+        m = pat.search(text)
+        if m:
+            line = text.count("\n", 0, m.start()) + 1
+            hits.append((label, line))
+    return hits
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="data_sovereignty",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    config_files = common.filter_files(files, CONFIG_PATTERNS)
+    migration_files = common.filter_files(files, MIGRATION_PATTERNS)
+    code_files = [f for f in files if common.match_any(f, [
+        "**/*.py", "**/*.go", "**/*.ts", "**/*.tsx", "**/*.js",
+        "**/*.rs", "**/*.java", "**/*.kt",
+    ])]
+
+    if not config_files and not migration_files and not code_files:
+        result.applicable = False
+        result.summary = "No infra/migration/code files in this PR."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    # 1) Public DB exposure
+    for f in config_files:
+        text = common.read_file_safe(f) or ""
+        if not text:
+            continue
+        for label, line in is_public_exposure(f, text):
+            result.add(common.Finding(
+                severity=common.Severity.BLOCKER,
+                title=f"Internal database may be publicly exposed: {label}",
+                description=(
+                    "This config file references a database service AND a "
+                    "public-network exposure pattern (0.0.0.0, 0.0.0.0/0, "
+                    "publicly_accessible, or LoadBalancer)."
+                ),
+                recommendation=(
+                    "Bind databases to private networks only. Use ClusterIP, "
+                    "private subnets, or VPC-internal endpoints. Front "
+                    "user-facing services with an explicit, audited proxy."
+                ),
+                file=f,
+                line=line,
+            ))
+
+    # 2) Migration rollback / retention
+    for f in migration_files:
+        text = common.read_file_safe(f) or ""
+        has_rollback = any(h in text for h in ROLLBACK_HINTS)
+        has_retention = any(h.lower() in text.lower() for h in RETENTION_HINTS)
+        if not has_rollback:
+            result.add(common.Finding(
+                severity=common.Severity.MAJOR,
+                title="Migration lacks visible rollback / down step",
+                description=(
+                    "This migration does not contain a `down(`, `DOWN`, "
+                    "`rollback`, or equivalent reverse step."
+                ),
+                recommendation=(
+                    "Add a reverse migration that restores the prior schema "
+                    "state, or document why the change is irreversible."
+                ),
+                file=f,
+            ))
+        if not has_retention and re.search(r"CREATE\s+TABLE", text, re.IGNORECASE):
+            result.add(common.Finding(
+                severity=common.Severity.MAJOR,
+                title="New table without data-retention note",
+                description=(
+                    "A new table is created but no retention/TTL/expiry "
+                    "field or note is visible in the migration."
+                ),
+                recommendation=(
+                    "Document the retention policy for this table (or add "
+                    "an `expires_at` / TTL column where appropriate). "
+                    "Reference your data-retention policy in `docs/`."
+                ),
+                file=f,
+            ))
+
+    # 3) Sensitive fields stored without encryption mention
+    sens_pat = re.compile("|".join(SENSITIVE_FIELD_PATTERNS), re.IGNORECASE)
+    suspect_files: list[str] = []
+    for f in migration_files + code_files:
+        text = common.read_file_safe(f) or ""
+        if not text:
+            continue
+        # Only inspect files that look like persistence or schema definitions.
+        looks_like_persistence = (
+            "schema" in f.lower()
+            or "model" in f.lower()
+            or f.endswith((".sql", ".prisma", ".graphql"))
+            or re.search(r"\bCREATE\s+TABLE\b", text, re.IGNORECASE)
+            or re.search(r"\bclass\s+\w+\(.*Model.*\)", text)
+        )
+        if not looks_like_persistence:
+            continue
+        if sens_pat.search(text) and not ENCRYPTION_HINTS.search(text):
+            suspect_files.append(f)
+    for f in suspect_files[:5]:  # cap noise
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Sensitive field persisted without visible encryption",
+            description=(
+                "This file appears to define schema/models containing "
+                "sensitive fields (email, phone, address, password, token, "
+                "etc.) but does not reference encryption (AES, KMS, Vault, "
+                "argon2/bcrypt/scrypt/pbkdf2)."
+            ),
+            recommendation=(
+                "Encrypt sensitive columns at rest (envelope encryption with "
+                "KMS), hash secrets with Argon2id/bcrypt, and document the "
+                "approach in `docs/security/`."
+            ),
+            file=f,
+        ))
+
+    if not result.findings:
+        result.summary = (
+            f"Inspected {len(config_files)} config + {len(migration_files)} "
+            "migration file(s); no data-sovereignty issues detected."
+        )
+    else:
+        result.summary = f"{len(result.findings)} data-sovereignty concern(s) raised."
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/devops_review.py
+++ b/.github/agents/devops_review.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+DevOps review agent.
+
+Rules:
+- BLOCKER if production deployment config changes without rollback notes.
+- BLOCKER if secrets are printed or exposed in shell/CI output.
+- MAJOR if observability/alerting is missing for a production-impacting change.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+PROD_INFRA_PATTERNS = [
+    "infra/prod/**", "infra/production/**",
+    "infra/**/prod/**", "infra/**/production/**",
+    "**/k8s/prod/**", "**/kubernetes/prod/**",
+    "**/terraform/prod/**", "**/helm/**/prod/**",
+    "**/values.prod.yaml", "**/values-prod.yaml",
+    "**/values.production.yaml",
+]
+
+NONPROD_INFRA_PATTERNS = [
+    "infra/**", "**/k8s/**", "**/terraform/**", "**/helm/**",
+    "**/Dockerfile*", "**/docker-compose*.yml",
+    ".github/workflows/**",
+]
+
+ROLLBACK_DOC_HINTS = [
+    "rollback", "revert", "fallback",
+]
+
+# Patterns that indicate secret exposure in shell/CI
+SECRET_EXPOSURE_PATTERNS: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "Secret echoed to stdout",
+        re.compile(r"\b(?:echo|printf)\s+[^|;\n]*\$\{?\s*(?:SECRET|TOKEN|PASSWORD|API_KEY|KEY|CREDENTIAL)[A-Z_0-9]*\}?", re.IGNORECASE),
+        "BLOCKER",
+    ),
+    (
+        "GITHUB_TOKEN echoed",
+        re.compile(r"\becho\s+[^|;\n]*\$\{?\s*GITHUB_TOKEN\}?"),
+        "BLOCKER",
+    ),
+    (
+        "set -x with sensitive env",
+        re.compile(r"^\s*set\s+-x\s*$.*?(?:SECRET|TOKEN|PASSWORD|API_KEY)", re.IGNORECASE | re.DOTALL | re.MULTILINE),
+        "MAJOR",
+    ),
+    (
+        "::set-output with secret",
+        re.compile(r"::set-output[^\n]*::[^\n]*\$\{?\s*(?:SECRET|TOKEN|PASSWORD|API_KEY)", re.IGNORECASE),
+        "BLOCKER",
+    ),
+]
+
+OBSERVABILITY_HINTS = [
+    r"\bprometheus\b", r"\bmetrics?\b", r"\balert(?:ing|manager)?\b",
+    r"\bgrafana\b", r"\bdatadog\b", r"\bsentry\b",
+    r"\bopentelemetry\b", r"\botel\b",
+    r"\bservicemonitor\b", r"\bPrometheusRule\b",
+    r"\blog(?:ging)?\b", r"\btrace\b", r"\bspan\b",
+]
+
+
+def has_rollback_notes(files: list[str]) -> bool:
+    # 1) any docs file mentioning rollback
+    doc_files = common.filter_files(files, ["docs/**", "**/*.md"])
+    for f in doc_files:
+        text = (common.read_file_safe(f) or "").lower()
+        if any(hint in text for hint in ROLLBACK_DOC_HINTS):
+            return True
+    # 2) RUNBOOK or ROLLBACK files
+    if common.filter_files(files, ["**/RUNBOOK*", "**/ROLLBACK*", "**/runbook*.md"]):
+        return True
+    return False
+
+
+def has_observability(files: list[str]) -> bool:
+    obs_pat = re.compile("|".join(OBSERVABILITY_HINTS), re.IGNORECASE)
+    for f in common.filter_files(files, NONPROD_INFRA_PATTERNS):
+        text = common.read_file_safe(f) or ""
+        if obs_pat.search(text):
+            return True
+    return False
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="devops",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    if not files:
+        result.applicable = False
+        result.summary = "No changes detected."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    prod_files = common.filter_files(files, PROD_INFRA_PATTERNS)
+    nonprod_files = common.filter_files(files, NONPROD_INFRA_PATTERNS)
+
+    if not prod_files and not nonprod_files:
+        result.applicable = False
+        result.summary = "No infra/CI files in this PR."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    if prod_files:
+        result.risk_level = "critical"
+        if not has_rollback_notes(files):
+            result.add(common.Finding(
+                severity=common.Severity.BLOCKER,
+                title="Production deploy config changed without rollback notes",
+                description=(
+                    f"{len(prod_files)} production infra file(s) changed but "
+                    "no rollback / revert / fallback note is present in any "
+                    "doc, runbook, or RUNBOOK/ROLLBACK file in this PR."
+                ),
+                recommendation=(
+                    "Add a `RUNBOOK.md` (or update `docs/runbooks/`) with "
+                    "explicit rollback steps, blast radius, and verification "
+                    "commands."
+                ),
+                file=prod_files[0],
+            ))
+        if not has_observability(files):
+            result.add(common.Finding(
+                severity=common.Severity.MAJOR,
+                title="Production change without observability/alerting hooks",
+                description=(
+                    "Production infra was modified but no metrics, alerts, "
+                    "logging, or tracing references appear in the touched "
+                    "files."
+                ),
+                recommendation=(
+                    "Wire up Prometheus rules, alerts, logs, or traces to "
+                    "this change so production behavior is observable."
+                ),
+                file=prod_files[0],
+            ))
+
+    # Secret exposure scan across infra + CI text files
+    scan_files = list(set(nonprod_files + prod_files + common.filter_files(files, [
+        "**/*.sh", "**/*.bash", "**/*.zsh", "**/Makefile*",
+        "**/*.yaml", "**/*.yml",
+    ])))
+    for f in scan_files:
+        text = common.read_file_safe(f) or ""
+        if not text:
+            continue
+        for title, pat, sev in SECRET_EXPOSURE_PATTERNS:
+            for m in pat.finditer(text):
+                line = text.count("\n", 0, m.start()) + 1
+                result.add(common.Finding(
+                    severity=common.Severity(sev),
+                    title=title,
+                    description=(
+                        "A pattern that exposes a secret to stdout/CI logs "
+                        "was detected. CI logs are durable and often visible "
+                        "to forks."
+                    ),
+                    recommendation=(
+                        "Never echo secret env vars. Use GitHub Actions' "
+                        "`::add-mask::` for runtime values, and load secrets "
+                        "via `${{ secrets.* }}` only inside steps that need "
+                        "them."
+                    ),
+                    file=f,
+                    line=line,
+                ))
+
+    if not result.findings:
+        result.summary = (
+            f"{len(prod_files)} prod and {len(nonprod_files) - len(prod_files)} "
+            "non-prod infra/CI file(s) inspected; no DevOps issues detected."
+        )
+    else:
+        result.summary = (
+            f"{len(result.findings)} DevOps concern(s) raised across "
+            f"{len(prod_files) + len(nonprod_files)} infra/CI file(s)."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/documentation_review.py
+++ b/.github/agents/documentation_review.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Documentation review agent.
+
+Rules:
+- MAJOR if architecture/protocol/tokenomics/compliance/governance behavior
+  changes without any docs updates (docs/, *.md, ADR-*, README*).
+- MINOR if a README or runbook in a touched module looks stale (code in a
+  directory changed and a README/RUNBOOK exists in that directory but was
+  not updated in this PR).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+# Domain prefixes whose behavior changes are expected to be reflected in docs.
+BEHAVIOR_DOMAIN_PREFIXES: tuple[str, ...] = (
+    "contracts/",
+    "smart-contracts/",
+    "chain/",
+    "blockchain/",
+    "tokenomics/",
+    "treasury/",
+    "identity/",
+    "zk/",
+    "governance/",
+    "dao/",
+    "protocol/",
+)
+
+DOC_FILE_PATTERNS = [
+    "docs/**",
+    "**/*.md",
+    "**/ADR-*",
+    "**/adr-*",
+    "**/README*",
+    "**/CHANGELOG*",
+    "**/CHANGES*",
+]
+
+STALE_DOC_NAMES = ("README.md", "README", "RUNBOOK.md", "RUNBOOK", "ARCHITECTURE.md")
+
+
+def _module_dir(path: str) -> str:
+    """Return the immediate parent directory of a path (or '' for root files)."""
+    if "/" not in path:
+        return ""
+    return path.rsplit("/", 1)[0]
+
+
+def _existing_doc_in_dir(repo_root: Path, directory: str) -> str | None:
+    """If a stale-doc-candidate file exists in `directory`, return its repo path."""
+    base = repo_root / directory if directory else repo_root
+    if not base.is_dir():
+        return None
+    for name in STALE_DOC_NAMES:
+        if (base / name).is_file():
+            return f"{directory}/{name}" if directory else name
+    return None
+
+
+def main() -> int:
+    changed = common.get_changed_files()
+    result = common.AgentResult(
+        agent="documentation",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    if not changed:
+        result.applicable = False
+        result.summary = "No changed files; documentation review not applicable."
+        common.emit_result(result, changed)
+        return common.exit_for_status(result)
+
+    behavior_changes = [
+        f for f in changed
+        if f.startswith(BEHAVIOR_DOMAIN_PREFIXES)
+    ]
+    doc_changes = [f for f in changed if common.match_any(f, DOC_FILE_PATTERNS)]
+
+    if not behavior_changes and not doc_changes:
+        # No domain we care about and no docs touched — nothing to assert.
+        result.applicable = False
+        result.summary = "No behavior-domain or documentation changes detected."
+        common.emit_result(result, changed)
+        return common.exit_for_status(result)
+
+    result.applicable = True
+
+    # --- Rule 1: behavior change with zero documentation updates -> MAJOR ---
+    if behavior_changes and not doc_changes:
+        domains_touched = sorted({
+            p.split("/", 1)[0] for p in behavior_changes if "/" in p
+        })
+        domains_str = ", ".join(domains_touched) if domains_touched else "core"
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Behavior change without documentation update",
+            description=(
+                f"Changes were detected in domains that affect protocol behavior "
+                f"({domains_str}), but no documentation files were updated in this "
+                f"PR (no docs/**, *.md, ADR-*, or README* updates). Material "
+                f"changes to architecture, protocol, tokenomics, compliance, or "
+                f"governance must be reflected in documentation so reviewers and "
+                f"future maintainers can understand the new behavior."
+            ),
+            recommendation=(
+                "Update the relevant documentation: add or revise an ADR under "
+                "docs/, update the module README, or extend protocol/tokenomics/"
+                "governance docs to describe the change. If this PR truly has no "
+                "behavior impact (e.g., pure refactor), say so explicitly in the "
+                "PR description."
+            ),
+        ))
+        result.risk_level = "high"
+
+    # --- Rule 2: stale README/RUNBOOK in a touched module -> MINOR ---
+    repo_root = Path.cwd()
+    touched_dirs = sorted({_module_dir(p) for p in changed})
+    doc_changes_set = set(doc_changes)
+
+    stale_candidates: list[tuple[str, str]] = []  # (touched_dir, doc_path)
+    for d in touched_dirs:
+        # Skip directories that are themselves under docs/ (they're docs already).
+        if d.startswith("docs/") or d == "docs":
+            continue
+        doc_path = _existing_doc_in_dir(repo_root, d)
+        if doc_path and doc_path not in doc_changes_set:
+            stale_candidates.append((d, doc_path))
+
+    # Cap at 5 to limit noise.
+    for touched_dir, doc_path in stale_candidates[:5]:
+        result.add(common.Finding(
+            severity=common.Severity.MINOR,
+            title="Possibly stale documentation alongside code change",
+            file=doc_path,
+            description=(
+                f"Code under '{touched_dir or '<root>'}' changed in this PR, but "
+                f"the local '{doc_path}' was not updated. If the change affects "
+                f"behavior, configuration, or operational steps documented there, "
+                f"this README/runbook may now be stale."
+            ),
+            recommendation=(
+                f"Review '{doc_path}' against the changes in this PR. If it is "
+                f"still accurate, no action is needed. Otherwise update it as "
+                f"part of this PR rather than leaving it for later."
+            ),
+        ))
+
+    if len(stale_candidates) > 5:
+        result.add(common.Finding(
+            severity=common.Severity.INFO,
+            title="Additional possibly-stale docs not listed",
+            description=(
+                f"{len(stale_candidates) - 5} additional README/runbook files in "
+                f"touched directories were not updated; only the first 5 are "
+                f"listed individually to limit noise."
+            ),
+            recommendation=(
+                "Spot-check the remaining module docs for accuracy."
+            ),
+        ))
+
+    if not result.findings:
+        result.summary = (
+            "Documentation review passed: behavior-domain changes are accompanied "
+            "by documentation updates, and no obviously-stale module docs were "
+            "detected."
+        )
+    else:
+        result.summary = (
+            f"Documentation review produced {len(result.findings)} finding(s). "
+            f"See details above."
+        )
+
+    common.emit_result(result, changed)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/economic_risk_review.py
+++ b/.github/agents/economic_risk_review.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Economic risk review agent.
+
+Rules:
+- BLOCKER if rewards, fees, curves, treasury, liquidity, or incentives changed
+  without simulation or invariant tests.
+- MAJOR if spam/Sybil/griefing cost is unclear (no rate-limit, deposit, or
+  reputation gate visible in incentive-touching files).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+INCENTIVE_PATTERNS = [
+    "tokenomics/**", "treasury/**",
+    "**/reward*", "**/incentive*", "**/curve*",
+    "**/liquidity*", "**/staking*",
+    "contracts/**", "smart-contracts/**", "**/*.sol",
+]
+
+ECON_KEYWORDS = [
+    r"\breward\b", r"\bincentive\b", r"\bemission\b",
+    r"\bfee\b", r"\btreasur(?:y|er)\b",
+    r"\bbond(?:ing)?[_ ]?curve\b", r"\bAMM\b",
+    r"\bliquidity\b", r"\bstak(?:e|ing)\b",
+    r"\bslash(?:ing)?\b",
+]
+
+SIM_TEST_PATTERNS = [
+    "**/simulations/**", "**/sims/**",
+    "**/*invariant*test*", "**/*invariant*spec*",
+    "**/*property*test*", "**/*fuzz*test*",
+    "**/test/**invariant*", "**/test/**fuzz*",
+]
+
+ANTI_ABUSE_HINTS = [
+    r"\brate[_ ]?limit\b",
+    r"\bcooldown\b",
+    r"\bdeposit\b",
+    r"\bstake(?:Required)?\b",
+    r"\breputation\b",
+    r"\bproof[_ ]?of[_ ]?work\b",
+    r"\bcaptcha\b",
+    r"\bnonce\b",
+    r"\bminAmount\b",
+    r"\brequire\([^)]*amount\s*>=",
+]
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="economic_risk",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    relevant = common.filter_files(files, INCENTIVE_PATTERNS)
+    if not relevant:
+        result.applicable = False
+        result.summary = "No incentive-relevant files in this PR."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    econ_pat = re.compile("|".join(ECON_KEYWORDS), re.IGNORECASE)
+    abuse_pat = re.compile("|".join(ANTI_ABUSE_HINTS), re.IGNORECASE)
+
+    econ_files: list[str] = []
+    files_with_abuse_guard: set[str] = set()
+
+    for f in relevant:
+        text = common.read_file_safe(f) or ""
+        if econ_pat.search(text):
+            econ_files.append(f)
+        if abuse_pat.search(text):
+            files_with_abuse_guard.add(f)
+
+    if not econ_files:
+        result.applicable = False
+        result.summary = "No incentive/economic keywords detected in relevant files."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    result.risk_level = "critical"
+
+    has_sim_or_invariant = bool(common.filter_files(files, SIM_TEST_PATTERNS))
+    if not has_sim_or_invariant:
+        # Allow generic test changes to soften this to MAJOR rather than BLOCKER
+        # — but the rule says BLOCKER. Keep it as BLOCKER per spec.
+        result.add(common.Finding(
+            severity=common.Severity.BLOCKER,
+            title="Incentive logic changed without simulation or invariant tests",
+            description=(
+                f"{len(econ_files)} file(s) reference rewards, fees, curves, "
+                "treasury, liquidity, staking, or slashing — but no "
+                "simulation, invariant, property, or fuzz tests were added "
+                "or updated."
+            ),
+            recommendation=(
+                "Add tests under `tests/invariant/`, `tests/simulations/`, or "
+                "`tests/fuzz/` covering: monotonicity of curves, conservation "
+                "of value, fee accounting, and edge cases (zero, max, dust)."
+            ),
+            file=econ_files[0],
+        ))
+
+    # Spam/Sybil/griefing cost clarity
+    files_without_guard = [f for f in econ_files if f not in files_with_abuse_guard]
+    if files_without_guard:
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Spam/Sybil/griefing cost is unclear",
+            description=(
+                f"{len(files_without_guard)} incentive file(s) do not show "
+                "any rate-limit, cooldown, deposit, stake, reputation, or "
+                "minimum-amount guard. Cheap-action paths can be exploited."
+            ),
+            recommendation=(
+                "Document the abuse model and add a guard appropriate to the "
+                "context (per-actor cooldowns, minimum stake, deposit, or "
+                "reputation gate). If the operation is intentionally free, "
+                "say so in a comment and explain why the abuse cost is borne "
+                "elsewhere."
+            ),
+            file=files_without_guard[0],
+        ))
+
+    if not result.findings:
+        result.summary = (
+            f"{len(econ_files)} incentive file(s) changed; simulation/"
+            "invariant tests present and abuse guards visible."
+        )
+    else:
+        result.summary = (
+            f"{len(econ_files)} incentive file(s) changed; "
+            f"{len(result.findings)} concern(s) raised."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/governance_review.py
+++ b/.github/agents/governance_review.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Governance review agent.
+
+Rules:
+- BLOCKER if proposal execution, quorum, delegation, voting power, emergency
+  powers, or admin permissions changed without governance tests.
+- MAJOR if emergency powers lack a time limit or audit log.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+GOV_PATTERNS = [
+    "governance/**", "dao/**",
+    "**/Governor*.sol", "**/Governance*.sol",
+    "**/Timelock*.sol", "**/Voting*.sol",
+    "**/governance*.py", "**/governance*.ts", "**/governance*.go", "**/governance*.rs",
+]
+
+GOV_KEYWORDS = [
+    r"\bquorum\b", r"\bdelegat(?:e|ion|ed)\b",
+    r"\bvotingPower\b", r"\bvoting[_ ]power\b",
+    r"\bproposal[_ ]?(?:execute|execution|threshold)?\b",
+    r"\bexecute(?:Proposal|Transaction)?\b",
+    r"\bemergency\b", r"\bpause\b", r"\bunpause\b", r"\bguardian\b",
+    r"\bonlyOwner\b", r"\bonlyAdmin\b", r"\bDEFAULT_ADMIN_ROLE\b",
+    r"\baccessControl\b", r"\bgrantRole\b", r"\brevokeRole\b",
+]
+
+EMERGENCY_KEYWORDS = [
+    r"\bemergency\b", r"\bpanic\b",
+    r"\bpause\b", r"\bunpause\b",
+    r"\bguardian\b",
+]
+
+TIME_LIMIT_HINTS = [
+    r"\bdeadline\b", r"\bexpir(?:y|es?|ation)\b",
+    r"\btimelock\b", r"\bblock\.timestamp\s*[<+]",
+    r"\bduration\b", r"\bMAX[_ ]?DURATION\b",
+]
+
+AUDIT_LOG_HINTS = [
+    r"\bemit\s+\w*Emergency\w*",
+    r"\bevent\s+\w*Emergency\w*",
+    r"\bemit\s+\w*Pause\w*",
+    r"\baudit[_ ]?log\b",
+]
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="governance",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    relevant = common.filter_files(files, GOV_PATTERNS)
+    # Also catch role/admin changes anywhere in solidity contracts.
+    contract_files = common.filter_files(files, ["**/*.sol", "contracts/**", "smart-contracts/**"])
+
+    gov_pat = re.compile("|".join(GOV_KEYWORDS), re.IGNORECASE)
+
+    candidate_files = list(set(relevant + contract_files))
+    gov_hit_files: list[str] = []
+    for f in candidate_files:
+        text = common.read_file_safe(f) or ""
+        if gov_pat.search(text):
+            gov_hit_files.append(f)
+
+    if not gov_hit_files:
+        result.applicable = False
+        result.summary = "No governance-relevant code changes detected."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    result.risk_level = "critical"
+
+    # Tests required
+    if not common.has_test_changes(files):
+        result.add(common.Finding(
+            severity=common.Severity.BLOCKER,
+            title="Governance/admin logic changed without tests",
+            description=(
+                f"{len(gov_hit_files)} file(s) reference quorum, delegation, "
+                "voting power, proposal execution, emergency powers, or admin "
+                "roles, but no tests were added or updated."
+            ),
+            recommendation=(
+                "Add tests for: quorum thresholds, vote counting, delegation "
+                "transitions, proposal lifecycle, role grants/revokes, and "
+                "any timelock or emergency path."
+            ),
+            file=gov_hit_files[0],
+        ))
+
+    # Emergency powers without time limits or audit logs
+    em_pat = re.compile("|".join(EMERGENCY_KEYWORDS), re.IGNORECASE)
+    time_pat = re.compile("|".join(TIME_LIMIT_HINTS), re.IGNORECASE)
+    audit_pat = re.compile("|".join(AUDIT_LOG_HINTS))
+
+    for f in gov_hit_files:
+        text = common.read_file_safe(f) or ""
+        if not em_pat.search(text):
+            continue
+        has_time = bool(time_pat.search(text))
+        has_audit = bool(audit_pat.search(text))
+        if not has_time:
+            result.add(common.Finding(
+                severity=common.Severity.MAJOR,
+                title="Emergency power without visible time limit",
+                description=(
+                    "This file references emergency / pause / guardian powers "
+                    "but does not appear to bound them in time (no deadline, "
+                    "expiration, timelock, or duration)."
+                ),
+                recommendation=(
+                    "Add an explicit time limit (e.g. `MAX_PAUSE_DURATION`) "
+                    "and document the rationale in the governance docs."
+                ),
+                file=f,
+            ))
+        if not has_audit:
+            result.add(common.Finding(
+                severity=common.Severity.MAJOR,
+                title="Emergency power without visible audit-log emission",
+                description=(
+                    "Emergency or pause logic was modified but no event "
+                    "emission or audit-log entry is visible in the file."
+                ),
+                recommendation=(
+                    "Emit a dedicated event whenever emergency powers are "
+                    "exercised, including the actor, reason, and timestamp."
+                ),
+                file=f,
+            ))
+
+    if not result.findings:
+        result.summary = (
+            f"{len(gov_hit_files)} governance file(s) changed; tests are "
+            "present and emergency-power constraints look intact."
+        )
+    else:
+        result.summary = (
+            f"{len(gov_hit_files)} governance file(s) changed; "
+            f"{len(result.findings)} concern(s) raised."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/performance_review.py
+++ b/.github/agents/performance_review.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Performance review agent.
+
+Rules:
+- MAJOR if loops over unbounded state are introduced in chain/contract/API
+  code.
+- MAJOR if large files / unbounded on-chain storage patterns are introduced.
+- MINOR if no benchmark exists for a performance-sensitive change.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+PERF_SENSITIVE_PATTERNS = [
+    "contracts/**", "smart-contracts/**", "**/*.sol",
+    "chain/**", "blockchain/**", "consensus/**", "node/**",
+    "api/**", "sdk/**",
+]
+
+# Solidity unbounded loop heuristics
+SOL_UNBOUNDED_LOOP_RE = re.compile(
+    r"for\s*\(\s*[^;]*;\s*[^;]*<\s*(?:[a-zA-Z_][\w.]*\.length|[a-zA-Z_][\w.]*\.size\(\))\s*;",
+)
+SOL_DYNAMIC_PUSH_RE = re.compile(r"\.push\s*\(")
+SOL_STATE_ARRAY_RE = re.compile(r"^\s*[a-zA-Z_]\w*\s*\[\]\s+(?:public|private|internal)?\s+\w+\s*;", re.MULTILINE)
+
+# Generic loop-over-collection without explicit bound
+GENERIC_UNBOUNDED_LOOP_PATTERNS = [
+    re.compile(r"for\s*\(\s*\w+\s+\w+\s*=\s*0\s*;\s*\w+\s*<\s*\w+\.length\s*;"),  # JS/Java/Go-ish
+    re.compile(r"for\s+\w+\s+in\s+\w+\s*:"),  # Python for-in
+    re.compile(r"\.forEach\s*\(\s*"),
+    re.compile(r"\.map\s*\(\s*"),
+]
+
+LARGE_STORAGE_HINTS = [
+    r"\bbytes\s+(?:public|private|internal)?\s*\w+\s*;",  # raw bytes state
+    r"\bmapping\s*\(\s*\w+\s*=>\s*\w+\[\]\s*\)",  # mapping to dynamic arrays
+    r"\bnew\s+bytes\s*\(\s*\d{4,}",  # new bytes(>=1000)
+]
+
+BENCH_PATTERNS = [
+    "**/bench/**", "**/benchmarks/**",
+    "**/*.bench.ts", "**/*.bench.js", "**/*_bench.go",
+    "**/criterion/**", "**/*.benchmark.*",
+    "**/perf/**", "**/test*/perf/**",
+]
+
+# Files we consider "performance sensitive" for the bench-presence check
+HOTPATH_HINT_RE = re.compile(
+    r"\b(?:hotpath|hot[_ ]?path|critical[_ ]?path|"
+    r"benchmark|optimi[sz]e|throughput|latency)\b",
+    re.IGNORECASE,
+)
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="performance",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    relevant = common.filter_files(files, PERF_SENSITIVE_PATTERNS)
+    if not relevant:
+        result.applicable = False
+        result.summary = "No performance-sensitive files in this PR."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    sol_files = [f for f in relevant if f.endswith(".sol")]
+
+    unbounded_loops: list[tuple[str, int]] = []
+    storage_concerns: list[tuple[str, int]] = []
+    generic_loops_in_chain: list[tuple[str, int]] = []
+    hotpath_files_without_bench: list[str] = []
+
+    storage_pat = re.compile("|".join(LARGE_STORAGE_HINTS))
+    has_bench_change = bool(common.filter_files(files, BENCH_PATTERNS))
+
+    for f in sol_files:
+        text = common.read_file_safe(f) or ""
+        # Solidity unbounded loop = iterating over a state array's length
+        for m in SOL_UNBOUNDED_LOOP_RE.finditer(text):
+            line = text.count("\n", 0, m.start()) + 1
+            # Best-effort filter: only flag if state-arrays are present in this file
+            if SOL_STATE_ARRAY_RE.search(text):
+                unbounded_loops.append((f, line))
+                break
+        for m in storage_pat.finditer(text):
+            line = text.count("\n", 0, m.start()) + 1
+            storage_concerns.append((f, line))
+            break
+        # `.push()` directly on state is an unbounded growth signal
+        if SOL_STATE_ARRAY_RE.search(text) and SOL_DYNAMIC_PUSH_RE.search(text):
+            # Only escalate if no length cap pattern is present
+            if not re.search(r"require\([^)]*\.length\s*<", text):
+                m = SOL_DYNAMIC_PUSH_RE.search(text)
+                if m:
+                    line = text.count("\n", 0, m.start()) + 1
+                    storage_concerns.append((f, line))
+
+    # Generic unbounded loops in chain/api/sdk code
+    chain_api_files = [f for f in relevant if not f.endswith(".sol")]
+    for f in chain_api_files:
+        text = common.read_file_safe(f) or ""
+        if not text:
+            continue
+        for pat in GENERIC_UNBOUNDED_LOOP_PATTERNS:
+            m = pat.search(text)
+            if m:
+                # Heuristic: only flag if the function or file mentions a
+                # state container (db/storage/list/array) so we don't fire
+                # on pure utility loops.
+                if re.search(r"\b(?:state|storage|db|repo|collection|array|list)\b", text, re.IGNORECASE):
+                    line = text.count("\n", 0, m.start()) + 1
+                    generic_loops_in_chain.append((f, line))
+                    break
+
+    # Bench presence for files mentioning hotpath/optimize keywords
+    for f in relevant:
+        text = common.read_file_safe(f) or ""
+        if HOTPATH_HINT_RE.search(text) and not has_bench_change:
+            hotpath_files_without_bench.append(f)
+
+    if unbounded_loops:
+        f, line = unbounded_loops[0]
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Loop over unbounded on-chain state introduced",
+            description=(
+                f"In {len(unbounded_loops)} Solidity file(s), a `for` loop "
+                "iterates over a state-array's `.length`. As the array grows, "
+                "gas costs grow linearly until the call exceeds the block "
+                "gas limit, denial-of-servicing the contract."
+            ),
+            recommendation=(
+                "Either bound the array, paginate the operation, or process "
+                "off-chain and submit a Merkle proof. Add an explicit "
+                "`require` on `.length` to make the bound visible."
+            ),
+            file=f,
+            line=line,
+        ))
+
+    if storage_concerns:
+        f, line = storage_concerns[0]
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Unbounded on-chain storage growth pattern",
+            description=(
+                "Detected dynamic state arrays, mappings to dynamic arrays, "
+                "or large `bytes(N)` allocations without an explicit length "
+                "cap."
+            ),
+            recommendation=(
+                "Add a hard length cap, paginate writes, or store off-chain "
+                "with a commitment on-chain."
+            ),
+            file=f,
+            line=line,
+        ))
+
+    if generic_loops_in_chain:
+        f, line = generic_loops_in_chain[0]
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Loop over unbounded collection in chain/API code",
+            description=(
+                "A loop iterates over a collection that appears to be backed "
+                "by state/storage/database. Without an explicit bound this "
+                "scales with state size."
+            ),
+            recommendation=(
+                "Paginate the operation, add an explicit upper bound, or "
+                "move the work off the request path."
+            ),
+            file=f,
+            line=line,
+        ))
+
+    if hotpath_files_without_bench:
+        result.add(common.Finding(
+            severity=common.Severity.MINOR,
+            title="No benchmark for performance-sensitive change",
+            description=(
+                f"{len(hotpath_files_without_bench)} file(s) reference "
+                "hotpath / optimize / throughput / latency, but no benchmark "
+                "files were touched."
+            ),
+            recommendation=(
+                "Add or update a benchmark under `benchmarks/` or `bench/` "
+                "to track regressions over time."
+            ),
+            file=hotpath_files_without_bench[0],
+        ))
+
+    if not result.findings:
+        result.summary = (
+            f"{len(relevant)} performance-sensitive file(s) inspected; no "
+            "obvious performance regressions detected."
+        )
+    else:
+        result.summary = (
+            f"{len(relevant)} performance-sensitive file(s) inspected; "
+            f"{len(result.findings)} concern(s) raised."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/pr_triage.py
+++ b/.github/agents/pr_triage.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+PR Triage Agent.
+
+Reads the changed files in the PR, applies .github/review-policy.yml, and
+emits a triage report (Markdown + JSON). This script never fails the build;
+its only job is to summarize and recommend.
+
+Outputs (in the working directory):
+  - triage_result.md
+  - triage_result.json
+
+Outputs (env-driven):
+  - GITHUB_STEP_SUMMARY    : Markdown summary appended for the Actions UI
+  - GITHUB_OUTPUT          : key=value pairs (risk_level, required_agents)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Allow running as `python .github/agents/pr_triage.py` from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+CRITICAL_DOMAINS = {
+    "smart_contracts",
+    "chain_core",
+    "tokenomics_treasury",
+    "identity_zk",
+    "governance",
+    "production_infra",
+    "migrations",
+}
+
+
+def classify_domain(path: str) -> str:
+    p = path.replace("\\", "/")
+    if p.startswith("contracts/") or p.startswith("smart-contracts/") or p.endswith((".sol", ".cairo", ".vy")):
+        return "smart-contracts"
+    if p.startswith(("chain/", "blockchain/", "consensus/", "node/")):
+        return "chain"
+    if p.startswith(("tokenomics/", "treasury/")):
+        return "tokenomics"
+    if p.startswith(("identity/", "zk/")) or "/zkdid/" in p or "zkproof" in p:
+        return "identity-zk"
+    if p.startswith(("governance/", "dao/")):
+        return "governance"
+    if p.startswith("infra/"):
+        return "infra"
+    if p.startswith("migrations/") or "/migrations/" in p:
+        return "migrations"
+    if p.startswith(("api/", "sdk/")) or p.endswith(".proto"):
+        return "api"
+    if p.startswith("mobile/") or "/wallet/" in p:
+        return "mobile-wallet"
+    if p.startswith(("frontend/", "web/")):
+        return "frontend"
+    if p.startswith(".github/"):
+        return "ci"
+    if p.startswith("docs/") or p.endswith(".md") or p.startswith("README"):
+        return "docs"
+    if "/tests/" in p or p.startswith("tests/") or "test_" in os.path.basename(p):
+        return "tests"
+    return "other"
+
+
+def build_reasons(files: list[str], rules: list[dict]) -> list[str]:
+    reasons: list[str] = []
+    for r in rules:
+        name = r.get("name") or "rule"
+        risk = r.get("risk_level") or "low"
+        sample = next(
+            (f for f in files if common.match_any(f, r.get("match") or [])),
+            None,
+        )
+        if sample:
+            reasons.append(f"`{name}` (**{risk}**) matched — e.g. `{sample}`")
+    return reasons
+
+
+def merge_policy(risk_level: str, has_critical_domain: bool) -> str:
+    if has_critical_domain or risk_level == "critical":
+        return (
+            "🔴 **Critical change.** Code Owner approval is required, all PR "
+            "Quality Gates must pass, and override is **not** allowed."
+        )
+    if risk_level == "high":
+        return (
+            "🟠 **High-risk change.** Code Owner approval is required and all "
+            "applicable PR Quality Gates must pass before merge."
+        )
+    if risk_level == "medium":
+        return (
+            "🟡 **Medium-risk change.** Standard review applies. PR Quality "
+            "Gates must pass; override is allowed with documented justification."
+        )
+    return (
+        "🟢 **Low-risk change.** Standard review applies. Most agents will "
+        "report `not applicable`."
+    )
+
+
+def render_markdown(
+    files: list[str],
+    rules: list[dict],
+    risk_level: str,
+    domains: list[str],
+    required_agents: list[str],
+    reviewers: list[str],
+    requires_tests: bool,
+    has_tests: bool,
+    has_docs: bool,
+    has_migrations: bool,
+    reasons: list[str],
+) -> str:
+    badges = {
+        "low": "🟢 LOW",
+        "medium": "🟡 MEDIUM",
+        "high": "🟠 HIGH",
+        "critical": "🔴 CRITICAL",
+    }
+    badge = badges.get(risk_level, risk_level.upper())
+    lines = [
+        "## 🔍 PR Triage Report",
+        "",
+        f"**Risk level:** {badge}",
+        f"**Files changed:** {len(files)}",
+        f"**Affected domains:** {', '.join(f'`{d}`' for d in domains) if domains else '_none_'}",
+        "",
+        "### Required review agents",
+    ]
+    if required_agents:
+        for a in required_agents:
+            lines.append(f"- `{a}`")
+    else:
+        lines.append("_None — defaults will apply._")
+    lines += ["", "### Recommended human reviewers"]
+    if reviewers:
+        for r in reviewers:
+            lines.append(f"- {r}")
+    else:
+        lines.append("_None._")
+
+    lines += ["", "### Why this classification"]
+    if reasons:
+        for r in reasons:
+            lines.append(f"- {r}")
+    else:
+        lines.append("- No specific policy rule matched. Defaults applied.")
+
+    lines += ["", "### Pre-merge checklist", ""]
+    lines.append(f"- [{'x' if has_tests or not requires_tests else ' '}] Tests touched"
+                 + (" _(required for this risk level)_" if requires_tests else ""))
+    lines.append(f"- [{'x' if has_docs else ' '}] Docs touched")
+    if has_migrations:
+        lines.append("- [ ] Migration includes rollback notes (verify in description)")
+
+    lines += ["", "### Merge policy", "", merge_policy(risk_level, any(r.get("name") in CRITICAL_DOMAINS for r in rules))]
+    lines += ["", "### Next steps for reviewers", "",
+              "1. Wait for **PR Quality Gates** to finish — every required agent must report `PASS`, `INFO`, or be non-applicable.",
+              "2. Resolve any `MAJOR` or `BLOCKER` findings before requesting re-review.",
+              "3. Confirm Code Owner approval is in place per `.github/CODEOWNERS`.",
+              "4. For `critical` PRs, verify ADRs / specs / runbooks are updated in this same PR.",
+              ""]
+    if files:
+        preview = files[:30]
+        lines += ["<details><summary>Changed files</summary>", ""]
+        for f in preview:
+            lines.append(f"- `{f}`")
+        if len(files) > len(preview):
+            lines.append(f"- … and {len(files) - len(preview)} more")
+        lines += ["", "</details>"]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    policy = common.load_policy()
+    rules = common.applicable_rules(files, policy)
+    risk_level = common.aggregate_risk_level(rules)
+    required_agents = common.required_agents_for(files, policy)
+    reviewers = common.recommended_reviewers_for(files, policy)
+    needs_tests = common.requires_tests(files, policy)
+    has_tests = common.has_test_changes(files)
+    has_docs = common.has_doc_changes(files)
+    has_migrations = common.has_migration_changes(files)
+
+    domain_set: list[str] = []
+    seen: set[str] = set()
+    for f in files:
+        d = classify_domain(f)
+        if d not in seen and d != "other":
+            seen.add(d)
+            domain_set.append(d)
+
+    reasons = build_reasons(files, rules)
+
+    md = render_markdown(
+        files=files,
+        rules=rules,
+        risk_level=risk_level,
+        domains=domain_set,
+        required_agents=required_agents,
+        reviewers=reviewers,
+        requires_tests=needs_tests,
+        has_tests=has_tests,
+        has_docs=has_docs,
+        has_migrations=has_migrations,
+        reasons=reasons,
+    )
+
+    payload = {
+        "risk_level": risk_level,
+        "files_changed": len(files),
+        "files": files,
+        "domains": domain_set,
+        "required_agents": required_agents,
+        "recommended_reviewers": reviewers,
+        "requires_tests": needs_tests,
+        "has_tests": has_tests,
+        "has_docs": has_docs,
+        "has_migrations": has_migrations,
+        "reasons": reasons,
+        "applicable_rules": [r.get("name") for r in rules],
+    }
+
+    out_dir = Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd()))
+    (out_dir / "triage_result.md").write_text(md, encoding="utf-8")
+    (out_dir / "triage_result.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write(md)
+        except OSError as e:
+            print(f"[pr_triage] could not write step summary: {e}", file=sys.stderr)
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        try:
+            with open(output_path, "a", encoding="utf-8") as fh:
+                fh.write(f"risk_level={risk_level}\n")
+                fh.write(f"required_agents={','.join(required_agents)}\n")
+                fh.write(f"files_changed={len(files)}\n")
+        except OSError as e:
+            print(f"[pr_triage] could not write GITHUB_OUTPUT: {e}", file=sys.stderr)
+
+    print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/privacy_zkdid_review.py
+++ b/.github/agents/privacy_zkdid_review.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Privacy / ZK-DID review agent.
+
+Rules:
+- BLOCKER if raw biometric, private identity, seed phrase, or sensitive PII
+  appears to be logged or stored.
+- MAJOR if identity-linking behavior changed without a privacy note.
+- MAJOR if zk-proof verification code changed without tests.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+PRIVACY_PATTERNS = [
+    "identity/**", "zk/**",
+    "**/zkdid/**", "**/*zk*proof*", "**/*zkproof*",
+    "**/did/**", "**/credential*",
+]
+
+# Sensitive identifiers that should never appear in logs / persistent stores.
+SENSITIVE_TERMS = [
+    "seed_phrase", "seedPhrase", "seed phrase",
+    "mnemonic",
+    "private_key", "privateKey", "priv_key", "privKey",
+    "biometric", "fingerprint_template", "face_template", "iris_template",
+    "passport_number", "passportNumber",
+    "ssn", "social_security",
+    "national_id", "nationalId", "tax_id", "taxId",
+    "DNIe", "eIDAS",
+    "dateOfBirth", "date_of_birth",
+]
+
+LOG_OR_STORE_RE = re.compile(
+    r"\b(?:log(?:ger)?\.(?:debug|info|warn|error|trace)|console\.(?:log|info|warn|error|debug)|"
+    r"println!|fmt\.(?:Print|Println|Printf)|System\.out\.print|"
+    r"db\.(?:save|insert|set|put)|redis\.(?:set|hset)|kv\.put|"
+    r"localStorage\.setItem|AsyncStorage\.setItem|UserDefaults)",
+    re.IGNORECASE,
+)
+
+ZK_VERIFY_RE = re.compile(
+    r"\b(?:verifyProof|verify_proof|Groth16Verify|PlonkVerify|"
+    r"snark[Vv]erify|verifier\.(?:verify|check))\b"
+)
+
+LINKING_KEYWORDS = [
+    r"\blink(?:ed|ing)?[_ ]?identit(?:y|ies)\b",
+    r"\bcorrelat(?:e|ion|ed)\b",
+    r"\bdeanonymi(?:s|z)e\b",
+    r"\bglobal[_ ]?identifier\b",
+    r"\bcross[_ ]?reference\b",
+]
+
+PRIVACY_DOC_PATTERNS = [
+    "docs/privacy/**",
+    "**/PRIVACY*",
+    "**/privacy.md",
+    "docs/**/privacy*.md",
+]
+
+
+def has_privacy_note(files: list[str]) -> bool:
+    return bool(common.filter_files(files, PRIVACY_DOC_PATTERNS))
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="privacy_zkdid",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    relevant = common.filter_files(files, PRIVACY_PATTERNS)
+    if not relevant and not files:
+        result.applicable = False
+        result.summary = "No changes detected."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    # We also scan general code for sensitive PII appearing in logs/stores —
+    # not only identity/ paths.
+    text_files = [f for f in files if common.match_any(f, [
+        "**/*.py", "**/*.js", "**/*.ts", "**/*.tsx", "**/*.jsx",
+        "**/*.go", "**/*.rs", "**/*.swift", "**/*.kt", "**/*.java",
+        "**/*.sol",
+    ])]
+
+    sensitive_lower = [s.lower() for s in SENSITIVE_TERMS]
+
+    pii_findings: list[tuple[str, int, str, str]] = []
+    for f in text_files:
+        text = common.read_file_safe(f) or ""
+        if not text:
+            continue
+        lower_text = text.lower()
+        # Quick reject: only do per-line scan if any sensitive term is present.
+        if not any(term in lower_text for term in sensitive_lower):
+            continue
+        for i, line in enumerate(text.splitlines(), 1):
+            ll = line.lower()
+            for term in sensitive_lower:
+                if term in ll and LOG_OR_STORE_RE.search(line):
+                    pii_findings.append((f, i, term, line.strip()[:160]))
+                    break
+
+    for f, line_no, term, snippet in pii_findings:
+        result.add(common.Finding(
+            severity=common.Severity.BLOCKER,
+            title=f"Sensitive identifier `{term}` in a logging or persistence call",
+            description=(
+                "A sensitive identifier appears on the same line as a log "
+                "or storage call. This is a high-risk pattern for leaking "
+                "PII, biometrics, or key material.\n\n"
+                f"```\n{snippet}\n```"
+            ),
+            recommendation=(
+                "Never log or store raw sensitive identifiers. Hash, redact, "
+                "or replace with an opaque reference. If transient handling "
+                "is genuinely required, document it in `docs/privacy/`."
+            ),
+            file=f,
+            line=line_no,
+        ))
+
+    # ZK proof verification touched without tests
+    zk_files = []
+    for f in relevant:
+        text = common.read_file_safe(f) or ""
+        if ZK_VERIFY_RE.search(text):
+            zk_files.append(f)
+    if zk_files and not common.has_test_changes(files):
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="ZK proof verification code changed without test changes",
+            description=(
+                f"{len(zk_files)} file(s) reference proof verification "
+                "(verifyProof / Groth16Verify / PlonkVerify / verifier.verify) "
+                "but no tests were updated."
+            ),
+            recommendation=(
+                "Add tests covering valid proofs, invalid proofs, malformed "
+                "inputs, and known edge cases. Verifier code must not regress."
+            ),
+            file=zk_files[0],
+        ))
+
+    # Identity-linking behavior changed without privacy note
+    linking_pat = re.compile("|".join(LINKING_KEYWORDS), re.IGNORECASE)
+    linking_hits: list[str] = []
+    for f in relevant:
+        text = common.read_file_safe(f) or ""
+        if linking_pat.search(text):
+            linking_hits.append(f)
+    if linking_hits and not has_privacy_note(files):
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Identity-linking behavior changed without a privacy note",
+            description=(
+                f"References to identity linking, correlation, or "
+                f"deanonymization detected in {len(linking_hits)} file(s), "
+                "with no privacy doc updated in this PR."
+            ),
+            recommendation=(
+                "Add or update `docs/privacy/` describing what gets linked, "
+                "under what authority, and how the user is informed."
+            ),
+            file=linking_hits[0],
+        ))
+
+    if relevant:
+        result.risk_level = "critical"
+
+    if not result.findings:
+        if relevant:
+            result.summary = (
+                f"{len(relevant)} privacy/ZK file(s) changed; no obvious "
+                "privacy regressions detected."
+            )
+        else:
+            result.applicable = False
+            result.summary = "No privacy-relevant code paths changed."
+    else:
+        result.summary = (
+            f"{len(result.findings)} privacy/ZK concern(s) raised."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/security_review.py
+++ b/.github/agents/security_review.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Security review agent.
+
+Rules:
+- BLOCKER on committed secrets/private keys/tokens.
+- BLOCKER on unsafe eval/exec/deserialization patterns.
+- BLOCKER on workflow using `pull_request_target`.
+- MAJOR on broad GitHub Actions permissions like `contents: write` unless
+  justification is present in a comment in the same file.
+- MAJOR on disabled TLS / certificate verification.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# Pattern catalogs
+# --------------------------------------------------------------------------- #
+
+# High-confidence secret patterns. These are intentionally conservative; the
+# goal is to surface obvious mistakes, not run a full secret-scanner.
+SECRET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("AWS access key id",          re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("AWS secret access key",      re.compile(r"(?i)aws(.{0,20})?(secret|sk)[\"']?\s*[:=]\s*[\"'][A-Za-z0-9/+=]{40}[\"']")),
+    ("GitHub token (ghp_/gho_/...)", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{30,}\b")),
+    ("Slack token",                re.compile(r"\bxox[abp]-[A-Za-z0-9-]{10,}\b")),
+    ("Google API key",             re.compile(r"\bAIza[0-9A-Za-z_\-]{35}\b")),
+    ("Stripe live key",            re.compile(r"\bsk_live_[0-9a-zA-Z]{24,}\b")),
+    ("PEM private key block",      re.compile(r"-----BEGIN (RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----")),
+    ("BIP-39 mnemonic header",     re.compile(r"(?im)^\s*(mnemonic|seed[_ ]?phrase)\s*[:=]\s*['\"]([a-z]+\s+){11,23}[a-z]+['\"]")),
+    ("Hex private key (32 bytes)", re.compile(r"(?i)(?:private[_ ]?key|priv[_ ]?key)\s*[:=]\s*[\"']?(0x)?[a-f0-9]{64}[\"']?")),
+    ("JWT-shaped token",           re.compile(r"\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\b")),
+    ("Generic API key assignment", re.compile(r"(?i)\b(api[_-]?key|secret[_-]?key|access[_-]?token)\s*[:=]\s*[\"'][A-Za-z0-9_\-]{24,}[\"']")),
+]
+
+# Files we never scan for secrets to avoid endless false positives.
+SECRET_SKIP_PATTERNS = [
+    "**/*.lock",
+    "**/package-lock.json",
+    "**/yarn.lock",
+    "**/Cargo.lock",
+    "**/poetry.lock",
+    "**/go.sum",
+    "**/*.min.js",
+    "**/*.snap",
+    "**/dist/**",
+    "**/build/**",
+    "**/node_modules/**",
+    "**/vendor/**",
+    "**/test*/fixtures/**",
+    "**/fixtures/**",
+    "**/__snapshots__/**",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "docs/**",
+    "**/*.md",
+]
+
+# Source-code patterns we treat as text candidates for secret + dangerous-pattern scanning.
+TEXT_CODE_PATTERNS = [
+    "**/*.py", "**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx",
+    "**/*.go", "**/*.rs", "**/*.sol", "**/*.java", "**/*.kt",
+    "**/*.swift", "**/*.rb", "**/*.cs", "**/*.cpp", "**/*.c", "**/*.h",
+    "**/*.yaml", "**/*.yml", "**/*.json", "**/*.toml", "**/*.env*",
+    "**/*.sh", "**/*.bash", "**/*.zsh", "**/*.cfg", "**/*.ini",
+    "**/.env*", "**/Dockerfile*", "**/Makefile*",
+]
+
+# Dangerous code patterns
+DANGEROUS_PATTERNS: list[tuple[str, re.Pattern[str], str, str]] = [
+    (
+        "Python eval()/exec() on dynamic input",
+        re.compile(r"\b(?:eval|exec)\s*\([^)]*(?:input|request|argv|environ|stdin)"),
+        "BLOCKER",
+        "Eval/exec on user-controlled input enables arbitrary code execution.",
+    ),
+    (
+        "Python pickle.load on untrusted input",
+        re.compile(r"\bpickle\.(?:load|loads)\s*\("),
+        "BLOCKER",
+        "`pickle` is unsafe for deserializing data from untrusted sources.",
+    ),
+    (
+        "PyYAML unsafe load",
+        re.compile(r"\byaml\.load\s*\((?![^)]*Loader\s*=\s*[A-Za-z_]*Safe)"),
+        "BLOCKER",
+        "`yaml.load` without `SafeLoader` allows arbitrary object construction.",
+    ),
+    (
+        "Java/Python ObjectInputStream / Marshal.load",
+        re.compile(r"\b(?:ObjectInputStream|Marshal\.load|jsonpickle\.decode)\b"),
+        "BLOCKER",
+        "Native deserialization of untrusted data is a known RCE vector.",
+    ),
+    (
+        "JavaScript eval()",
+        re.compile(r"(?<!\w)eval\s*\("),
+        "MAJOR",
+        "Avoid `eval()` in JS/TS; it complicates auditing and enables injection.",
+    ),
+    (
+        "child_process exec with template literal",
+        re.compile(r"\b(?:exec|execSync|spawn|spawnSync)\s*\(\s*`[^`]*\$\{"),
+        "MAJOR",
+        "Shell-style exec with interpolated strings is a command-injection risk.",
+    ),
+    (
+        "Disabled TLS verification (Python requests)",
+        re.compile(r"verify\s*=\s*False"),
+        "MAJOR",
+        "TLS verification disabled — disables MITM protection.",
+    ),
+    (
+        "Disabled TLS verification (curl/wget)",
+        re.compile(r"\bcurl\b[^|;\n]*\s(-k|--insecure)\b|\bwget\b[^|;\n]*\s--no-check-certificate\b"),
+        "MAJOR",
+        "TLS verification disabled in shell command.",
+    ),
+    (
+        "Disabled TLS verification (Node/Go)",
+        re.compile(r"rejectUnauthorized\s*:\s*false|InsecureSkipVerify\s*:\s*true"),
+        "MAJOR",
+        "TLS verification disabled in client config.",
+    ),
+    (
+        "MD5/SHA1 used for security",
+        re.compile(r"\b(?:hashlib\.md5|hashlib\.sha1|crypto\.createHash\(['\"]md5['\"]\)|crypto\.createHash\(['\"]sha1['\"]\))"),
+        "MINOR",
+        "MD5/SHA-1 are broken for security uses; verify this is non-security context.",
+    ),
+]
+
+# Workflow-specific checks
+WORKFLOW_PATTERNS = ["**/.github/workflows/*.yml", "**/.github/workflows/*.yaml",
+                    ".github/workflows/*.yml", ".github/workflows/*.yaml"]
+
+
+def is_skipped(path: str) -> bool:
+    return common.match_any(path, SECRET_SKIP_PATTERNS)
+
+
+def scan_secrets(path: str, text: str) -> list[common.Finding]:
+    findings: list[common.Finding] = []
+    for label, pat in SECRET_PATTERNS:
+        for m in pat.finditer(text):
+            line_no = text.count("\n", 0, m.start()) + 1
+            findings.append(common.Finding(
+                severity=common.Severity.BLOCKER,
+                title=f"Possible committed secret: {label}",
+                description=(
+                    f"A pattern matching `{label}` was found in this file. "
+                    "Even if it is a placeholder, committing real secrets must "
+                    "be assumed when patterns match these formats."
+                ),
+                recommendation=(
+                    "Remove the value, rotate the credential, and load it from "
+                    "a secret manager or `${{ secrets.* }}` in CI. Add the file "
+                    "or pattern to `.gitignore` if appropriate."
+                ),
+                file=path,
+                line=line_no,
+            ))
+    return findings
+
+
+def scan_dangerous(path: str, text: str) -> list[common.Finding]:
+    findings: list[common.Finding] = []
+    for title, pat, sev_str, why in DANGEROUS_PATTERNS:
+        for m in pat.finditer(text):
+            line_no = text.count("\n", 0, m.start()) + 1
+            findings.append(common.Finding(
+                severity=common.Severity(sev_str),
+                title=title,
+                description=why,
+                recommendation=(
+                    "Review this call site. If unavoidable, document the "
+                    "justification inline and ensure inputs are validated."
+                ),
+                file=path,
+                line=line_no,
+            ))
+    return findings
+
+
+def scan_workflow(path: str, text: str) -> list[common.Finding]:
+    findings: list[common.Finding] = []
+
+    # pull_request_target is a hard rule per project policy.
+    if re.search(r"^\s*pull_request_target\s*:", text, re.MULTILINE):
+        findings.append(common.Finding(
+            severity=common.Severity.BLOCKER,
+            title="Workflow uses `pull_request_target`",
+            description=(
+                "`pull_request_target` runs in the context of the base repo "
+                "with read/write secrets and the base ref's workflow file. "
+                "Combined with checkout of PR head, it is a well-known "
+                "exploit path. Project policy forbids it."
+            ),
+            recommendation=(
+                "Use `pull_request` (and `merge_group` for required-check "
+                "compatibility) instead. If you need post-merge actions, run "
+                "them on `push` to the protected branch."
+            ),
+            file=path,
+        ))
+
+    # Broad permissions check
+    perm_block = re.search(r"^permissions\s*:\s*\n((?:\s+\S.*\n)+)",
+                           text, re.MULTILINE)
+    broad_perms = ("contents: write", "packages: write", "id-token: write",
+                   "actions: write", "deployments: write", "pull-requests: write")
+    if "permissions: write-all" in text:
+        findings.append(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Workflow grants `permissions: write-all`",
+            description="This grants every scope, vastly expanding blast radius if a step is compromised.",
+            recommendation="Replace with a minimal, explicit `permissions:` block (read-only by default).",
+            file=path,
+        ))
+    elif perm_block:
+        block = perm_block.group(1)
+        for bp in broad_perms:
+            if bp in block:
+                # Allow if a comment justifying it is on the same line or the line above.
+                m = re.search(rf"^.*{re.escape(bp)}.*$", block, re.MULTILINE)
+                snippet = m.group(0) if m else ""
+                if "#" in snippet and "justif" in snippet.lower():
+                    continue
+                findings.append(common.Finding(
+                    severity=common.Severity.MAJOR,
+                    title=f"Broad workflow permission: `{bp}`",
+                    description=(
+                        f"`{bp}` expands the GITHUB_TOKEN's authority. With no "
+                        "inline justification comment, this should be tightened."
+                    ),
+                    recommendation=(
+                        f"Remove `{bp}` if not needed, or add a comment on the "
+                        "same line starting with `# justification:` explaining why."
+                    ),
+                    file=path,
+                ))
+
+    # No permissions block at all on a non-trivial workflow
+    if not perm_block and "permissions:" not in text:
+        findings.append(common.Finding(
+            severity=common.Severity.MINOR,
+            title="Workflow has no `permissions:` block",
+            description="Without an explicit block, GITHUB_TOKEN inherits the repo-default permissions.",
+            recommendation="Add an explicit `permissions:` block scoped to read-only by default.",
+            file=path,
+        ))
+
+    return findings
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="security",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    if not files:
+        result.applicable = False
+        result.summary = "No changes detected."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    scanned = 0
+    for f in files:
+        if is_skipped(f):
+            continue
+        text = common.read_file_safe(f)
+        if text is None:
+            continue
+        scanned += 1
+
+        if common.match_any(f, TEXT_CODE_PATTERNS) or "/.env" in f or f.endswith(".env"):
+            for finding in scan_secrets(f, text):
+                result.add(finding)
+            for finding in scan_dangerous(f, text):
+                result.add(finding)
+
+        if common.match_any(f, WORKFLOW_PATTERNS) or f.startswith(".github/workflows/"):
+            for finding in scan_workflow(f, text):
+                result.add(finding)
+
+    if any(common.match_any(f, [
+        "contracts/**", "smart-contracts/**", "**/*.sol",
+        "identity/**", "zk/**", "tokenomics/**", "treasury/**",
+        "governance/**", "infra/prod/**", "migrations/**",
+    ]) for f in files):
+        result.risk_level = "critical"
+
+    if not result.findings:
+        result.summary = f"Scanned {scanned} file(s); no security issues detected."
+    else:
+        result.summary = (
+            f"Scanned {scanned} file(s); found {len(result.findings)} issue(s)."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/testing_review.py
+++ b/.github/agents/testing_review.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Testing review agent.
+
+Rules:
+- BLOCKER for critical PRs without relevant tests.
+- MAJOR if only snapshots changed for logic changes.
+- MINOR if coverage appears reduced (heuristic: more code added than tests).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+CODE_PATTERNS = [
+    "**/*.py", "**/*.go", "**/*.rs", "**/*.ts", "**/*.tsx",
+    "**/*.js", "**/*.jsx", "**/*.sol", "**/*.java", "**/*.kt",
+    "**/*.swift", "**/*.cpp", "**/*.c", "**/*.h",
+]
+
+TEST_PATTERNS = [
+    "**/tests/**", "**/test/**",
+    "**/test_*.py", "**/*_test.go",
+    "**/*.test.ts", "**/*.test.tsx", "**/*.test.js",
+    "**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js",
+    "**/*.t.sol",
+]
+
+SNAPSHOT_PATTERNS = [
+    "**/__snapshots__/**", "**/*.snap",
+]
+
+
+def is_test_file(f: str) -> bool:
+    return common.match_any(f, TEST_PATTERNS)
+
+
+def is_snapshot(f: str) -> bool:
+    return common.match_any(f, SNAPSHOT_PATTERNS)
+
+
+def is_code_file(f: str) -> bool:
+    return common.match_any(f, CODE_PATTERNS) and not is_test_file(f) and not is_snapshot(f)
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    policy = common.load_policy()
+    result = common.AgentResult(
+        agent="testing",
+        status=common.Status.PASS,
+        risk_level="low",
+    )
+
+    if not files:
+        result.applicable = False
+        result.summary = "No changes detected."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    risk = common.aggregate_risk_level(common.applicable_rules(files, policy))
+    result.risk_level = risk
+
+    code_files = [f for f in files if is_code_file(f)]
+    test_files = [f for f in files if is_test_file(f)]
+    snap_files = [f for f in files if is_snapshot(f)]
+
+    if not code_files and not test_files and not snap_files:
+        result.applicable = False
+        result.summary = "No code or test files in this PR."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    needs_tests = common.requires_tests(files, policy) or risk in ("high", "critical")
+
+    if needs_tests and not test_files:
+        result.add(common.Finding(
+            severity=common.Severity.BLOCKER,
+            title=f"{risk.title()}-risk PR has no test changes",
+            description=(
+                f"This PR is classified `{risk}` but no test files were "
+                "added or updated."
+            ),
+            recommendation=(
+                "Add tests covering the changed behavior. For critical "
+                "subsystems (chain, contracts, tokenomics, governance, "
+                "identity), include invariant or property tests."
+            ),
+            file=code_files[0] if code_files else files[0],
+        ))
+
+    if snap_files and code_files and not test_files:
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Logic changes covered only by snapshot updates",
+            description=(
+                f"{len(code_files)} code file(s) changed alongside "
+                f"{len(snap_files)} snapshot file(s), but no actual test "
+                "code was added or updated. Snapshots auto-update without "
+                "asserting intent."
+            ),
+            recommendation=(
+                "Add explicit assertions describing what the new behavior "
+                "should be, not just what it currently is."
+            ),
+            file=code_files[0],
+        ))
+
+    # Coverage-reduction heuristic: count added lines in code vs. test files.
+    # Use git numstat — works without external coverage tooling.
+    if code_files and test_files:
+        try:
+            base = common._resolve_base_ref()
+            if base:
+                rc, out, _ = common._run([
+                    "git", "diff", "--numstat", f"{base}...HEAD",
+                ])
+                if rc == 0:
+                    code_added = 0
+                    test_added = 0
+                    for line in out.splitlines():
+                        parts = line.split("\t")
+                        if len(parts) != 3:
+                            continue
+                        added_str, _, p = parts
+                        if added_str == "-":
+                            continue
+                        try:
+                            added = int(added_str)
+                        except ValueError:
+                            continue
+                        if is_test_file(p):
+                            test_added += added
+                        elif is_code_file(p):
+                            code_added += added
+                    # Heuristic: if code grows by >100 lines and tests by <10% of that.
+                    if code_added > 100 and test_added < max(10, code_added // 10):
+                        result.add(common.Finding(
+                            severity=common.Severity.MINOR,
+                            title="Test growth lags behind code growth",
+                            description=(
+                                f"This PR adds ~{code_added} lines of code "
+                                f"and only ~{test_added} lines of tests. "
+                                "Coverage likely decreased."
+                            ),
+                            recommendation=(
+                                "Add more tests for the new code paths. "
+                                "Consider running coverage locally and "
+                                "comparing to base."
+                            ),
+                        ))
+        except Exception as e:  # noqa: BLE001
+            print(f"[testing] numstat heuristic skipped: {e}", file=sys.stderr)
+
+    if not result.findings:
+        result.summary = (
+            f"{len(code_files)} code + {len(test_files)} test file(s) "
+            "changed; testing posture looks healthy."
+        )
+    else:
+        result.summary = (
+            f"{len(code_files)} code + {len(test_files)} test file(s) "
+            f"changed; {len(result.findings)} concern(s) raised."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/tokenomics_review.py
+++ b/.github/agents/tokenomics_review.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Tokenomics review agent.
+
+Rules:
+- BLOCKER if supply/mint/burn/reserve/treasury/fee/vesting/reward logic
+  changed without invariant tests.
+- BLOCKER if a fixed supply can be bypassed (e.g. mint without supply cap).
+- MAJOR if rounding or decimal-precision logic changed without tests.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+TOKENOMICS_PATTERNS = [
+    "tokenomics/**", "treasury/**",
+    "contracts/**", "smart-contracts/**", "**/*.sol",
+    "**/token*.py", "**/token*.ts", "**/token*.go", "**/token*.rs",
+    "**/reward*.py", "**/reward*.ts", "**/reward*.go", "**/reward*.rs",
+    "**/vesting*.py", "**/vesting*.ts", "**/vesting*.go", "**/vesting*.rs",
+    "**/treasury*.py", "**/treasury*.ts", "**/treasury*.go", "**/treasury*.rs",
+]
+
+# Keywords that indicate value-affecting logic
+VALUE_KEYWORDS = [
+    r"\bmint\b", r"\bburn\b", r"\btotalSupply\b",
+    r"\bsupply\b", r"\bmaxSupply\b", r"\bMAX_SUPPLY\b",
+    r"\breserve\b", r"\btreasury\b",
+    r"\bfee\b", r"\btransferFee\b", r"\bfeeRate\b",
+    r"\bvest(ing)?\b", r"\bcliff\b",
+    r"\breward\b", r"\bemission\b", r"\binflation\b",
+    r"\bbond(ing)?[_ ]?curve\b",
+]
+
+ROUNDING_KEYWORDS = [
+    r"\bdecimals\b", r"\bDecimal\b",
+    r"\bWAD\b", r"\bRAY\b", r"\b1e1[0-9]\b", r"\b1e[2-9]\b",
+    r"\bround(?:ing|ed|Down|Up|HalfUp)?\b",
+    r"\bmulDiv\b", r"\bfullMul\b",
+]
+
+# Patterns that suggest mint without a supply cap check.
+UNCAPPED_MINT_RE = re.compile(
+    r"function\s+\w*[Mm]int\w*\s*\([^)]*\)[^{]*\{(?:(?!\}).){0,500}",
+    re.DOTALL,
+)
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="tokenomics",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    relevant = common.filter_files(files, TOKENOMICS_PATTERNS)
+    if not relevant:
+        result.applicable = False
+        result.summary = "No tokenomics-relevant files in this PR."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    value_pat = re.compile("|".join(VALUE_KEYWORDS), re.IGNORECASE)
+    rounding_pat = re.compile("|".join(ROUNDING_KEYWORDS))
+
+    value_hits: list[tuple[str, int]] = []
+    rounding_hits: list[tuple[str, int]] = []
+    uncapped_mint_files: list[str] = []
+
+    for f in relevant:
+        text = common.read_file_safe(f) or ""
+        for m in value_pat.finditer(text):
+            value_hits.append((f, text.count("\n", 0, m.start()) + 1))
+            break
+        for m in rounding_pat.finditer(text):
+            rounding_hits.append((f, text.count("\n", 0, m.start()) + 1))
+            break
+
+        # Solidity-only check: mint function bodies that never reference a cap.
+        if f.endswith(".sol"):
+            for body_match in UNCAPPED_MINT_RE.finditer(text):
+                body = body_match.group(0)
+                # If the function body doesn't mention any cap-like guard,
+                # flag it.
+                cap_referenced = any(re.search(p, body, re.IGNORECASE) for p in [
+                    r"\bMAX_SUPPLY\b", r"\bmaxSupply\b", r"\bcap\(\)",
+                    r"\btotalSupply\(\)\s*[<+\-]", r"\bsupplyCap\b",
+                    r"require\([^)]*supply",
+                ])
+                if not cap_referenced:
+                    uncapped_mint_files.append(f)
+                    break
+
+    if not value_hits:
+        result.summary = "Tokenomics-adjacent files changed but no value-affecting keywords detected."
+        result.risk_level = "medium"
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    result.risk_level = "critical"
+
+    has_tests = common.has_test_changes(files)
+    if not has_tests:
+        first_f, first_line = value_hits[0]
+        result.add(common.Finding(
+            severity=common.Severity.BLOCKER,
+            title="Token value-affecting logic changed without invariant tests",
+            description=(
+                "Detected modifications referencing supply, mint, burn, reserve, "
+                "treasury, fee, vesting, reward, emission, or bonding-curve "
+                "logic — but no tests are touched in this PR."
+            ),
+            recommendation=(
+                "Add invariant and property tests covering: total-supply "
+                "conservation, mint/burn accounting, fee accumulation, "
+                "vesting schedules, and reward distribution. For Solidity, "
+                "Foundry's `invariant_*` tests are recommended."
+            ),
+            file=first_f,
+            line=first_line,
+        ))
+
+    if uncapped_mint_files:
+        result.add(common.Finding(
+            severity=common.Severity.BLOCKER,
+            title="Mint function appears to bypass supply cap",
+            description=(
+                f"Detected mint function(s) in {len(uncapped_mint_files)} "
+                "Solidity file(s) whose bodies do not reference `MAX_SUPPLY`, "
+                "`maxSupply`, `cap()`, `supplyCap`, or any guard against "
+                "exceeding total supply."
+            ),
+            recommendation=(
+                "Add an explicit `require(totalSupply() + amount <= MAX_SUPPLY)` "
+                "guard, or document why this mint is unbounded (e.g. a vault "
+                "wrapper). Cover with invariant tests."
+            ),
+            file=uncapped_mint_files[0],
+        ))
+
+    if rounding_hits and not has_tests:
+        first_f, first_line = rounding_hits[0]
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Rounding/decimal-precision logic changed without tests",
+            description=(
+                "Code referencing decimals, WAD/RAY, rounding, or mulDiv was "
+                "modified but no tests were updated."
+            ),
+            recommendation=(
+                "Add unit tests that exercise edge cases: dust amounts, max "
+                "values, and known overflow boundaries. Verify rounding "
+                "direction is consistent with system invariants."
+            ),
+            file=first_f,
+            line=first_line,
+        ))
+
+    if not result.findings:
+        result.summary = (
+            f"Tokenomics-relevant changes in {len(relevant)} file(s); "
+            "tests are present and no obvious risks detected."
+        )
+    else:
+        result.summary = (
+            f"Tokenomics changes in {len(relevant)} file(s); "
+            f"{len(result.findings)} concern(s) raised."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/agents/ux_safety_review.py
+++ b/.github/agents/ux_safety_review.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+UX safety review agent.
+
+Rules:
+- MAJOR if wallet, seed-phrase, transfer, governance, or other irreversible
+  action UX changed without warning copy or tests.
+- MAJOR if a user can perform a destructive action without explicit
+  confirmation.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+UI_PATTERNS = [
+    "frontend/**", "web/**", "mobile/**",
+    "**/wallet/**", "**/components/**",
+]
+
+CRITICAL_UX_KEYWORDS = [
+    r"\bwallet\b", r"\bseed[_ ]?phrase\b", r"\bmnemonic\b",
+    r"\btransfer\b", r"\bsend\b", r"\bsign(?:[_ ]?Transaction)?\b",
+    r"\bvote\b", r"\bdelegate\b", r"\bproposal\b",
+    r"\bdelete\b", r"\bremove\b", r"\bdestroy\b",
+    r"\brevoke\b", r"\bapprove\b", r"\bunlock\b",
+    r"\bwithdraw\b", r"\bredeem\b",
+]
+
+CONFIRMATION_HINTS = [
+    r"\bconfirm\b", r"\bconfirmation\b",
+    r"\bareYouSure\b", r"\bare\s+you\s+sure\b",
+    r"\bdouble[_ ]?check\b",
+    r"\bdialog\b", r"\bmodal\b",
+    r"\bcheckbox\b",
+    r"\btype\s+(?:to|the)\s+confirm\b",
+]
+
+WARNING_HINTS = [
+    r"\bwarning\b", r"\bcaution\b", r"\bdanger\b",
+    r"\birreversible\b", r"\bcannot\s+be\s+undone\b",
+    r"\bpermanent\b",
+]
+
+UI_FILE_EXTS = (".tsx", ".jsx", ".ts", ".js", ".vue", ".svelte", ".swift", ".kt")
+
+
+def main() -> int:
+    files = common.get_changed_files()
+    result = common.AgentResult(
+        agent="ux_safety",
+        status=common.Status.PASS,
+        risk_level="medium",
+    )
+
+    relevant = common.filter_files(files, UI_PATTERNS)
+    relevant = [f for f in relevant if f.endswith(UI_FILE_EXTS) or f.endswith(".swift")]
+    if not relevant:
+        result.applicable = False
+        result.summary = "No UI/component files in this PR."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    crit_pat = re.compile("|".join(CRITICAL_UX_KEYWORDS), re.IGNORECASE)
+    conf_pat = re.compile("|".join(CONFIRMATION_HINTS), re.IGNORECASE)
+    warn_pat = re.compile("|".join(WARNING_HINTS), re.IGNORECASE)
+
+    risky_files: list[str] = []
+    files_without_confirm: list[str] = []
+    files_without_warning: list[str] = []
+
+    for f in relevant:
+        text = common.read_file_safe(f) or ""
+        if not text:
+            continue
+        if not crit_pat.search(text):
+            continue
+        risky_files.append(f)
+        if not conf_pat.search(text):
+            files_without_confirm.append(f)
+        if not warn_pat.search(text):
+            files_without_warning.append(f)
+
+    if not risky_files:
+        result.applicable = False
+        result.summary = "No critical UX surfaces touched."
+        common.emit_result(result, files)
+        return common.exit_for_status(result)
+
+    has_tests = common.has_test_changes(files)
+    if not has_tests:
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Critical UX surface changed without test changes",
+            description=(
+                f"{len(risky_files)} UI file(s) reference wallet, "
+                "seed-phrase, transfer/send, sign, vote, delegate, "
+                "withdraw, or delete actions. No UI tests were added or "
+                "updated."
+            ),
+            recommendation=(
+                "Add tests covering the irreversible-action flow: confirm "
+                "modal renders, button is disabled until typed confirmation "
+                "matches, and warning copy is visible."
+            ),
+            file=risky_files[0],
+        ))
+
+    if files_without_warning:
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="Irreversible action UI lacks visible warning copy",
+            description=(
+                f"{len(files_without_warning)} file(s) implement a critical "
+                "action but contain no warning / caution / irreversible / "
+                "permanent / cannot-be-undone copy."
+            ),
+            recommendation=(
+                "Add explicit warning text near the action button. For "
+                "wallet/seed-phrase flows, include 'never share' guidance."
+            ),
+            file=files_without_warning[0],
+        ))
+
+    if files_without_confirm:
+        result.add(common.Finding(
+            severity=common.Severity.MAJOR,
+            title="User can perform destructive action without confirmation",
+            description=(
+                f"{len(files_without_confirm)} file(s) implement a "
+                "destructive or irreversible action without any confirm / "
+                "modal / dialog / type-to-confirm pattern."
+            ),
+            recommendation=(
+                "Wrap destructive actions in a confirmation modal. For "
+                "high-stakes actions (large transfers, account deletion), "
+                "require typing a phrase to confirm."
+            ),
+            file=files_without_confirm[0],
+        ))
+
+    if not result.findings:
+        result.summary = (
+            f"{len(risky_files)} UX-critical file(s) reviewed; warning copy "
+            "and confirmations look intact."
+        )
+    else:
+        result.summary = (
+            f"{len(risky_files)} UX-critical file(s) reviewed; "
+            f"{len(result.findings)} concern(s) raised."
+        )
+
+    common.emit_result(result, files)
+    return common.exit_for_status(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -1,0 +1,315 @@
+# Review Policy
+#
+# Maps changed-path patterns to risk_level, required review agents,
+# recommended human reviewers, and whether tests are required.
+#
+# Risk levels: low, medium, high, critical
+# Agents: architecture, security, blockchain, tokenomics, compliance,
+#         privacy_zkdid, governance, economic_risk, devops, performance,
+#         data_sovereignty, api, ux_safety, testing, documentation
+#
+# `match` patterns use simple glob semantics (fnmatch). Pattern order
+# matters: the FIRST matching rule wins for path classification, but
+# all matching rules contribute their required_agents to the union.
+
+defaults:
+  risk_level: low
+  required_agents:
+    - architecture
+    - security
+    - testing
+    - documentation
+  recommended_reviewers:
+    - "@SOVEREIGN-NET/core-maintainers"
+  requires_tests: false
+  allows_override: true
+
+rules:
+  # ---------------- CRITICAL ----------------
+  - name: smart_contracts
+    match:
+      - "contracts/**"
+      - "smart-contracts/**"
+      - "**/*.sol"
+      - "**/*.cairo"
+      - "**/*.vy"
+    risk_level: critical
+    required_agents:
+      - architecture
+      - security
+      - blockchain
+      - tokenomics
+      - compliance
+      - economic_risk
+      - testing
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/protocol"
+      - "@SOVEREIGN-NET/security"
+      - "@SOVEREIGN-NET/tokenomics"
+    requires_tests: true
+    allows_override: false
+
+  - name: chain_core
+    match:
+      - "chain/**"
+      - "blockchain/**"
+      - "consensus/**"
+      - "node/**"
+    risk_level: critical
+    required_agents:
+      - architecture
+      - security
+      - blockchain
+      - performance
+      - testing
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/protocol"
+      - "@SOVEREIGN-NET/security"
+    requires_tests: true
+    allows_override: false
+
+  - name: tokenomics_treasury
+    match:
+      - "tokenomics/**"
+      - "treasury/**"
+    risk_level: critical
+    required_agents:
+      - architecture
+      - security
+      - tokenomics
+      - compliance
+      - economic_risk
+      - governance
+      - testing
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/tokenomics"
+      - "@SOVEREIGN-NET/compliance"
+    requires_tests: true
+    allows_override: false
+
+  - name: identity_zk
+    match:
+      - "identity/**"
+      - "zk/**"
+      - "**/zkdid/**"
+      - "**/*zkproof*"
+    risk_level: critical
+    required_agents:
+      - architecture
+      - security
+      - privacy_zkdid
+      - data_sovereignty
+      - testing
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/privacy"
+      - "@SOVEREIGN-NET/security"
+    requires_tests: true
+    allows_override: false
+
+  - name: governance
+    match:
+      - "governance/**"
+      - "dao/**"
+    risk_level: critical
+    required_agents:
+      - architecture
+      - security
+      - governance
+      - tokenomics
+      - compliance
+      - economic_risk
+      - testing
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/governance"
+      - "@SOVEREIGN-NET/compliance"
+    requires_tests: true
+    allows_override: false
+
+  - name: production_infra
+    match:
+      - "infra/prod/**"
+      - "infra/production/**"
+      - "infra/**/prod/**"
+      - "**/k8s/prod/**"
+      - "**/terraform/prod/**"
+    risk_level: critical
+    required_agents:
+      - architecture
+      - security
+      - devops
+      - data_sovereignty
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/devops"
+      - "@SOVEREIGN-NET/security"
+    requires_tests: false
+    allows_override: false
+
+  - name: migrations
+    match:
+      - "migrations/**"
+      - "**/migrations/**"
+      - "**/*.migration.sql"
+    risk_level: critical
+    required_agents:
+      - architecture
+      - security
+      - devops
+      - data_sovereignty
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/data"
+      - "@SOVEREIGN-NET/devops"
+    requires_tests: false
+    allows_override: false
+
+  # ---------------- HIGH ----------------
+  - name: api_surface
+    match:
+      - "api/**"
+      - "sdk/**"
+      - "**/openapi*.yaml"
+      - "**/openapi*.yml"
+      - "**/openapi*.json"
+      - "**/*.proto"
+    risk_level: high
+    required_agents:
+      - architecture
+      - security
+      - api
+      - performance
+      - testing
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/api"
+      - "@SOVEREIGN-NET/security"
+    requires_tests: true
+    allows_override: true
+
+  - name: ci_workflows
+    match:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+    risk_level: high
+    required_agents:
+      - security
+      - devops
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/devops"
+      - "@SOVEREIGN-NET/security"
+    requires_tests: false
+    allows_override: false
+
+  - name: mobile_wallet
+    match:
+      - "mobile/**"
+      - "**/wallet/**"
+    risk_level: high
+    required_agents:
+      - architecture
+      - security
+      - ux_safety
+      - privacy_zkdid
+      - testing
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/ux"
+      - "@SOVEREIGN-NET/security"
+    requires_tests: true
+    allows_override: true
+
+  # ---------------- MEDIUM ----------------
+  - name: frontend
+    match:
+      - "frontend/**"
+      - "web/**"
+    risk_level: medium
+    required_agents:
+      - architecture
+      - security
+      - ux_safety
+      - testing
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/ux"
+    requires_tests: true
+    allows_override: true
+
+  - name: infra_nonprod
+    match:
+      - "infra/**"
+    risk_level: medium
+    required_agents:
+      - security
+      - devops
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/devops"
+    requires_tests: false
+    allows_override: true
+
+  - name: agent_scripts
+    match:
+      - ".github/agents/**"
+    risk_level: medium
+    required_agents:
+      - security
+      - devops
+      - testing
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/devops"
+      - "@SOVEREIGN-NET/security"
+    requires_tests: false
+    allows_override: true
+
+  # ---------------- LOW ----------------
+  - name: documentation
+    match:
+      - "docs/**"
+      - "**/*.md"
+      - "README*"
+    risk_level: low
+    required_agents:
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/documentation"
+    requires_tests: false
+    allows_override: true
+
+  - name: compliance_docs
+    match:
+      - "docs/compliance/**"
+    risk_level: high
+    required_agents:
+      - compliance
+      - documentation
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/compliance"
+    requires_tests: false
+    allows_override: false
+
+  - name: tests_only
+    match:
+      - "**/tests/**"
+      - "**/test_*.py"
+      - "**/*_test.go"
+      - "**/*.test.ts"
+      - "**/*.test.tsx"
+      - "**/*.test.js"
+      - "**/*.spec.ts"
+      - "**/*.spec.tsx"
+      - "**/*.spec.js"
+    risk_level: low
+    required_agents:
+      - testing
+    recommended_reviewers:
+      - "@SOVEREIGN-NET/core-maintainers"
+    requires_tests: false
+    allows_override: true

--- a/.github/workflows/pr-quality-gates.yml
+++ b/.github/workflows/pr-quality-gates.yml
@@ -1,0 +1,294 @@
+name: PR Quality Gates
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-quality-gates-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+# A reusable composite of setup steps would be ideal, but to keep the workflow
+# self-contained and selectable as required checks (one check per job name),
+# each job below is independently runnable.
+
+jobs:
+  # ------------------------------------------------------------------ #
+  # Each job below MUST keep a stable `name:` so it can be selected as a
+  # required status check in the GitHub branch-protection rule. Do not
+  # rename without updating the rule in repository settings.
+  # ------------------------------------------------------------------ #
+
+  architecture:
+    name: architecture
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run architecture review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/architecture_review.py
+
+  security:
+    name: security
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run security review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/security_review.py
+
+  blockchain:
+    name: blockchain
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run blockchain review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/blockchain_review.py
+
+  tokenomics:
+    name: tokenomics
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run tokenomics review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/tokenomics_review.py
+
+  compliance:
+    name: compliance
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run compliance review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/compliance_review.py
+
+  privacy_zkdid:
+    name: privacy_zkdid
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run privacy/ZK-DID review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/privacy_zkdid_review.py
+
+  governance:
+    name: governance
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run governance review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/governance_review.py
+
+  economic_risk:
+    name: economic_risk
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run economic-risk review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/economic_risk_review.py
+
+  devops:
+    name: devops
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run devops review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/devops_review.py
+
+  performance:
+    name: performance
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run performance review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/performance_review.py
+
+  data_sovereignty:
+    name: data_sovereignty
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run data-sovereignty review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/data_sovereignty_review.py
+
+  api:
+    name: api
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run API review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/api_review.py
+
+  ux_safety:
+    name: ux_safety
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run UX-safety review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/ux_safety_review.py
+
+  testing:
+    name: testing
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run testing review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/testing_review.py
+
+  documentation:
+    name: documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run documentation review
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python .github/agents/documentation_review.py

--- a/.github/workflows/pr-quality-gates.yml
+++ b/.github/workflows/pr-quality-gates.yml
@@ -2,8 +2,16 @@ name: PR Quality Gates
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-  merge_group:
+    # `labeled` fires the workflow when an operator adds the
+    # `review-agents` label; `synchronize` re-runs subsequent pushes
+    # while the PR keeps the label. Other PR events (opened / closed /
+    # ready_for_review) are intentionally absent — the gate skips them.
+    types: [labeled, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review (optional — leaves blank to scan HEAD)"
+        required: false
 
 permissions:
   contents: read
@@ -15,6 +23,10 @@ concurrency:
 # A reusable composite of setup steps would be ideal, but to keep the workflow
 # self-contained and selectable as required checks (one check per job name),
 # each job below is independently runnable.
+#
+# OPT-IN GATE: every job below is guarded by an `if:` that requires either the
+# `review-agents` label on the PR or a manual workflow_dispatch trigger. Other
+# PR events skip every job.
 
 jobs:
   # ------------------------------------------------------------------ #
@@ -25,6 +37,7 @@ jobs:
 
   architecture:
     name: architecture
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -36,13 +49,14 @@ jobs:
           python-version: "3.11"
       - name: Run architecture review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/architecture_review.py
 
   security:
     name: security
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -54,13 +68,14 @@ jobs:
           python-version: "3.11"
       - name: Run security review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/security_review.py
 
   blockchain:
     name: blockchain
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -72,13 +87,14 @@ jobs:
           python-version: "3.11"
       - name: Run blockchain review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/blockchain_review.py
 
   tokenomics:
     name: tokenomics
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -90,13 +106,14 @@ jobs:
           python-version: "3.11"
       - name: Run tokenomics review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/tokenomics_review.py
 
   compliance:
     name: compliance
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -108,13 +125,14 @@ jobs:
           python-version: "3.11"
       - name: Run compliance review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/compliance_review.py
 
   privacy_zkdid:
     name: privacy_zkdid
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -126,13 +144,14 @@ jobs:
           python-version: "3.11"
       - name: Run privacy/ZK-DID review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/privacy_zkdid_review.py
 
   governance:
     name: governance
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -144,13 +163,14 @@ jobs:
           python-version: "3.11"
       - name: Run governance review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/governance_review.py
 
   economic_risk:
     name: economic_risk
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -162,13 +182,14 @@ jobs:
           python-version: "3.11"
       - name: Run economic-risk review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/economic_risk_review.py
 
   devops:
     name: devops
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -180,13 +201,14 @@ jobs:
           python-version: "3.11"
       - name: Run devops review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/devops_review.py
 
   performance:
     name: performance
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -198,13 +220,14 @@ jobs:
           python-version: "3.11"
       - name: Run performance review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/performance_review.py
 
   data_sovereignty:
     name: data_sovereignty
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -216,13 +239,14 @@ jobs:
           python-version: "3.11"
       - name: Run data-sovereignty review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/data_sovereignty_review.py
 
   api:
     name: api
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -234,13 +258,14 @@ jobs:
           python-version: "3.11"
       - name: Run API review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/api_review.py
 
   ux_safety:
     name: ux_safety
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -252,13 +277,14 @@ jobs:
           python-version: "3.11"
       - name: Run UX-safety review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/ux_safety_review.py
 
   testing:
     name: testing
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -270,13 +296,14 @@ jobs:
           python-version: "3.11"
       - name: Run testing review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/testing_review.py
 
   documentation:
     name: documentation
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -288,7 +315,7 @@ jobs:
           python-version: "3.11"
       - name: Run documentation review
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: python .github/agents/documentation_review.py

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,9 +1,12 @@
 name: PR Triage
 
 on:
+  # Opt-in gate: same as pr-quality-gates.yml. Triggers only when an
+  # operator adds the `review-agents` label or runs workflow_dispatch.
+  # Default PR turnaround stays fast.
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-  merge_group:
+    types: [labeled, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -17,6 +20,7 @@ concurrency:
 jobs:
   triage:
     name: triage
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'review-agents')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -38,10 +42,9 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "base_sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
             echo "base_ref=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            echo "base_sha=${{ github.event.merge_group.base_sha }}" >> "$GITHUB_OUTPUT"
-            echo "base_ref=${{ github.event.merge_group.base_ref }}" >> "$GITHUB_OUTPUT"
           else
+            # workflow_dispatch — no base; agents that need it should
+            # fall back to development.
             echo "base_sha=" >> "$GITHUB_OUTPUT"
             echo "base_ref=" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,116 @@
+name: PR Triage
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-triage-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    name: triage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compute base ref for changed-file detection
+        id: base
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "base_sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "base_ref=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            echo "base_sha=${{ github.event.merge_group.base_sha }}" >> "$GITHUB_OUTPUT"
+            echo "base_ref=${{ github.event.merge_group.base_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_sha=" >> "$GITHUB_OUTPUT"
+            echo "base_ref=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run PR triage
+        id: triage
+        env:
+          PR_BASE_SHA: ${{ steps.base.outputs.base_sha }}
+          PR_BASE_REF: ${{ steps.base.outputs.base_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          python .github/agents/pr_triage.py
+
+      - name: Upload triage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-triage-result
+          path: |
+            triage_result.md
+            triage_result.json
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Post or update sticky PR comment
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const marker = '<!-- pr-triage-sticky -->';
+            let body = '';
+            try {
+              body = fs.readFileSync('triage_result.md', 'utf8');
+            } catch (err) {
+              core.setFailed(`Could not read triage_result.md: ${err.message}`);
+              return;
+            }
+
+            const fullBody = `${marker}\n${body}`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+              core.info(`Updated existing triage comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: fullBody,
+              });
+              core.info('Created new triage comment');
+            }


### PR DESCRIPTION
## Summary

User-authored infrastructure for PR review automation, **gated as opt-in via the `review-agents` label** (revised after first commit).

## Opt-in trigger

The 17 review-agent jobs in `pr-quality-gates.yml` and the triage job in `pr-triage.yml` skip every PR unless the operator adds the `review-agents` label. Manual `workflow_dispatch` always runs regardless of the label.

- **Per PR:** add the `review-agents` label → workflow fires on the `labeled` event and re-runs on every push while the label remains.
- **Manual:** `gh workflow run pr-quality-gates.yml` (or the **Run workflow** button) — `if:` includes `github.event_name == 'workflow_dispatch'` so manual runs always execute.

## What's in

- `.github/agents/` — 17 domain-specific Python agents (security, privacy/ZK-DID, blockchain, governance, tokenomics, performance, testing, UX safety, compliance, data sovereignty, devops, documentation, architecture, economic risk, API, triage). `common.py` is the shared scaffold.
- `.github/workflows/pr-quality-gates.yml` — gated workflow with one job per agent, each independently selectable as a required check.
- `.github/workflows/pr-triage.yml` — gated triage / labeling.
- `.github/CODEOWNERS` — review ownership map.
- `.github/review-policy.yml` — policy declarations consumed by the agents.
- `.github/BRANCH_PROTECTION_SETUP.md` — operator runbook (now documents the label gate and how to flip back to "always-on" later).

## No code / runtime changes

Configuration + tooling only. With the gate in place, this PR is safe to merge without affecting the default PR landscape — the workflows stay dormant until someone adds the label.

## Diff

`+4 676` / `−37`, all under `.github/`.