### PR TITLE
feat: wire PQ messaging — handler registration, mesh relay, deposit collection

### DIFF
--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -79,6 +79,8 @@ pub struct MeshMessageHandler {
     /// When set, received OracleAttestation gossip payloads are forwarded here for
     /// deserialization and processing by the oracle runtime component.
     pub oracle_attestation_sender: Option<OracleAttestationSender>,
+    /// Message relay sender — encrypted messaging envelopes forwarded to the messaging layer.
+    pub message_relay_sender: Option<tokio::sync::mpsc::Sender<(String, Vec<u8>)>>,
 }
 
 /// DHT rate limit configuration
@@ -116,7 +118,14 @@ impl MeshMessageHandler {
             validator_message_buffer: Arc::new(std::sync::Mutex::new(Vec::new())),
             identity_store_forward: None,
             oracle_attestation_sender: None,
+            message_relay_sender: None,
         }
+    }
+
+    /// Wire the message relay sender for encrypted messaging.
+    pub fn set_message_relay_sender(&mut self, sender: tokio::sync::mpsc::Sender<(String, Vec<u8>)>) {
+        self.message_relay_sender = Some(sender);
+        info!("🔗 Message relay sender wired to mesh message handler");
     }
 
     /// Wire the oracle attestation sender.
@@ -893,6 +902,21 @@ impl MeshMessageHandler {
                     debug!(
                         "Received OracleAttestation ({} bytes) but oracle sender not wired — ignoring",
                         payload.len()
+                    );
+                }
+            }
+            ZhtpMeshMessage::MessageRelay { recipient_did, envelope } => {
+                if let Some(ref tx) = self.message_relay_sender {
+                    if let Err(e) = tx.try_send((recipient_did.clone(), envelope)) {
+                        warn!(
+                            "MessageRelay dropped for {} (inbox full or closed)",
+                            &recipient_did[..16.min(recipient_did.len())]
+                        );
+                    }
+                } else {
+                    debug!(
+                        "Received MessageRelay for {} but relay sender not wired",
+                        &recipient_did[..16.min(recipient_did.len())]
                     );
                 }
             }

--- a/lib-network/src/types/mesh_message.rs
+++ b/lib-network/src/types/mesh_message.rs
@@ -71,6 +71,8 @@ pub enum MessageType {
     OracleAttestation = 32,
     /// Relay-routed message envelope for true multi-hop forwarding.
     RoutedMessage = 33,
+    /// Encrypted message relay for PQ messaging.
+    MessageRelay = 34,
 }
 
 /// Message envelope for multi-hop routing
@@ -706,6 +708,13 @@ pub enum ZhtpMeshMessage {
         route_history: Vec<PublicKey>,
         payload: Vec<u8>,
     },
+
+    /// Encrypted message relay for PQ messaging.
+    /// Sent to all mesh peers — the peer hosting the recipient DID delivers it.
+    MessageRelay {
+        recipient_did: String,
+        envelope: Vec<u8>,
+    },
 }
 
 /// Acknowledgement for store-and-forward message delivery
@@ -1019,6 +1028,13 @@ impl ZhtpMeshMessage {
             } => (
                 MessageType::RoutedMessage,
                 bincode::serialize(&(destination, ttl, hop_count, route_history, payload))?,
+            ),
+            Self::MessageRelay {
+                recipient_did,
+                envelope,
+            } => (
+                MessageType::MessageRelay,
+                bincode::serialize(&(recipient_did, envelope))?,
             ),
         };
         Ok((msg_type, payload))
@@ -1340,6 +1356,14 @@ impl ZhtpMeshMessage {
                     hop_count,
                     route_history,
                     payload,
+                }
+            }
+            MessageType::MessageRelay => {
+                let (recipient_did, envelope): (String, Vec<u8>) =
+                    bincode::deserialize(payload)?;
+                Self::MessageRelay {
+                    recipient_did,
+                    envelope,
                 }
             }
         };

--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -141,9 +141,19 @@ impl MessagingHandler {
 
         // Check if recipient is online on this node
         if self.presence.is_online(&recipient_did).await {
-            // TODO: deliver directly via QUIC stream to recipient's phone
+            // Recipient connected to this node — deliver directly
+            // The recipient will pick it up on their next /msg/receive poll
+            self.deposits
+                .deposit(
+                    &envelope.sender_did,
+                    &recipient_did,
+                    vec![envelope_bytes],
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("Deposit failed: {}", e))?;
+
             info!(
-                "Message relayed to online recipient {}",
+                "Message delivered to local recipient {}",
                 &recipient_did[..16.min(recipient_did.len())]
             );
             return json_response(json!({
@@ -152,13 +162,44 @@ impl MessagingHandler {
             }));
         }
 
-        // Recipient not on this node — try mesh relay
-        // TODO: query mesh for which node the recipient is connected to
-        // For now: return "queued" and let the sender deposit on disconnect
+        // Recipient not on this node — try mesh relay via QUIC broadcast
+        if let Ok(mesh_router) = crate::runtime::mesh_router_provider::get_global_mesh_router().await {
+            let quic_guard = mesh_router.quic_protocol.read().await;
+            if let Some(ref qp) = *quic_guard {
+                let peer_ids = qp.connected_peer_ids();
+                if !peer_ids.is_empty() {
+                    // Broadcast envelope to all mesh peers — the one hosting the recipient delivers it
+                    let mesh_msg = lib_network::types::mesh_message::ZhtpMeshMessage::MessageRelay {
+                        recipient_did: recipient_did.clone(),
+                        envelope: envelope_bytes.clone(),
+                    };
+                    let mut relayed = false;
+                    for peer_id in &peer_ids {
+                        if qp.send_to_peer(peer_id, mesh_msg.clone()).await.is_ok() {
+                            relayed = true;
+                        }
+                    }
+                    drop(quic_guard);
+
+                    if relayed {
+                        info!(
+                            "Message relayed via mesh for {}",
+                            &recipient_did[..16.min(recipient_did.len())]
+                        );
+                        return json_response(json!({
+                            "status": "relayed",
+                            "recipient_did": recipient_did,
+                        }));
+                    }
+                }
+            }
+        }
+
+        // Nobody could deliver — tell sender to deposit before disconnecting
         json_response(json!({
             "status": "queued",
             "recipient_did": recipient_did,
-            "message": "Recipient not online. Deposit envelopes before disconnecting.",
+            "message": "Recipient not reachable. Deposit envelopes before disconnecting.",
         }))
     }
 

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -993,6 +993,65 @@ impl ZhtpUnifiedServer {
         // Register DHT handler on ZHTP (already registered on mesh_router for pure UDP)
         zhtp_router.register_handler("/api/v1/dht".to_string(), dht_handler);
 
+        // Post-quantum encrypted messaging
+        {
+            let blockchain_arc = crate::runtime::blockchain_provider::get_global_blockchain()
+                .await
+                .unwrap_or_else(|_| {
+                    // Fallback: create a placeholder — will be replaced when blockchain is ready
+                    Arc::new(tokio::sync::RwLock::new(lib_blockchain::Blockchain::default()))
+                });
+            let deposits = Arc::new(crate::messaging::deposit::DepositStore::new());
+            let presence = Arc::new(crate::messaging::presence::PresenceTracker::new());
+
+            // Spawn deposit cleanup task (every 5 minutes)
+            let deposits_cleanup = deposits.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(300));
+                loop {
+                    interval.tick().await;
+                    let expired = deposits_cleanup.cleanup_expired().await;
+                    if expired > 0 {
+                        tracing::info!("Cleaned up {} expired message deposits", expired);
+                    }
+                }
+            });
+
+            // Wire mesh relay receiver — incoming relayed messages get deposited
+            let deposits_relay = deposits.clone();
+            let (relay_tx, mut relay_rx) = tokio::sync::mpsc::channel::<(String, Vec<u8>)>(256);
+            tokio::spawn(async move {
+                while let Some((recipient_did, envelope)) = relay_rx.recv().await {
+                    let sender = "mesh_relay".to_string();
+                    if let Err(e) = deposits_relay
+                        .deposit(&sender, &recipient_did, vec![envelope])
+                        .await
+                    {
+                        tracing::warn!("Failed to deposit relayed message: {}", e);
+                    }
+                }
+            });
+
+            // Wire relay sender to mesh message handler
+            if let Ok(mesh_router) = crate::runtime::mesh_router_provider::get_global_mesh_router().await {
+                if let Some(qp) = mesh_router.quic_protocol.read().await.as_ref() {
+                    if let Some(handler) = qp.message_handler.as_ref() {
+                        handler.write().await.set_message_relay_sender(relay_tx);
+                    }
+                }
+            }
+
+            let msg_handler: Arc<dyn ZhtpRequestHandler> = Arc::new(
+                crate::messaging::handler::MessagingHandler::new(
+                    blockchain_arc,
+                    deposits,
+                    presence,
+                ),
+            );
+            zhtp_router.register_handler("/api/v1/msg".to_string(), msg_handler);
+            tracing::info!("Post-quantum messaging handler registered");
+        }
+
         // PoUW validator (created early so it can be shared with Web4 handlers)
         // Derive node key/id from identity manager; never use shared placeholder material.
         let (pouw_node_key, pouw_node_id) = {


### PR DESCRIPTION
## Summary
Wires the messaging system end-to-end:
- Handler registered at `/api/v1/msg/*` in the QUIC server
- `MessageRelay` mesh message type (type 34) for cross-node delivery
- Incoming relays deposited for recipient via channel
- Deposit cleanup every 5 minutes
- `handle_send` routes: local → mesh broadcast → queued

## Endpoints live
```
POST /api/v1/msg/session/init      — get recipient Kyber key
POST /api/v1/msg/send              — relay encrypted envelope
POST /api/v1/msg/deposit           — deposit before disconnect
GET  /api/v1/msg/receive           — poll for pending
POST /api/v1/msg/presence/watch    — subscribe to presence
```

## Test plan
- [x] Build passes
- [ ] Staged deploy per protocol