### PR TITLE
feat: GET /api/v1/msg/inbound — server-push stream (closes #2545)

### DIFF
--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -142,21 +142,17 @@ impl MessagingHandler {
 
         let recipient_did = envelope.recipient_did.clone();
 
-        // Check if recipient is online on this node
-        if self.presence.is_online(&recipient_did).await {
-            // Recipient connected to this node — deliver directly
-            // The recipient will pick it up on their next /msg/receive poll
-            self.deposits
-                .deposit(
-                    &envelope.sender_did,
-                    &recipient_did,
-                    vec![envelope_bytes],
-                )
-                .await
-                .map_err(|e| anyhow::anyhow!("Deposit failed: {}", e))?;
+        let messaging_provider =
+            crate::runtime::messaging_provider::get_global_messaging_provider();
 
+        // Check if recipient has a live inbound subscriber on this node — push it
+        // straight onto the stream. Skips the deposit-then-poll round trip.
+        if messaging_provider
+            .try_push(&recipient_did, envelope_bytes.clone())
+            .await
+        {
             info!(
-                "Message delivered to local recipient {}",
+                "Message pushed to live subscriber for {}",
                 &recipient_did[..16.min(recipient_did.len())]
             );
             return json_response(json!({
@@ -165,7 +161,7 @@ impl MessagingHandler {
             }));
         }
 
-        // Always deposit locally — recipient may connect to any node including this one
+        // Always deposit locally — recipient may poll any node, or come online later
         let _ = self.deposits
             .deposit(&envelope.sender_did, &recipient_did, vec![envelope_bytes.clone()])
             .await;

--- a/zhtp/src/messaging/inbound_stream.rs
+++ b/zhtp/src/messaging/inbound_stream.rs
@@ -1,0 +1,136 @@
+//! Streaming handler for `GET /api/v1/msg/inbound`.
+//!
+//! After the QUIC handler authenticates the request and writes the initial
+//! `ZhtpResponseWire` (status 200, empty body), it hands the send stream to
+//! `run_inbound_stream`. We then:
+//!
+//! 1. Resolve the canonical recipient DID against the chain identity registry
+//!    (same logic as `handle_receive`).
+//! 2. Drain any existing deposits for this DID as the first batch of frames.
+//! 3. Register an mpsc subscriber and write each subsequent envelope as a
+//!    `[u32 BE length][envelope bytes]` frame.
+//! 4. On any write error (client disconnect, transport failure) we unregister
+//!    the subscriber and return.
+//!
+//! Wire framing: each frame is `[4 bytes BE length][payload bytes]`. No
+//! sub-framing of envelopes; one frame == one bincode-serialized MessageEnvelope.
+//!
+//! The deposit store remains the offline-drain backstop. If the subscriber
+//! disconnects mid-stream, new envelopes from this point on will accumulate
+//! there until the client reopens.
+
+use anyhow::Result;
+use quinn::SendStream;
+use tokio::io::AsyncWriteExt;
+use tracing::{info, warn};
+
+/// Resolve the authenticated requester's key_id to a canonical chain DID.
+/// Mirrors the logic in `handle_receive`. Tries:
+/// 1. `did:zhtp:{key_id_hex}` direct registry lookup.
+/// 2. Registry scan: `blake3(public_key) == key_id`.
+/// 3. Registry scan: `blake3(public_key || kyber_public_key) == key_id`.
+async fn resolve_recipient_did(requester_key_id: &str) -> Option<String> {
+    let blockchain_arc =
+        crate::runtime::blockchain_provider::get_global_blockchain().await.ok()?;
+    let blockchain = blockchain_arc.read().await;
+
+    let key_id_did = format!("did:zhtp:{}", requester_key_id);
+    if blockchain.identity_registry.contains_key(&key_id_did) {
+        return Some(key_id_did);
+    }
+
+    for (did, id) in blockchain.identity_registry.iter() {
+        if id.public_key.len() < 32 {
+            continue;
+        }
+        let dil_hash = hex::encode(lib_crypto::hash_blake3(&id.public_key));
+        if dil_hash == requester_key_id {
+            return Some(did.clone());
+        }
+        if !id.kyber_public_key.is_empty() {
+            let combined = [&id.public_key[..], &id.kyber_public_key[..]].concat();
+            let combined_hash = hex::encode(lib_crypto::hash_blake3(&combined));
+            if combined_hash == requester_key_id {
+                return Some(did.clone());
+            }
+        }
+    }
+
+    // Fallback: assume the raw key_id is itself the canonical DID suffix
+    Some(key_id_did)
+}
+
+/// Write a single framed envelope to the send stream.
+async fn write_frame(send: &mut SendStream, envelope: &[u8]) -> Result<()> {
+    let len = envelope.len() as u32;
+    send.write_all(&len.to_be_bytes()).await?;
+    send.write_all(envelope).await?;
+    Ok(())
+}
+
+/// Run the inbound stream until the peer disconnects or a write fails.
+/// `requester_key_id` is the hex-encoded `request.requester.0` (32 bytes).
+pub async fn run_inbound_stream(
+    mut send: SendStream,
+    requester_key_id: String,
+) -> Result<()> {
+    let recipient_did = match resolve_recipient_did(&requester_key_id).await {
+        Some(d) => d,
+        None => {
+            warn!(
+                "msg/inbound: could not resolve recipient DID for key_id={}",
+                requester_key_id
+            );
+            let _ = send.finish();
+            return Ok(());
+        }
+    };
+
+    info!("msg/inbound: stream opened for {}", recipient_did);
+
+    let provider = crate::runtime::messaging_provider::get_global_messaging_provider();
+
+    // 1. Drain existing deposits as the initial batch.
+    if let Ok(deposits) = provider.get_deposits().await {
+        let deliveries = deposits.collect_for_recipient(&recipient_did).await;
+        let mut count = 0usize;
+        for delivery in deliveries {
+            for envelope in delivery.envelopes {
+                if write_frame(&mut send, &envelope).await.is_err() {
+                    info!(
+                        "msg/inbound: client disconnected during initial drain for {}",
+                        recipient_did
+                    );
+                    return Ok(());
+                }
+                count += 1;
+            }
+        }
+        if count > 0 {
+            info!(
+                "msg/inbound: drained {} envelopes from deposit store for {}",
+                count, recipient_did
+            );
+        }
+    }
+
+    // 2. Register a live subscriber. This replaces any previous subscriber for
+    // this DID (the prior stream's sender is dropped, its read loop will exit).
+    let mut rx = provider.register_subscriber(recipient_did.clone()).await;
+
+    info!("msg/inbound: subscriber registered for {}", recipient_did);
+
+    // 3. Push frames until the peer disconnects or a write fails.
+    while let Some(envelope) = rx.recv().await {
+        if write_frame(&mut send, &envelope).await.is_err() {
+            info!("msg/inbound: write failed (client gone) for {}", recipient_did);
+            break;
+        }
+    }
+
+    // 4. Cleanup.
+    provider.unregister_subscriber(&recipient_did).await;
+    let _ = send.finish();
+    info!("msg/inbound: stream closed for {}", recipient_did);
+    Ok(())
+}

--- a/zhtp/src/messaging/mod.rs
+++ b/zhtp/src/messaging/mod.rs
@@ -9,3 +9,4 @@ pub mod ratchet;
 pub mod deposit;
 pub mod presence;
 pub mod handler;
+pub mod inbound_stream;

--- a/zhtp/src/runtime/messaging_provider.rs
+++ b/zhtp/src/runtime/messaging_provider.rs
@@ -1,0 +1,83 @@
+//! Global messaging state for inbound push streams.
+//!
+//! Exposes:
+//! - The shared `DepositStore` (so the inbound-stream handler can drain on open)
+//! - The inbound-subscriber registry (DID -> mpsc::Sender for live frames)
+//!
+//! Used by the QUIC handler's special-case for `GET /api/v1/msg/inbound`,
+//! and by `handle_send` / mesh relay to push frames live when a subscriber
+//! is registered for the recipient.
+
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::{mpsc, RwLock};
+
+use crate::messaging::deposit::DepositStore;
+
+/// Maximum buffered frames per subscriber. Senders use `try_send`; if the
+/// subscriber falls behind the frame falls back to the deposit store.
+pub const SUBSCRIBER_QUEUE_DEPTH: usize = 32;
+
+#[derive(Clone)]
+pub struct MessagingProvider {
+    deposits: Arc<RwLock<Option<Arc<DepositStore>>>>,
+    /// recipient_did -> sender. One subscriber per DID at a time (latest wins).
+    subscribers: Arc<RwLock<HashMap<String, mpsc::Sender<Vec<u8>>>>>,
+}
+
+impl MessagingProvider {
+    pub fn new() -> Self {
+        Self {
+            deposits: Arc::new(RwLock::new(None)),
+            subscribers: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn set_deposits(&self, deposits: Arc<DepositStore>) {
+        *self.deposits.write().await = Some(deposits);
+    }
+
+    pub async fn get_deposits(&self) -> Result<Arc<DepositStore>> {
+        self.deposits
+            .read()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Deposit store not yet attached"))
+    }
+
+    /// Register a subscriber for a recipient DID. Replaces any prior subscriber
+    /// (the previous channel will close when its sender is dropped).
+    pub async fn register_subscriber(
+        &self,
+        recipient_did: String,
+    ) -> mpsc::Receiver<Vec<u8>> {
+        let (tx, rx) = mpsc::channel::<Vec<u8>>(SUBSCRIBER_QUEUE_DEPTH);
+        self.subscribers.write().await.insert(recipient_did, tx);
+        rx
+    }
+
+    /// Remove a subscriber (called on disconnect).
+    pub async fn unregister_subscriber(&self, recipient_did: &str) {
+        self.subscribers.write().await.remove(recipient_did);
+    }
+
+    /// Attempt to push an envelope to the registered subscriber for this DID.
+    /// Returns `true` if the push succeeded. `false` means no subscriber or
+    /// the subscriber's queue is full — caller should fall back to deposit.
+    pub async fn try_push(&self, recipient_did: &str, envelope: Vec<u8>) -> bool {
+        let subscribers = self.subscribers.read().await;
+        if let Some(tx) = subscribers.get(recipient_did) {
+            tx.try_send(envelope).is_ok()
+        } else {
+            false
+        }
+    }
+}
+
+static GLOBAL_MESSAGING_PROVIDER: OnceLock<MessagingProvider> = OnceLock::new();
+
+pub fn get_global_messaging_provider() -> &'static MessagingProvider {
+    GLOBAL_MESSAGING_PROVIDER.get_or_init(MessagingProvider::new)
+}

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -71,6 +71,7 @@ pub mod did_startup;
 pub mod edge_state_provider; // Global access to edge node state for header-only sync
 pub mod identity_manager_provider;
 pub mod mesh_router_provider;
+pub mod messaging_provider;
 pub mod network_blockchain_event_receiver;
 pub mod network_blockchain_provider;
 pub mod node_identity;

--- a/zhtp/src/server/quic_handler.rs
+++ b/zhtp/src/server/quic_handler.rs
@@ -747,6 +747,47 @@ impl QuicHandler {
             return Ok(());
         }
 
+        // Special-case: streaming inbound message endpoint. We write the success
+        // header here, then hand the send stream to the streaming runner which
+        // pushes [u32 BE len][envelope] frames until the peer disconnects.
+        // Do NOT route through the regular handler chain (which expects a
+        // single ZhtpResponse) and do NOT finish() the stream — the runner does.
+        let is_inbound_stream = matches!(request.method, lib_protocols::types::ZhtpMethod::Get)
+            && request.uri == "/api/v1/msg/inbound";
+        if is_inbound_stream {
+            let requester_key_id = request
+                .requester
+                .as_ref()
+                .map(|id| hex::encode(&id.0))
+                .unwrap_or_default();
+            if requester_key_id.is_empty() {
+                let error_response = ZhtpResponseWire::error(
+                    wire_request.request_id,
+                    ZhtpStatus::Unauthorized,
+                    "Authenticated DID required".to_string(),
+                );
+                write_response(&mut send, &error_response).await?;
+                return Ok(());
+            }
+            let ok_response = ZhtpResponseWire::success(
+                wire_request.request_id,
+                ZhtpResponse::success(Vec::new(), None),
+            );
+            write_response(&mut send, &ok_response)
+                .await
+                .context("Failed to write inbound stream header")?;
+            // Hand off — the runner owns the send stream from here.
+            if let Err(e) = crate::messaging::inbound_stream::run_inbound_stream(
+                send,
+                requester_key_id,
+            )
+            .await
+            {
+                warn!("msg/inbound stream ended with error: {}", e);
+            }
+            return Ok(());
+        }
+
         let router = self.zhtp_router.read().await;
         let response = router.route_request(request).await.unwrap_or_else(|e| {
             warn!("Handler error: {}", e);

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -1004,6 +1004,12 @@ impl ZhtpUnifiedServer {
             let deposits = Arc::new(crate::messaging::deposit::DepositStore::new());
             let presence = Arc::new(crate::messaging::presence::PresenceTracker::new());
 
+            // Publish deposits to the global messaging provider so the QUIC handler
+            // (which special-cases /api/v1/msg/inbound for streaming) can drain on open.
+            crate::runtime::messaging_provider::get_global_messaging_provider()
+                .set_deposits(deposits.clone())
+                .await;
+
             // Spawn deposit cleanup task (every 5 minutes)
             let deposits_cleanup = deposits.clone();
             tokio::spawn(async move {
@@ -1017,12 +1023,23 @@ impl ZhtpUnifiedServer {
                 }
             });
 
-            // Wire mesh relay receiver — incoming relayed messages get deposited
+            // Wire mesh relay receiver — incoming relayed messages either push to a
+            // live inbound subscriber or fall back to the deposit store.
             let deposits_relay = deposits.clone();
             let (relay_tx, mut relay_rx) = tokio::sync::mpsc::channel::<(String, Vec<u8>)>(256);
             tokio::spawn(async move {
+                let provider =
+                    crate::runtime::messaging_provider::get_global_messaging_provider();
                 while let Some((recipient_did, envelope)) = relay_rx.recv().await {
-                    // Extract sender DID from the envelope if possible
+                    // Try live push first
+                    if provider.try_push(&recipient_did, envelope.clone()).await {
+                        tracing::debug!(
+                            "Relay pushed to live subscriber for {}",
+                            recipient_did
+                        );
+                        continue;
+                    }
+                    // Fallback: deposit
                     let sender = bincode::deserialize::<crate::messaging::envelope::MessageEnvelope>(&envelope)
                         .map(|env| env.sender_did)
                         .unwrap_or_else(|_| "mesh_relay".to_string());


### PR DESCRIPTION
Implements T4 of epic #2541. Persistent QUIC stream pushing message envelopes to authenticated identity. Existing /msg/receive untouched as offline-drain backstop. Closes #2545.