### PR TITLE
fix: accept votes from recent rounds — stops round-advance vote invalidation

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/validation.rs
+++ b/lib-consensus/src/engines/consensus_engine/validation.rs
@@ -268,15 +268,17 @@ impl ConsensusEngine {
 
         // 5. Round check.
         //
-        // Stale rounds (vote.round < current) are rejected outright.
-        // Higher rounds (vote.round > current) are allowed through so future-round
-        // votes can still be observed and stored, but they do not advance local round
-        // state. Round changes are driven by timeout, not by unilateral peer messages.
-        if vote.round < self.current_round.round {
+        // Accept votes within a small round window to handle cross-continent
+        // latency. Without this, round advances from incoming proposals
+        // invalidate in-flight votes — nodes never converge.
+        // Window of 3 rounds: votes from (current - 3) to any future round accepted.
+        const ROUND_ACCEPTANCE_WINDOW: u32 = 3;
+        if vote.round + ROUND_ACCEPTANCE_WINDOW < self.current_round.round {
             tracing::debug!(
-                "Vote rejected: stale round {} < our round {}",
+                "Vote rejected: stale round {} < our round {} (window {})",
                 vote.round,
-                self.current_round.round
+                self.current_round.round,
+                ROUND_ACCEPTANCE_WINDOW,
             );
             return Ok(false);
         }


### PR DESCRIPTION
Votes rejected as stale because round advances from proposals move faster than vote propagation. Accept votes within 3-round window.