### PR TITLE
fix: wallet list/transactions must not gate on in-memory identity_manager

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -12,6 +12,10 @@ name = "chain_audit"
 path = "chain_audit.rs"
 
 [[bin]]
+name = "wallet_probe"
+path = "wallet_probe.rs"
+
+[[bin]]
 name = "sled_migration"
 path = "sled_migration.rs"
 

--- a/tools/wallet_probe.rs
+++ b/tools/wallet_probe.rs
@@ -1,0 +1,150 @@
+/// Wallet Probe — read-only investigation tool.
+///
+/// Given a sled path and a hex identity id (or DID), it:
+///  - locates the identity in identity_registry by DID key OR by either
+///    derivation: blake3(dilithium) / blake3(dilithium||kyber)
+///  - prints the identity record + both computed derivations
+///  - scans wallet_registry for wallets owned by EITHER derivation
+///  - prints registry totals
+///
+/// Usage: wallet_probe <sled_path> <hex_id_or_did>
+
+use anyhow::Result;
+use lib_blockchain::storage::{BlockchainStore, SledStore};
+use lib_blockchain::Blockchain;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn main() -> Result<()> {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/opt/zhtp/data/testnet/sled".to_string());
+    let target = std::env::args()
+        .nth(2)
+        .unwrap_or_default()
+        .trim_start_matches("did:zhtp:")
+        .to_lowercase();
+
+    println!("Opening sled at: {}", path);
+    let store: Arc<dyn BlockchainStore> = Arc::new(SledStore::open(PathBuf::from(&path))?);
+
+    let mut blockchain = match Blockchain::load_from_store(store)? {
+        Some(bc) => bc,
+        None => {
+            println!("No committed blocks in sled.");
+            return Ok(());
+        }
+    };
+
+    println!(
+        "Post-tx-replay (no genesis): identities={} wallets={}",
+        blockchain.identity_registry.len(),
+        blockchain.wallet_registry.len()
+    );
+
+    // load_from_store replays transactions only — genesis identities/wallets
+    // are populated by apply_genesis_state via direct inserts in build_block0,
+    // NOT via transactions. Apply genesis so the registry matches what a
+    // running node actually serves.
+    match lib_blockchain::genesis::GenesisConfig::from_embedded() {
+        Ok(gen) => match gen.apply_genesis_state(&mut blockchain) {
+            Ok(()) => println!("Applied embedded genesis state."),
+            Err(e) => println!("apply_genesis_state failed: {}", e),
+        },
+        Err(e) => println!("from_embedded failed: {}", e),
+    }
+
+    println!("Chain height: {}", blockchain.get_height());
+    println!("identity_registry entries: {}", blockchain.identity_registry.len());
+    println!("wallet_registry   entries: {}", blockchain.wallet_registry.len());
+    println!("target id/did: {}\n", target);
+
+    // ── Locate the identity ────────────────────────────────────────────────
+    let mut matched: Option<(String, [u8; 32], [u8; 32])> = None; // (did, dil_hash, combined_hash)
+    for (did, id) in blockchain.identity_registry.iter() {
+        if id.public_key.len() < 32 {
+            continue;
+        }
+        let dil = lib_crypto::hash_blake3(&id.public_key);
+        let combined = if !id.kyber_public_key.is_empty() {
+            lib_crypto::hash_blake3(
+                &[&id.public_key[..], &id.kyber_public_key[..]].concat(),
+            )
+        } else {
+            dil
+        };
+        let did_hex = did.trim_start_matches("did:zhtp:").to_lowercase();
+        if did_hex == target
+            || hex::encode(dil) == target
+            || hex::encode(combined) == target
+        {
+            println!("=== IDENTITY MATCHED ===");
+            println!("  registry DID key : {}", did);
+            println!("  display_name     : {}", id.display_name);
+            println!("  public_key len   : {} bytes", id.public_key.len());
+            println!("  kyber_public_key : {} bytes", id.kyber_public_key.len());
+            println!("  blake3(dilithium)            = {}", hex::encode(dil));
+            println!("  blake3(dilithium||kyber)     = {}", hex::encode(combined));
+            println!("  owned_wallets ({}):", id.owned_wallets.len());
+            for w in &id.owned_wallets {
+                println!("    - {}", w);
+            }
+            matched = Some((did.clone(), dil, combined));
+            break;
+        }
+    }
+    let (did, dil_hash, combined_hash) = match matched {
+        Some(m) => m,
+        None => {
+            println!("!! No identity in registry matches that id/did by any derivation.");
+            return Ok(());
+        }
+    };
+
+    // ── Scan wallet_registry for wallets owned by either derivation ────────
+    println!("\n=== WALLETS OWNED BY EITHER DERIVATION ===");
+    let did_bytes = hex::decode(did.trim_start_matches("did:zhtp:")).unwrap_or_default();
+    let mut hits = 0;
+    for (wallet_id_hex, w) in blockchain.wallet_registry.iter() {
+        let owner = match &w.owner_identity_id {
+            Some(o) => o.as_bytes().to_vec(),
+            None => continue,
+        };
+        let matches_dil = owner.as_slice() == dil_hash.as_slice();
+        let matches_combined = owner.as_slice() == combined_hash.as_slice();
+        let matches_did = owner.as_slice() == did_bytes.as_slice();
+        if matches_dil || matches_combined || matches_did {
+            hits += 1;
+            let tag = if matches_dil {
+                "blake3(dilithium)"
+            } else if matches_combined {
+                "blake3(dil||kyber)"
+            } else {
+                "DID-bytes"
+            };
+            println!(
+                "  wallet {} type={} owner={} [{}] initial_balance={}",
+                wallet_id_hex,
+                w.wallet_type,
+                hex::encode(&owner),
+                tag,
+                w.initial_balance
+            );
+        }
+    }
+    println!("\n{} wallet(s) owned by this identity across all derivations.", hits);
+
+    // ── Also: every distinct owner_identity_id in the registry (sample) ────
+    if hits == 0 {
+        println!("\n=== SAMPLE: first 10 wallet owners in registry (for derivation comparison) ===");
+        for (wid, w) in blockchain.wallet_registry.iter().take(10) {
+            println!(
+                "  wallet {} owner={:?}",
+                wid,
+                w.owner_identity_id.as_ref().map(|o| hex::encode(o.as_bytes()))
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -270,30 +270,23 @@ impl WalletHandler {
         // TODO: Gate cross-identity wallet list once mobile app is updated.
         // For now, return full data to maintain backward compatibility.
 
-        // Get the identity
-        let identity = match self.get_identity_by_id(&identity_id_bytes).await {
-            Some(identity) => identity,
-            None => {
-                let error_response = json!({
-                    "status": "identity_not_found",
-                    "identity_id": identity_id,
-                    "total_wallets": 0,
-                    "total_balance": 0,
-                    "wallets": []
-                });
-                let json_response = serde_json::to_vec(&error_response)?;
-                return Ok(ZhtpResponse::success_with_content_type(
-                    json_response,
-                    "application/json".to_string(),
-                    None,
-                ));
-            }
-        };
+        // The in-memory identity_manager is an optional fast-path for the rich
+        // Identity object (it carries the WalletManager with staked/pending
+        // detail). It is NOT rebuilt from chain on restart and only holds
+        // identities that registered/handshook live on THIS node — so a miss
+        // here is normal and MUST NOT hide on-chain wallets. The authoritative
+        // source is blockchain.wallet_registry; fall through to it whenever
+        // the in-memory manager has nothing for this identity.
+        let identity_opt = self.get_identity_by_id(&identity_id_bytes).await;
 
-        // Get wallets from the identity's wallet manager (created during identity registration).
-        // If empty (e.g. after sled wipe + seed recovery), fall back to scanning
-        // blockchain.wallet_registry for wallets owned by this identity.
-        let wallet_summaries = identity.list_wallets();
+        // Get wallets from the identity's wallet manager (created during identity
+        // registration). If absent (identity not in the in-memory manager) or
+        // empty (e.g. after restart / sled wipe + seed recovery), fall back to
+        // scanning blockchain.wallet_registry for wallets owned by this identity.
+        let wallet_summaries = identity_opt
+            .as_ref()
+            .map(|identity| identity.list_wallets())
+            .unwrap_or_default();
 
         let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
 
@@ -363,6 +356,13 @@ impl WalletHandler {
                 None,
             ));
         }
+
+        // Reached only when wallet_summaries is non-empty, which implies the
+        // in-memory identity was present (summaries were derived from it).
+        let identity = match identity_opt {
+            Some(identity) => identity,
+            None => unreachable!("non-empty wallet_summaries implies identity present"),
+        };
 
         for summary in wallet_summaries.iter() {
             // Get full wallet details to access staked_balance and pending_rewards
@@ -1288,23 +1288,23 @@ impl WalletHandler {
         // TODO: Gate cross-identity transaction history once mobile app is updated.
         // For now, return full data to maintain backward compatibility.
 
-        let identity = match self.get_identity_by_id(&identity_id_bytes).await {
-            Some(identity) => identity,
-            None => {
-                return create_json_response(json!({
-                    "status": "identity_not_found",
-                    "identity_id": identity_id,
-                    "total_transactions": 0,
-                    "transactions": []
-                }));
-            }
-        };
+        // The in-memory identity_manager is an optional fast-path only; a miss
+        // must not hide on-chain transaction history. Fall through to the
+        // blockchain wallet_registry + block scan regardless.
+        let identity_opt = self.get_identity_by_id(&identity_id_bytes).await;
 
-        let identity_did = identity.did.clone();
+        let identity_did = identity_opt
+            .as_ref()
+            .map(|identity| identity.did.clone())
+            .unwrap_or_else(|| format!("did:zhtp:{}", identity_id));
         let mut tracked_key_ids: HashSet<[u8; 32]> = HashSet::new();
-        tracked_key_ids.insert(identity.public_key.key_id);
-        for wallet in identity.list_wallets() {
-            tracked_key_ids.insert(wallet.id.0);
+        // The URL identity id is itself a tracked key id (DID == key_id form).
+        tracked_key_ids.insert(identity_id_bytes);
+        if let Some(ref identity) = identity_opt {
+            tracked_key_ids.insert(identity.public_key.key_id);
+            for wallet in identity.list_wallets() {
+                tracked_key_ids.insert(wallet.id.0);
+            }
         }
 
         // Get blockchain


### PR DESCRIPTION
## Problem
`/api/v1/wallet/list/<id>` and `/api/v1/wallet/transactions/<id>` returned 0 even though the wallet exists on-chain.

`handle_list_wallets` / `handle_get_transactions` looked the identity up in the **in-memory `identity_manager`** and early-returned `identity_not_found` (0 wallets) on a miss — before scanning the authoritative `blockchain.wallet_registry`.

`identity_manager` is a live cache: not rebuilt from chain on restart, only holds identities that registered/handshook live on **that** node. After a restart, or on any node the identity never touched, the lookup misses and the handler hid wallets that are present in `wallet_registry` on every node.

## Evidence
Probed g1 and g3 (read-only, copied sled) — byte-identical: 150 identities, 426 wallets. Identity `did:zhtp:b525da14…` owns Primary wallet `ab0821df88…` in `wallet_registry` (genesis allocation). The API returned 0 purely because of the `identity_manager` gate.

## Fix
`identity_manager` is now an optional fast-path for the rich `Identity` object only. Both handlers always fall through to scan `blockchain.wallet_registry` (authoritative, replicated):
- `handle_list_wallets`: `identity_opt` is `Option`; empty `wallet_summaries` when absent → existing registry-scan fallback runs.
- `handle_get_transactions`: `tracked_key_ids` always seeds the URL identity id → existing registry + block scan run regardless.

No derivation change — the wallet is owned by `blake3(dilithium)` and the app already queries that id.

Also adds `tools/wallet_probe.rs` — read-only diagnostic used to find this.

Local: workspace build + zhtp-cli tests + DAO-READY gates all pass.