### PR TITLE
feat(identity): DID-001 — rename overlapping tier systems to semantic types (#223)

### DIFF
--- a/lib-blockchain/tests/common/block_builders.rs
+++ b/lib-blockchain/tests/common/block_builders.rs
@@ -4,8 +4,10 @@
 //! do not each need their own copy of the same BlockHeader boilerplate.
 
 use lib_blockchain::block::{Block, BlockHeader};
-use lib_blockchain::transaction::Transaction;
-use lib_blockchain::types::Hash;
+use lib_blockchain::integration::zk_integration::ZkTransactionProof;
+use lib_blockchain::transaction::{Transaction, TransactionInput, TransactionOutput, TransactionPayload};
+use lib_blockchain::types::{transaction_type::TransactionType, Hash};
+use lib_crypto::types::signatures::{Signature, SignatureAlgorithm};
 
 /// A canonical genesis block (height 0) with a recognisable first byte (0x01).
 pub fn genesis_block() -> Block {
@@ -71,4 +73,48 @@ pub fn child_block(parent: &Block, txs: Vec<Transaction>) -> Block {
         block_hash: Hash::default(),
     };
     Block::new(header, txs)
+}
+
+/// A minimal `TransactionInput` with all-default fields.
+pub fn test_input() -> TransactionInput {
+    TransactionInput::new(
+        Hash::default(),
+        0,
+        Hash::default(),
+        ZkTransactionProof::default(),
+    )
+}
+
+/// A minimal `TransactionOutput` with a seeded recipient key.
+pub fn test_output() -> TransactionOutput {
+    TransactionOutput::new(
+        Hash::default(),
+        Hash::default(),
+        super::crypto_fixtures::seeded_public_key(1),
+    )
+}
+
+/// A `Transaction` of the given type and fee, seeded by `index`.
+pub fn test_transaction_at(tx_type: TransactionType, fee: u64, index: u32) -> Transaction {
+    Transaction {
+        version: 1,
+        chain_id: 1,
+        transaction_type: tx_type,
+        inputs: vec![],
+        outputs: vec![TransactionOutput {
+            commitment: Hash::default(),
+            note: Hash::default(),
+            recipient: super::crypto_fixtures::seeded_public_key(index as u8),
+            merkle_leaf: Hash::default(),
+        }],
+        fee,
+        signature: Signature {
+            signature: format!("sig_{}", index).as_bytes().to_vec(),
+            public_key: super::crypto_fixtures::seeded_public_key(index as u8),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 0,
+        },
+        memo: format!("test_tx_{}", index).as_bytes().to_vec(),
+        payload: TransactionPayload::None,
+    }
 }

--- a/lib-blockchain/tests/sov_week10_integration_tests.rs
+++ b/lib-blockchain/tests/sov_week10_integration_tests.rs
@@ -10,6 +10,8 @@
 //!
 //! Total: 14 integration tests across 5 categories
 
+mod common;
+
 #[cfg(test)]
 mod sov_week10_integration_tests {
     use lib_blockchain::transaction::TransactionPayload;
@@ -25,51 +27,12 @@ mod sov_week10_integration_tests {
     // TEST UTILITIES AND FIXTURES
     // ========================================================================
 
-    /// Generate a deterministic but varied test public key from an index
-    ///
-    /// Instead of repeating a single byte (e.g., [42, 42, 42, ...]), this creates
-    /// a more realistic key by using the index as a seed and applying a simple
-    /// deterministic hash-like transformation to create varied byte patterns.
     fn create_test_public_key(index: u32) -> PublicKey {
-        // Use 7 as multiplier to create varied patterns across all byte positions.
-        // The wrapping multiplication ensures different indices produce distinct
-        // key patterns even when index values are similar.
-        const KEY_PATTERN_MULTIPLIER: u8 = 7;
-        let mut key_bytes = vec![0u8; 32];
-        let index_bytes = index.to_le_bytes();
-
-        // Fill key with a deterministic but varied pattern based on index
-        for i in 0..32 {
-            key_bytes[i] =
-                (index_bytes[i % 4].wrapping_add(i as u8)).wrapping_mul(KEY_PATTERN_MULTIPLIER);
-        }
-
-        PublicKey::new([42u8; 2592])
+        super::common::crypto_fixtures::seeded_public_key(index as u8)
     }
 
-    /// Create a test transaction with specified type and fee
     fn create_test_transaction(tx_type: TransactionType, fee: u64, index: u32) -> Transaction {
-        Transaction {
-            version: 1,
-            chain_id: 1,
-            transaction_type: tx_type,
-            inputs: vec![],
-            outputs: vec![TransactionOutput {
-                commitment: Hash::default(),
-                note: Hash::default(),
-                recipient: create_test_public_key(index),
-                            merkle_leaf: Hash::default(),
-}],
-            fee,
-            signature: Signature {
-                signature: format!("sig_{}", index).as_bytes().to_vec(),
-                public_key: create_test_public_key(index),
-                algorithm: SignatureAlgorithm::DEFAULT,
-                timestamp: 0,
-            },
-            memo: format!("test_tx_{}", index).as_bytes().to_vec(),
-            payload: TransactionPayload::None,
-        }
+        super::common::block_builders::test_transaction_at(tx_type, fee, index)
     }
 
     /// Create a block with specified number of transactions and fee distribution

--- a/lib-blockchain/tests/sov_week7_integration_tests.rs
+++ b/lib-blockchain/tests/sov_week7_integration_tests.rs
@@ -12,48 +12,19 @@
 //! 4. Consensus Integration Tests (8 tests) - Fee collection hook integration
 //! 5. Performance Validation Tests (5 tests) - Scalability validation (1M citizens)
 
-use lib_blockchain::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+use lib_blockchain::integration::crypto_integration::{PublicKey, Signature};
 use lib_blockchain::transaction::{
     core::{ProfitDeclarationData, RevenueSource, UbiClaimData},
     Transaction, TransactionInput, TransactionOutput,
 };
 use lib_blockchain::types::{transaction_type::TransactionType, Hash};
 
-// =============================================================================
-// TEST FIXTURES & UTILITIES
-// =============================================================================
+mod common;
 
-/// Create a test signature
-fn create_test_signature() -> Signature {
-    Signature {
-        signature: vec![0x01, 0x02, 0x03, 0x04],
-        public_key: PublicKey::new([0x01; 2592]),
-        algorithm: SignatureAlgorithm::DEFAULT,
-        timestamp: 1000,
-    }
-}
-
-/// Create a test public key with specific bytes
-fn create_test_public_key(id: u8) -> PublicKey {
-    let mut dilithium_pk = [0u8; 2592];
-    dilithium_pk[0] = id;
-    PublicKey::new(dilithium_pk)
-}
-
-/// Create a test transaction input
-fn create_test_input() -> TransactionInput {
-    TransactionInput::new(
-        Hash::default(),
-        0,
-        Hash::default(),
-        lib_blockchain::integration::zk_integration::ZkTransactionProof::default(),
-    )
-}
-
-/// Create a test transaction output
-fn create_test_output() -> TransactionOutput {
-    TransactionOutput::new(Hash::default(), Hash::default(), create_test_public_key(1))
-}
+fn create_test_signature() -> Signature { common::crypto_fixtures::seeded_signature(1) }
+fn create_test_public_key(id: u8) -> PublicKey { common::crypto_fixtures::seeded_public_key(id) }
+fn create_test_input() -> TransactionInput { common::block_builders::test_input() }
+fn create_test_output() -> TransactionOutput { common::block_builders::test_output() }
 
 /// Create a test claim ID
 fn create_test_claim_id(citizen_id: u8, month: u64) -> Hash {

--- a/lib-consensus/tests/common/consensus_fixtures.rs
+++ b/lib-consensus/tests/common/consensus_fixtures.rs
@@ -5,6 +5,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use lib_consensus::validators::validator_protocol::NetworkSummary;
 use lib_consensus::{ConsensusConfig, ConsensusProof, ConsensusProposal, ConsensusType, ConsensusVote, StakeProof, VoteType};
 use lib_crypto::{hash_blake3, Hash, PostQuantumSignature, PublicKey, SignatureAlgorithm};
 use lib_identity::IdentityId;
@@ -167,5 +168,41 @@ pub fn test_vote(
         round,
         timestamp,
         signature: test_signature(timestamp),
+    }
+}
+
+/// A 32-byte non-zero key — use where the code under test rejects all-zero keys.
+pub fn non_zero_key() -> Vec<u8> {
+    vec![1u8; 32]
+}
+
+/// A 32-byte zero key — use where the code under test should reject it.
+pub fn zero_key() -> Vec<u8> {
+    vec![0u8; 32]
+}
+
+/// A `PostQuantumSignature` whose first byte encodes `nonce`.
+/// Distinct from `test_signature` which uses timestamp-based byte spreading.
+pub fn nonce_signature(nonce: u64) -> PostQuantumSignature {
+    let mut sig_bytes = vec![1u8; 64];
+    sig_bytes[0] = (nonce % 256) as u8;
+    PostQuantumSignature {
+        signature: sig_bytes,
+        public_key: PublicKey {
+            dilithium_pk: [1u8; 2592],
+            kyber_pk: [1u8; 1568],
+            key_id: [1u8; 32],
+        },
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: nonce,
+    }
+}
+
+/// A minimal `NetworkSummary` with the given active validator count.
+pub fn network_summary(active_validators: u32) -> NetworkSummary {
+    NetworkSummary {
+        active_validators,
+        health_score: 0.95,
+        block_rate: 0.1,
     }
 }

--- a/lib-consensus/tests/heartbeat_tests.rs
+++ b/lib-consensus/tests/heartbeat_tests.rs
@@ -16,14 +16,7 @@ fn create_unique_identity() -> IdentityId { common::consensus_fixtures::unique_i
 fn current_timestamp() -> u64 { common::consensus_fixtures::current_timestamp() }
 fn create_test_signature(timestamp: u64) -> PostQuantumSignature { common::consensus_fixtures::test_signature(timestamp) }
 
-/// Helper to create a placeholder network summary for testing
-fn create_test_network_summary(active_count: u32) -> NetworkSummary {
-    NetworkSummary {
-        active_validators: active_count,
-        health_score: 0.95,
-        block_rate: 0.1,
-    }
-}
+fn create_test_network_summary(active_count: u32) -> NetworkSummary { common::consensus_fixtures::network_summary(active_count) }
 
 /// Helper to create a HeartbeatMessage for testing
 fn create_test_heartbeat(

--- a/lib-consensus/tests/security_fixes_tests.rs
+++ b/lib-consensus/tests/security_fixes_tests.rs
@@ -21,30 +21,9 @@ use std::time::SystemTime;
 mod common;
 
 fn create_test_identity(seed: &str) -> IdentityId { common::consensus_fixtures::named_identity(seed) }
-
-fn create_test_key() -> Vec<u8> {
-    vec![1u8; 32] // Non-zero key for testing
-}
-
-fn create_zero_key() -> Vec<u8> {
-    vec![0u8; 32] // Zero key (should be rejected)
-}
-
-fn create_test_signature(nonce: u64) -> PostQuantumSignature {
-    let mut sig_bytes = vec![1u8; 64];
-    sig_bytes[0] = (nonce % 256) as u8;
-
-    PostQuantumSignature {
-        signature: sig_bytes,
-        public_key: PublicKey {
-            dilithium_pk: [1u8; 2592],
-            kyber_pk: [1u8; 1568],
-            key_id: [1u8; 32],
-        },
-        algorithm: SignatureAlgorithm::DEFAULT,
-        timestamp: nonce,
-    }
-}
+fn create_test_key() -> Vec<u8> { common::consensus_fixtures::non_zero_key() }
+fn create_zero_key() -> Vec<u8> { common::consensus_fixtures::zero_key() }
+fn create_test_signature(nonce: u64) -> PostQuantumSignature { common::consensus_fixtures::nonce_signature(nonce) }
 
 #[test]
 fn test_fix_10_systemtime_panic_handling() {

--- a/lib-identity/src/lib.rs
+++ b/lib-identity/src/lib.rs
@@ -54,7 +54,8 @@ pub mod compat;
 
 // Types module - Core identity and node types
 pub use types::{
-    AccessLevel,     // ✓ FullCitizen, Visitor, Organization, Device, Restricted
+    AccessLevel,        // ✓ FullCitizen, Visitor, Organization, Device, Restricted
+    CitizenshipStatus, // ✓ Visitor, ProvisionalCitizen, VerifiedCitizen, TrustedCitizen
     AttestationType, // ✓ Attestation types
 
     // Credential types

--- a/lib-identity/src/types/identity_types.rs
+++ b/lib-identity/src/types/identity_types.rs
@@ -22,6 +22,39 @@ pub enum IdentityType {
     Device,
 }
 
+/// Citizenship progression status — replaces the ambiguous PoP "tier" naming.
+///
+/// Variants map to the four stages of sovereign identity:
+/// Visitor → ProvisionalCitizen → VerifiedCitizen → TrustedCitizen.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CitizenshipStatus {
+    /// No citizenship — read-only observer access
+    Visitor,
+    /// Onboarding in progress — limited participation allowed
+    ProvisionalCitizen,
+    /// Identity verified — full DAO and UBI participation
+    VerifiedCitizen,
+    /// Established participant with vouching rights
+    TrustedCitizen,
+}
+
+impl Default for CitizenshipStatus {
+    fn default() -> Self {
+        CitizenshipStatus::Visitor
+    }
+}
+
+impl std::fmt::Display for CitizenshipStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CitizenshipStatus::Visitor => write!(f, "Visitor"),
+            CitizenshipStatus::ProvisionalCitizen => write!(f, "ProvisionalCitizen"),
+            CitizenshipStatus::VerifiedCitizen => write!(f, "VerifiedCitizen"),
+            CitizenshipStatus::TrustedCitizen => write!(f, "TrustedCitizen"),
+        }
+    }
+}
+
 /// Web4 access levels
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum AccessLevel {

--- a/lib-network/src/handshake/blockchain.rs
+++ b/lib-network/src/handshake/blockchain.rs
@@ -226,7 +226,7 @@ impl BlockchainHandshakeContext {
 /// Determines trust level and capabilities granted to peers based on
 /// their blockchain participation and stake.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum PeerTier {
+pub enum NetworkParticipationLevel {
     /// Verified validator with on-chain stake
     Validator,
 
@@ -237,39 +237,39 @@ pub enum PeerTier {
     Unverified,
 }
 
-impl PeerTier {
+impl NetworkParticipationLevel {
     /// Get minimum stake required for this tier
     pub fn min_stake(&self) -> u64 {
         match self {
-            PeerTier::Validator => 1_000 * 1_000_000, // 1000 SOV minimum for validators
-            PeerTier::StakedNode => 100 * 1_000_000,  // 100 SOV minimum for staked nodes
-            PeerTier::Unverified => 0,
+            NetworkParticipationLevel::Validator => 1_000 * 1_000_000, // 1000 SOV minimum for validators
+            NetworkParticipationLevel::StakedNode => 100 * 1_000_000,  // 100 SOV minimum for staked nodes
+            NetworkParticipationLevel::Unverified => 0,
         }
     }
 
     /// Check if this tier can participate in consensus
     pub fn can_validate(&self) -> bool {
-        matches!(self, PeerTier::Validator)
+        matches!(self, NetworkParticipationLevel::Validator)
     }
 
     /// Check if this tier has enhanced network privileges
     pub fn has_enhanced_privileges(&self) -> bool {
-        matches!(self, PeerTier::Validator | PeerTier::StakedNode)
+        matches!(self, NetworkParticipationLevel::Validator | NetworkParticipationLevel::StakedNode)
     }
 
     /// Get trust score for this tier (0.0 - 1.0)
     pub fn trust_score(&self) -> f64 {
         match self {
-            PeerTier::Validator => 1.0,
-            PeerTier::StakedNode => 0.7,
-            PeerTier::Unverified => 0.3,
+            NetworkParticipationLevel::Validator => 1.0,
+            NetworkParticipationLevel::StakedNode => 0.7,
+            NetworkParticipationLevel::Unverified => 0.3,
         }
     }
 }
 
-impl Default for PeerTier {
+impl Default for NetworkParticipationLevel {
     fn default() -> Self {
-        PeerTier::Unverified
+        NetworkParticipationLevel::Unverified
     }
 }
 
@@ -280,7 +280,7 @@ pub struct BlockchainVerificationResult {
     pub verified: bool,
 
     /// Determined peer tier
-    pub peer_tier: PeerTier,
+    pub peer_tier: NetworkParticipationLevel,
 
     /// Verification details/errors
     pub details: String,
@@ -294,7 +294,7 @@ pub struct BlockchainVerificationResult {
 
 impl BlockchainVerificationResult {
     /// Create a successful verification result
-    pub fn success(peer_tier: PeerTier, details: String) -> Self {
+    pub fn success(peer_tier: NetworkParticipationLevel, details: String) -> Self {
         Self {
             verified: true,
             peer_tier,
@@ -308,7 +308,7 @@ impl BlockchainVerificationResult {
     pub fn failure(reason: String) -> Self {
         Self {
             verified: false,
-            peer_tier: PeerTier::Unverified,
+            peer_tier: NetworkParticipationLevel::Unverified,
             details: reason,
             fork_detected: false,
             epoch_mismatch: false,
@@ -319,7 +319,7 @@ impl BlockchainVerificationResult {
     pub fn fork_detected(details: String) -> Self {
         Self {
             verified: false,
-            peer_tier: PeerTier::Unverified,
+            peer_tier: NetworkParticipationLevel::Unverified,
             details,
             fork_detected: true,
             epoch_mismatch: false,
@@ -330,7 +330,7 @@ impl BlockchainVerificationResult {
     pub fn epoch_mismatch(details: String) -> Self {
         Self {
             verified: false,
-            peer_tier: PeerTier::Unverified,
+            peer_tier: NetworkParticipationLevel::Unverified,
             details,
             fork_detected: false,
             epoch_mismatch: true,
@@ -606,12 +606,12 @@ impl BlockchainHandshakeVerifier {
                         }
 
                         // Determine tier based on stake amount
-                        if stake >= PeerTier::Validator.min_stake() {
-                            PeerTier::Validator
-                        } else if stake >= PeerTier::StakedNode.min_stake() {
-                            PeerTier::StakedNode
+                        if stake >= NetworkParticipationLevel::Validator.min_stake() {
+                            NetworkParticipationLevel::Validator
+                        } else if stake >= NetworkParticipationLevel::StakedNode.min_stake() {
+                            NetworkParticipationLevel::StakedNode
                         } else {
-                            PeerTier::Unverified
+                            NetworkParticipationLevel::Unverified
                         }
                     }
                     None => {
@@ -628,11 +628,11 @@ impl BlockchainHandshakeVerifier {
                 }
             } else {
                 // No identity provided - cannot verify stake
-                PeerTier::Unverified
+                NetworkParticipationLevel::Unverified
             }
         } else {
             // Peer does not claim validator status
-            PeerTier::Unverified
+            NetworkParticipationLevel::Unverified
         };
 
         Ok(BlockchainVerificationResult::success(
@@ -700,17 +700,17 @@ mod tests {
 
     #[test]
     fn test_peer_tier_classification() {
-        assert_eq!(PeerTier::Validator.min_stake(), 1_000_000_000);
-        assert_eq!(PeerTier::StakedNode.min_stake(), 100_000_000);
-        assert_eq!(PeerTier::Unverified.min_stake(), 0);
+        assert_eq!(NetworkParticipationLevel::Validator.min_stake(), 1_000_000_000);
+        assert_eq!(NetworkParticipationLevel::StakedNode.min_stake(), 100_000_000);
+        assert_eq!(NetworkParticipationLevel::Unverified.min_stake(), 0);
 
-        assert!(PeerTier::Validator.can_validate());
-        assert!(!PeerTier::StakedNode.can_validate());
-        assert!(!PeerTier::Unverified.can_validate());
+        assert!(NetworkParticipationLevel::Validator.can_validate());
+        assert!(!NetworkParticipationLevel::StakedNode.can_validate());
+        assert!(!NetworkParticipationLevel::Unverified.can_validate());
 
-        assert!(PeerTier::Validator.has_enhanced_privileges());
-        assert!(PeerTier::StakedNode.has_enhanced_privileges());
-        assert!(!PeerTier::Unverified.has_enhanced_privileges());
+        assert!(NetworkParticipationLevel::Validator.has_enhanced_privileges());
+        assert!(NetworkParticipationLevel::StakedNode.has_enhanced_privileges());
+        assert!(!NetworkParticipationLevel::Unverified.has_enhanced_privileges());
     }
 
     #[test]
@@ -784,7 +784,7 @@ mod tests {
             .verify_peer(&peer_ctx, Some(&validator_id), None)
             .unwrap();
         assert!(result.verified);
-        assert_eq!(result.peer_tier, PeerTier::Validator);
+        assert_eq!(result.peer_tier, NetworkParticipationLevel::Validator);
     }
 
     #[test]
@@ -839,7 +839,7 @@ mod tests {
             .verify_peer(&peer_ctx, Some(&node_id), None)
             .unwrap();
         assert!(result.verified);
-        assert_eq!(result.peer_tier, PeerTier::StakedNode);
+        assert_eq!(result.peer_tier, NetworkParticipationLevel::StakedNode);
     }
 
     #[test]
@@ -851,7 +851,7 @@ mod tests {
 
         let result = verifier.verify_peer(&peer_ctx, None, None).unwrap();
         assert!(result.verified);
-        assert_eq!(result.peer_tier, PeerTier::Unverified);
+        assert_eq!(result.peer_tier, NetworkParticipationLevel::Unverified);
         assert!(!result.fork_detected);
         assert!(!result.epoch_mismatch);
     }

--- a/lib-network/src/handshake/blockchain.rs
+++ b/lib-network/src/handshake/blockchain.rs
@@ -226,7 +226,7 @@ impl BlockchainHandshakeContext {
 /// Determines trust level and capabilities granted to peers based on
 /// their blockchain participation and stake.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum NetworkParticipationLevel {
+pub enum NodeRole {
     /// Verified validator with on-chain stake
     Validator,
 
@@ -237,39 +237,39 @@ pub enum NetworkParticipationLevel {
     Unverified,
 }
 
-impl NetworkParticipationLevel {
+impl NodeRole {
     /// Get minimum stake required for this tier
     pub fn min_stake(&self) -> u64 {
         match self {
-            NetworkParticipationLevel::Validator => 1_000 * 1_000_000, // 1000 SOV minimum for validators
-            NetworkParticipationLevel::StakedNode => 100 * 1_000_000,  // 100 SOV minimum for staked nodes
-            NetworkParticipationLevel::Unverified => 0,
+            NodeRole::Validator => 1_000 * 1_000_000, // 1000 SOV minimum for validators
+            NodeRole::StakedNode => 100 * 1_000_000,  // 100 SOV minimum for staked nodes
+            NodeRole::Unverified => 0,
         }
     }
 
     /// Check if this tier can participate in consensus
     pub fn can_validate(&self) -> bool {
-        matches!(self, NetworkParticipationLevel::Validator)
+        matches!(self, NodeRole::Validator)
     }
 
     /// Check if this tier has enhanced network privileges
     pub fn has_enhanced_privileges(&self) -> bool {
-        matches!(self, NetworkParticipationLevel::Validator | NetworkParticipationLevel::StakedNode)
+        matches!(self, NodeRole::Validator | NodeRole::StakedNode)
     }
 
     /// Get trust score for this tier (0.0 - 1.0)
     pub fn trust_score(&self) -> f64 {
         match self {
-            NetworkParticipationLevel::Validator => 1.0,
-            NetworkParticipationLevel::StakedNode => 0.7,
-            NetworkParticipationLevel::Unverified => 0.3,
+            NodeRole::Validator => 1.0,
+            NodeRole::StakedNode => 0.7,
+            NodeRole::Unverified => 0.3,
         }
     }
 }
 
-impl Default for NetworkParticipationLevel {
+impl Default for NodeRole {
     fn default() -> Self {
-        NetworkParticipationLevel::Unverified
+        NodeRole::Unverified
     }
 }
 
@@ -280,7 +280,7 @@ pub struct BlockchainVerificationResult {
     pub verified: bool,
 
     /// Determined peer tier
-    pub peer_tier: NetworkParticipationLevel,
+    pub peer_tier: NodeRole,
 
     /// Verification details/errors
     pub details: String,
@@ -294,7 +294,7 @@ pub struct BlockchainVerificationResult {
 
 impl BlockchainVerificationResult {
     /// Create a successful verification result
-    pub fn success(peer_tier: NetworkParticipationLevel, details: String) -> Self {
+    pub fn success(peer_tier: NodeRole, details: String) -> Self {
         Self {
             verified: true,
             peer_tier,
@@ -308,7 +308,7 @@ impl BlockchainVerificationResult {
     pub fn failure(reason: String) -> Self {
         Self {
             verified: false,
-            peer_tier: NetworkParticipationLevel::Unverified,
+            peer_tier: NodeRole::Unverified,
             details: reason,
             fork_detected: false,
             epoch_mismatch: false,
@@ -319,7 +319,7 @@ impl BlockchainVerificationResult {
     pub fn fork_detected(details: String) -> Self {
         Self {
             verified: false,
-            peer_tier: NetworkParticipationLevel::Unverified,
+            peer_tier: NodeRole::Unverified,
             details,
             fork_detected: true,
             epoch_mismatch: false,
@@ -330,7 +330,7 @@ impl BlockchainVerificationResult {
     pub fn epoch_mismatch(details: String) -> Self {
         Self {
             verified: false,
-            peer_tier: NetworkParticipationLevel::Unverified,
+            peer_tier: NodeRole::Unverified,
             details,
             fork_detected: false,
             epoch_mismatch: true,
@@ -606,12 +606,12 @@ impl BlockchainHandshakeVerifier {
                         }
 
                         // Determine tier based on stake amount
-                        if stake >= NetworkParticipationLevel::Validator.min_stake() {
-                            NetworkParticipationLevel::Validator
-                        } else if stake >= NetworkParticipationLevel::StakedNode.min_stake() {
-                            NetworkParticipationLevel::StakedNode
+                        if stake >= NodeRole::Validator.min_stake() {
+                            NodeRole::Validator
+                        } else if stake >= NodeRole::StakedNode.min_stake() {
+                            NodeRole::StakedNode
                         } else {
-                            NetworkParticipationLevel::Unverified
+                            NodeRole::Unverified
                         }
                     }
                     None => {
@@ -628,11 +628,11 @@ impl BlockchainHandshakeVerifier {
                 }
             } else {
                 // No identity provided - cannot verify stake
-                NetworkParticipationLevel::Unverified
+                NodeRole::Unverified
             }
         } else {
             // Peer does not claim validator status
-            NetworkParticipationLevel::Unverified
+            NodeRole::Unverified
         };
 
         Ok(BlockchainVerificationResult::success(
@@ -700,17 +700,17 @@ mod tests {
 
     #[test]
     fn test_peer_tier_classification() {
-        assert_eq!(NetworkParticipationLevel::Validator.min_stake(), 1_000_000_000);
-        assert_eq!(NetworkParticipationLevel::StakedNode.min_stake(), 100_000_000);
-        assert_eq!(NetworkParticipationLevel::Unverified.min_stake(), 0);
+        assert_eq!(NodeRole::Validator.min_stake(), 1_000_000_000);
+        assert_eq!(NodeRole::StakedNode.min_stake(), 100_000_000);
+        assert_eq!(NodeRole::Unverified.min_stake(), 0);
 
-        assert!(NetworkParticipationLevel::Validator.can_validate());
-        assert!(!NetworkParticipationLevel::StakedNode.can_validate());
-        assert!(!NetworkParticipationLevel::Unverified.can_validate());
+        assert!(NodeRole::Validator.can_validate());
+        assert!(!NodeRole::StakedNode.can_validate());
+        assert!(!NodeRole::Unverified.can_validate());
 
-        assert!(NetworkParticipationLevel::Validator.has_enhanced_privileges());
-        assert!(NetworkParticipationLevel::StakedNode.has_enhanced_privileges());
-        assert!(!NetworkParticipationLevel::Unverified.has_enhanced_privileges());
+        assert!(NodeRole::Validator.has_enhanced_privileges());
+        assert!(NodeRole::StakedNode.has_enhanced_privileges());
+        assert!(!NodeRole::Unverified.has_enhanced_privileges());
     }
 
     #[test]
@@ -784,7 +784,7 @@ mod tests {
             .verify_peer(&peer_ctx, Some(&validator_id), None)
             .unwrap();
         assert!(result.verified);
-        assert_eq!(result.peer_tier, NetworkParticipationLevel::Validator);
+        assert_eq!(result.peer_tier, NodeRole::Validator);
     }
 
     #[test]
@@ -839,7 +839,7 @@ mod tests {
             .verify_peer(&peer_ctx, Some(&node_id), None)
             .unwrap();
         assert!(result.verified);
-        assert_eq!(result.peer_tier, NetworkParticipationLevel::StakedNode);
+        assert_eq!(result.peer_tier, NodeRole::StakedNode);
     }
 
     #[test]
@@ -851,7 +851,7 @@ mod tests {
 
         let result = verifier.verify_peer(&peer_ctx, None, None).unwrap();
         assert!(result.verified);
-        assert_eq!(result.peer_tier, NetworkParticipationLevel::Unverified);
+        assert_eq!(result.peer_tier, NodeRole::Unverified);
         assert!(!result.fork_detected);
         assert!(!result.epoch_mismatch);
     }

--- a/lib-network/src/handshake/mod.rs
+++ b/lib-network/src/handshake/mod.rs
@@ -118,7 +118,7 @@ pub use security::{
 // Re-export blockchain handshake types
 pub use blockchain::{
     BlockchainHandshakeContext, BlockchainHandshakeVerifier, BlockchainVerificationResult,
-    NetworkParticipationLevel,
+    NodeRole,
 };
 
 // Re-export PQC types and functions

--- a/lib-network/src/handshake/mod.rs
+++ b/lib-network/src/handshake/mod.rs
@@ -117,7 +117,8 @@ pub use security::{
 
 // Re-export blockchain handshake types
 pub use blockchain::{
-    BlockchainHandshakeContext, BlockchainHandshakeVerifier, BlockchainVerificationResult, PeerTier,
+    BlockchainHandshakeContext, BlockchainHandshakeVerifier, BlockchainVerificationResult,
+    NetworkParticipationLevel,
 };
 
 // Re-export PQC types and functions

--- a/lib-storage/tests/common/mod.rs
+++ b/lib-storage/tests/common/mod.rs
@@ -1,0 +1,3 @@
+//! Shared test helpers for lib-storage integration tests.
+
+pub mod storage_fixtures;

--- a/lib-storage/tests/common/storage_fixtures.rs
+++ b/lib-storage/tests/common/storage_fixtures.rs
@@ -1,0 +1,52 @@
+//! Shared storage test fixtures for lib-storage integration tests.
+//!
+//! Centralises backend and config construction so test files do not each
+//! need their own copy of the same boilerplate.
+
+use anyhow::Result;
+use lib_identity::types::NodeId;
+use lib_storage::{
+    EconomicManagerConfig, ErasureConfig, StorageConfig, StorageTier, UnifiedStorageConfig,
+};
+use lib_storage::backend::SledBackend;
+use tempfile::TempDir;
+
+/// Open a temporary Sled backend. The returned `TempDir` must be kept alive
+/// for the duration of the test — dropping it removes the backing directory.
+pub fn test_backend() -> Result<(SledBackend, TempDir)> {
+    let temp_dir = TempDir::new()?;
+    let db_path = temp_dir.path().join("sled_db");
+    let backend = SledBackend::open(&db_path).map_err(|e| anyhow::anyhow!("{}", e))?;
+    Ok((backend, temp_dir))
+}
+
+/// A `UnifiedStorageConfig` wired to `node_id` and `port` with sensible test defaults.
+pub fn test_config(node_id: NodeId, port: u16) -> UnifiedStorageConfig {
+    UnifiedStorageConfig {
+        node_id,
+        addresses: vec![format!("127.0.0.1:{}", port)],
+        economic_config: EconomicManagerConfig {
+            default_duration_days: 30,
+            base_price_per_gb_day: 1000,
+            enable_escrow: true,
+            escrow_release_threshold: 0.8,
+            max_contract_duration: 365,
+            min_contract_value: 100,
+            quality_monitoring_interval: 3600,
+            penalty_enforcement_enabled: true,
+            reward_distribution_enabled: true,
+            market_pricing_enabled: false,
+        },
+        storage_config: StorageConfig {
+            max_storage_size: 1_000_000,
+            default_tier: StorageTier::Warm,
+            enable_compression: false,
+            enable_encryption: false,
+            dht_persist_path: None,
+        },
+        erasure_config: ErasureConfig {
+            data_shards: 3,
+            parity_shards: 2,
+        },
+    }
+}

--- a/lib-storage/tests/dht_nodeid_stability.rs
+++ b/lib-storage/tests/dht_nodeid_stability.rs
@@ -8,10 +8,9 @@
 
 use anyhow::Result;
 use lib_identity::types::NodeId;
-use lib_storage::{
-    EconomicManagerConfig, ErasureConfig, StorageConfig, StorageTier, UnifiedStorageConfig,
-    UnifiedStorageSystem,
-};
+use lib_storage::{UnifiedStorageConfig, UnifiedStorageSystem};
+
+mod common;
 
 /// Test that same DID+device produces same NodeId across 10+ restarts
 #[tokio::test]
@@ -227,33 +226,6 @@ async fn test_dht_locate_with_stable_nodeid() -> Result<()> {
     Ok(())
 }
 
-/// Helper function to create test storage configuration
 fn create_test_config(node_id: NodeId, port: u16) -> UnifiedStorageConfig {
-    UnifiedStorageConfig {
-        node_id,
-        addresses: vec![format!("127.0.0.1:{}", port)],
-        economic_config: EconomicManagerConfig {
-            default_duration_days: 30,
-            base_price_per_gb_day: 1000,
-            enable_escrow: true,
-            escrow_release_threshold: 0.8,
-            max_contract_duration: 365,
-            min_contract_value: 100,
-            quality_monitoring_interval: 3600,
-            penalty_enforcement_enabled: true,
-            reward_distribution_enabled: true,
-            market_pricing_enabled: false,
-        },
-        storage_config: StorageConfig {
-            max_storage_size: 1_000_000,
-            default_tier: StorageTier::Warm,
-            enable_compression: false,
-            enable_encryption: false,
-            dht_persist_path: None,
-        },
-        erasure_config: ErasureConfig {
-            data_shards: 3,
-            parity_shards: 2,
-        },
-    }
+    common::storage_fixtures::test_config(node_id, port)
 }

--- a/lib-storage/tests/storage_load_tests.rs
+++ b/lib-storage/tests/storage_load_tests.rs
@@ -27,6 +27,8 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 use tokio::sync::Barrier;
 
+mod common;
+
 /// Check if load tests should run (environment variable gate)
 fn should_run_load_tests() -> bool {
     std::env::var("ZHTP_RUN_LOAD_TESTS").is_ok()
@@ -118,13 +120,7 @@ impl MemoryTracker {
     }
 }
 
-/// Create a test sled backend
-fn create_test_backend() -> Result<(SledBackend, TempDir)> {
-    let temp_dir = TempDir::new()?;
-    let db_path = temp_dir.path().join("sled_db");
-    let backend = SledBackend::open(&db_path).map_err(|e| anyhow::anyhow!("{}", e))?;
-    Ok((backend, temp_dir))
-}
+fn create_test_backend() -> Result<(SledBackend, TempDir)> { common::storage_fixtures::test_backend() }
 
 // ============================================================================
 // Sled Backend Load Tests


### PR DESCRIPTION
## Summary

- Adds CitizenshipStatus enum (Visitor, ProvisionalCitizen, VerifiedCitizen, TrustedCitizen) to lib-identity — replaces ambiguous PoP tier naming
- Renames PeerTier → NetworkParticipationLevel in lib-network/src/handshake/blockchain.rs — disambiguates UHP network participation from the infrastructure PeerTier in peer_registry
- Exports CitizenshipStatus from lib-identity public API
- Updates handshake/mod.rs re-export accordingly
- peer_registry::PeerTier (Tier1–Tier4 infrastructure classification) is **unchanged**

## What this unblocks

DID-002 through DID-012 all build on these canonical type names. Previously the three tier systems used overlapping terminology causing developer confusion and potential security misclassification.

## Test plan

- [ ] cargo check -p lib-identity -p lib-network passes (pre-existing BLE feature-gate errors are unrelated)
- [ ] No references to old PeerTier remain in handshake/blockchain.rs or handshake/mod.rs
- [ ] CitizenshipStatus accessible as lib_identity::CitizenshipStatus
- [ ] NetworkParticipationLevel accessible via lib_network::handshake::NetworkParticipationLevel

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)