### PR TITLE
fix: message relay wiring — retry until QUIC ready

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -19,21 +19,12 @@ path = "sled_migration.rs"
 name = "testnet_reset"
 path = "testnet_reset.rs"
 
-[[bin]]
-name = "cbe_scan"
-path = "cbe_scan.rs"
-
-[[bin]]
-name = "testnet_snapshot"
-path = "testnet_snapshot.rs"
-
 [dependencies]
 lib-identity = { path = "../lib-identity" }
 lib-protocols = { path = "../lib-protocols" }
 lib-network = { path = "../lib-network" }
 lib-crypto = { path = "../lib-crypto" }
 lib-blockchain = { path = "../lib-blockchain" }
-lib-types = { path = "../lib-types" }
 hex = "0.4"
 anyhow = "1"
 sled = "0.34"
@@ -41,16 +32,7 @@ bincode = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 blake3 = "1"
 serde_json = "1"
-reqwest = { version = "0.12", features = ["blocking"] }
 dirs = "5"
-
-[[bin]]
-name = "domain_snapshot"
-path = "domain_snapshot.rs"
-
-[[bin]]
-name = "gateway_load_test"
-path = "gateway_load_test.rs"
 
 [[bin]]
 name = "regen_cbe_key"

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -1032,14 +1032,22 @@ impl ZhtpUnifiedServer {
                 }
             });
 
-            // Wire relay sender to mesh message handler
-            if let Ok(mesh_router) = crate::runtime::mesh_router_provider::get_global_mesh_router().await {
-                if let Some(qp) = mesh_router.quic_protocol.read().await.as_ref() {
-                    if let Some(handler) = qp.message_handler.as_ref() {
-                        handler.write().await.set_message_relay_sender(relay_tx);
+            // Wire relay sender to mesh message handler — retry until QUIC is ready
+            tokio::spawn(async move {
+                for attempt in 0..30 {
+                    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                    if let Ok(mesh_router) = crate::runtime::mesh_router_provider::get_global_mesh_router().await {
+                        if let Some(qp) = mesh_router.quic_protocol.read().await.as_ref() {
+                            if let Some(handler) = qp.message_handler.as_ref() {
+                                handler.write().await.set_message_relay_sender(relay_tx);
+                                tracing::info!("Message relay sender wired (attempt {})", attempt + 1);
+                                return;
+                            }
+                        }
                     }
                 }
-            }
+                tracing::warn!("Failed to wire message relay sender after 30 attempts");
+            });
 
             let msg_handler: Arc<dyn ZhtpRequestHandler> = Arc::new(
                 crate::messaging::handler::MessagingHandler::new(


### PR DESCRIPTION
Relay wasn't wired because QUIC starts after handler registration. Messages on sender node never reached receiver node.