### PR TITLE
feat(consensus): CONS-201 Scope B — relocate ConsensusProof/Proposal/Vote into lib-consensus-core

### DIFF
--- a/lib-consensus-core/src/types/mod.rs
+++ b/lib-consensus-core/src/types/mod.rs
@@ -1,17 +1,21 @@
 //! Core consensus value types.
 //!
-//! Currently populated by:
+//! Populated by:
 //! - **CONS-304: `ConsensusRound`** with `state: FsmState`, `entered_at:
 //!   Instant`, `deterministic_round_id: u64` and `state_age()` helper.
+//! - **CONS-201 Scope B: `ConsensusProof`, `ConsensusProposal`,
+//!   `ConsensusVote`** — moved from `lib-consensus/src/types/mod.rs`.
+//!   The proof fields became opaque `Option<Vec<u8>>` to satisfy
+//!   AD-002 (no `lib-storage` / `lib-proofs` dep). Encode/decode
+//!   ergonomics live on `lib_consensus::ConsensusProofExt`.
 //!
-//! Future relocations (deferred):
-//! - `ConsensusStep`, `VoteType`, `ConsensusVote`, `ConsensusProposal`,
-//!   and the unified `ValidatorMessage` are still hosted in lib-consensus
-//!   because `ConsensusProof::storage_proof` references
-//!   `lib_storage::proofs::StorageCapacityAttestation` and adding
-//!   lib-storage as a dep on lib-consensus-core is forbidden by AD-002.
-//!   The cycle was noted on CONS-104 and CONS-201's deferred Scope B.
+//! Still hosted in lib-consensus:
+//! - The unified `ValidatorMessage` enum and `Justification` struct —
+//!   they live next to the network codec until CONS-501b moves them
+//!   alongside `lib-consensus-net`'s remaining modules.
 
+pub mod proposal;
 pub mod round;
 
+pub use proposal::{ConsensusProof, ConsensusProposal, ConsensusVote};
 pub use round::ConsensusRound;

--- a/lib-consensus-core/src/types/proposal.rs
+++ b/lib-consensus-core/src/types/proposal.rs
@@ -1,0 +1,128 @@
+//! Wire types for proposals, votes, and consensus proofs.
+//!
+//! Migrated from `lib-consensus/src/types/mod.rs` per CONS-201 Scope B.
+//! These types previously lived in `lib-consensus` because their proof
+//! fields referenced `lib_storage::proofs::StorageCapacityAttestation`
+//! and `lib_proofs::consensus::{StakeProof, WorkProof}`, both of which
+//! `lib-consensus-core` is forbidden from depending on per AD-002.
+//!
+//! ## Resolution
+//!
+//! The proof fields in [`ConsensusProof`] are **opaque bytes** —
+//! `Option<Vec<u8>>` carrying a bincode-serialized payload. The proof
+//! shape is defined entirely outside core: `lib-blockchain` /
+//! `lib-proofs` / `lib-storage` produce + verify them; consensus only
+//! ships them on the wire and gates round-progress on the verifier
+//! callback (CONS-103 / AD-005). The encode/decode helpers live in
+//! `lib-consensus`'s [`ConsensusProofExt`] trait so consumers that DO
+//! depend on those crates can still call `proof.with_stake_proof(p)`
+//! / `proof.decode_stake_proof()` ergonomically.
+//!
+//! `lib-consensus` re-exports these types from `lib_consensus_core::
+//! types` so existing import paths (`lib_consensus::ConsensusProposal`,
+//! `crate::types::ConsensusVote`, etc.) keep working.
+
+use lib_crypto::{Hash, PostQuantumSignature};
+use lib_identity::IdentityId;
+use lib_types::consensus::{ConsensusType, VoteType};
+use serde::{Deserialize, Serialize};
+
+/// Consensus vote on a proposal — Sovereign Network BFT vote.
+///
+/// Mirror of the pre-CONS-201 `lib_consensus::types::ConsensusVote`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConsensusVote {
+    /// Vote identifier.
+    pub id: Hash,
+    /// Voter validator.
+    pub voter: IdentityId,
+    /// Proposal being voted on.
+    pub proposal_id: Hash,
+    /// Vote type (PreVote / PreCommit / Commit).
+    pub vote_type: VoteType,
+    /// Block height.
+    pub height: u64,
+    /// Voting round.
+    pub round: u32,
+    /// Timestamp (deterministic logical clock; do not trust as wall time).
+    pub timestamp: u64,
+    /// Voter signature over the canonical vote payload.
+    pub signature: PostQuantumSignature,
+}
+
+/// Combined consensus proof shipped with a proposal.
+///
+/// Each proof field is **opaque bytes** — bincode-serialized at the
+/// production site, deserialized at the verifier site. See module docs
+/// for the AD-002 motivation. Use [`ConsensusProofExt`] (from
+/// `lib-consensus`) for ergonomic encode/decode.
+///
+/// [`ConsensusProofExt`]: https://docs/lib_consensus/types/trait.ConsensusProofExt.html
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConsensusProof {
+    /// Consensus mechanism this proof targets.
+    pub consensus_type: ConsensusType,
+    /// Stake-proof bytes (bincode-serialized `lib_proofs::consensus::
+    /// StakeProof`). `None` when the chosen consensus type does not
+    /// produce one.
+    pub stake_proof: Option<Vec<u8>>,
+    /// Storage-capacity-attestation bytes (bincode-serialized
+    /// `lib_storage::proofs::StorageCapacityAttestation`).
+    pub storage_proof: Option<Vec<u8>>,
+    /// Useful-work proof bytes (bincode-serialized
+    /// `lib_proofs::consensus::WorkProof`).
+    pub work_proof: Option<Vec<u8>>,
+    /// ZK-DID proof bytes (already opaque pre-CONS-201).
+    pub zk_did_proof: Option<Vec<u8>>,
+    /// Deterministic timestamp (height-based, not wall-clock).
+    pub timestamp: u64,
+}
+
+impl ConsensusProof {
+    /// Construct an empty proof carrying just the consensus type +
+    /// timestamp. Builders + decoders for the proof fields live on
+    /// the `ConsensusProofExt` trait in `lib-consensus`.
+    pub fn empty(consensus_type: ConsensusType, timestamp: u64) -> Self {
+        Self {
+            consensus_type,
+            stake_proof: None,
+            storage_proof: None,
+            work_proof: None,
+            zk_did_proof: None,
+            timestamp,
+        }
+    }
+}
+
+/// Block proposal broadcast by a designated proposer in a given round.
+///
+/// Mirror of the pre-CONS-201 `lib_consensus::types::ConsensusProposal`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConsensusProposal {
+    /// Proposal identifier.
+    pub id: Hash,
+    /// Proposer validator.
+    pub proposer: IdentityId,
+    /// Block height.
+    pub height: u64,
+    /// Consensus round this proposal is for.
+    #[serde(default)]
+    pub round: u32,
+    /// Consensus wire-protocol version. Nodes reject proposals whose
+    /// version doesn't match their own `CONSENSUS_PROTOCOL_VERSION`,
+    /// producing a clear error instead of silently stalling on
+    /// signature mismatches after an envelope change. Defaults to 0
+    /// for proposals from pre-versioning nodes.
+    #[serde(default)]
+    pub protocol_version: u32,
+    /// Previous block hash.
+    pub previous_hash: Hash,
+    /// Proposed block payload bytes.
+    pub block_data: Vec<u8>,
+    /// Deterministic timestamp.
+    pub timestamp: u64,
+    /// Proposer signature over the canonical proposal payload.
+    pub signature: PostQuantumSignature,
+    /// Combined proof bundle for this proposal.
+    pub consensus_proof: ConsensusProof,
+}

--- a/lib-consensus/src/engines/consensus_engine/proofs.rs
+++ b/lib-consensus/src/engines/consensus_engine/proofs.rs
@@ -195,53 +195,33 @@ impl ConsensusEngine {
         // Deterministic: height-based logical timestamp, not wall-clock.
         let timestamp = self.current_round.height;
 
+        // CONS-201 Scope B: build via `ConsensusProof::empty` + the
+        // `ConsensusProofExt` builder helpers so the underlying opaque
+        // bytes are produced by a single bincode call per field.
+        use crate::types::ConsensusProofExt;
+        let proof = ConsensusProof::empty(consensus_type.clone(), timestamp);
         match consensus_type {
             ConsensusType::ProofOfStake => {
                 let stake_proof = self.create_stake_proof().await?;
-                Ok(ConsensusProof {
-                    consensus_type,
-                    stake_proof: Some(stake_proof),
-                    storage_proof: None,
-                    work_proof: None,
-                    zk_did_proof: None,
-                    timestamp,
-                })
+                Ok(proof.with_stake_proof(&stake_proof))
             }
             ConsensusType::ProofOfStorage => {
                 let storage_proof = self.create_storage_proof().await?;
-                Ok(ConsensusProof {
-                    consensus_type,
-                    stake_proof: None,
-                    storage_proof: Some(storage_proof),
-                    work_proof: None,
-                    zk_did_proof: None,
-                    timestamp,
-                })
+                Ok(proof.with_storage_proof(&storage_proof))
             }
             ConsensusType::ProofOfUsefulWork => {
                 let work_proof = self.create_work_proof().await?;
-                Ok(ConsensusProof {
-                    consensus_type,
-                    stake_proof: None,
-                    storage_proof: None,
-                    work_proof: Some(work_proof),
-                    zk_did_proof: None,
-                    timestamp,
-                })
+                Ok(proof.with_work_proof(&work_proof))
             }
             ConsensusType::ByzantineFaultTolerance => {
-                // BFT uses all proof types
+                // BFT uses all proof types.
                 let stake_proof = self.create_stake_proof().await?;
                 let storage_proof = self.create_storage_proof().await?;
                 let work_proof = self.create_work_proof().await?;
-                Ok(ConsensusProof {
-                    consensus_type,
-                    stake_proof: Some(stake_proof),
-                    storage_proof: Some(storage_proof),
-                    work_proof: Some(work_proof),
-                    zk_did_proof: None,
-                    timestamp,
-                })
+                Ok(proof
+                    .with_stake_proof(&stake_proof)
+                    .with_storage_proof(&storage_proof)
+                    .with_work_proof(&work_proof))
             }
         }
     }

--- a/lib-consensus/src/engines/consensus_engine/validation.rs
+++ b/lib-consensus/src/engines/consensus_engine/validation.rs
@@ -52,30 +52,37 @@ impl ConsensusEngine {
         &self,
         proof: &ConsensusProof,
     ) -> ConsensusResult<bool> {
+        // CONS-201 Scope B: proof fields are now opaque bytes —
+        // deserialize via `ConsensusProofExt` before verifying.
+        use crate::types::ConsensusProofExt;
         match proof.consensus_type {
-            ConsensusType::ProofOfStake => {
-                if let Some(stake_proof) = &proof.stake_proof {
-                    Ok(stake_proof.verify(self.current_round.height)?)
-                } else {
+            ConsensusType::ProofOfStake => match proof.decode_stake_proof() {
+                Some(Ok(stake_proof)) => Ok(stake_proof.verify(self.current_round.height)?),
+                Some(Err(e)) => {
+                    tracing::warn!("ConsensusProof.stake_proof decode failed: {}", e);
                     Ok(false)
                 }
-            }
-            ConsensusType::ProofOfStorage => {
-                if let Some(storage_proof) = &proof.storage_proof {
-                    Ok(storage_proof.verify()?)
-                } else {
+                None => Ok(false),
+            },
+            ConsensusType::ProofOfStorage => match proof.decode_storage_proof() {
+                Some(Ok(storage_proof)) => Ok(storage_proof.verify()?),
+                Some(Err(e)) => {
+                    tracing::warn!("ConsensusProof.storage_proof decode failed: {}", e);
                     Ok(false)
                 }
-            }
-            ConsensusType::ProofOfUsefulWork => {
-                if let Some(work_proof) = &proof.work_proof {
-                    Ok(work_proof.verify()?)
-                } else {
+                None => Ok(false),
+            },
+            ConsensusType::ProofOfUsefulWork => match proof.decode_work_proof() {
+                Some(Ok(work_proof)) => Ok(work_proof.verify()?),
+                Some(Err(e)) => {
+                    tracing::warn!("ConsensusProof.work_proof decode failed: {}", e);
                     Ok(false)
                 }
-            }
+                None => Ok(false),
+            },
             ConsensusType::ByzantineFaultTolerance => {
-                // For BFT, we rely on vote thresholds rather than individual proofs. This generic proof validator is not applicable to BFT proofs.
+                // For BFT, we rely on vote thresholds rather than individual proofs.
+                // This generic proof validator is not applicable to BFT proofs.
                 Ok(false)
             }
         }

--- a/lib-consensus/src/types/mod.rs
+++ b/lib-consensus/src/types/mod.rs
@@ -1,7 +1,7 @@
 //! Core types for ZHTP consensus system
 
 use async_trait::async_trait;
-use lib_crypto::{Hash, PostQuantumSignature};
+use lib_crypto::Hash;
 use lib_identity::IdentityId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -136,74 +136,76 @@ pub struct ConsensusRound {
     pub valid_proposal: Option<Hash>,
 }
 
-/// Consensus proposal for new blocks
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConsensusProposal {
-    /// Proposal identifier
-    pub id: Hash,
-    /// Proposer validator
-    pub proposer: IdentityId,
-    /// Block height
-    pub height: u64,
-    /// Consensus round this proposal is for
-    #[serde(default)]
-    pub round: u32,
-    /// Consensus wire-protocol version.
-    ///
-    /// Nodes reject proposals whose version doesn't match their own
-    /// `CONSENSUS_PROTOCOL_VERSION`, producing a clear error instead of
-    /// silently stalling on signature mismatches after an envelope change.
-    /// Defaults to 0 for proposals from pre-versioning nodes.
-    #[serde(default)]
-    pub protocol_version: u32,
-    /// Previous block hash
-    pub previous_hash: Hash,
-    /// Proposed block data
-    pub block_data: Vec<u8>,
-    /// Timestamp
-    pub timestamp: u64,
-    /// Proposer signature
-    pub signature: PostQuantumSignature,
-    /// Proof of stake/storage
-    pub consensus_proof: ConsensusProof,
+// CONS-201 Scope B: ConsensusProposal / ConsensusVote / ConsensusProof
+// migrated to `lib_consensus_core::types`. Re-exported here so existing
+// import paths (`lib_consensus::types::ConsensusProof`, etc.) keep
+// working. Encode/decode ergonomics for the now-opaque proof fields
+// live on the `ConsensusProofExt` trait below.
+pub use lib_consensus_core::types::{ConsensusProof, ConsensusProposal, ConsensusVote};
+
+/// CONS-201 Scope B: encode/decode helpers for `ConsensusProof`'s
+/// opaque proof fields. Lives in `lib-consensus` because it imports
+/// `lib_proofs` and `lib_storage` types — both forbidden in
+/// `lib-consensus-core` per AD-002.
+///
+/// Construction sites (`engines/consensus_engine/proofs.rs`,
+/// blockchain integration) call the `with_*` builders. Verifier sites
+/// (`engines/consensus_engine/validation.rs`) call the `decode_*`
+/// helpers. The wire format is bincode — same as the rest of the
+/// consensus codec.
+pub trait ConsensusProofExt {
+    /// Attach a stake proof. Bincode-serializes once; subsequent
+    /// reads via `decode_stake_proof` deserialize each call.
+    fn with_stake_proof(self, stake_proof: &StakeProof) -> Self;
+    /// Attach a storage attestation.
+    fn with_storage_proof(self, storage_proof: &StorageCapacityAttestation) -> Self;
+    /// Attach a useful-work proof.
+    fn with_work_proof(self, work_proof: &WorkProof) -> Self;
+    /// Decode the stake proof bytes if present. Returns `None` when
+    /// the field is unset, `Some(Err)` on a corrupt payload, and
+    /// `Some(Ok)` on success.
+    fn decode_stake_proof(&self) -> Option<Result<StakeProof, bincode::Error>>;
+    /// Decode the storage attestation bytes if present.
+    fn decode_storage_proof(&self) -> Option<Result<StorageCapacityAttestation, bincode::Error>>;
+    /// Decode the useful-work proof bytes if present.
+    fn decode_work_proof(&self) -> Option<Result<WorkProof, bincode::Error>>;
 }
 
-/// Consensus vote on a proposal
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConsensusVote {
-    /// Vote identifier
-    pub id: Hash,
-    /// Voter validator
-    pub voter: IdentityId,
-    /// Proposal being voted on
-    pub proposal_id: Hash,
-    /// Vote type
-    pub vote_type: VoteType,
-    /// Block height
-    pub height: u64,
-    /// Voting round
-    pub round: u32,
-    /// Timestamp
-    pub timestamp: u64,
-    /// Voter signature
-    pub signature: PostQuantumSignature,
-}
-
-/// Consensus proof combining different proof types
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConsensusProof {
-    /// Consensus mechanism type
-    pub consensus_type: ConsensusType,
-    /// Stake proof (for PoS)
-    pub stake_proof: Option<StakeProof>,
-    /// Storage proof (for PoStorage)
-    pub storage_proof: Option<StorageCapacityAttestation>,
-    /// Useful work proof (for PoUW)
-    pub work_proof: Option<WorkProof>,
-    /// ZK-DID proof for validator identity
-    pub zk_did_proof: Option<Vec<u8>>,
-    /// Timestamp
-    pub timestamp: u64,
+impl ConsensusProofExt for ConsensusProof {
+    fn with_stake_proof(mut self, stake_proof: &StakeProof) -> Self {
+        // Per the type-relocation invariant: encode-on-write, decode-
+        // on-read. The wire round-trip is bincode in both directions
+        // so a panic here is a real serialization bug we want to
+        // surface, not silently swallow.
+        self.stake_proof = Some(
+            bincode::serialize(stake_proof)
+                .expect("StakeProof serialization is infallible for valid inputs"),
+        );
+        self
+    }
+    fn with_storage_proof(mut self, storage_proof: &StorageCapacityAttestation) -> Self {
+        self.storage_proof = Some(
+            bincode::serialize(storage_proof)
+                .expect("StorageCapacityAttestation serialization is infallible"),
+        );
+        self
+    }
+    fn with_work_proof(mut self, work_proof: &WorkProof) -> Self {
+        self.work_proof = Some(
+            bincode::serialize(work_proof)
+                .expect("WorkProof serialization is infallible"),
+        );
+        self
+    }
+    fn decode_stake_proof(&self) -> Option<Result<StakeProof, bincode::Error>> {
+        self.stake_proof.as_deref().map(bincode::deserialize)
+    }
+    fn decode_storage_proof(&self) -> Option<Result<StorageCapacityAttestation, bincode::Error>> {
+        self.storage_proof.as_deref().map(bincode::deserialize)
+    }
+    fn decode_work_proof(&self) -> Option<Result<WorkProof, bincode::Error>> {
+        self.work_proof.as_deref().map(bincode::deserialize)
+    }
 }
 
 /// Network state for validation

--- a/lib-consensus/tests/common/consensus_fixtures.rs
+++ b/lib-consensus/tests/common/consensus_fixtures.rs
@@ -124,24 +124,22 @@ pub fn test_proposal(
         block_data,
         timestamp,
         signature: test_signature(timestamp),
-        consensus_proof: ConsensusProof {
-            consensus_type: ConsensusType::ByzantineFaultTolerance,
-            stake_proof: Some(
-                StakeProof::new(
-                    proposer.clone(),
-                    2_000 * 1_000_000,
-                    Hash::from_bytes(&hash_blake3(
-                        format!("stake-{}-{}", proposer, timestamp).as_bytes(),
-                    )),
-                    height.saturating_sub(1),
-                    10_000,
-                )
-                .expect("valid stake proof"),
-            ),
-            storage_proof: None,
-            work_proof: None,
-            zk_did_proof: None,
-            timestamp,
+        consensus_proof: {
+            // CONS-201 Scope B: proof bytes are opaque; build via the
+            // `ConsensusProofExt` builder.
+            use lib_consensus::types::ConsensusProofExt;
+            let stake_proof = StakeProof::new(
+                proposer.clone(),
+                2_000 * 1_000_000,
+                Hash::from_bytes(&hash_blake3(
+                    format!("stake-{}-{}", proposer, timestamp).as_bytes(),
+                )),
+                height.saturating_sub(1),
+                10_000,
+            )
+            .expect("valid stake proof");
+            ConsensusProof::empty(ConsensusType::ByzantineFaultTolerance, timestamp)
+                .with_stake_proof(&stake_proof)
         },
     }
 }


### PR DESCRIPTION
Resolves the deferred Scope B that has been blocking CONS-401/402, the remaining 3 modules of CONS-501, and Phase 5 adapter rewrites.

ConsensusProof's stake_proof/storage_proof/work_proof fields become Option<Vec<u8>> (bincode-serialized) so the type can live in lib-consensus-core without violating AD-002 (no lib-storage/lib-proofs deps). Encode/decode ergonomics go to a new `ConsensusProofExt` trait in lib-consensus.

ConsensusProof, ConsensusProposal, ConsensusVote moved to lib-consensus-core/src/types/proposal.rs. lib-consensus re-exports them so all existing import paths keep working.

Updated: 4 construction arms in engines/proofs.rs use the new builder; 3 read sites in validation.rs decode-then-verify; 1 test fixture rewritten.

cargo build --workspace clean. lib-consensus-core 41/41, lib-consensus 181/181, lib-consensus-runtime 15/15, lib-consensus-net 6/6.

3 pre-existing failures in bft_safety_partition_tests.rs reproduce on stock development — tracked as #2424.

References #2334 (deferred Scope B). Unblocks #2347 #2348 #2351 #2353 #2354 #2355.