### PR TITLE
fix: backfill genesis identities into sled — unblock height 7332 halt

### DIFF
--- a/lib-blockchain/src/blockchain/replay.rs
+++ b/lib-blockchain/src/blockchain/replay.rs
@@ -148,7 +148,56 @@ impl Blockchain {
         bc.store = Some(store);
         bc.executor = Some(executor);
 
+        // Backfill genesis-only identities into the sled store. Genesis
+        // populates bc.identity_registry directly without going through
+        // transactions, so identities created at genesis are absent from
+        // sled's identity tree. Any later IdentityUpdate against them halts
+        // consensus with "Cannot update non-existent identity".
+        bc.backfill_genesis_identities_to_store();
+
         Ok(Some(bc))
+    }
+
+    /// Ensure every in-memory genesis identity is also present in the sled
+    /// identity store. Idempotent — overwrites existing entries with the
+    /// genesis-derived consensus + metadata.
+    fn backfill_genesis_identities_to_store(&self) {
+        let Some(ref store) = self.store else {
+            return;
+        };
+        let mut written = 0usize;
+        for (did, data) in &self.identity_registry {
+            let did_hash = crate::storage::did_to_hash(did);
+            // Skip if already present (avoids overwriting state that may have
+            // diverged via on-chain updates).
+            match store.get_identity(&did_hash) {
+                Ok(Some(_)) => continue,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        "backfill: get_identity({}) failed: {} — attempting write anyway",
+                        did,
+                        e
+                    );
+                }
+            }
+            let (consensus, metadata) = crate::storage::convert_legacy_identity(data);
+            if let Err(e) = store.put_identity_direct(&did_hash, &consensus) {
+                tracing::warn!("backfill: put_identity_direct({}): {}", did, e);
+                continue;
+            }
+            if let Err(e) = store.put_identity_metadata_direct(&did_hash, &metadata) {
+                tracing::warn!("backfill: put_identity_metadata_direct({}): {}", did, e);
+                continue;
+            }
+            written += 1;
+        }
+        if written > 0 {
+            tracing::info!(
+                "Backfilled {} genesis identities into sled identity store",
+                written
+            );
+        }
     }
 
     /// Ensure SOV token contract exists during replay (idempotent).

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -549,7 +549,9 @@ impl GenesisConfig {
             bc.wallet_blocks.insert(wallet_key, 0u64);
         }
 
-        // identities
+        // identities — populates in-memory registry only.
+        // Sled-store backfill happens post-replay (see backfill_genesis_identities_to_store),
+        // because bc.store is not yet attached at the time apply_genesis_state runs.
         for id in &alloc.identities {
             let pk_bytes = hex::decode(&id.public_key).map_err(|e| {
                 anyhow::anyhow!(

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -1218,6 +1218,35 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
         Ok(())
     }
 
+    /// Write an identity consensus entry directly, bypassing the block-tx batch.
+    ///
+    /// Used for one-off bootstrap writes (genesis backfill) that must happen
+    /// outside of a normal begin_block/commit_block cycle. Idempotent.
+    fn put_identity_direct(
+        &self,
+        did_hash: &[u8; 32],
+        identity: &IdentityConsensus,
+    ) -> StorageResult<()> {
+        // Default falls back to the batched API; implementations that need
+        // non-tx writes override this.
+        let _ = (did_hash, identity);
+        Err(StorageError::Database(
+            "put_identity_direct not supported by this backend".to_string(),
+        ))
+    }
+
+    /// Write identity metadata directly, bypassing the block-tx batch.
+    fn put_identity_metadata_direct(
+        &self,
+        did_hash: &[u8; 32],
+        metadata: &IdentityMetadata,
+    ) -> StorageResult<()> {
+        let _ = (did_hash, metadata);
+        Err(StorageError::Database(
+            "put_identity_metadata_direct not supported by this backend".to_string(),
+        ))
+    }
+
     /// List identity DID hashes registered at a specific block height.
     ///
     /// Useful for syncing and auditing identity registrations.

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1461,6 +1461,36 @@ impl BlockchainStore for SledStore {
         Ok(())
     }
 
+    fn put_identity_direct(
+        &self,
+        did_hash: &[u8; 32],
+        identity: &IdentityConsensus,
+    ) -> StorageResult<()> {
+        let value = Self::serialize(identity)?;
+        self.identities
+            .insert(did_hash.as_ref(), value)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        self.identities
+            .flush()
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    fn put_identity_metadata_direct(
+        &self,
+        did_hash: &[u8; 32],
+        metadata: &IdentityMetadata,
+    ) -> StorageResult<()> {
+        let value = Self::serialize(metadata)?;
+        self.identity_metadata
+            .insert(did_hash.as_ref(), value)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        self.identity_metadata
+            .flush()
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        Ok(())
+    }
+
     fn get_identities_at_height(&self, height: u64) -> StorageResult<Vec<[u8; 32]>> {
         // Scan all identities and filter by registration height
         // Returns did_hashes, not full identity data


### PR DESCRIPTION
Genesis loader didn't persist identities to sled. IdentityUpdate against a genesis identity halted consensus deterministically. Post-replay backfill writes the missing entries via new put_identity_direct / put_identity_metadata_direct trait methods.