### PR TITLE
feat(identity): DID-003/004/005 — CitizenshipStatus voting/UBI, NetworkParticipationLevel, DaoAccessContract (#225 #226 #227)

### DIFF
--- a/lib-identity/src/lib.rs
+++ b/lib-identity/src/lib.rs
@@ -54,9 +54,10 @@ pub mod compat;
 
 // Types module - Core identity and node types
 pub use types::{
-    AccessLevel,        // ✓ FullCitizen, Visitor, Organization, Device, Restricted
+    AccessLevel,       // ✓ FullCitizen, Visitor, Organization, Device, Restricted
     CitizenshipStatus, // ✓ Visitor, ProvisionalCitizen, VerifiedCitizen, TrustedCitizen
-    AttestationType, // ✓ Attestation types
+    DaoAccessContract, // ✓ None, PublicAccess, EmploymentAccess (DAO-scoped contracts)
+    AttestationType,   // ✓ Attestation types
 
     // Credential types
     CredentialType, // ✓ Credential type enumeration

--- a/lib-identity/src/types/identity_types.rs
+++ b/lib-identity/src/types/identity_types.rs
@@ -38,6 +38,28 @@ pub enum CitizenshipStatus {
     TrustedCitizen,
 }
 
+impl CitizenshipStatus {
+    /// DAO voting power granted to this citizenship tier.
+    pub fn voting_power(&self) -> u32 {
+        match self {
+            CitizenshipStatus::Visitor => 0,
+            CitizenshipStatus::ProvisionalCitizen => 1,
+            CitizenshipStatus::VerifiedCitizen => 10,
+            CitizenshipStatus::TrustedCitizen => 15,
+        }
+    }
+
+    /// Monthly UBI entitlement in SOV micro-units (1 SOV = 1_000_000 units).
+    pub fn monthly_ubi(&self) -> u64 {
+        match self {
+            CitizenshipStatus::Visitor => 0,
+            CitizenshipStatus::ProvisionalCitizen => 500 * 1_000_000,
+            CitizenshipStatus::VerifiedCitizen => 1_000 * 1_000_000,
+            CitizenshipStatus::TrustedCitizen => 1_500 * 1_000_000,
+        }
+    }
+}
+
 impl Default for CitizenshipStatus {
     fn default() -> Self {
         CitizenshipStatus::Visitor
@@ -85,6 +107,55 @@ impl std::fmt::Display for AccessLevel {
             AccessLevel::Device => write!(f, "Device"),
             AccessLevel::Restricted => write!(f, "Restricted"),
         }
+    }
+}
+
+/// DAO access contract held by an identity.
+///
+/// Separate from `AccessLevel` (Web4 service access) — this type governs
+/// what role an identity holds within a specific DAO. Auto-issued for
+/// VerifiedCitizen+; EmploymentAccess is granted by DAO admins.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum DaoAccessContract {
+    /// No DAO access contract
+    None,
+    /// Public participation access — auto-issued to VerifiedCitizen and above
+    PublicAccess {
+        /// Epoch-based timestamp of issuance
+        issued_at: u64,
+        /// Privacy-preserving public identity hash
+        verified_sid: Hash,
+    },
+    /// Employment-level access — issued by DAO admins for specific roles
+    EmploymentAccess {
+        /// DAO that issued this contract
+        dao_id: Hash,
+        /// Role identifier within the DAO
+        role: String,
+        /// Identity that signed the issuance
+        issued_by: Hash,
+        /// Epoch-based timestamp of issuance
+        issued_at: u64,
+        /// Optional expiry epoch (None = indefinite)
+        expires_at: Option<u64>,
+    },
+}
+
+impl DaoAccessContract {
+    /// Returns true if the contract grants any access (not None).
+    pub fn has_access(&self) -> bool {
+        !matches!(self, DaoAccessContract::None)
+    }
+
+    /// Returns true only for employment-level contracts.
+    pub fn is_employment(&self) -> bool {
+        matches!(self, DaoAccessContract::EmploymentAccess { .. })
+    }
+}
+
+impl Default for DaoAccessContract {
+    fn default() -> Self {
+        DaoAccessContract::None
     }
 }
 

--- a/lib-network/src/handshake/blockchain.rs
+++ b/lib-network/src/handshake/blockchain.rs
@@ -221,48 +221,46 @@ impl BlockchainHandshakeContext {
     }
 }
 
-/// Peer tier classification based on stake and validation status
+/// Network participation level for UHP Tier 2 blockchain authentication.
 ///
-/// Determines trust level and capabilities granted to peers based on
-/// their blockchain participation and stake.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// Replaces the ambiguous "peer tier" naming. Ordered Unverified < Staked < Validator
+/// so comparisons (`>=`) express minimum-privilege requirements cleanly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum NetworkParticipationLevel {
-    /// Verified validator with on-chain stake
-    Validator,
-
-    /// Node with stake but not actively validating
-    StakedNode,
-
-    /// Unverified peer (default for new connections)
-    Unverified,
+    /// No on-chain stake — relay-only, no routing privileges
+    Unverified = 0,
+    /// Staked node — trusted routing (minimum 500 SOV)
+    Staked = 1,
+    /// Active block producer — full consensus participation (minimum 10,000 SOV)
+    Validator = 2,
 }
 
 impl NetworkParticipationLevel {
-    /// Get minimum stake required for this tier
+    /// Minimum stake required to reach this level (SOV micro-units, 1 SOV = 1_000_000).
     pub fn min_stake(&self) -> u64 {
         match self {
-            NetworkParticipationLevel::Validator => 1_000 * 1_000_000, // 1000 SOV minimum for validators
-            NetworkParticipationLevel::StakedNode => 100 * 1_000_000,  // 100 SOV minimum for staked nodes
             NetworkParticipationLevel::Unverified => 0,
+            NetworkParticipationLevel::Staked => 500 * 1_000_000,
+            NetworkParticipationLevel::Validator => 10_000 * 1_000_000,
         }
     }
 
-    /// Check if this tier can participate in consensus
+    /// Whether this level can participate in block production and consensus.
     pub fn can_validate(&self) -> bool {
         matches!(self, NetworkParticipationLevel::Validator)
     }
 
-    /// Check if this tier has enhanced network privileges
+    /// Whether this level has enhanced routing privileges.
     pub fn has_enhanced_privileges(&self) -> bool {
-        matches!(self, NetworkParticipationLevel::Validator | NetworkParticipationLevel::StakedNode)
+        *self >= NetworkParticipationLevel::Staked
     }
 
-    /// Get trust score for this tier (0.0 - 1.0)
+    /// Trust score used for connection weighting (0.0–1.0).
     pub fn trust_score(&self) -> f64 {
         match self {
-            NetworkParticipationLevel::Validator => 1.0,
-            NetworkParticipationLevel::StakedNode => 0.7,
             NetworkParticipationLevel::Unverified => 0.3,
+            NetworkParticipationLevel::Staked => 0.7,
+            NetworkParticipationLevel::Validator => 1.0,
         }
     }
 }
@@ -608,8 +606,8 @@ impl BlockchainHandshakeVerifier {
                         // Determine tier based on stake amount
                         if stake >= NetworkParticipationLevel::Validator.min_stake() {
                             NetworkParticipationLevel::Validator
-                        } else if stake >= NetworkParticipationLevel::StakedNode.min_stake() {
-                            NetworkParticipationLevel::StakedNode
+                        } else if stake >= NetworkParticipationLevel::Staked.min_stake() {
+                            NetworkParticipationLevel::Staked
                         } else {
                             NetworkParticipationLevel::Unverified
                         }
@@ -700,16 +698,16 @@ mod tests {
 
     #[test]
     fn test_peer_tier_classification() {
-        assert_eq!(NetworkParticipationLevel::Validator.min_stake(), 1_000_000_000);
-        assert_eq!(NetworkParticipationLevel::StakedNode.min_stake(), 100_000_000);
+        assert_eq!(NetworkParticipationLevel::Validator.min_stake(), 10_000 * 1_000_000);
+        assert_eq!(NetworkParticipationLevel::Staked.min_stake(), 500 * 1_000_000);
         assert_eq!(NetworkParticipationLevel::Unverified.min_stake(), 0);
 
         assert!(NetworkParticipationLevel::Validator.can_validate());
-        assert!(!NetworkParticipationLevel::StakedNode.can_validate());
+        assert!(!NetworkParticipationLevel::Staked.can_validate());
         assert!(!NetworkParticipationLevel::Unverified.can_validate());
 
         assert!(NetworkParticipationLevel::Validator.has_enhanced_privileges());
-        assert!(NetworkParticipationLevel::StakedNode.has_enhanced_privileges());
+        assert!(NetworkParticipationLevel::Staked.has_enhanced_privileges());
         assert!(!NetworkParticipationLevel::Unverified.has_enhanced_privileges());
     }
 
@@ -828,7 +826,7 @@ mod tests {
         let mut verifier = BlockchainHandshakeVerifier::new(local_ctx);
 
         let node_id = Hash::from_bytes(&[4u8; 32]);
-        let node_stake = 500_000_000; // 500 SOV (above StakedNode threshold)
+        let node_stake = 500 * 1_000_000; // 500 SOV (meets Staked threshold exactly)
 
         verifier.add_validator_stake(node_id.clone(), node_stake, 1);
 
@@ -839,7 +837,7 @@ mod tests {
             .verify_peer(&peer_ctx, Some(&node_id), None)
             .unwrap();
         assert!(result.verified);
-        assert_eq!(result.peer_tier, NetworkParticipationLevel::StakedNode);
+        assert_eq!(result.peer_tier, NetworkParticipationLevel::Staked);
     }
 
     #[test]

--- a/lib-network/src/handshake/blockchain.rs
+++ b/lib-network/src/handshake/blockchain.rs
@@ -226,7 +226,7 @@ impl BlockchainHandshakeContext {
 /// Replaces the ambiguous "peer tier" naming. Ordered Unverified < Staked < Validator
 /// so comparisons (`>=`) express minimum-privilege requirements cleanly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum NetworkParticipationLevel {
+pub enum NodeRole {
     /// No on-chain stake — relay-only, no routing privileges
     Unverified = 0,
     /// Staked node — trusted routing (minimum 500 SOV)
@@ -235,39 +235,39 @@ pub enum NetworkParticipationLevel {
     Validator = 2,
 }
 
-impl NetworkParticipationLevel {
+impl NodeRole {
     /// Minimum stake required to reach this level (SOV micro-units, 1 SOV = 1_000_000).
     pub fn min_stake(&self) -> u64 {
         match self {
-            NetworkParticipationLevel::Unverified => 0,
-            NetworkParticipationLevel::Staked => 500 * 1_000_000,
-            NetworkParticipationLevel::Validator => 10_000 * 1_000_000,
+            NodeRole::Unverified => 0,
+            NodeRole::Staked => 500 * 1_000_000,
+            NodeRole::Validator => 10_000 * 1_000_000,
         }
     }
 
     /// Whether this level can participate in block production and consensus.
     pub fn can_validate(&self) -> bool {
-        matches!(self, NetworkParticipationLevel::Validator)
+        matches!(self, NodeRole::Validator)
     }
 
     /// Whether this level has enhanced routing privileges.
     pub fn has_enhanced_privileges(&self) -> bool {
-        *self >= NetworkParticipationLevel::Staked
+        *self >= NodeRole::Staked
     }
 
     /// Trust score used for connection weighting (0.0–1.0).
     pub fn trust_score(&self) -> f64 {
         match self {
-            NetworkParticipationLevel::Unverified => 0.3,
-            NetworkParticipationLevel::Staked => 0.7,
-            NetworkParticipationLevel::Validator => 1.0,
+            NodeRole::Unverified => 0.3,
+            NodeRole::Staked => 0.7,
+            NodeRole::Validator => 1.0,
         }
     }
 }
 
-impl Default for NetworkParticipationLevel {
+impl Default for NodeRole {
     fn default() -> Self {
-        NetworkParticipationLevel::Unverified
+        NodeRole::Unverified
     }
 }
 
@@ -278,7 +278,7 @@ pub struct BlockchainVerificationResult {
     pub verified: bool,
 
     /// Determined peer tier
-    pub peer_tier: NetworkParticipationLevel,
+    pub peer_tier: NodeRole,
 
     /// Verification details/errors
     pub details: String,
@@ -292,7 +292,7 @@ pub struct BlockchainVerificationResult {
 
 impl BlockchainVerificationResult {
     /// Create a successful verification result
-    pub fn success(peer_tier: NetworkParticipationLevel, details: String) -> Self {
+    pub fn success(peer_tier: NodeRole, details: String) -> Self {
         Self {
             verified: true,
             peer_tier,
@@ -306,7 +306,7 @@ impl BlockchainVerificationResult {
     pub fn failure(reason: String) -> Self {
         Self {
             verified: false,
-            peer_tier: NetworkParticipationLevel::Unverified,
+            peer_tier: NodeRole::Unverified,
             details: reason,
             fork_detected: false,
             epoch_mismatch: false,
@@ -317,7 +317,7 @@ impl BlockchainVerificationResult {
     pub fn fork_detected(details: String) -> Self {
         Self {
             verified: false,
-            peer_tier: NetworkParticipationLevel::Unverified,
+            peer_tier: NodeRole::Unverified,
             details,
             fork_detected: true,
             epoch_mismatch: false,
@@ -328,7 +328,7 @@ impl BlockchainVerificationResult {
     pub fn epoch_mismatch(details: String) -> Self {
         Self {
             verified: false,
-            peer_tier: NetworkParticipationLevel::Unverified,
+            peer_tier: NodeRole::Unverified,
             details,
             fork_detected: false,
             epoch_mismatch: true,
@@ -604,12 +604,12 @@ impl BlockchainHandshakeVerifier {
                         }
 
                         // Determine tier based on stake amount
-                        if stake >= NetworkParticipationLevel::Validator.min_stake() {
-                            NetworkParticipationLevel::Validator
-                        } else if stake >= NetworkParticipationLevel::Staked.min_stake() {
-                            NetworkParticipationLevel::Staked
+                        if stake >= NodeRole::Validator.min_stake() {
+                            NodeRole::Validator
+                        } else if stake >= NodeRole::Staked.min_stake() {
+                            NodeRole::Staked
                         } else {
-                            NetworkParticipationLevel::Unverified
+                            NodeRole::Unverified
                         }
                     }
                     None => {
@@ -626,11 +626,11 @@ impl BlockchainHandshakeVerifier {
                 }
             } else {
                 // No identity provided - cannot verify stake
-                NetworkParticipationLevel::Unverified
+                NodeRole::Unverified
             }
         } else {
             // Peer does not claim validator status
-            NetworkParticipationLevel::Unverified
+            NodeRole::Unverified
         };
 
         Ok(BlockchainVerificationResult::success(
@@ -698,17 +698,17 @@ mod tests {
 
     #[test]
     fn test_peer_tier_classification() {
-        assert_eq!(NetworkParticipationLevel::Validator.min_stake(), 10_000 * 1_000_000);
-        assert_eq!(NetworkParticipationLevel::Staked.min_stake(), 500 * 1_000_000);
-        assert_eq!(NetworkParticipationLevel::Unverified.min_stake(), 0);
+        assert_eq!(NodeRole::Validator.min_stake(), 10_000 * 1_000_000);
+        assert_eq!(NodeRole::Staked.min_stake(), 500 * 1_000_000);
+        assert_eq!(NodeRole::Unverified.min_stake(), 0);
 
-        assert!(NetworkParticipationLevel::Validator.can_validate());
-        assert!(!NetworkParticipationLevel::Staked.can_validate());
-        assert!(!NetworkParticipationLevel::Unverified.can_validate());
+        assert!(NodeRole::Validator.can_validate());
+        assert!(!NodeRole::Staked.can_validate());
+        assert!(!NodeRole::Unverified.can_validate());
 
-        assert!(NetworkParticipationLevel::Validator.has_enhanced_privileges());
-        assert!(NetworkParticipationLevel::Staked.has_enhanced_privileges());
-        assert!(!NetworkParticipationLevel::Unverified.has_enhanced_privileges());
+        assert!(NodeRole::Validator.has_enhanced_privileges());
+        assert!(NodeRole::Staked.has_enhanced_privileges());
+        assert!(!NodeRole::Unverified.has_enhanced_privileges());
     }
 
     #[test]
@@ -782,7 +782,7 @@ mod tests {
             .verify_peer(&peer_ctx, Some(&validator_id), None)
             .unwrap();
         assert!(result.verified);
-        assert_eq!(result.peer_tier, NetworkParticipationLevel::Validator);
+        assert_eq!(result.peer_tier, NodeRole::Validator);
     }
 
     #[test]
@@ -837,7 +837,7 @@ mod tests {
             .verify_peer(&peer_ctx, Some(&node_id), None)
             .unwrap();
         assert!(result.verified);
-        assert_eq!(result.peer_tier, NetworkParticipationLevel::Staked);
+        assert_eq!(result.peer_tier, NodeRole::Staked);
     }
 
     #[test]
@@ -849,7 +849,7 @@ mod tests {
 
         let result = verifier.verify_peer(&peer_ctx, None, None).unwrap();
         assert!(result.verified);
-        assert_eq!(result.peer_tier, NetworkParticipationLevel::Unverified);
+        assert_eq!(result.peer_tier, NodeRole::Unverified);
         assert!(!result.fork_detected);
         assert!(!result.epoch_mismatch);
     }

--- a/lib-network/src/handshake/mod.rs
+++ b/lib-network/src/handshake/mod.rs
@@ -118,7 +118,7 @@ pub use security::{
 // Re-export blockchain handshake types
 pub use blockchain::{
     BlockchainHandshakeContext, BlockchainHandshakeVerifier, BlockchainVerificationResult,
-    NetworkParticipationLevel,
+    NodeRole,
 };
 
 // Re-export PQC types and functions


### PR DESCRIPTION
## Summary

- **DID-003** (#225): CitizenshipStatus gets oting_power() (0/1/10/15) and monthly_ubi() (0/500k/1M/1.5M SOV) methods
- **DID-004** (#226): NetworkParticipationLevel variant StakedNode → Staked; added PartialOrd+Ord; stake thresholds updated to spec (500 SOV / 10,000 SOV); simplified privilege check via >=
- **DID-005** (#227): DaoAccessContract enum added (None, PublicAccess, EmploymentAccess) — named DaoAccessContract rather than AccessLevel to avoid collision with existing Web4 AccessLevel; exported from lib-identity public API

**Base branch:** did/DID-001-rename-tier-systems (chains on DID-001 types)

## Test plan

- [ ] cargo check -p lib-identity -p lib-network — only pre-existing BLE feature-gate errors, none from these changes
- [ ] CitizenshipStatus::voting_power() returns 0/1/10/15 for each variant
- [ ] CitizenshipStatus::monthly_ubi() returns correct SOV micro-unit amounts
- [ ] NetworkParticipationLevel::Staked.min_stake() == 500 * 1_000_000
- [ ] NetworkParticipationLevel::Validator.min_stake() == 10_000 * 1_000_000
- [ ] NetworkParticipationLevel::Staked >= NetworkParticipationLevel::Unverified (Ord works)
- [ ] DaoAccessContract::PublicAccess { .. }.has_access() == true
- [ ] DaoAccessContract::None.has_access() == false

Closes #225
Closes #226
Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)