### PR TITLE
fix(msg): inbound subscriber cleanup no longer evicts live streams

### DIFF
--- a/zhtp/src/messaging/inbound_stream.rs
+++ b/zhtp/src/messaging/inbound_stream.rs
@@ -116,9 +116,15 @@ pub async fn run_inbound_stream(
 
     // 2. Register a live subscriber. This replaces any previous subscriber for
     // this DID (the prior stream's sender is dropped, its read loop will exit).
-    let mut rx = provider.register_subscriber(recipient_did.clone()).await;
+    // The `id` is what makes the cleanup at step 4 safe — without it, a stale
+    // stream exiting after a fresh registration would remove the live entry
+    // by key and the new subscriber would die microseconds after registering.
+    let (sub_id, mut rx) = provider.register_subscriber(recipient_did.clone()).await;
 
-    info!("msg/inbound: subscriber registered for {}", recipient_did);
+    info!(
+        "msg/inbound: subscriber registered for {} (id={})",
+        recipient_did, sub_id
+    );
 
     // 3. Push frames until the peer disconnects or a write fails.
     while let Some(envelope) = rx.recv().await {
@@ -128,9 +134,15 @@ pub async fn run_inbound_stream(
         }
     }
 
-    // 4. Cleanup.
-    provider.unregister_subscriber(&recipient_did).await;
+    // 4. Cleanup. The id-aware unregister is a no-op if the entry has
+    // already been superseded by a newer registration — exactly the
+    // case that bit us when stale streams from prior sessions were
+    // removing the live one's entry.
+    provider.unregister_subscriber(&recipient_did, sub_id).await;
     let _ = send.finish();
-    info!("msg/inbound: stream closed for {}", recipient_did);
+    info!(
+        "msg/inbound: stream closed for {} (id={})",
+        recipient_did, sub_id
+    );
     Ok(())
 }

--- a/zhtp/src/runtime/messaging_provider.rs
+++ b/zhtp/src/runtime/messaging_provider.rs
@@ -10,6 +10,7 @@
 
 use anyhow::Result;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::{mpsc, RwLock};
 
@@ -19,11 +20,27 @@ use crate::messaging::deposit::DepositStore;
 /// subscriber falls behind the frame falls back to the deposit store.
 pub const SUBSCRIBER_QUEUE_DEPTH: usize = 32;
 
+/// Opaque token returned at registration. Required to call
+/// `unregister_subscriber`. Prevents the stale-stream-removes-live-stream
+/// race: when a new register replaces the prior tx, the stale stream's
+/// `rx.recv()` returns `None` and it tries to clean up — but a bare
+/// `remove(did)` would nuke the *new* entry by key. Tokens keyed by
+/// monotonic id let `unregister` no-op when the entry has been
+/// superseded.
+pub type SubscriberId = u64;
+
+struct SubscriberEntry {
+    id: SubscriberId,
+    tx: mpsc::Sender<Vec<u8>>,
+}
+
 #[derive(Clone)]
 pub struct MessagingProvider {
     deposits: Arc<RwLock<Option<Arc<DepositStore>>>>,
-    /// recipient_did -> sender. One subscriber per DID at a time (latest wins).
-    subscribers: Arc<RwLock<HashMap<String, mpsc::Sender<Vec<u8>>>>>,
+    /// recipient_did -> (id, sender). One subscriber per DID at a time
+    /// (latest wins); the id lets stale stream cleanups be idempotent.
+    subscribers: Arc<RwLock<HashMap<String, SubscriberEntry>>>,
+    next_id: Arc<AtomicU64>,
 }
 
 impl MessagingProvider {
@@ -31,6 +48,7 @@ impl MessagingProvider {
         Self {
             deposits: Arc::new(RwLock::new(None)),
             subscribers: Arc::new(RwLock::new(HashMap::new())),
+            next_id: Arc::new(AtomicU64::new(1)),
         }
     }
 
@@ -47,20 +65,38 @@ impl MessagingProvider {
             .ok_or_else(|| anyhow::anyhow!("Deposit store not yet attached"))
     }
 
-    /// Register a subscriber for a recipient DID. Replaces any prior subscriber
-    /// (the previous channel will close when its sender is dropped).
+    /// Register a subscriber for a recipient DID. Replaces any prior
+    /// subscriber (the previous channel will close when its sender is
+    /// dropped). Returns the new subscriber's id so the caller can pass
+    /// it back to `unregister_subscriber` for a safe, idempotent cleanup.
     pub async fn register_subscriber(
         &self,
         recipient_did: String,
-    ) -> mpsc::Receiver<Vec<u8>> {
+    ) -> (SubscriberId, mpsc::Receiver<Vec<u8>>) {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = mpsc::channel::<Vec<u8>>(SUBSCRIBER_QUEUE_DEPTH);
-        self.subscribers.write().await.insert(recipient_did, tx);
-        rx
+        self.subscribers
+            .write()
+            .await
+            .insert(recipient_did, SubscriberEntry { id, tx });
+        (id, rx)
     }
 
-    /// Remove a subscriber (called on disconnect).
-    pub async fn unregister_subscriber(&self, recipient_did: &str) {
-        self.subscribers.write().await.remove(recipient_did);
+    /// Remove a subscriber if and only if the entry currently in the
+    /// map matches the id returned at registration. Called on stream
+    /// exit. The id check is what prevents a stale stream's cleanup
+    /// from removing a freshly-registered live stream.
+    pub async fn unregister_subscriber(
+        &self,
+        recipient_did: &str,
+        id: SubscriberId,
+    ) {
+        let mut subs = self.subscribers.write().await;
+        if let Some(entry) = subs.get(recipient_did) {
+            if entry.id == id {
+                subs.remove(recipient_did);
+            }
+        }
     }
 
     /// Attempt to push an envelope to the registered subscriber for this DID.
@@ -68,8 +104,8 @@ impl MessagingProvider {
     /// the subscriber's queue is full — caller should fall back to deposit.
     pub async fn try_push(&self, recipient_did: &str, envelope: Vec<u8>) -> bool {
         let subscribers = self.subscribers.read().await;
-        if let Some(tx) = subscribers.get(recipient_did) {
-            tx.try_send(envelope).is_ok()
+        if let Some(entry) = subscribers.get(recipient_did) {
+            entry.tx.try_send(envelope).is_ok()
         } else {
             false
         }


### PR DESCRIPTION
## Summary

- `run_inbound_stream`'s exit path called `unregister_subscriber(did)` which removed the map entry by key. When a stale stream from a previous client session was evicted by a fresh `register_subscriber` (its tx dropped → `rx.recv()` returned `None`), it then ran the cleanup and removed the **fresh** entry. The live subscriber died microseconds after registering — clients saw `/msg/inbound` immediately close every time.
- `register_subscriber` now mints a monotonic `SubscriberId` and stores it alongside the tx. `unregister_subscriber(did, id)` is a no-op when the entry's id differs (i.e. it's already been superseded). Stale stream cleanup is idempotent against eviction.

## Repro (before fix)

Server log per /msg/inbound open:
```
msg/inbound: stream opened for did:zhtp:…
msg/inbound: subscriber registered for did:zhtp:…
msg/inbound: stream closed for did:zhtp:…   ← 21µs after register
```

The 21µs is the time it takes the stale stream's `rx.recv()` to unblock with `None` after the fresh `register_subscriber` insert dropped its tx — and then the stale stream's cleanup pulled the fresh entry out of the map.

## Test plan

- [ ] Two phones, fresh app start, sender → receiver: receiver's `/msg/inbound` stays open; `try_push` lands the envelope; receiver decrypts in real time.
- [ ] One phone, force-quit then relaunch: previous session's stream is replaced cleanly; new stream stays subscribed.
- [ ] Server log no longer shows "stream closed" microseconds after "subscriber registered" for the same DID.