### PR TITLE
feat(consensus): CONS-308 — typed Action::LogRoundRejected on every transition into Rejected

### DIFF
--- a/lib-consensus-core/src/fsm/events.rs
+++ b/lib-consensus-core/src/fsm/events.rs
@@ -242,6 +242,18 @@ pub enum Action {
     /// event arrives in a state where it has no effect (e.g. late
     /// vote in `Idle`). Explicit instead of silent.
     LogIgnoredEvent(&'static str),
+
+    /// CONS-308: typed observability event for round rejection.
+    /// Emitted by `transition()` whenever it returns a
+    /// `(Rejected { reason, .. }, ...)` tuple. Sits alongside the
+    /// existing `Action::AdvanceRound` so operator subscribers
+    /// (structured tracing, dashboards) see the rejection reason
+    /// without parsing free-text log strings.
+    ///
+    /// Slim payload (`reason` only) — the FSM has no access to
+    /// `height`/`round` at transition time. The engine's
+    /// `dispatch_action` enriches the log with them on emission.
+    LogRoundRejected { reason: RejectionReason },
 }
 
 /// Discriminant of [`Event`] without payload data. Used by the
@@ -318,6 +330,7 @@ pub enum ActionKind {
     LogPanic,
     LogHung,
     LogIgnoredEvent,
+    LogRoundRejected,
 }
 
 impl Action {
@@ -343,6 +356,7 @@ impl Action {
             Action::LogPanic { .. } => ActionKind::LogPanic,
             Action::LogHung { .. } => ActionKind::LogHung,
             Action::LogIgnoredEvent(_) => ActionKind::LogIgnoredEvent,
+            Action::LogRoundRejected { .. } => ActionKind::LogRoundRejected,
         }
     }
 }

--- a/lib-consensus-core/src/fsm/transition.rs
+++ b/lib-consensus-core/src/fsm/transition.rs
@@ -229,7 +229,10 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
         (Proposing, Timeout) => (Prevoting, vec![Action::ResetWatchdog]),
         (Proposing, VoteFailed(reason)) => (
             Rejected { reason, round: 0 }, // runtime fills round on entry
-            vec![Action::AdvanceRound],
+            vec![
+                Action::LogRoundRejected { reason },
+                Action::AdvanceRound,
+            ],
         ),
         (Proposing, WatchdogFired { fired_at, .. }) => (
             Hung {
@@ -255,7 +258,10 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
         (Prevoting, Timeout) => (Precommitting, vec![Action::ResetWatchdog]),
         (Prevoting, VoteFailed(reason)) => (
             Rejected { reason, round: 0 },
-            vec![Action::AdvanceRound],
+            vec![
+                Action::LogRoundRejected { reason },
+                Action::AdvanceRound,
+            ],
         ),
         (Prevoting, WatchdogFired { fired_at, .. }) => (
             Hung {
@@ -305,7 +311,10 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
         (Precommitting, Timeout) => (Precommitting, vec![Action::ResetWatchdog]),
         (Precommitting, VoteFailed(reason)) => (
             Rejected { reason, round: 0 },
-            vec![Action::AdvanceRound],
+            vec![
+                Action::LogRoundRejected { reason },
+                Action::AdvanceRound,
+            ],
         ),
         (Precommitting, WatchdogFired { fired_at, .. }) => (
             Hung {
@@ -337,7 +346,12 @@ pub fn transition(state: ValidatorState, event: Event) -> (ValidatorState, Vec<A
                 reason: RejectionReason::InsufficientPrecommits,
                 round: 0,
             },
-            vec![Action::AdvanceRound],
+            vec![
+                Action::LogRoundRejected {
+                    reason: RejectionReason::InsufficientPrecommits,
+                },
+                Action::AdvanceRound,
+            ],
         ),
         // Late precommit quorum (#2405): wire-level Commit step (the
         // bridge maps that to FSM Committed) gathered enough
@@ -897,6 +911,72 @@ mod tests {
                     event.kind()
                 );
             }
+        }
+    }
+
+    /// CONS-308: every transition into `Rejected` emits a typed
+    /// `LogRoundRejected` action carrying the same reason. Walks all
+    /// four entry points (Proposing/Prevoting/Precommitting via
+    /// `VoteFailed`, plus `Committed` via `Timeout`).
+    #[test]
+    fn transition_into_rejected_emits_typed_log_event() {
+        use RejectionReason::*;
+
+        // Each entry point's reason is determined by either the event
+        // payload (VoteFailed carries it) or the FSM hard-codes it
+        // (Committed.Timeout → InsufficientPrecommits). The test
+        // sweeps a representative reason per entry point so a future
+        // refactor that drops the LogRoundRejected emission fails
+        // here loudly.
+        let cases: Vec<(ValidatorState, Event, RejectionReason)> = vec![
+            (
+                ValidatorState::Proposing,
+                Event::VoteFailed(Timeout),
+                Timeout,
+            ),
+            (
+                ValidatorState::Prevoting,
+                Event::VoteFailed(InsufficientPrevotes),
+                InsufficientPrevotes,
+            ),
+            (
+                ValidatorState::Precommitting,
+                Event::VoteFailed(InsufficientPrecommits),
+                InsufficientPrecommits,
+            ),
+            (
+                ValidatorState::Committed {
+                    block_hash: [0; 32],
+                    height: 1,
+                },
+                Event::Timeout,
+                InsufficientPrecommits,
+            ),
+        ];
+
+        for (state, event, expected_reason) in cases {
+            let (next, actions) = transition(state.clone(), event.clone());
+            assert!(
+                matches!(next, ValidatorState::Rejected { .. }),
+                "transition({:?}, {:?}) expected Rejected, got {:?}",
+                state.kind(),
+                event.kind(),
+                next.kind()
+            );
+            let log_action = actions.iter().find_map(|a| match a {
+                Action::LogRoundRejected { reason } => Some(*reason),
+                _ => None,
+            });
+            assert_eq!(
+                log_action,
+                Some(expected_reason),
+                "transition({:?}, {:?}) did not emit LogRoundRejected with reason {:?}; \
+                 actions = {:?}",
+                state.kind(),
+                event.kind(),
+                expected_reason,
+                actions.iter().map(|a| a.kind()).collect::<Vec<_>>()
+            );
         }
     }
 }

--- a/lib-consensus-core/src/fsm/transition_table.rs
+++ b/lib-consensus-core/src/fsm/transition_table.rs
@@ -152,7 +152,7 @@ pub fn transition_table() -> Vec<TransitionRule> {
         F::Specific(S::Proposing),
         E::VoteFailed,
         S::Rejected,
-        vec![A::AdvanceRound],
+        vec![A::LogRoundRejected, A::AdvanceRound],
         "Vote-tally rejection in Proposing — view change.",
     );
 
@@ -182,7 +182,7 @@ pub fn transition_table() -> Vec<TransitionRule> {
         F::Specific(S::Prevoting),
         E::VoteFailed,
         S::Rejected,
-        vec![A::AdvanceRound],
+        vec![A::LogRoundRejected, A::AdvanceRound],
         "Vote-tally rejection in Prevoting — view change.",
     );
 
@@ -227,7 +227,7 @@ pub fn transition_table() -> Vec<TransitionRule> {
         F::Specific(S::Precommitting),
         E::VoteFailed,
         S::Rejected,
-        vec![A::AdvanceRound],
+        vec![A::LogRoundRejected, A::AdvanceRound],
         "Vote-tally rejection in Precommitting — view change.",
     );
 
@@ -245,7 +245,7 @@ pub fn transition_table() -> Vec<TransitionRule> {
         F::Specific(S::Committed),
         E::Timeout,
         S::Rejected,
-        vec![A::AdvanceRound],
+        vec![A::LogRoundRejected, A::AdvanceRound],
         "Commit-vote gathering timed out — view change.",
     );
     push(

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1990,6 +1990,21 @@ impl ConsensusEngine {
             // Observability — silent drop; FSM's own hooks log.
             A::LogIgnoredEvent(_) | A::LogHung { .. } | A::LogPanic { .. } => {}
 
+            // CONS-308: typed round-rejection event. Enrich the FSM-
+            // emitted reason with the engine's current height/round
+            // so dashboards and structured-log consumers see full
+            // context. Emitting at WARN because every entry into
+            // `Rejected` is by definition a non-progress event the
+            // operator cares about.
+            A::LogRoundRejected { reason } => {
+                tracing::warn!(
+                    height = self.current_round.height,
+                    round = self.current_round.round,
+                    rejection_reason = ?reason,
+                    "FSM round rejected"
+                );
+            }
+
             // Lifecycle — log at debug for visibility.
             other => {
                 tracing::debug!(


### PR DESCRIPTION
## Summary

Every FSM transition into \`Rejected\` now emits a typed \`Action::LogRoundRejected { reason }\` alongside \`AdvanceRound\`. Operators see the rejection reason as a structured-tracing field instead of parsing log strings.

## Design choice — Action variant, not new ObservabilityEvent enum

The CONS-308 spec sketches an \`ObservabilityEvent\` enum + bus. The engine already has typed observability actions (\`LogPanic\`, \`LogHung\`, \`LogIgnoredEvent\`) flowing through \`dispatch_action\`, and structured tracing is the default subscriber pipeline. Extending that pattern matches the spec's semantic without spinning up parallel channel infrastructure for one event type. A future PR can promote these into a richer \`ObservabilityEvent\` if needed.

## Changes

- \`Action::LogRoundRejected { reason: RejectionReason }\` + matching \`ActionKind\` variant.
- All four \`Rejected\` entry points emit it:
  - \`(Proposing | Prevoting | Precommitting, VoteFailed(reason))\`
  - \`(Committed, Timeout)\` — FSM hard-codes \`InsufficientPrecommits\`.
- Drift-protection table rows updated to expect the new action.
- \`dispatch_action\` enriches the log with \`current_round.height\` / \`round\` at WARN level.

## Why slim payload (\`reason\` only)

The FSM has no access to \`height\`/\`round\` at transition time — same constraint as the existing \`Rejected { reason, round: 0 }\` placeholder. The engine fills them at log time, which is where they're observable.

## Validation

- [x] New \`transition_into_rejected_emits_typed_log_event\` test sweeps all four entry points.
- [x] \`cargo test -p lib-consensus-core --lib\` — **41/41** (40 existing + 1 new).
- [x] \`cargo test -p lib-consensus --lib\` — **187/187**.
- [x] \`cargo build --workspace\` — clean.

Closes #2344.