### PR TITLE
fix: three consensus bugs — height runaway, bootstrapping deadlock, broadcast mismatch

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/network.rs
+++ b/lib-consensus/src/engines/consensus_engine/network.rs
@@ -73,24 +73,17 @@ impl ConsensusEngine {
         // Ensure validator membership snapshot is initialized for the current height
         self.snapshot_validator_set(self.current_round.height);
 
-        // Track BFT mode for transition logging
-        let mut last_bft_mode = self.is_bft_mode_active();
+        // Track BFT mode for transition logging.
+        // Start as false to force the transition block to run on the first tick
+        // when validators are already seeded — otherwise the node stays in
+        // Bootstrapping forever because current_bft_mode == last_bft_mode.
+        let mut last_bft_mode = false;
         let validator_count = self.get_validator_count();
 
         // CONS-305: Start in Bootstrapping state — do NOT propose immediately.
         // Wait for quorum connectivity before entering active consensus.
         tracing::info!(
             "🔄 Starting consensus loop in BOOTSTRAPPING state ({} validators detected) at height {}",
-            validator_count,
-            self.current_round.height,
-        );
-
-        // Stay in Bootstrapping until caught up to the chain tip.
-        // The loop below checks catch-up status and transitions to active
-        // consensus only when local height is near the network tip.
-        tracing::info!(
-            "⛏️ Bootstrapping: {} validators detected, local height {}. \
-             Waiting for catch-up sync before entering active consensus.",
             validator_count,
             self.current_round.height,
         );

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -2054,9 +2054,17 @@ impl ConsensusEngine {
 
         // CONS-305: If the FSM landed in Rejected (from VoteFailed or Timeout),
         // the runtime must reset to Idle → Proposing for the next round.
-        // This handles ALL paths into Rejected, not just Commit timeout.
+        // CRITICAL: On rejection, stay at the SAME height with round+1.
+        // Only advance height after a block is committed.
         if matches!(self.fsm_state, lib_consensus_core::fsm::ValidatorState::Rejected { .. }) {
-            self.advance_to_next_round();
+            self.current_round.round += 1;
+            self.current_round.step = ConsensusStep::Propose;
+            self.current_round.proposer = None;
+            self.current_round.proposals.clear();
+            self.current_round.votes.clear();
+            self.current_round.timed_out = false;
+            self.current_round.locked_proposal = None;
+            self.current_round.valid_proposal = None;
             self.snapshot_validator_set(self.current_round.height);
             self.fsm_state = lib_consensus_core::fsm::ValidatorState::Idle;
             let (next, actions) = lib_consensus_core::fsm::transition(

--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -55,15 +55,24 @@ impl ConsensusMeshBroadcaster {
         validator_ids: &[IdentityId],
         target_height: u64,
     ) -> HashSet<Vec<u8>> {
-        let targets: HashSet<Vec<u8>> = validator_ids
-            .iter()
-            .map(|id| id.as_bytes().to_vec())
-            .collect();
+        // Broadcast to ALL connected mesh peers. The consensus engine provides
+        // IdentityId (32-byte DID hash) but the mesh indexes by NodeId (derived
+        // from DID + device + network_genesis). Rather than maintaining a mapping,
+        // send to every connected peer — in a small validator set this is correct
+        // and avoids the identity→node ID resolution problem.
+        let quic_guard = self.mesh_router.quic_protocol.read().await;
+        let targets: HashSet<Vec<u8>> = if let Some(ref qp) = *quic_guard {
+            qp.connected_peer_ids().into_iter().collect()
+        } else {
+            HashSet::new()
+        };
+        drop(quic_guard);
 
         tracing::debug!(
-            "Consensus broadcast target set for height {} resolved to {} candidate peer node IDs",
+            "Consensus broadcast for height {}: {} connected mesh peers (engine requested {} validator_ids)",
             target_height,
-            targets.len()
+            targets.len(),
+            validator_ids.len()
         );
 
         targets


### PR DESCRIPTION
## Summary

Three bugs preventing consensus from producing blocks:

- **Height runaway**: `advance_to_next_round()` incremented height on every failed round. Nodes diverged to height 10000+ while chain was at 0. Fix: increment round, not height, on rejection.
- **Bootstrapping deadlock**: `last_bft_mode` initialized to current state at startup. When validators are pre-seeded, mode transition never fires → node stays in Bootstrapping forever. Fix: init to false.
- **Broadcast mismatch**: Broadcaster used IdentityId as peer_id, but QUIC mesh indexes by NodeId. No peer matched → proposals/votes never sent. Fix: broadcast to all connected mesh peers.

After fix: proposals now flow between nodes, height stays at 1 with round incrementing. Remaining issue: round timer too fast (1s per phase) for cross-continent latency → nodes advance rounds faster than proposals arrive.

## Test plan
- [x] Deployed to all 5 nodes
- [x] Proposals received across all validators
- [x] Height stays at 1 (no runaway)
- [ ] Blocks committed (blocked by round timer — separate fix)