### PR TITLE
fix: reset FSM from Rejected on round advance — root cause of consensus stall

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1370,6 +1370,13 @@ impl ConsensusEngine {
             self.current_round.locked_proposal = None;
             self.current_round.valid_proposal = None;
 
+            // Reset FSM from Rejected → Proposing so ProposalAdmitted can
+            // transition to Prevoting. Without this, the FSM stays in Rejected
+            // and ignores all events — votes are never cast.
+            if matches!(self.fsm_state, lib_consensus_core::fsm::ValidatorState::Rejected { .. }) {
+                self.fsm_state = lib_consensus_core::fsm::ValidatorState::Proposing;
+            }
+
             // Fall through to process this proposal normally at the new round
         }
 


### PR DESCRIPTION
FSM stayed in Rejected after failed rounds. Incoming proposals were admitted but ProposalAdmitted was ignored by the Rejected catch-all. No prevotes ever cast. Chain stalled permanently after restart.