### PR TITLE
debug: log full DIDs at deposit + receive lookup

### DIFF
--- a/zhtp/src/messaging/deposit.rs
+++ b/zhtp/src/messaging/deposit.rs
@@ -86,10 +86,11 @@ impl DepositStore {
         }
 
         info!(
-            "Deposited {} envelopes from {} for {} (expires in {}h)",
+            "Deposited {} envelopes from {} for {} (FULL recipient={}, expires in {}h)",
             count,
             &sender_did[..16.min(sender_did.len())],
             &recipient_did[..16.min(recipient_did.len())],
+            recipient_did,
             DEFAULT_DEPOSIT_TTL_SECS / 3600,
         );
 

--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -285,11 +285,21 @@ impl MessagingHandler {
             }
         };
 
+        info!(
+            "msg/receive lookup: requester_key_id={} -> recipient_did={}",
+            requester_key_id, recipient_did
+        );
+
         // Mark as online
         self.presence.set_online(&recipient_did).await;
 
         // Collect pending deposits
         let deliveries = self.deposits.collect_for_recipient(&recipient_did).await;
+        info!(
+            "msg/receive collected {} deliveries for {}",
+            deliveries.len(),
+            recipient_did
+        );
 
         let mut all_envelopes: Vec<serde_json::Value> = Vec::new();
         for delivery in &deliveries {


### PR DESCRIPTION
Diagnostic logs to pinpoint why receive returns empty despite deposits being present.