### PR TITLE
fix(blockchain): genesis-pin fresh-node chain import to block unverified adoption

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -20,7 +20,7 @@ use crate::transaction::{
 };
 use crate::types::transaction_type::TransactionType;
 use crate::types::{Difficulty, DifficultyConfig, Hash};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use lib_storage::dht::storage::DhtStorage;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -4270,79 +4270,6 @@ impl Blockchain {
             .map_err(|e| anyhow::anyhow!("Failed to serialize blockchain: {}", e))
     }
 
-    /// Validate imported oracle state for consistency (ORACLE-10).
-    ///
-    /// Performs the following validations:
-    /// - Committee members must exist in validator_registry (no ghost members)
-    /// - Finalized prices must be in ascending epoch order
-    /// - No price from a future epoch (relative to imported block height)
-    fn validate_imported_oracle_state(
-        &self,
-        oracle_state: &crate::oracle::OracleState,
-        last_oracle_epoch_processed: u64,
-        imported_block_height: u64,
-    ) -> Result<()> {
-        // 1. Verify committee members are all in validator_registry (no ghost members)
-        // Precompute HashSet of validator key_ids for O(1) lookup (O(n) total instead of O(n*m))
-        let validator_key_ids: HashSet<[u8; 32]> = self
-            .validator_registry
-            .values()
-            .map(|v| lib_crypto::hash_blake3(&v.consensus_key))
-            .collect();
-        for member_key_id in oracle_state.committee.members() {
-            if !validator_key_ids.contains(member_key_id) {
-                return Err(anyhow::anyhow!(
-                    "Ghost committee member: validator with key_id {} not found in registry",
-                    hex::encode(member_key_id)
-                ));
-            }
-        }
-
-        // 2. Verify finalized prices are in ascending epoch order
-        let mut prev_epoch: Option<u64> = None;
-        for (epoch_id, _price) in oracle_state.all_finalized_prices() {
-            if let Some(prev) = prev_epoch {
-                if *epoch_id <= prev {
-                    return Err(anyhow::anyhow!(
-                        "Finalized prices not in ascending epoch order: {} followed by {}",
-                        prev,
-                        epoch_id
-                    ));
-                }
-            }
-            prev_epoch = Some(*epoch_id);
-        }
-
-        // 3. Verify no price is from a future epoch (relative to imported block height)
-        // Estimate max reasonable epoch from the imported block height.
-        // Assuming ~10 second blocks, timestamp ≈ height * 10 for a rough estimate.
-        let estimated_tip_timestamp = imported_block_height.saturating_mul(10);
-        let max_reasonable_epoch = oracle_state
-            .epoch_id(estimated_tip_timestamp)
-            .saturating_add(10); // Allow some buffer
-
-        for (epoch_id, _price) in oracle_state.all_finalized_prices() {
-            if *epoch_id > max_reasonable_epoch {
-                return Err(anyhow::anyhow!(
-                    "Future epoch price detected: epoch {} at imported height {} (max reasonable epoch: {})",
-                    epoch_id, imported_block_height, max_reasonable_epoch
-                ));
-            }
-        }
-
-        // 4. Verify last_oracle_epoch_processed is consistent with finalized prices
-        if let Some((&max_epoch, _)) = oracle_state.all_finalized_prices().iter().next_back() {
-            if last_oracle_epoch_processed < max_epoch {
-                return Err(anyhow::anyhow!(
-                    "Inconsistent last_oracle_epoch_processed: {} but have finalized price for epoch {}",
-                    last_oracle_epoch_processed, max_epoch
-                ));
-            }
-        }
-
-        Ok(())
-    }
-
     /// Evaluate and potentially merge a blockchain from another node
     /// Uses consensus rules to decide whether to adopt the imported chain
     pub async fn evaluate_and_merge_chain(
@@ -4358,60 +4285,115 @@ impl Blockchain {
         let import: BlockchainImport = bincode::deserialize(&data)
             .map_err(|e| anyhow::anyhow!("Failed to deserialize blockchain: {}", e))?;
 
-        // Fast path: if local chain is empty (fresh node bootstrap), directly adopt
-        // the imported chain without verification against empty state.
-        // An empty blockchain has no state to validate transactions against,
-        // so verify_block() would reject valid genesis transactions.
-        // Check both is_empty() (no blocks at all) and height==0 (has placeholder genesis).
+        // SECURITY — fresh-node safety: a node with no chain of its own MUST NOT
+        // adopt an imported chain on trust. The legacy fast path assigned the
+        // import's precomputed blocks AND state maps (validator_registry,
+        // utxo_set, identity_registry, …) directly, letting any peer substitute
+        // a fabricated genesis, validator set, and balances onto a bootstrapping
+        // node — a complete chain-substitution takeover.
+        //
+        // Instead: pin block 0 to this node's own embedded genesis.toml, verify
+        // continuity, and apply every imported block through the standard
+        // verified sync path (`apply_block_trusted_for_sync`). All state is
+        // *derived* from the verified blocks; the import's state maps are never
+        // trusted. Block 0 carries the canonical genesis state, so subsequent
+        // blocks are validated against real state — the reason the legacy path
+        // gave for skipping verification (empty state) no longer applies.
+        //
+        // Check both is_empty() (no blocks at all) and height==0 (placeholder genesis).
         if self.blocks.is_empty() || self.height == 0 {
             if import.blocks.is_empty() {
                 info!("Both local and imported chains are empty - nothing to merge");
                 return Ok(crate::ChainMergeResult::LocalKept);
             }
-            let imported_height = import.blocks.len() as u64 - 1;
-            info!("Local chain is empty - directly adopting imported chain (height={}, identities={}, validators={}, oracle_prices={})",
-                  imported_height, import.identity_registry.len(), import.validator_registry.len(),
-                  import.oracle_state.as_ref().map(|s| s.finalized_prices_len()).unwrap_or(0));
-            self.blocks = import.blocks;
-            self.height = imported_height;
-            self.utxo_set = import.utxo_set;
-            self.identity_registry = import.identity_registry;
-            self.wallet_registry =
-                self.convert_wallet_references_to_full_data(&import.wallet_references);
-            self.validator_registry = import.validator_registry;
-            self.token_contracts = import.token_contracts;
-            self.web4_contracts = import.web4_contracts;
-            self.contract_blocks = import.contract_blocks;
-            self.dao_registry_index = import.dao_registry_index;
-            self.rebuild_dao_registry_index();
 
-            // ORACLE-10: Import oracle state if present
-            if let Some(oracle_state) = import.oracle_state {
-                // Validate imported oracle state before accepting
-                match self.validate_imported_oracle_state(
-                    &oracle_state,
-                    import.last_oracle_epoch_processed,
-                    imported_height,
-                ) {
-                    Ok(()) => {
-                        self.oracle_state = oracle_state;
-                        self.last_oracle_epoch_processed = import.last_oracle_epoch_processed;
-                        info!(
-                            "🔮 Oracle state imported: {} finalized prices, epoch {}",
-                            self.oracle_state.finalized_prices_len(),
-                            self.last_oracle_epoch_processed
-                        );
-                    }
-                    Err(e) => {
-                        warn!("⚠️ Oracle state validation failed during import: {}. Starting with empty oracle state.", e);
-                        // Start with default oracle state - will be backfilled from blocks
-                    }
-                }
-            } else {
-                warn!("⚠️ Oracle state not present in import — new node will start without oracle prices (backfill from blocks)");
+            let BlockchainImport {
+                blocks: imported_blocks,
+                ..
+            } = import;
+            info!(
+                "Fresh node bootstrap: verifying imported chain ({} blocks) before adoption",
+                imported_blocks.len()
+            );
+
+            // 1. Genesis pinning — rebuild the canonical block 0 from the
+            //    genesis.toml baked into this binary. An import whose block 0
+            //    differs is on a different network and is rejected outright.
+            let cfg = crate::genesis::GenesisConfig::from_embedded()
+                .context("loading embedded genesis.toml for genesis pinning")?;
+            let mut adopted = cfg
+                .build_block0()
+                .context("building canonical genesis block 0")?;
+            cfg.verify_hash(&adopted.blocks[0].header.block_hash.as_array())
+                .context("verifying canonical genesis hash")?;
+
+            let canonical_genesis_hash = adopted.blocks[0].hash();
+            let imported_genesis_hash = imported_blocks[0].hash();
+            if imported_genesis_hash != canonical_genesis_hash {
+                return Err(anyhow::anyhow!(
+                    "Imported chain rejected: genesis block mismatch.\n  \
+                     expected (canonical): {}\n  imported            : {}\n  \
+                     The peer is on a different network — refusing to adopt.",
+                    canonical_genesis_hash,
+                    imported_genesis_hash,
+                ));
             }
 
-            info!("Successfully adopted imported chain during bootstrap");
+            // 2. Carry process-local runtime handles (the #[serde(skip)] fields)
+            //    onto the canonical chain before it replaces `self`. These are
+            //    not chain state and must survive the swap.
+            if let Some(processor) = self.economic_processor.take() {
+                adopted.economic_processor = Some(processor);
+            }
+            adopted.storage_manager = self.storage_manager.take();
+            adopted.store = self.store.take();
+            adopted.proof_aggregator = self.proof_aggregator.take();
+            adopted.broadcast_sender = self.broadcast_sender.take();
+            adopted.treasury_kernel = self.treasury_kernel.take();
+            adopted.executor = self.executor.take();
+            adopted.auto_persist_enabled = self.auto_persist_enabled;
+            std::mem::swap(&mut self.event_publisher, &mut adopted.event_publisher);
+            *self = adopted;
+
+            // 3. Apply each imported block through the verified sync path.
+            //    Continuity is checked explicitly; transaction validity and all
+            //    state derivation are handled by `apply_block_trusted_for_sync`.
+            for (height, block) in imported_blocks.into_iter().enumerate().skip(1) {
+                let expected_previous = self
+                    .blocks
+                    .last()
+                    .expect("chain always retains the genesis block")
+                    .hash();
+                if block.header.previous_hash != expected_previous.as_array() {
+                    return Err(anyhow::anyhow!(
+                        "Imported chain rejected: block {} breaks continuity \
+                         (previous_hash does not link to block {})",
+                        height,
+                        height - 1,
+                    ));
+                }
+                if block.header.height != height as u64 {
+                    return Err(anyhow::anyhow!(
+                        "Imported chain rejected: block at index {} declares height {}",
+                        height,
+                        block.header.height,
+                    ));
+                }
+                self.apply_block_trusted_for_sync(block).await.map_err(|e| {
+                    anyhow::anyhow!(
+                        "Imported chain rejected: block {} failed verification during adoption: {}",
+                        height,
+                        e
+                    )
+                })?;
+            }
+
+            info!(
+                "✅ Verified imported chain adopted during bootstrap (height={}, identities={}, validators={})",
+                self.height,
+                self.identity_registry.len(),
+                self.validator_registry.len()
+            );
             return Ok(crate::ChainMergeResult::ImportedAdopted);
         }
 

--- a/lib-blockchain/tests/fresh_node_safety_tests.rs
+++ b/lib-blockchain/tests/fresh_node_safety_tests.rs
@@ -1,0 +1,215 @@
+//! Fresh-node safety: a bootstrapping node must not adopt an unverified chain.
+//!
+//! Background
+//! ----------
+//! `Blockchain::evaluate_and_merge_chain()` is reached on a fresh node when it
+//! syncs its first chain from a network peer (QUIC bootstrap, UDP mesh transfer,
+//! or the import API). The deserialized `BlockchainImport` is fully attacker-
+//! controlled.
+//!
+//! The legacy fast path, taken when the local chain was empty, assigned the
+//! import's precomputed `blocks` **and** state maps (`validator_registry`,
+//! `utxo_set`, `identity_registry`, …) directly — performing no genesis check,
+//! no continuity check, and no block verification. A malicious peer could hand a
+//! bootstrapping node a fabricated genesis, a validator set it controls, and
+//! arbitrary balances: a complete chain-substitution takeover.
+//!
+//! The fix pins block 0 to the node's own embedded `genesis.toml`, verifies
+//! continuity, applies every block through the verified sync path, and *derives*
+//! all state from the blocks — the import's state maps are never trusted.
+//!
+//! These tests exercise that contract directly.
+
+use anyhow::Result;
+use lib_blockchain::types::Hash;
+use lib_blockchain::{Block, BlockHeader, Blockchain, BlockchainImport, ValidatorInfo};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Build a minimal empty block chaining onto `parent` at the next height.
+/// `extra_nonce` perturbs the timestamp so distinct calls yield distinct hashes.
+fn build_next_block(parent: &Block, extra_nonce: u64) -> Block {
+    let mut header = BlockHeader {
+        version: 1,
+        previous_hash: parent.hash().into(),
+        data_helix_root: Hash::default().into(),
+        timestamp: parent.timestamp() + 10 + extra_nonce,
+        height: parent.header.height + 1,
+        verification_helix_root: [0u8; 32],
+        state_root: Hash::default().into(),
+        bft_quorum_root: [0u8; 32],
+        block_hash: Hash::default(),
+    };
+    header.block_hash = header.calculate_hash();
+    Block::new(header, vec![])
+}
+
+/// A throwaway `ValidatorInfo` an attacker might try to smuggle in via the
+/// import's `validator_registry` map.
+fn attacker_validator() -> ValidatorInfo {
+    ValidatorInfo {
+        identity_id: "attacker_validator".to_string(),
+        stake: 1_000_000_000,
+        storage_provided: 100 * 1024 * 1024 * 1024,
+        consensus_key: [0xAA; 2592],
+        networking_key: vec![0xBB; 32],
+        rewards_key: vec![0xCC; 32],
+        network_address: "10.0.0.1:9000".to_string(),
+        commission_rate: 5,
+        status: "active".to_string(),
+        registered_at: 1,
+        last_activity: 1,
+        blocks_validated: 0,
+        slash_count: 0,
+        admission_source: "forged".to_string(),
+        governance_proposal_id: None,
+        oracle_key_id: None,
+    }
+}
+
+/// Produce a legitimate exported chain of `extra_blocks` blocks above genesis.
+async fn legit_export(extra_blocks: usize) -> Result<Vec<u8>> {
+    let mut node = Blockchain::new()?;
+    for _ in 0..extra_blocks {
+        let parent = node.latest_block().expect("chain has a tip").clone();
+        let block = build_next_block(&parent, 0);
+        node.add_block(block).await?;
+    }
+    node.export_chain()
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// A fresh node MUST reject an import whose block 0 is not its own canonical
+/// genesis — this is the chain-substitution defense.
+#[tokio::test]
+async fn fresh_node_rejects_forged_genesis() -> Result<()> {
+    let export = legit_export(1).await?;
+    let mut import: BlockchainImport =
+        bincode::deserialize(&export).expect("legit export deserializes");
+
+    // Forge block 0: bump the timestamp and recompute its hash so it is a
+    // structurally valid block that simply is not the canonical genesis.
+    let mut forged_header = import.blocks[0].header.clone();
+    forged_header.timestamp += 1;
+    forged_header.block_hash = forged_header.calculate_hash();
+    import.blocks[0] = Block::new(forged_header, vec![]);
+
+    let forged_bytes = bincode::serialize(&import).expect("re-serialize forged import");
+
+    let mut node = Blockchain::new()?;
+    let canonical_genesis = node.blocks[0].hash();
+
+    let result = node.evaluate_and_merge_chain(forged_bytes).await;
+
+    assert!(
+        result.is_err(),
+        "fresh node MUST reject a forged genesis — got Ok({:?})",
+        result.ok()
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("genesis block mismatch"),
+        "rejection must fire on the genesis-pin check, got: {err}"
+    );
+
+    // The rejected import must not have corrupted the node.
+    assert_eq!(node.height, 0, "node height must be untouched after rejection");
+    assert_eq!(node.blocks.len(), 1, "node must still hold only its genesis");
+    assert_eq!(
+        node.blocks[0].hash(),
+        canonical_genesis,
+        "node's genesis block must be untouched after rejection"
+    );
+    Ok(())
+}
+
+/// A fresh node MUST reject an import whose blocks do not form an unbroken
+/// hash chain from the pinned genesis.
+#[tokio::test]
+async fn fresh_node_rejects_broken_continuity() -> Result<()> {
+    let export = legit_export(2).await?;
+    let mut import: BlockchainImport =
+        bincode::deserialize(&export).expect("legit export deserializes");
+
+    // Sever the link between block 0 and block 1.
+    import.blocks[1].header.previous_hash = [0xFF; 32];
+
+    let tampered = bincode::serialize(&import).expect("re-serialize tampered import");
+
+    let mut node = Blockchain::new()?;
+    let result = node.evaluate_and_merge_chain(tampered).await;
+
+    assert!(
+        result.is_err(),
+        "fresh node MUST reject a chain with broken continuity — got Ok({:?})",
+        result.ok()
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("breaks continuity"),
+        "rejection must fire on the continuity check, got: {err}"
+    );
+    assert_eq!(node.height, 0, "node must be untouched after rejection");
+    Ok(())
+}
+
+/// A fresh node MUST derive its state from the verified blocks and ignore the
+/// import's precomputed state maps — an attacker cannot smuggle in a validator
+/// set or balances by populating those maps.
+#[tokio::test]
+async fn fresh_node_ignores_forged_state_maps() -> Result<()> {
+    let export = legit_export(1).await?;
+    let mut import: BlockchainImport =
+        bincode::deserialize(&export).expect("legit export deserializes");
+
+    // The blocks stay legitimate; only the trusted-on-faith maps are forged.
+    import
+        .validator_registry
+        .insert("attacker_validator".to_string(), attacker_validator());
+    let forged_validator_count = import.validator_registry.len();
+    assert!(forged_validator_count > 0, "test must actually inject a validator");
+
+    let bytes = bincode::serialize(&import).expect("re-serialize import");
+
+    let mut node = Blockchain::new()?;
+    let result = node.evaluate_and_merge_chain(bytes).await;
+
+    // The blocks are valid, so the import itself succeeds.
+    assert!(
+        result.is_ok(),
+        "an import with legitimate blocks must still be adopted, got: {:?}",
+        result.err()
+    );
+    assert_eq!(node.height, 1, "the one legitimate block must be applied");
+
+    // …but the attacker's forged validator must NOT have leaked into state.
+    assert!(
+        !node.validator_registry.contains_key("attacker_validator"),
+        "forged validator from the import map must be ignored — state is \
+         derived from blocks, not copied from the import"
+    );
+    Ok(())
+}
+
+/// Sanity baseline: a wholly legitimate export is still adopted by a fresh
+/// node, confirming the verification path does not reject honest chains.
+#[tokio::test]
+async fn fresh_node_adopts_legitimate_chain() -> Result<()> {
+    let export = legit_export(3).await?;
+
+    let mut node = Blockchain::new()?;
+    let result = node.evaluate_and_merge_chain(export).await?;
+
+    assert!(
+        matches!(result, lib_blockchain::ChainMergeResult::ImportedAdopted),
+        "a legitimate 3-block chain must be adopted, got {result:?}"
+    );
+    assert_eq!(node.height, 3, "all three blocks must be applied");
+    assert_eq!(node.blocks.len(), 4, "genesis + 3 blocks");
+    Ok(())
+}

--- a/zhtp/src/runtime/services/bootstrap_service.rs
+++ b/zhtp/src/runtime/services/bootstrap_service.rs
@@ -245,11 +245,24 @@ impl BootstrapService {
 
         info!("Appending {} new blocks to local chain", new_blocks.len());
 
-        // Append blocks to local chain
+        // Apply blocks through the verified sync path. `apply_block_trusted_for_sync`
+        // checks chain continuity (prev-hash linkage) and derives all state from
+        // each block — a malicious peer cannot inject forked or fabricated state.
+        // A raw `blocks.push()` would have skipped both verification AND state
+        // derivation, leaving registries/UTXO stale and the chain unguarded.
         let mut blockchain_guard = blockchain.write().await;
         for block in new_blocks {
-            blockchain_guard.blocks.push(block);
-            blockchain_guard.height += 1;
+            let block_height = block.header.height;
+            blockchain_guard
+                .apply_block_trusted_for_sync(block)
+                .await
+                .with_context(|| {
+                    format!(
+                        "rejecting block {} during incremental sync from {} — \
+                         verification failed",
+                        block_height, peer_label
+                    )
+                })?;
         }
 
         info!(


### PR DESCRIPTION
## Problem

A node bootstrapping its first chain reaches `Blockchain::evaluate_and_merge_chain` with a fully attacker-controlled `BlockchainImport` (network bytes from a QUIC bootstrap peer, a UDP mesh transfer, or the import API).

The legacy **fast path**, taken when the local chain was empty (`blocks.is_empty() || height == 0`), assigned the import's precomputed `blocks` **and** every state map — `validator_registry`, `utxo_set`, `identity_registry`, `token_contracts`, … — directly. It performed:

- **no genesis check** — the imported block 0 could be any fabricated genesis;
- **no continuity check** — blocks need not form a hash chain;
- **no block verification** — transactions were never re-validated.

A malicious or MITM'd peer could hand a fresh node a fabricated genesis, a validator set it controls (→ ownership of all future BFT consensus), and arbitrary SOV balances. This is a complete **chain-substitution takeover** on bootstrap. The incremental sync path in `bootstrap_service` had the sibling bug: it `push()`ed peer blocks with zero verification *and* never applied their state.

## Fix

Both network-reachable adoption paths now verify before adopting, using infrastructure that already exists in the codebase.

**`evaluate_and_merge_chain` fresh-node path** (`lib-blockchain/src/blockchain.rs`)
- **Genesis pinning** — rebuilds canonical block 0 from the binary's embedded `genesis.toml` (`GenesisConfig::from_embedded().build_block0()`, the same routine `Blockchain::new()` uses) and rejects any import whose block 0 differs, before any state is touched.
- **Continuity** — requires an unbroken `previous_hash`/`height` chain from the pinned genesis.
- **Verified application** — applies each block through the existing `apply_block_trusted_for_sync`, which re-verifies and **derives** state from the blocks. The import's precomputed state maps are never trusted.
- Removes the now-dead `validate_imported_oracle_state` — oracle state is derived from block replay like every other registry.

**`bootstrap_service` incremental sync** (`zhtp/src/runtime/services/bootstrap_service.rs`)
- Replaces the raw `blocks.push()` / `height += 1` loop (which skipped verification **and** state derivation, leaving registries stale) with `apply_block_trusted_for_sync` per block, aborting the sync on the first bad block.

## Tests

New `lib-blockchain/tests/fresh_node_safety_tests.rs` (4 tests):
- `fresh_node_rejects_forged_genesis` — forged block 0 rejected; node uncorrupted.
- `fresh_node_rejects_broken_continuity` — severed hash link rejected.
- `fresh_node_ignores_forged_state_maps` — an attacker validator injected into the import map is absent after adoption (state derived, not copied).
- `fresh_node_adopts_legitimate_chain` — honest chains still adopted.

Verification: `cargo check` clean for `lib-blockchain` and `zhtp`; all 4 new tests pass; existing `contract_dao_multinode_e2e` (6 tests — fresh nodes B/C now sync via the verified path) and `issue_954_no_reorg_after_commit_tests` (3 tests) still pass.

## Out of scope

- The **slow path's** genesis-replacement fallback (`blockchain.rs` ~line 4554) also adopts `import` state directly — a separate concern on non-fresh nodes, gated through `ChainEvaluator`/`verify_block`.
- **Signed BFT checkpoints** — no infra exists (`store_consensus_checkpoint` is a no-op stub); this would additionally defend against long-range parallel-chain attacks. Genesis pinning + continuity + per-block verification fully closes the reported fresh-node substitution attack.