### PR TITLE
fix: credential tx no-op arm in per-tx executor — unhalt chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7258,6 +7258,7 @@ dependencies = [
  "lib-identity",
  "lib-network",
  "lib-protocols",
+ "lib-types",
  "serde",
  "serde_json",
  "sled",

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -3379,6 +3379,14 @@ impl BlockExecutor {
             | TransactionType::GatewayUpdate
             | TransactionType::GatewayUnregister => Ok(TxOutcome::LegacySystem),
 
+            // Credential lifecycle — state applied by process_credential_transactions()
+            // in finish_block_processing(). Per-tx pass is a no-op (mirrors Gateway / Oracle).
+            // Without this arm a RegisterCredential or UpdateCredentialPassword tx falls
+            // through to the catch-all and halts the chain via TxApplyError::UnsupportedType
+            // even though the validator and the pre-validation passthrough both admit it.
+            TransactionType::RegisterCredential
+            | TransactionType::UpdateCredentialPassword => Ok(TxOutcome::LegacySystem),
+
             TransactionType::TreasuryAllocation => {
                 self.apply_treasury_allocation(mutator, tx)?;
                 Ok(TxOutcome::TreasuryAllocation)

--- a/lib-blockchain/src/integration/identity_integration.rs
+++ b/lib-blockchain/src/integration/identity_integration.rs
@@ -376,6 +376,7 @@ mod tests {
             dao_fee: 0,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
+            kyber_public_key: Vec::new(),
         };
 
         assert!(validate_identity_data(&identity_data)?);
@@ -398,6 +399,7 @@ mod tests {
             dao_fee: 0,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
+            kyber_public_key: Vec::new(),
         };
 
         let registration_id = process_identity_registration(&identity_data)?;

--- a/lib-blockchain/src/utils.rs
+++ b/lib-blockchain/src/utils.rs
@@ -324,6 +324,7 @@ pub mod testing {
             dao_fee: 100,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
+            kyber_public_key: Vec::new(),
         }
     }
 }

--- a/lib-blockchain/tests/consensus_integration_tests.rs
+++ b/lib-blockchain/tests/consensus_integration_tests.rs
@@ -1,0 +1,38 @@
+//! Consensus integration tests — DAO proposal and vote lifecycle
+
+use lib_blockchain::types::Hash;
+use lib_blockchain::Blockchain;
+
+/// A DAO proposal transaction can be created and retrieved from the chain.
+#[test]
+fn test_dao_proposal_creation() {
+    let mut bc = Blockchain::new().expect("genesis");
+
+    let proposal_id = Hash::new([0x01u8; 32]);
+    bc.push_test_dao_proposal(proposal_id, 51);
+
+    let proposals = bc.get_dao_proposals();
+    assert_eq!(proposals.len(), 1, "expected one proposal");
+    assert_eq!(
+        proposals[0].proposal_id, proposal_id,
+        "proposal ID round-trips correctly"
+    );
+    assert_eq!(proposals[0].proposer, "did:zhtp:test");
+    assert_eq!(proposals[0].quorum_required, 51);
+}
+
+/// A DAO vote transaction can be created and retrieved for a given proposal.
+#[test]
+fn test_dao_vote_creation() {
+    let mut bc = Blockchain::new().expect("genesis");
+
+    let proposal_id = Hash::new([0x02u8; 32]);
+    bc.push_test_dao_proposal(proposal_id, 51);
+    bc.push_test_dao_vote(proposal_id, "did:zhtp:voter1", "yes");
+
+    let votes = bc.get_dao_votes_for_proposal(&proposal_id);
+    assert_eq!(votes.len(), 1, "expected one vote");
+    assert_eq!(votes[0].voter, "did:zhtp:voter1");
+    assert_eq!(votes[0].vote_choice, "yes");
+    assert_eq!(votes[0].proposal_id, proposal_id);
+}

--- a/lib-blockchain/tests/observer_admission_integration_tests.rs
+++ b/lib-blockchain/tests/observer_admission_integration_tests.rs
@@ -99,6 +99,24 @@ fn make_block_with_txs(height: u64, prev: Hash, txs: Vec<Transaction>) -> Block 
 fn apply_genesis(executor: &BlockExecutor) -> Hash {
     let g = create_genesis_block();
     executor.apply_block(&g).expect("apply genesis");
+    // Fund the dummy signer (all-zero key_id from dummy_signature) so the
+    // RegisterObserver / Suspend / Revoke / Reauth fee can be debited.
+    // Without this the executor returns InsufficientBalance for every
+    // observer tx the test sends.
+    {
+        use lib_blockchain::storage::{Address, TokenId};
+        let sov = TokenId::new(lib_blockchain::contracts::utils::generate_lib_token_id());
+        // PublicKey::new derives key_id = blake3(dilithium_pk). dummy_signature
+        // uses PublicKey::new([0u8; 2592]), so the signer Address is
+        // blake3([0u8; 2592]), not the zero address.
+        let dilithium_zero = [0u8; 2592];
+        let key_id: [u8; 32] = blake3::hash(&dilithium_zero).into();
+        let signer = Address::new(key_id);
+        executor
+            .store()
+            .force_set_token_balances(&[(sov, signer, 10_000_000u128)])
+            .expect("seed dummy signer balance");
+    }
     g.header.block_hash
 }
 
@@ -185,13 +203,13 @@ fn replay_determinism_for_admission_tx_sequence() {
         let b1 = make_block_with_txs(
             1,
             g,
-            vec![register_tx("did:zhtp:obsA", "did:zhtp:spA", ObserverProofLevel::Basic, 1)],
+            vec![register_tx("did:zhtp:obsA", "did:zhtp:spA", ObserverProofLevel::Basic, 0)],
         );
         exec.apply_block(&b1).expect("b1");
         let b2 = make_block_with_txs(
             2,
             b1.header.block_hash,
-            vec![register_tx("did:zhtp:obsB", "did:zhtp:spB", ObserverProofLevel::Enhanced, 2)],
+            vec![register_tx("did:zhtp:obsB", "did:zhtp:spB", ObserverProofLevel::Enhanced, 1)],
         );
         exec.apply_block(&b2).expect("b2");
         fingerprint_registry(&s)
@@ -211,14 +229,14 @@ fn duplicate_registration_rejected() {
     let b1 = make_block_with_txs(
         1,
         g,
-        vec![register_tx("did:zhtp:dupA", "did:zhtp:spX", ObserverProofLevel::Basic, 1)],
+        vec![register_tx("did:zhtp:dupA", "did:zhtp:spX", ObserverProofLevel::Basic, 0)],
     );
     exec.apply_block(&b1).expect("first registration must succeed");
 
     let b2 = make_block_with_txs(
         2,
         b1.header.block_hash,
-        vec![register_tx("did:zhtp:dupA", "did:zhtp:spX", ObserverProofLevel::Basic, 2)],
+        vec![register_tx("did:zhtp:dupA", "did:zhtp:spX", ObserverProofLevel::Basic, 1)],
     );
     let err = exec
         .apply_block(&b2)
@@ -239,7 +257,7 @@ fn invalid_sponsor_binding_rejected() {
     let b1 = make_block_with_txs(
         1,
         g,
-        vec![register_tx("did:zhtp:noSp", "", ObserverProofLevel::Basic, 1)],
+        vec![register_tx("did:zhtp:noSp", "", ObserverProofLevel::Basic, 0)],
     );
     let err = exec
         .apply_block(&b1)
@@ -261,7 +279,7 @@ fn anonymous_sponsor_rejected_by_policy() {
     let b1 = make_block_with_txs(
         1,
         g,
-        vec![register_tx("did:zhtp:anonObs", "did:zhtp:anonSp", ObserverProofLevel::None, 1)],
+        vec![register_tx("did:zhtp:anonObs", "did:zhtp:anonSp", ObserverProofLevel::None, 0)],
     );
     let err = exec
         .apply_block(&b1)
@@ -283,14 +301,14 @@ fn sponsor_quota_enforced_for_basic_tier() {
     let b1 = make_block_with_txs(
         1,
         g,
-        vec![register_tx("did:zhtp:quotaA", "did:zhtp:spQ", ObserverProofLevel::Basic, 1)],
+        vec![register_tx("did:zhtp:quotaA", "did:zhtp:spQ", ObserverProofLevel::Basic, 0)],
     );
     exec.apply_block(&b1).expect("first observer under Basic sponsor");
 
     let b2 = make_block_with_txs(
         2,
         b1.header.block_hash,
-        vec![register_tx("did:zhtp:quotaB", "did:zhtp:spQ", ObserverProofLevel::Basic, 2)],
+        vec![register_tx("did:zhtp:quotaB", "did:zhtp:spQ", ObserverProofLevel::Basic, 1)],
     );
     let err = exec
         .apply_block(&b2)
@@ -313,7 +331,7 @@ fn pending_observer_cannot_bootstrap() {
     let b1 = make_block_with_txs(
         1,
         g,
-        vec![register_tx("did:zhtp:pendObs", "did:zhtp:spP", ObserverProofLevel::Basic, 1)],
+        vec![register_tx("did:zhtp:pendObs", "did:zhtp:spP", ObserverProofLevel::Basic, 0)],
     );
     exec.apply_block(&b1).expect("register");
     let record = record_for(&s, "did:zhtp:pendObs").expect("record exists");
@@ -343,7 +361,7 @@ fn status_transitions_active_suspend_reauthorize() {
     let b1 = make_block_with_txs(
         1,
         g,
-        vec![register_tx("did:zhtp:lifeObs", "did:zhtp:lifeSp", ObserverProofLevel::Basic, 1)],
+        vec![register_tx("did:zhtp:lifeObs", "did:zhtp:lifeSp", ObserverProofLevel::Basic, 0)],
     );
     exec.apply_block(&b1).expect("register");
     assert_eq!(
@@ -356,7 +374,7 @@ fn status_transitions_active_suspend_reauthorize() {
     let b2 = make_block_with_txs(
         2,
         b1.header.block_hash,
-        vec![suspend_tx("did:zhtp:lifeObs", "did:zhtp:lifeSp", 2)],
+        vec![suspend_tx("did:zhtp:lifeObs", "did:zhtp:lifeSp", 1)],
     );
     exec.apply_block(&b2).expect("suspend active");
     assert_eq!(
@@ -378,7 +396,7 @@ fn status_transitions_active_suspend_reauthorize() {
     let b3 = make_block_with_txs(
         3,
         b2.header.block_hash,
-        vec![reauth_tx("did:zhtp:lifeObs", "did:zhtp:lifeSp", 3)],
+        vec![reauth_tx("did:zhtp:lifeObs", "did:zhtp:lifeSp", 2)],
     );
     exec.apply_block(&b3).expect("reauthorize suspended");
     let reactivated = record_for(&s, "did:zhtp:lifeObs").unwrap();
@@ -402,7 +420,7 @@ fn status_transitions_revoke_paths_all_deny_bootstrap() {
         let b1 = make_block_with_txs(
             1,
             g,
-            vec![register_tx("did:zhtp:rA", "did:zhtp:spR", ObserverProofLevel::Basic, 1)],
+            vec![register_tx("did:zhtp:rA", "did:zhtp:spR", ObserverProofLevel::Basic, 0)],
         );
         exec.apply_block(&b1).expect("register");
         let h = did_to_hash(&"did:zhtp:rA".to_string());
@@ -414,7 +432,7 @@ fn status_transitions_revoke_paths_all_deny_bootstrap() {
         let b2 = make_block_with_txs(
             2,
             b1.header.block_hash,
-            vec![revoke_tx("did:zhtp:rA", "did:zhtp:spR", 2)],
+            vec![revoke_tx("did:zhtp:rA", "did:zhtp:spR", 1)],
         );
         exec.apply_block(&b2).expect("A->R");
         let rec = s.get_observer_record(&h).unwrap().unwrap();
@@ -435,13 +453,13 @@ fn status_transitions_revoke_paths_all_deny_bootstrap() {
         let b1 = make_block_with_txs(
             1,
             g,
-            vec![register_tx("did:zhtp:rS", "did:zhtp:spS", ObserverProofLevel::Basic, 1)],
+            vec![register_tx("did:zhtp:rS", "did:zhtp:spS", ObserverProofLevel::Basic, 0)],
         );
         exec.apply_block(&b1).expect("register");
         let b2 = make_block_with_txs(
             2,
             b1.header.block_hash,
-            vec![suspend_tx("did:zhtp:rS", "did:zhtp:spS", 2)],
+            vec![suspend_tx("did:zhtp:rS", "did:zhtp:spS", 1)],
         );
         exec.apply_block(&b2).expect("A->S");
         let h = did_to_hash(&"did:zhtp:rS".to_string());
@@ -453,7 +471,7 @@ fn status_transitions_revoke_paths_all_deny_bootstrap() {
         let b3 = make_block_with_txs(
             3,
             b2.header.block_hash,
-            vec![revoke_tx("did:zhtp:rS", "did:zhtp:spS", 3)],
+            vec![revoke_tx("did:zhtp:rS", "did:zhtp:spS", 2)],
         );
         exec.apply_block(&b3).expect("S->R");
         let rec = s.get_observer_record(&h).unwrap().unwrap();
@@ -468,7 +486,7 @@ fn status_transitions_revoke_paths_all_deny_bootstrap() {
         let b1 = make_block_with_txs(
             1,
             g,
-            vec![register_tx("did:zhtp:rP", "did:zhtp:spP2", ObserverProofLevel::Basic, 1)],
+            vec![register_tx("did:zhtp:rP", "did:zhtp:spP2", ObserverProofLevel::Basic, 0)],
         );
         exec.apply_block(&b1).expect("register");
         let h = did_to_hash(&"did:zhtp:rP".to_string());
@@ -478,7 +496,7 @@ fn status_transitions_revoke_paths_all_deny_bootstrap() {
         let b2 = make_block_with_txs(
             2,
             b1.header.block_hash,
-            vec![revoke_tx("did:zhtp:rP", "did:zhtp:spP2", 2)],
+            vec![revoke_tx("did:zhtp:rP", "did:zhtp:spP2", 1)],
         );
         exec.apply_block(&b2).expect("P->R revoke");
         let rec = s.get_observer_record(&h).unwrap().unwrap();
@@ -496,7 +514,7 @@ fn trusted_sync_source_enforcement_via_evaluate_admission() {
     let b1 = make_block_with_txs(
         1,
         g,
-        vec![register_tx("did:zhtp:tsObs", "did:zhtp:tsSp", ObserverProofLevel::Basic, 1)],
+        vec![register_tx("did:zhtp:tsObs", "did:zhtp:tsSp", ObserverProofLevel::Basic, 0)],
     );
     exec.apply_block(&b1).expect("register");
     let h = did_to_hash(&"did:zhtp:tsObs".to_string());
@@ -529,7 +547,7 @@ fn expired_record_denied_bootstrap() {
     let exec = BlockExecutor::with_store(s.clone());
     let g = apply_genesis(&exec);
     // Register with an explicit expires_at in the past.
-    let mut tx = register_tx("did:zhtp:expObs", "did:zhtp:expSp", ObserverProofLevel::Basic, 1);
+    let mut tx = register_tx("did:zhtp:expObs", "did:zhtp:expSp", ObserverProofLevel::Basic, 0);
     if let lib_blockchain::transaction::TransactionPayload::RegisterObserver(ref mut data) = tx.payload {
         data.expires_at = Some(NOW - 1);
     } else {

--- a/lib-blockchain/tests/token_regression_tests.rs
+++ b/lib-blockchain/tests/token_regression_tests.rs
@@ -210,6 +210,7 @@ fn register_identity(blockchain: &mut Blockchain, identity_id: &str, pubkey: &Pu
             dao_fee: 0,
             controlled_nodes: vec![],
             owned_wallets: vec![],
+            kyber_public_key: Vec::new(),
         },
     );
     blockchain

--- a/lib-blockchain/tests/utxo_tests.rs
+++ b/lib-blockchain/tests/utxo_tests.rs
@@ -73,6 +73,7 @@ async fn test_utxo_creation_and_tracking() -> Result<()> {
         dao_fee: 1000,          // Increase DAO fee too
         controlled_nodes: Vec::new(),
         owned_wallets: Vec::new(),
+        kyber_public_key: Vec::new(),
     };
 
     let transaction = Transaction::new_identity_registration(
@@ -272,6 +273,7 @@ async fn test_utxo_spending() -> Result<()> {
         dao_fee: 1000,
         controlled_nodes: Vec::new(),
         owned_wallets: Vec::new(),
+        kyber_public_key: Vec::new(),
     };
 
     let creation_tx = Transaction::new_identity_registration(
@@ -362,6 +364,7 @@ async fn test_utxo_set_consistency() -> Result<()> {
             dao_fee: 1000,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
+            kyber_public_key: Vec::new(),
         };
 
         let transaction = Transaction::new_identity_registration(
@@ -482,6 +485,7 @@ async fn test_mixed_transaction_block() -> Result<()> {
         dao_fee: 1000,
         controlled_nodes: Vec::new(),
         owned_wallets: Vec::new(),
+        kyber_public_key: Vec::new(),
     };
 
     let creation_tx = Transaction::new_identity_registration(

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -25,6 +25,9 @@ lib-protocols = { path = "../lib-protocols" }
 lib-network = { path = "../lib-network" }
 lib-crypto = { path = "../lib-crypto" }
 lib-blockchain = { path = "../lib-blockchain" }
+# chain_audit / testnet_reset / replay_wallets reference `lib_types::sov::*`
+# but this manifest never declared the dep — pre-existing workspace breakage.
+lib-types = { path = "../lib-types" }
 hex = "0.4"
 anyhow = "1"
 sled = "0.34"


### PR DESCRIPTION
## Trouble
Chain has been halted since 2026-05-13 20:11:13 UTC (~18h). \`POST /api/v1/identity/claim-username/\` (#2553 / commit 549a25d9) submits a \`RegisterCredential\` tx. The proposer drained it into block 32062; the Commit executor rejected it with \`UnsupportedType\`; runtime auto-halted.

## Why
\`RegisterCredential\` and \`UpdateCredentialPassword\` are recognised by:
- \`tx_validate.rs\` PHASE2_ALLOWED_TYPES ✓
- \`executor.rs\` pre-validation passthrough (line 1048) ✓
- \`blockchain/credentials.rs::process_credential_transactions\` ✓

…but the per-tx apply match in \`executor.rs:~3389\` was never updated, so the tx falls through to \`_ => UnsupportedType\` and trips the auto-halt.

## Fix
Single match arm mirroring the existing Gateway-lifecycle no-op arm directly above. Block-level state mutation continues to happen in \`process_credential_transactions()\` (unchanged).

## Disk state (verified)
All 5 validators unanimously at height 32061; nobody persisted 32062. No fork, no partial application. Mempool is in-memory-only, so offending tx vanishes on restart.

## Deploy
Halt-before-deploy rule already satisfied (chain is parked). Rolling deploy safe because no block production to fork. On restart: disk tip 32061, mempool empty, FSM fresh — validators renegotiate proposer for 32062, build empty/coinbase-only block, resume.