### PR TITLE
feat: messaging precursors — Kyber key on-chain, genesis sync fix, access zones

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -1325,6 +1325,25 @@ impl Blockchain {
     /// Finish block processing after state mutations are complete.
     /// This handles post-processing steps that happen regardless of which path was used.
     async fn finish_block_processing(&mut self, block: Block) -> Result<()> {
+        // Genesis state restoration: when applying block 0 during catch-up sync,
+        // the genesis identities/wallets/validators are populated via direct inserts
+        // in build_block0(), not via transactions. Re-apply genesis state so synced
+        // nodes have the full registries.
+        if block.header.height == 0 && self.identity_registry.is_empty() {
+            if let Ok(cfg) = crate::genesis::GenesisConfig::from_embedded() {
+                let applied = cfg.apply_genesis_state(self);
+                info!(
+                    "Genesis state restored during sync: {} identities, {} wallets, {} validators",
+                    self.identity_registry.len(),
+                    self.wallet_registry.len(),
+                    self.validator_registry.len(),
+                );
+                if let Err(e) = applied {
+                    warn!("Genesis state restoration incomplete: {}", e);
+                }
+            }
+        }
+
         // Remove processed transactions from pending pool
         self.remove_pending_transactions(&block.transactions);
 

--- a/lib-blockchain/src/blockchain/gateways.rs
+++ b/lib-blockchain/src/blockchain/gateways.rs
@@ -70,6 +70,7 @@ impl Blockchain {
             dao_fee: 0,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
+                    kyber_public_key: Vec::new(),
         };
 
         let registration_tx = Transaction::new_identity_registration(
@@ -155,6 +156,7 @@ impl Blockchain {
             dao_fee: 0,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
+                    kyber_public_key: Vec::new(),
         };
 
         let update_tx = Transaction::new_identity_update(

--- a/lib-blockchain/src/blockchain/identity.rs
+++ b/lib-blockchain/src/blockchain/identity.rs
@@ -529,6 +529,7 @@ impl Blockchain {
             dao_fee: 0,
             controlled_nodes: Vec::new(),
             owned_wallets: vec![wallet_id.to_string()],
+            kyber_public_key: Vec::new(),
         };
 
         let registration_tx = Transaction::new_identity_registration(

--- a/lib-blockchain/src/blockchain/validators.rs
+++ b/lib-blockchain/src/blockchain/validators.rs
@@ -83,6 +83,7 @@ impl Blockchain {
             dao_fee: 0,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
+                    kyber_public_key: Vec::new(),
         };
 
         let registration_tx = Transaction::new_identity_registration(
@@ -168,6 +169,7 @@ impl Blockchain {
             dao_fee: 0,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
+                    kyber_public_key: Vec::new(),
         };
 
         let update_tx = Transaction::new_identity_update(

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -572,6 +572,7 @@ impl GenesisConfig {
                     dao_fee: 0,
                     controlled_nodes: vec![],
                     owned_wallets: vec![],
+                    kyber_public_key: vec![],
                 },
             );
             bc.identity_blocks.insert(id.did.clone(), 0u64);
@@ -626,6 +627,91 @@ impl GenesisConfig {
                         entry.wallet_id, e
                     );
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Re-apply genesis state (identities, wallets, validators, council) to an existing
+    /// blockchain during catch-up sync. Called when a synced node receives block 0 but
+    /// the identity/wallet registries are empty because genesis state is populated via
+    /// direct inserts in build_block0(), not via transactions.
+    pub fn apply_genesis_state(&self, bc: &mut crate::Blockchain) -> Result<()> {
+        {
+            let alloc = &self.allocations;
+            // identities
+            for id in &alloc.identities {
+                let pk_bytes = hex::decode(&id.public_key).unwrap_or_default();
+                if !bc.identity_registry.contains_key(&id.did) {
+                    bc.identity_registry.insert(
+                        id.did.clone(),
+                        crate::transaction::IdentityTransactionData {
+                            did: id.did.clone(),
+                            display_name: id.display_name.clone(),
+                            public_key: pk_bytes,
+                            ownership_proof: vec![],
+                            identity_type: id.identity_type.clone(),
+                            did_document_hash: crate::types::Hash::default(),
+                            created_at: id.created_at,
+                            registration_fee: 0,
+                            dao_fee: 0,
+                            controlled_nodes: vec![],
+                            owned_wallets: vec![],
+                            kyber_public_key: vec![],
+                        },
+                    );
+                    bc.identity_blocks.insert(id.did.clone(), 0u64);
+                }
+            }
+            // wallets
+            for w in &alloc.wallets {
+                let wallet_id_bytes = hex::decode(&w.wallet_id).unwrap_or_default();
+                let wallet_key = w.wallet_id.clone();
+                if !bc.wallet_registry.contains_key(&wallet_key) {
+                    let pk_bytes = hex::decode(&w.public_key).unwrap_or_default();
+                    let owner_id = w.owner_identity_id.as_ref().map(|oid| {
+                        let hex_part = oid.strip_prefix("did:zhtp:").unwrap_or(oid);
+                        let bytes = hex::decode(hex_part).unwrap_or_default();
+                        let mut h = [0u8; 32];
+                        let len = bytes.len().min(32);
+                        h[..len].copy_from_slice(&bytes[..len]);
+                        crate::types::Hash::from_slice(&h)
+                    });
+                    let mut wid = [0u8; 32];
+                    let len = wallet_id_bytes.len().min(32);
+                    wid[..len].copy_from_slice(&wallet_id_bytes[..len]);
+                    bc.wallet_registry.insert(
+                        wallet_key.clone(),
+                        crate::transaction::WalletTransactionData {
+                            wallet_id: crate::types::Hash::from_slice(&wid),
+                            wallet_type: w.wallet_type.clone(),
+                            wallet_name: String::new(),
+                            alias: None,
+                            public_key: pk_bytes,
+                            owner_identity_id: owner_id,
+                            seed_commitment: crate::types::Hash::default(),
+                            created_at: w.created_at,
+                            registration_fee: 0,
+                            capabilities: 0,
+                            initial_balance: 0,
+                        },
+                    );
+                    bc.wallet_blocks.insert(wallet_key, 0u64);
+                }
+            }
+        }
+
+        // council
+        if bc.council_members.is_empty() {
+            bc.council_threshold = self.bootstrap_council.threshold;
+            for member in &self.bootstrap_council.members {
+                bc.council_members.push(crate::dao::CouncilMember {
+                    identity_id: member.did.clone(),
+                    wallet_id: member.wallet.clone(),
+                    stake_amount: 0,
+                    joined_at_height: 0,
+                });
             }
         }
 

--- a/lib-blockchain/src/integration/economic_integration.rs
+++ b/lib-blockchain/src/integration/economic_integration.rs
@@ -479,6 +479,7 @@ impl EconomicTransactionProcessor {
                     dao_fee: 0,
                     controlled_nodes: Vec::new(),
                     owned_wallets: Vec::new(),
+                    kyber_public_key: Vec::new(),
                 })
             }
             EconomyTransactionType::ProposalVote | EconomyTransactionType::ProposalExecution => {
@@ -498,6 +499,7 @@ impl EconomicTransactionProcessor {
                     dao_fee: economy_tx.dao_fee as u64,
                     controlled_nodes: Vec::new(),
                     owned_wallets: Vec::new(),
+                    kyber_public_key: Vec::new(),
                 })
             }
             _ => None, // Regular payments don't require identity verification

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -531,6 +531,10 @@ pub struct IdentityTransactionData {
     pub controlled_nodes: Vec<String>,
     /// Wallet IDs owned by this identity
     pub owned_wallets: Vec<String>,
+    /// Kyber1024 public key for post-quantum key encapsulation (messaging, encryption).
+    /// 1568 bytes when present. Empty for identities registered before this field was added.
+    #[serde(default)]
+    pub kyber_public_key: Vec<u8>,
 }
 
 /// Wallet registration transaction data (processed by lib-identity package)
@@ -774,6 +778,7 @@ impl Transaction {
             dao_fee: 0,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
+                    kyber_public_key: Vec::new(),
         };
 
         Transaction {
@@ -2037,7 +2042,14 @@ impl IdentityTransactionData {
             dao_fee,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
+            kyber_public_key: Vec::new(),
         }
+    }
+
+    /// Set the Kyber1024 public key for post-quantum key encapsulation.
+    pub fn with_kyber_public_key(mut self, kyber_pk: Vec<u8>) -> Self {
+        self.kyber_public_key = kyber_pk;
+        self
     }
 
     /// Create identity transaction data with node and wallet associations
@@ -2068,6 +2080,7 @@ impl IdentityTransactionData {
             dao_fee,
             controlled_nodes,
             owned_wallets,
+            kyber_public_key: Vec::new(),
         }
     }
 

--- a/zhtp/src/api/handlers/identity/backup_recovery.rs
+++ b/zhtp/src/api/handlers/identity/backup_recovery.rs
@@ -533,6 +533,7 @@ async fn auto_create_identity_from_seed(
                     dao_fee: 0,
                     controlled_nodes: vec![],
                     owned_wallets: vec![],
+                    kyber_public_key: vec![],
                 };
                 let reg_tx = lib_blockchain::transaction::Transaction::new_identity_registration(
                     identity_data.clone(),
@@ -1749,6 +1750,7 @@ pub async fn handle_migrate_identity(
                     dao_fee: 0,
                     controlled_nodes: vec![],
                     owned_wallets: wallet_ids_all.iter().cloned().collect(),
+                    kyber_public_key: vec![],
                 };
 
                 if let Err(e) = blockchain.register_identity(identity_tx) {

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1710,7 +1710,8 @@ impl IdentityHandler {
             Hash::default(),
             0,
             0,
-        );
+        )
+        .with_kyber_public_key(kyber_public_key.clone().unwrap_or_default());
 
         use lib_blockchain::transaction::TransactionOutput;
 

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -898,6 +898,14 @@ impl ZhtpRequestHandler for TokenHandler {
     ) -> lib_protocols::zhtp::ZhtpResult<ZhtpResponse> {
         info!("Token handler: {} {}", request.method, request.uri);
 
+        // Access zone gate: password sessions cannot access token/balance endpoints
+        if crate::session_manager::is_request_password_session(&request).await {
+            return Ok(create_error_response(
+                ZhtpStatus::Forbidden,
+                "Token access requires key authentication (mobile app or seed phrase recovery)".to_string(),
+            ));
+        }
+
         let response = match (request.method.clone(), request.uri.as_str()) {
             // POST /api/v1/token/create
             (ZhtpMethod::Post, "/api/v1/token/create") => self.handle_create_token(request).await,

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -77,6 +77,14 @@ impl ZhtpRequestHandler for WalletHandler {
     async fn handle_request(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
         tracing::info!("Wallet handler: {} {}", request.method, request.uri);
 
+        // Access zone gate: password sessions cannot access wallet endpoints
+        if crate::session_manager::is_request_password_session(&request).await {
+            return Ok(create_error_response(
+                ZhtpStatus::Forbidden,
+                "Wallet access requires key authentication (mobile app or seed phrase recovery)".to_string(),
+            ));
+        }
+
         let response = match (request.method, request.uri.as_str()) {
             // GET /api/v1/wallet/list/{identity_id}
             (ZhtpMethod::Get, path) if path.starts_with("/api/v1/wallet/list/") => {
@@ -1649,6 +1657,7 @@ impl WalletHandler {
                     dao_fee: 0,
                     controlled_nodes: vec![],
                     owned_wallets: vec![],
+                    kyber_public_key: vec![],
                 };
 
                 // Create IdentityRegistration system transaction for block persistence

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -631,6 +631,7 @@ async fn migrate_identities_to_blockchain() -> Result<(u32, u32)> {
             dao_fee: 0,
             controlled_nodes: vec![],
             owned_wallets: vec![],
+            kyber_public_key: vec![],
         };
 
         // Register on blockchain
@@ -1274,6 +1275,7 @@ mod tests {
                 created_at: 1_700_000_000,
                 controlled_nodes: vec![],
                 owned_wallets: vec![],
+                kyber_public_key: vec![],
             },
         );
 
@@ -1331,6 +1333,7 @@ mod tests {
                 created_at: 1_700_000_100,
                 controlled_nodes: vec![],
                 owned_wallets: vec![],
+                kyber_public_key: vec![],
             },
         );
 

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -2741,6 +2741,7 @@ impl RuntimeOrchestrator {
                             .keys()
                             .map(|id| hex::encode(&id.0))
                             .collect(),
+                        kyber_public_key: vec![],
                     };
 
                     // Register identity on blockchain
@@ -2921,6 +2922,7 @@ impl RuntimeOrchestrator {
                                         .keys()
                                         .map(|id| hex::encode(&id.0))
                                         .collect(),
+                                    kyber_public_key: vec![],
                                 };
 
                             match blockchain_ref.register_identity(identity_data) {

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -400,6 +400,7 @@ impl GenesisFundingService {
                 dao_fee: 0,
                 controlled_nodes: controlled_node_ids,
                 owned_wallets: vec![hex::encode(&user_primary_wallet_id.as_ref().unwrap().0 .0)],
+                kyber_public_key: vec![],
             };
 
             if blockchain.identity_registry.contains_key(&user_did) {
@@ -493,6 +494,7 @@ impl GenesisFundingService {
                             .map(|id| vec![hex::encode(id.0)])
                             .unwrap_or_default(),
                         owned_wallets: Vec::new(),
+                        kyber_public_key: Vec::new(),
                     },
                 );
                 blockchain.identity_blocks.insert(validator_did.clone(), 0);

--- a/zhtp/src/server/mesh/identity_api.rs
+++ b/zhtp/src/server/mesh/identity_api.rs
@@ -1561,6 +1561,7 @@ async fn record_identity_on_blockchain(identity_result: &serde_json::Value) -> R
         dao_fee: 50,
         controlled_nodes: Vec::new(),
         owned_wallets: Vec::new(),
+        kyber_public_key: vec![],
     };
 
     let identity_tx_hash = blockchain_guard.register_identity(identity_data)?;

--- a/zhtp/src/session_manager.rs
+++ b/zhtp/src/session_manager.rs
@@ -8,6 +8,32 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use std::sync::OnceLock;
+
+static GLOBAL_SESSION_MANAGER: OnceLock<Arc<SessionManager>> = OnceLock::new();
+
+/// Set the global session manager instance. Called once during startup.
+pub fn set_global_session_manager(manager: Arc<SessionManager>) {
+    let _ = GLOBAL_SESSION_MANAGER.set(manager);
+}
+
+/// Check if a request's bearer token is from a password session (public zone only).
+/// Returns true if the token is a password session → handler should reject wallet access.
+pub async fn is_request_password_session(request: &lib_protocols::types::ZhtpRequest) -> bool {
+    let token = match request.headers.get("Authorization") {
+        Some(auth) => match auth.strip_prefix("Bearer ") {
+            Some(t) => t.to_string(),
+            None => return false,
+        },
+        None => return false,
+    };
+    if let Some(mgr) = GLOBAL_SESSION_MANAGER.get() {
+        mgr.is_password_session(&token).await
+    } else {
+        false
+    }
+}
+
 /// Session manager for the ZHTP server
 #[derive(Debug)]
 pub struct SessionManager {


### PR DESCRIPTION
## Summary

Three precursors for the PQ messaging epic (#2459):

- **#2478**: Kyber public key stored on-chain in IdentityTransactionData — any node can look up encryption keys for KEM
- **#2479**: Genesis state restored during catch-up sync — fixes restarted nodes losing 149 identities  
- **#2480**: Password sessions rejected at wallet/token handlers — only key sessions access wallets/balances

## Test plan
- [x] Build passes
- [ ] Deploy and verify restarted nodes recover identities
- [ ] Verify password signin cannot access wallet endpoints
- [ ] Verify new identity registrations include Kyber key