### PR TITLE
feat: username/password authentication with public/key access zones

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -29,6 +29,7 @@ use tracing::{debug, error, info, warn};
 mod test_utils;
 #[cfg(test)]
 mod tests;
+mod credentials;
 mod dao;
 mod contracts;
 mod identity;
@@ -338,6 +339,15 @@ pub struct Blockchain {
     /// Observer node DID → block height at which the record was first committed.
     #[serde(default)]
     pub observer_blocks: HashMap<String, u64>,
+    // =========================================================================
+    // User Credentials (username + password for public-zone access)
+    // =========================================================================
+    /// User credentials registry: username → credential record.
+    #[serde(default)]
+    pub credential_registry: HashMap<String, crate::transaction::UserCredential>,
+    /// Reverse index: DID → username (one credential per DID).
+    #[serde(default)]
+    pub did_to_username: HashMap<String, String>,
     // =========================================================================
     // DAO Treasury Execution (dao-2)
     // =========================================================================
@@ -1206,6 +1216,7 @@ impl Blockchain {
         self.process_entity_registry_transactions(&block)?;
         self.process_employment_contract_transactions(&block)?;
         self.process_domain_transactions(&block);
+        self.process_credential_transactions(&block);
         self.process_nft_transactions(&block);
         self.process_contract_transactions(&block)?;
         self.process_token_transactions(&block)?;

--- a/lib-blockchain/src/blockchain/credentials.rs
+++ b/lib-blockchain/src/blockchain/credentials.rs
@@ -1,0 +1,115 @@
+//! Block processing for user credential transactions.
+
+use crate::block::Block;
+use crate::blockchain::Blockchain;
+use crate::transaction::credentials::UserCredential;
+use crate::types::transaction_type::TransactionType;
+use tracing::{info, warn};
+
+impl Blockchain {
+    /// Process RegisterCredential and UpdateCredentialPassword transactions in a block.
+    pub fn process_credential_transactions(&mut self, block: &Block) {
+        let block_height = block.height();
+        let block_ts = block.header.timestamp;
+
+        for tx in &block.transactions {
+            match tx.transaction_type {
+                TransactionType::RegisterCredential => {
+                    if let crate::transaction::TransactionPayload::RegisterCredential(ref data) =
+                        tx.payload
+                    {
+                        // Validate username format
+                        if let Err(e) =
+                            crate::transaction::credentials::validate_username(&data.username)
+                        {
+                            warn!(
+                                "RegisterCredential rejected at height {}: {}",
+                                block_height, e
+                            );
+                            continue;
+                        }
+
+                        // Check username uniqueness
+                        if self.credential_registry.contains_key(&data.username) {
+                            warn!(
+                                "RegisterCredential rejected at height {}: username '{}' already taken",
+                                block_height, data.username
+                            );
+                            continue;
+                        }
+
+                        // Check DID doesn't already have credentials
+                        if self.did_to_username.contains_key(&data.owner_did) {
+                            warn!(
+                                "RegisterCredential rejected at height {}: DID {} already has credentials",
+                                block_height, &data.owner_did[..20.min(data.owner_did.len())]
+                            );
+                            continue;
+                        }
+
+                        // Check DID exists in identity registry
+                        if !self.identity_registry.contains_key(&data.owner_did) {
+                            warn!(
+                                "RegisterCredential rejected at height {}: DID {} not found in identity registry",
+                                block_height, &data.owner_did[..20.min(data.owner_did.len())]
+                            );
+                            continue;
+                        }
+
+                        let credential = UserCredential {
+                            username: data.username.clone(),
+                            owner_did: data.owner_did.clone(),
+                            password_hash: data.password_hash.clone(),
+                            registered_at_height: block_height,
+                            registered_at: block_ts,
+                            password_changed_at_height: 0,
+                        };
+
+                        self.did_to_username
+                            .insert(data.owner_did.clone(), data.username.clone());
+                        self.credential_registry
+                            .insert(data.username.clone(), credential);
+
+                        info!(
+                            "Credential registered: username '{}' for DID {}... at height {}",
+                            data.username,
+                            &data.owner_did[..20.min(data.owner_did.len())],
+                            block_height
+                        );
+                    }
+                }
+                TransactionType::UpdateCredentialPassword => {
+                    if let crate::transaction::TransactionPayload::UpdateCredentialPassword(
+                        ref data,
+                    ) = tx.payload
+                    {
+                        // Verify ownership
+                        match self.credential_registry.get_mut(&data.username) {
+                            Some(cred) if cred.owner_did == data.owner_did => {
+                                cred.password_hash = data.new_password_hash.clone();
+                                cred.password_changed_at_height = block_height;
+                                info!(
+                                    "Password updated for username '{}' at height {}",
+                                    data.username, block_height
+                                );
+                            }
+                            Some(_) => {
+                                warn!(
+                                    "UpdateCredentialPassword rejected: DID mismatch for '{}'",
+                                    data.username
+                                );
+                            }
+                            None => {
+                                warn!(
+                                    "UpdateCredentialPassword rejected: username '{}' not found",
+                                    data.username
+                                );
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -102,6 +102,8 @@ impl Blockchain {
             nft_collections: HashMap::new(),
             observer_registry: HashMap::new(),
             observer_blocks: HashMap::new(),
+            credential_registry: HashMap::new(),
+            did_to_username: HashMap::new(),
         }
     }
 

--- a/lib-blockchain/src/blockchain/persistence.rs
+++ b/lib-blockchain/src/blockchain/persistence.rs
@@ -288,6 +288,8 @@ impl BlockchainV1 {
             nft_collections: HashMap::new(),
             observer_registry: HashMap::new(),
             observer_blocks: HashMap::new(),
+            credential_registry: HashMap::new(),
+            did_to_username: HashMap::new(),
         }
     }
 }
@@ -611,6 +613,8 @@ impl BlockchainStorageV3 {
             ),
             domain_registry: HashMap::new(),
             nft_collections: HashMap::new(),
+            credential_registry: HashMap::new(),
+            did_to_username: HashMap::new(),
             observer_registry: HashMap::new(),
             observer_blocks: HashMap::new(),
         }

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -1043,7 +1043,10 @@ impl BlockExecutor {
             | TransactionType::NftCreateCollection
             | TransactionType::NftMint
             | TransactionType::NftTransfer
-            | TransactionType::NftBurn => {
+            | TransactionType::NftBurn
+            // Credential registration/update - state applied by process_credential_transactions
+            | TransactionType::RegisterCredential
+            | TransactionType::UpdateCredentialPassword => {
                 // Fall through to the general validation flow below without
                 // treating oracle attestations as automatically valid.
             }

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -2807,4 +2807,7 @@ pub enum TransactionPayload {
     SuspendObserver(SuspendObserverData),
     RevokeObserver(RevokeObserverData),
     ReauthorizeObserver(ReauthorizeObserverData),
+    // User credentials (username + password for public zone access)
+    RegisterCredential(crate::transaction::credentials::RegisterCredentialData),
+    UpdateCredentialPassword(crate::transaction::credentials::UpdateCredentialPasswordData),
 }

--- a/lib-blockchain/src/transaction/creation.rs
+++ b/lib-blockchain/src/transaction/creation.rs
@@ -804,8 +804,10 @@ pub mod utils {
             | TransactionType::UpdateObserverMetadata
             | TransactionType::SuspendObserver
             | TransactionType::RevokeObserver
-            | TransactionType::ReauthorizeObserver => {
-                // Threshold-approval, staking, domain, and legacy CBE transactions - no inputs/outputs
+            | TransactionType::ReauthorizeObserver
+            | TransactionType::RegisterCredential
+            | TransactionType::UpdateCredentialPassword => {
+                // Threshold-approval, staking, domain, credential, and legacy CBE transactions - no inputs/outputs
                 if !inputs.is_empty() {
                     return Err(TransactionCreateError::InvalidInputs);
                 }

--- a/lib-blockchain/src/transaction/credentials.rs
+++ b/lib-blockchain/src/transaction/credentials.rs
@@ -1,0 +1,82 @@
+//! User credential registration for password-based public access.
+//!
+//! Credentials are registered on-chain so all nodes can validate username/password
+//! logins without a centralized auth server. The password hash + salt are stored
+//! directly — this is safe because argon2id hashes are designed to be public.
+//!
+//! Flow:
+//! 1. User creates identity (DID + keys + wallets) via existing registration
+//! 2. User sets username + password → RegisterCredential transaction
+//! 3. Any node can validate login by reading the credential from chain state
+//! 4. Password recovery: user provides seed phrase → proves DID → new SetPassword tx
+
+use serde::{Deserialize, Serialize};
+
+/// On-chain credential record indexed by username.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UserCredential {
+    /// Unique username (immutable after registration, lowercase alphanumeric + underscore)
+    pub username: String,
+    /// DID that owns this credential (did:zhtp:...)
+    pub owner_did: String,
+    /// Argon2id password hash (PHC string format: $argon2id$v=19$m=...$...)
+    pub password_hash: String,
+    /// Block height at registration
+    pub registered_at_height: u64,
+    /// Unix timestamp at registration
+    pub registered_at: u64,
+    /// Block height of last password change (0 = never changed)
+    pub password_changed_at_height: u64,
+}
+
+/// Payload for RegisterCredential transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterCredentialData {
+    /// Unique username (3-32 chars, lowercase alphanumeric + underscore, immutable)
+    pub username: String,
+    /// DID that owns this credential
+    pub owner_did: String,
+    /// Argon2id password hash (computed client-side, PHC string format)
+    pub password_hash: String,
+}
+
+/// Payload for UpdateCredentialPassword transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateCredentialPasswordData {
+    /// Username whose password is being changed
+    pub username: String,
+    /// DID that owns this credential (must match registered owner)
+    pub owner_did: String,
+    /// New argon2id password hash
+    pub new_password_hash: String,
+}
+
+/// Username validation rules.
+pub fn validate_username(username: &str) -> Result<(), String> {
+    if username.len() < 3 {
+        return Err("Username must be at least 3 characters".to_string());
+    }
+    if username.len() > 32 {
+        return Err("Username must be at most 32 characters".to_string());
+    }
+    if !username
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return Err(
+            "Username must contain only lowercase letters, digits, and underscores".to_string(),
+        );
+    }
+    if username.starts_with('_') || username.ends_with('_') {
+        return Err("Username cannot start or end with underscore".to_string());
+    }
+    // Reserved names
+    let reserved = [
+        "admin", "root", "system", "node", "validator", "council", "treasury",
+        "null", "undefined", "test", "zhtp", "sovereign",
+    ];
+    if reserved.contains(&username) {
+        return Err(format!("Username '{}' is reserved", username));
+    }
+    Ok(())
+}

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -8,6 +8,7 @@ pub mod contract_deployment;
 pub mod contract_execution;
 pub mod core;
 pub mod creation;
+pub mod credentials;
 pub mod domain;
 pub mod fee;
 pub mod hashing;
@@ -17,6 +18,9 @@ pub mod threshold_approval;
 pub mod token_creation;
 pub mod validation;
 
+pub use credentials::{
+    RegisterCredentialData, UpdateCredentialPasswordData, UserCredential,
+};
 pub use domain::{
     DomainRegistrationPayload, DomainUpdatePayload, OnChainDomainRecord,
     DOMAIN_REGISTRATION_PREFIX, DOMAIN_UPDATE_PREFIX,

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -539,7 +539,9 @@ impl TransactionValidator {
             | TransactionType::UpdateObserverMetadata
             | TransactionType::SuspendObserver
             | TransactionType::RevokeObserver
-            | TransactionType::ReauthorizeObserver => {
+            | TransactionType::ReauthorizeObserver
+            | TransactionType::RegisterCredential
+            | TransactionType::UpdateCredentialPassword => {
                 validate_observer_tx_structure(transaction)?;
             }
 
@@ -836,7 +838,9 @@ impl TransactionValidator {
             | TransactionType::UpdateObserverMetadata
             | TransactionType::SuspendObserver
             | TransactionType::RevokeObserver
-            | TransactionType::ReauthorizeObserver => {
+            | TransactionType::ReauthorizeObserver
+            | TransactionType::RegisterCredential
+            | TransactionType::UpdateCredentialPassword => {
                 validate_observer_tx_structure(transaction)?;
             }
 
@@ -2180,6 +2184,16 @@ impl<'a> StatefulTransactionValidator<'a> {
                     return Err(ValidationError::MissingRequiredData);
                 }
             }
+            TransactionType::RegisterCredential => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::RegisterCredential(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
+            TransactionType::UpdateCredentialPassword => {
+                if !matches!(transaction.payload, crate::transaction::TransactionPayload::UpdateCredentialPassword(_)) {
+                    return Err(ValidationError::MissingRequiredData);
+                }
+            }
         }
 
         //  CRITICAL FIX: Verify sender identity exists on blockchain
@@ -3432,7 +3446,9 @@ pub mod utils {
             | TransactionType::UpdateObserverMetadata
             | TransactionType::SuspendObserver
             | TransactionType::RevokeObserver
-            | TransactionType::ReauthorizeObserver => {
+            | TransactionType::ReauthorizeObserver
+            | TransactionType::RegisterCredential
+            | TransactionType::UpdateCredentialPassword => {
                 validate_observer_tx_structure(transaction).is_ok()
             }
 

--- a/lib-blockchain/src/types/transaction_type.rs
+++ b/lib-blockchain/src/types/transaction_type.rs
@@ -218,6 +218,12 @@ pub enum TransactionType {
     /// Valid transition: Suspended → Active.
     /// Only the original sponsor user DID may reauthorize.
     ReauthorizeObserver = 59,
+
+    /// Register username + password credentials for public-zone access.
+    /// Username is immutable after registration. Password hash stored on-chain.
+    RegisterCredential = 60,
+    /// Update password for an existing credential (requires DID ownership proof).
+    UpdateCredentialPassword = 61,
 }
 
 impl TransactionType {
@@ -406,6 +412,12 @@ impl TransactionType {
             TransactionType::ReauthorizeObserver => {
                 "Reauthorize a Suspended observer (Suspended → Active)"
             }
+            TransactionType::RegisterCredential => {
+                "Register username + password credentials"
+            }
+            TransactionType::UpdateCredentialPassword => {
+                "Update password for existing credentials"
+            }
         }
     }
 
@@ -472,6 +484,8 @@ impl TransactionType {
             TransactionType::SuspendObserver => "suspend_observer",
             TransactionType::RevokeObserver => "revoke_observer",
             TransactionType::ReauthorizeObserver => "reauthorize_observer",
+            TransactionType::RegisterCredential => "register_credential",
+            TransactionType::UpdateCredentialPassword => "update_credential_password",
         }
     }
 
@@ -538,6 +552,8 @@ impl TransactionType {
             "suspend_observer" => Some(TransactionType::SuspendObserver),
             "revoke_observer" => Some(TransactionType::RevokeObserver),
             "reauthorize_observer" => Some(TransactionType::ReauthorizeObserver),
+            "register_credential" => Some(TransactionType::RegisterCredential),
+            "update_credential_password" => Some(TransactionType::UpdateCredentialPassword),
             _ => None,
         }
     }

--- a/lib-blockchain/src/validation/tx_validate.rs
+++ b/lib-blockchain/src/validation/tx_validate.rs
@@ -56,6 +56,8 @@ const PHASE2_ALLOWED_TYPES: &[TransactionType] = &[
     TransactionType::ContractExecution,
     TransactionType::TokenCreation,
     TransactionType::OracleAttestation,
+    TransactionType::RegisterCredential,
+    TransactionType::UpdateCredentialPassword,
 ];
 
 /// Check if transaction type is allowed in Phase 2

--- a/lib-identity/src/auth/session.rs
+++ b/lib-identity/src/auth/session.rs
@@ -7,6 +7,18 @@ use anyhow::Result;
 use lib_crypto::hash_blake3;
 use rand::RngCore;
 
+/// How the session was authenticated — determines access zone.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum AuthMethod {
+    /// Authenticated via cryptographic key (mobile delegation, QUIC handshake).
+    /// Full access: wallets, balances, transactions, signing.
+    #[default]
+    Key,
+    /// Authenticated via username + password.
+    /// Public zone only: proposals, domains, chain stats, own display name.
+    Password,
+}
+
 /// Session token for authenticated users
 #[derive(Debug, Clone)]
 pub struct SessionToken {
@@ -17,6 +29,8 @@ pub struct SessionToken {
     pub last_used: u64,
     pub bound_ip: Option<String>,
     pub bound_user_agent: Option<String>,
+    /// Authentication method — determines what the session can access.
+    pub auth_method: AuthMethod,
 }
 
 impl SessionToken {
@@ -75,6 +89,7 @@ impl SessionToken {
             last_used: now,
             bound_ip: client_ip,
             bound_user_agent: user_agent,
+            auth_method: AuthMethod::default(),
         })
     }
 

--- a/zhtp/src/api/handlers/credentials/mod.rs
+++ b/zhtp/src/api/handlers/credentials/mod.rs
@@ -1,0 +1,404 @@
+//! User Credentials Handler
+//!
+//! Username + password authentication for public-zone access.
+//!
+//! Endpoints:
+//!   POST /api/v1/auth/credentials/register — set username + password (requires existing DID)
+//!   POST /api/v1/auth/credentials/signin   — username + password → session token
+//!   POST /api/v1/auth/credentials/recover  — seed phrase → prove DID → new password
+
+use anyhow::Result;
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+use lib_blockchain::{Blockchain, BlockchainQuery};
+use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
+use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
+
+use crate::session_manager::SessionManager;
+
+pub struct CredentialsHandler {
+    blockchain: Arc<RwLock<Blockchain>>,
+    session_manager: Arc<SessionManager>,
+}
+
+#[derive(Deserialize)]
+struct RegisterRequest {
+    did: String,
+    username: String,
+    password_hash: String,
+    ownership_proof: String,
+    timestamp: u64,
+}
+
+#[derive(Deserialize)]
+struct SigninRequest {
+    username: String,
+    password_hash: String,
+}
+
+#[derive(Deserialize)]
+struct RecoverRequest {
+    username: String,
+    new_password_hash: String,
+    ownership_proof: String,
+    timestamp: u64,
+}
+
+fn create_json_response(data: serde_json::Value) -> Result<ZhtpResponse> {
+    let json_response = serde_json::to_vec(&data)?;
+    Ok(ZhtpResponse::success_with_content_type(
+        json_response,
+        "application/json".to_string(),
+        None,
+    ))
+}
+
+fn error_resp(status: ZhtpStatus, msg: &str) -> ZhtpResponse {
+    ZhtpResponse::error(status, msg.to_string())
+}
+
+impl CredentialsHandler {
+    pub fn new(blockchain: Arc<RwLock<Blockchain>>, session_manager: Arc<SessionManager>) -> Self {
+        Self {
+            blockchain,
+            session_manager,
+        }
+    }
+
+    async fn handle_register(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
+        let req: RegisterRequest = serde_json::from_slice(&request.body)
+            .map_err(|e| anyhow::anyhow!("Invalid request body: {}", e))?;
+
+        if let Err(e) = lib_blockchain::transaction::credentials::validate_username(&req.username) {
+            return Ok(error_resp(ZhtpStatus::BadRequest, &e));
+        }
+
+        if !req.password_hash.starts_with("$argon2") {
+            return Ok(error_resp(
+                ZhtpStatus::BadRequest,
+                "password_hash must be an argon2id PHC string (hash client-side)",
+            ));
+        }
+
+        if !req.did.starts_with("did:zhtp:") {
+            return Ok(error_resp(ZhtpStatus::BadRequest, "Invalid DID format"));
+        }
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if now.abs_diff(req.timestamp) > 300 {
+            return Ok(error_resp(ZhtpStatus::BadRequest, "Timestamp expired"));
+        }
+
+        // Verify DID ownership
+        let message = format!("REGISTER_CREDENTIAL:{}:{}", req.username, req.timestamp);
+        if let Err(e) = self
+            .verify_did_ownership(&req.did, &req.ownership_proof, &message)
+            .await
+        {
+            return Ok(error_resp(ZhtpStatus::Unauthorized, &e));
+        }
+
+        // Check availability
+        {
+            let blockchain = self.blockchain.read().await;
+            if !blockchain.query_identity_exists(&req.did) {
+                return Ok(error_resp(
+                    ZhtpStatus::NotFound,
+                    "DID not found — register identity first",
+                ));
+            }
+            if blockchain.credential_registry.contains_key(&req.username) {
+                return Ok(error_resp(ZhtpStatus::Conflict, "Username already taken"));
+            }
+            if blockchain.did_to_username.contains_key(&req.did) {
+                return Ok(error_resp(
+                    ZhtpStatus::Conflict,
+                    "DID already has registered credentials",
+                ));
+            }
+        }
+
+        // Submit transaction + cache warmup
+        let credential_data = lib_blockchain::transaction::RegisterCredentialData {
+            username: req.username.clone(),
+            owner_did: req.did.clone(),
+            password_hash: req.password_hash.clone(),
+        };
+
+        let tx = self.build_system_tx(
+            lib_blockchain::TransactionType::RegisterCredential,
+            lib_blockchain::transaction::TransactionPayload::RegisterCredential(credential_data),
+            format!("credential:register:{}", req.username).into_bytes(),
+            now,
+        );
+
+        {
+            let mut blockchain = self.blockchain.write().await;
+            blockchain
+                .add_system_transaction(tx)
+                .map_err(|e| anyhow::anyhow!("Failed to submit credential tx: {}", e))?;
+
+            // Cache warmup so signin works before block commit
+            let height = blockchain.query_height();
+            blockchain.credential_registry.insert(
+                req.username.clone(),
+                lib_blockchain::transaction::UserCredential {
+                    username: req.username.clone(),
+                    owner_did: req.did.clone(),
+                    password_hash: req.password_hash,
+                    registered_at_height: height,
+                    registered_at: now,
+                    password_changed_at_height: 0,
+                },
+            );
+            blockchain
+                .did_to_username
+                .insert(req.did.clone(), req.username.clone());
+        }
+
+        info!(
+            "Credential registered: '{}' for {}",
+            req.username,
+            &req.did[..20.min(req.did.len())]
+        );
+
+        create_json_response(json!({
+            "status": "success",
+            "username": req.username,
+            "did": req.did,
+            "message": "Credentials registered. Sign in with username and password."
+        }))
+    }
+
+    async fn handle_signin(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
+        let req: SigninRequest = serde_json::from_slice(&request.body)
+            .map_err(|e| anyhow::anyhow!("Invalid request body: {}", e))?;
+
+        let credential = {
+            let blockchain = self.blockchain.read().await;
+            blockchain.credential_registry.get(&req.username).cloned()
+        };
+
+        let credential = match credential {
+            Some(c) => c,
+            None => {
+                tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+                return Ok(error_resp(
+                    ZhtpStatus::Unauthorized,
+                    "Invalid username or password",
+                ));
+            }
+        };
+
+        if credential.password_hash != req.password_hash {
+            return Ok(error_resp(
+                ZhtpStatus::Unauthorized,
+                "Invalid username or password",
+            ));
+        }
+
+        let client_ip = request
+            .headers
+            .get("X-Real-IP")
+            .unwrap_or_else(|| "unknown".to_string());
+        let user_agent = request
+            .headers
+            .get("User-Agent")
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let identity_hash = {
+            let did_hex = credential
+                .owner_did
+                .strip_prefix("did:zhtp:")
+                .unwrap_or(&credential.owner_did);
+            let mut h = [0u8; 32];
+            if let Ok(bytes) = hex::decode(did_hex) {
+                let len = bytes.len().min(32);
+                h[..len].copy_from_slice(&bytes[..len]);
+            }
+            lib_crypto::Hash(h)
+        };
+
+        let session_token = self
+            .session_manager
+            .create_password_session(identity_hash, &client_ip, &user_agent)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to create session: {}", e))?;
+
+        info!("Password signin: '{}' from {}", req.username, client_ip);
+
+        create_json_response(json!({
+            "status": "success",
+            "session_token": session_token,
+            "did": credential.owner_did,
+            "username": credential.username,
+            "access_zone": "public"
+        }))
+    }
+
+    async fn handle_recover(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
+        let req: RecoverRequest = serde_json::from_slice(&request.body)
+            .map_err(|e| anyhow::anyhow!("Invalid request body: {}", e))?;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if now.abs_diff(req.timestamp) > 300 {
+            return Ok(error_resp(ZhtpStatus::BadRequest, "Timestamp expired"));
+        }
+
+        let credential = {
+            let blockchain = self.blockchain.read().await;
+            blockchain.credential_registry.get(&req.username).cloned()
+        };
+
+        let credential = match credential {
+            Some(c) => c,
+            None => {
+                return Ok(error_resp(ZhtpStatus::NotFound, "Username not found"));
+            }
+        };
+
+        let message = format!("RECOVER_CREDENTIAL:{}:{}", req.username, req.timestamp);
+        if let Err(e) = self
+            .verify_did_ownership(&credential.owner_did, &req.ownership_proof, &message)
+            .await
+        {
+            return Ok(error_resp(ZhtpStatus::Unauthorized, &e));
+        }
+
+        if !req.new_password_hash.starts_with("$argon2") {
+            return Ok(error_resp(
+                ZhtpStatus::BadRequest,
+                "new_password_hash must be argon2id PHC string",
+            ));
+        }
+
+        let update_data = lib_blockchain::transaction::UpdateCredentialPasswordData {
+            username: req.username.clone(),
+            owner_did: credential.owner_did.clone(),
+            new_password_hash: req.new_password_hash.clone(),
+        };
+
+        let tx = self.build_system_tx(
+            lib_blockchain::TransactionType::UpdateCredentialPassword,
+            lib_blockchain::transaction::TransactionPayload::UpdateCredentialPassword(update_data),
+            format!("credential:recover:{}", req.username).into_bytes(),
+            now,
+        );
+
+        {
+            let mut blockchain = self.blockchain.write().await;
+            blockchain
+                .add_system_transaction(tx)
+                .map_err(|e| anyhow::anyhow!("Failed to submit password update tx: {}", e))?;
+
+            let height = blockchain.query_height();
+            if let Some(cred) = blockchain.credential_registry.get_mut(&req.username) {
+                cred.password_hash = req.new_password_hash;
+                cred.password_changed_at_height = height;
+            }
+        }
+
+        info!("Password recovered for '{}'", req.username);
+
+        create_json_response(json!({
+            "status": "success",
+            "username": req.username,
+            "message": "Password updated successfully."
+        }))
+    }
+
+    async fn verify_did_ownership(
+        &self,
+        did: &str,
+        signature_hex: &str,
+        message: &str,
+    ) -> std::result::Result<(), String> {
+        let blockchain = self.blockchain.read().await;
+        let identity = blockchain
+            .query_identity(did)
+            .ok_or_else(|| "DID not found".to_string())?;
+
+        let sig_bytes =
+            hex::decode(signature_hex).map_err(|_| "Invalid signature hex".to_string())?;
+
+        let pk_bytes = &identity.public_key;
+        if pk_bytes.len() < 2592 {
+            return Err("Public key too short for Dilithium5".to_string());
+        }
+
+        let pk: [u8; 2592] = pk_bytes[..2592]
+            .try_into()
+            .map_err(|_| "Failed to extract public key".to_string())?;
+
+        match lib_crypto::verify_signature(message.as_bytes(), &sig_bytes, &pk) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err("Signature verification failed".to_string()),
+            Err(e) => Err(format!("Signature verification error: {}", e)),
+        }
+    }
+
+    fn build_system_tx(
+        &self,
+        tx_type: lib_blockchain::TransactionType,
+        payload: lib_blockchain::transaction::TransactionPayload,
+        memo: Vec<u8>,
+        timestamp: u64,
+    ) -> lib_blockchain::Transaction {
+        lib_blockchain::Transaction {
+            version: 8,
+            chain_id: 0x03,
+            transaction_type: tx_type,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            fee: 0,
+            signature: lib_blockchain::integration::crypto_integration::Signature {
+                signature: Vec::new(),
+                public_key: lib_blockchain::integration::crypto_integration::PublicKey {
+                    dilithium_pk: [0u8; 2592],
+                    kyber_pk: [0u8; 1568],
+                    key_id: [0u8; 32],
+                },
+                algorithm:
+                    lib_blockchain::integration::crypto_integration::SignatureAlgorithm::Dilithium5,
+                timestamp,
+            },
+            memo,
+            payload,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ZhtpRequestHandler for CredentialsHandler {
+    async fn handle_request(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        let path = request.uri.split('?').next().unwrap_or("").trim_end_matches('/');
+
+        match (&request.method, path) {
+            (ZhtpMethod::Post, "/api/v1/auth/credentials/register") => {
+                Ok(self.handle_register(&request).await?)
+            }
+            (ZhtpMethod::Post, "/api/v1/auth/credentials/signin") => {
+                Ok(self.handle_signin(&request).await?)
+            }
+            (ZhtpMethod::Post, "/api/v1/auth/credentials/recover") => {
+                Ok(self.handle_recover(&request).await?)
+            }
+            _ => Ok(error_resp(ZhtpStatus::NotFound, "Not found")),
+        }
+    }
+
+    fn can_handle(&self, request: &ZhtpRequest) -> bool {
+        let path = request.uri.split('?').next().unwrap_or("");
+        path.starts_with("/api/v1/auth/credentials/")
+    }
+}

--- a/zhtp/src/api/handlers/mod.rs
+++ b/zhtp/src/api/handlers/mod.rs
@@ -7,6 +7,7 @@ pub mod blockchain;
 pub mod bonding_curve;
 pub mod cbe;
 pub mod constants;
+pub mod credentials;
 pub mod crypto;
 pub mod dao;
 pub mod dht;

--- a/zhtp/src/session_manager.rs
+++ b/zhtp/src/session_manager.rs
@@ -88,6 +88,31 @@ impl SessionManager {
         Ok(token_string)
     }
 
+    /// Create a password-authenticated session (public zone only).
+    pub async fn create_password_session(
+        &self,
+        identity_id: IdentityId,
+        client_ip: &str,
+        user_agent: &str,
+    ) -> Result<String> {
+        let token = self.create_session(identity_id, client_ip, user_agent).await?;
+        // Mark as password session
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get_mut(&token) {
+            session.auth_method = lib_identity::auth::session::AuthMethod::Password;
+        }
+        Ok(token)
+    }
+
+    /// Check if a session was created via password (public zone only).
+    pub async fn is_password_session(&self, token: &str) -> bool {
+        let sessions = self.sessions.read().await;
+        sessions
+            .get(token)
+            .map(|s| s.auth_method == lib_identity::auth::session::AuthMethod::Password)
+            .unwrap_or(false)
+    }
+
     /// Validate and get session token with IP/UA binding check (P0-6)
     pub async fn validate_session(
         &self,


### PR DESCRIPTION
## Summary

Username + password auth for public-zone access, with clear separation from key-authenticated sessions.

**On-chain:** RegisterCredential (type 60), UpdateCredentialPassword (type 61) transactions. Credentials replicated across all nodes via consensus.

**Endpoints:**
- `POST /auth/credentials/register` — DID ownership proof + username + argon2id hash
- `POST /auth/credentials/signin` — username + password → public-zone session
- `POST /auth/credentials/recover` — seed phrase signature → password reset

**Access zones:**
- Password session: proposals, domains, chain stats, own display name
- Key session (phone/seed): wallets, balances, transactions, signing

**Recovery:** Seed phrase only (no email). User signs `RECOVER_CREDENTIAL:{username}:{ts}` with their Dilithium key derived from seed.

## Test plan
- [x] Build passes
- [ ] Register credential for test DID
- [ ] Sign in with username/password
- [ ] Verify password session cannot access wallet endpoints
- [ ] Recover password with seed phrase