### PR TITLE
feat(consensus): CONS-503 — parallel fan-out for ConsensusMeshBroadcaster

### DIFF
--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -123,30 +123,73 @@ impl ConsensusMessageBroadcaster for ConsensusMeshBroadcaster {
             quic_protocol.try_reconnect_to_bootstrap().await;
         }
 
+        // CONS-503: parallel fan-out with per-peer + global timeouts.
+        // Pre-CONS-503 the loop was sequential — one stalled peer
+        // serialized N peers behind it, blowing past the broadcast
+        // budget for the whole round. Each send now runs concurrently
+        // under a `per_peer_budget` cap (`total_budget / N`), with a
+        // global `total_budget` deadline as a backstop.
+        use futures::stream::{FuturesUnordered, StreamExt};
+        use lib_consensus_core::budget::MAX_BROADCAST_BUDGET_MS;
+
+        let recipient_count = recipients.len() as u32;
+        let total_budget = Duration::from_millis(MAX_BROADCAST_BUDGET_MS);
+        // saturating_div(0) returns 0 for `Duration`, but `recipients.is_empty()`
+        // already short-circuited above, so divisor >= 1.
+        let per_peer_budget = total_budget
+            .checked_div(recipient_count)
+            .unwrap_or(total_budget);
+
+        let mut tasks: FuturesUnordered<_> = recipients
+            .into_iter()
+            .map(|peer_id| {
+                let qp = quic_protocol.clone();
+                let msg = message.clone();
+                async move {
+                    tokio::time::timeout(
+                        per_peer_budget,
+                        qp.send_to_peer(
+                            &peer_id,
+                            lib_network::types::mesh_message::ZhtpMeshMessage::ValidatorMessage(
+                                msg,
+                            ),
+                        ),
+                    )
+                    .await
+                }
+            })
+            .collect();
+
+        let global_deadline = tokio::time::Instant::now() + total_budget;
         let mut delivered = 0usize;
-        for peer_id in recipients {
-            if quic_protocol
-                .send_to_peer(
-                    &peer_id,
-                    lib_network::types::mesh_message::ZhtpMeshMessage::ValidatorMessage(
-                        message.clone(),
-                    ),
-                )
-                .await
-                .is_ok()
-            {
-                delivered += 1;
+        let mut timed_out = 0usize;
+        let mut failed = 0usize;
+
+        loop {
+            match tokio::time::timeout_at(global_deadline, tasks.next()).await {
+                Ok(Some(Ok(Ok(_)))) => delivered += 1, // send returned Ok within per-peer budget
+                Ok(Some(Ok(Err(_)))) => failed += 1,    // send returned Err
+                Ok(Some(Err(_))) => timed_out += 1,    // per-peer timeout
+                Ok(None) => break,                      // all tasks drained
+                Err(_) => {
+                    // Global deadline hit — abandon remaining tasks
+                    timed_out += tasks.len();
+                    break;
+                }
             }
         }
 
         debug!(
-            "Consensus broadcast (height {}) delivered to {} validator peer(s)",
-            target_height, delivered
+            "Consensus broadcast (height {}) parallel fan-out: delivered={} failed={} timed_out={} of {} peers",
+            target_height, delivered, failed, timed_out, recipient_count
         );
         if delivered == 0 {
             Err(Box::new(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                "Consensus broadcast had zero successful deliveries",
+                format!(
+                    "Consensus broadcast had zero successful deliveries (failed={} timed_out={})",
+                    failed, timed_out
+                ),
             )))
         } else {
             Ok(())


### PR DESCRIPTION
Replaces the sequential per-peer broadcast loop with FuturesUnordered + per-peer + global timeouts.

Pre-CONS-503: `for peer_id in recipients { send_to_peer(...).await }` — one stalled peer serialized N peers behind it, blowing the broadcast budget for the round.

Post-CONS-503:
- Each `send_to_peer` runs concurrently under per-peer budget cap (MAX_BROADCAST_BUDGET_MS / N).
- Global deadline (MAX_BROADCAST_BUDGET_MS) is the backstop so the total call always returns within the consensus budget.
- Outcome counters distinguish delivered / failed / timed_out for diagnostics.

## Acceptance

- ✅ `for peer_id in recipients { ... .await }` pattern is gone.
- ✅ Per-peer tokio::time::timeout applied.
- ✅ One stalled peer no longer serializes the rest.

## Move-to-runtime deferred

CONS-503 also calls for moving the struct to lib-consensus-runtime/src/adapters/. That requires pulling MeshRouter up the dep graph (it lives in zhtp::server::mesh) or introducing a transport trait — heavier change. Tracking under CONS-507 where the broadcaster move lands cleanly with the lib-network retirement.

## Validation

cargo build --workspace clean (56.56 s warm). No tests changed; consensus crate test suites unchanged.

Closes #2353.