### PR TITLE
feat: consensus-derived PoUW reward index — /pouw/rewards no longer node-local

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -108,6 +108,23 @@ pub struct DaoRegistryIndexEntry {
     pub created_at: u64,
 }
 
+/// A single PoUW reward payout, observed on-chain.
+///
+/// Recorded whenever a `TokenMint` transaction carrying a `pouw:mint:` memo
+/// is applied during block processing. Because every node processes the same
+/// blocks, the resulting index is identical on every node — unlike the
+/// node-local `RewardCalculator` ledger. This is the consensus-derived source
+/// for `/api/v1/pouw/rewards/<did>`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PouwMintRecord {
+    /// Amount of SOV minted to the recipient (atomic units).
+    pub amount: u128,
+    /// Block height at which the mint was applied.
+    pub block_height: u64,
+    /// Hash of the TokenMint transaction.
+    pub tx_hash: [u8; 32],
+}
+
 /// Blockchain state with identity registry and UTXO management
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -473,6 +490,13 @@ pub struct Blockchain {
     /// keys/dao-wallets.json (registered 2026-04-10).
     #[serde(default)]
     pub fee_router: crate::contracts::economics::fee_router::FeeRouter,
+    /// PoUW reward payouts observed on-chain, keyed by recipient key_id.
+    /// Rebuilt deterministically from block replay (`process_token_transactions`),
+    /// so it is identical on every node — the consensus-derived backing for the
+    /// `/api/v1/pouw/rewards` query. `#[serde(skip)]`: never persisted, always
+    /// derived from blocks.
+    #[serde(skip)]
+    pub pouw_mint_index: HashMap<[u8; 32], Vec<PouwMintRecord>>,
 }
 
 /// Validator information stored on-chain.

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -81,6 +81,49 @@ impl Blockchain {
         call.contract_type == crate::types::ContractType::Token && call.method == "transfer"
     }
 
+    /// Rebuild the PoUW reward mint index from all in-memory blocks.
+    ///
+    /// Scans every block for `TokenMint` transactions carrying a `pouw:mint:`
+    /// memo and records them keyed by recipient key_id. Clears the index
+    /// first, so it is idempotent. Called once after chain load — necessary
+    /// because `load_from_store` deliberately skips token-tx processing, so
+    /// the incremental hook in `process_token_transactions` does not fire on
+    /// that path. The per-block hook still keeps the index current for live
+    /// block commits.
+    pub fn rebuild_pouw_mint_index(&mut self) {
+        self.pouw_mint_index.clear();
+        let mut total = 0usize;
+        for block in &self.blocks {
+            let height = block.height();
+            for tx in &block.transactions {
+                if tx.transaction_type != TransactionType::TokenMint {
+                    continue;
+                }
+                if !tx.memo.starts_with(b"pouw:mint:") {
+                    continue;
+                }
+                let Some(mint) = tx.token_mint_data() else {
+                    continue;
+                };
+                let tx_hash = tx.hash().as_array();
+                let entry = self.pouw_mint_index.entry(mint.to).or_default();
+                if !entry.iter().any(|r| r.tx_hash == tx_hash) {
+                    entry.push(crate::PouwMintRecord {
+                        amount: mint.amount,
+                        block_height: height,
+                        tx_hash,
+                    });
+                    total += 1;
+                }
+            }
+        }
+        tracing::info!(
+            "PoUW mint index rebuilt: {} reward payouts across {} recipients",
+            total,
+            self.pouw_mint_index.len()
+        );
+    }
+
     /// Process token transfer and mint transactions from a block.
     pub fn process_token_transactions(&mut self, block: &Block) -> Result<()> {
         let sov_token_id = crate::contracts::utils::generate_lib_token_id();
@@ -581,6 +624,26 @@ impl Blockchain {
                         let store_ref: &dyn crate::storage::BlockchainStore = store.as_ref();
                         if let Err(e) = store_ref.put_token_contract(token) {
                             warn!("Failed to persist token contract after mint: {}", e);
+                        }
+                    }
+
+                    // PoUW reward index (option A): a TokenMint carrying a
+                    // `pouw:mint:` memo is a proof-of-useful-work payout. Record
+                    // it keyed by recipient key_id so /api/v1/pouw/rewards can
+                    // report consensus-derived history. This runs in every
+                    // block-processing path (live commit + replay), so the
+                    // index is rebuilt deterministically and is identical on
+                    // every node. Dedup by tx_hash guards against a block being
+                    // processed twice.
+                    if transaction.memo.starts_with(b"pouw:mint:") {
+                        let tx_hash = transaction.hash().as_array();
+                        let entry = self.pouw_mint_index.entry(mint.to).or_default();
+                        if !entry.iter().any(|r| r.tx_hash == tx_hash) {
+                            entry.push(crate::PouwMintRecord {
+                                amount: mint.amount,
+                                block_height: block.height(),
+                                tx_hash,
+                            });
                         }
                     }
                 }

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -104,6 +104,7 @@ impl Blockchain {
             observer_blocks: HashMap::new(),
             credential_registry: HashMap::new(),
             did_to_username: HashMap::new(),
+            pouw_mint_index: HashMap::new(),
         }
     }
 
@@ -682,6 +683,11 @@ impl Blockchain {
             blockchain.wallet_registry.len(),
             blockchain.token_contracts.len()
         );
+
+        // load_from_store deliberately skips token-tx processing, so the
+        // PoUW mint index is not built incrementally on this path. Rebuild it
+        // from the loaded blocks so /api/v1/pouw/rewards has the full history.
+        blockchain.rebuild_pouw_mint_index();
 
         Ok(Some(blockchain))
     }

--- a/lib-blockchain/src/blockchain/persistence.rs
+++ b/lib-blockchain/src/blockchain/persistence.rs
@@ -290,6 +290,7 @@ impl BlockchainV1 {
             observer_blocks: HashMap::new(),
             credential_registry: HashMap::new(),
             did_to_username: HashMap::new(),
+            pouw_mint_index: HashMap::new(),
         }
     }
 }
@@ -617,6 +618,7 @@ impl BlockchainStorageV3 {
             did_to_username: HashMap::new(),
             observer_registry: HashMap::new(),
             observer_blocks: HashMap::new(),
+            pouw_mint_index: HashMap::new(),
         }
     }
 }

--- a/lib-blockchain/src/blockchain/replay.rs
+++ b/lib-blockchain/src/blockchain/replay.rs
@@ -148,6 +148,12 @@ impl Blockchain {
         bc.store = Some(store);
         bc.executor = Some(executor);
 
+        // Rebuild the PoUW mint index from the replayed blocks so
+        // /api/v1/pouw/rewards reports the full on-chain history. (The
+        // per-block hook in process_token_transactions also populates it
+        // during replay; this is an idempotent, authoritative re-scan.)
+        bc.rebuild_pouw_mint_index();
+
         // Backfill genesis-only identities into the sled store. Genesis
         // populates bc.identity_registry directly without going through
         // transactions, so identities created at genesis are absent from

--- a/lib-blockchain/src/lib.rs
+++ b/lib-blockchain/src/lib.rs
@@ -100,7 +100,8 @@ pub use block::{
 // Blockchain module
 pub use blockchain::{
     Blockchain, BlockchainBroadcastMessage, BlockchainImport, ConsensusCheckpoint,
-    EconomicsTransaction, ValidatorInfo, GatewayInfo, ADMISSION_SOURCE_BOOTSTRAP_GENESIS,
+    EconomicsTransaction, PouwMintRecord, ValidatorInfo, GatewayInfo,
+    ADMISSION_SOURCE_BOOTSTRAP_GENESIS,
 };
 pub use query::{BlockchainQuery, BlockchainMutate};
 #[cfg(feature = "contracts")]

--- a/zhtp/src/api/handlers/pouw/mod.rs
+++ b/zhtp/src/api/handlers/pouw/mod.rs
@@ -646,37 +646,64 @@ impl PouwHandler {
         }
 
         let (limit, offset) = Self::parse_pagination(&request.uri);
-        let calculator = &*self.reward_calculator;
-        let rewards = calculator.get_client_rewards(client_did).await;
 
-        let total_earned: u128 =
-            Self::checked_reward_sum(&rewards, "total_earned", &format!("client {}", client_did));
-        let paid_rewards: Vec<_> = rewards
+        // Option A: report reward history from the consensus-derived on-chain
+        // index (`pouw_mint_index`) instead of the node-local RewardCalculator
+        // ledger. The index is rebuilt deterministically from block replay, so
+        // every node returns the same numbers — no per-node flicker. It holds
+        // only PAID rewards (a reward becomes an on-chain `pouw:mint` TokenMint
+        // when the payout task runs); rewards still pending payout are not yet
+        // on-chain and are reported as 0 pending until the next epoch payout.
+        let key_id: [u8; 32] = match client_did
+            .strip_prefix("did:zhtp:")
+            .and_then(|h| hex::decode(h).ok())
+            .filter(|b| b.len() == 32)
+        {
+            Some(b) => {
+                let mut a = [0u8; 32];
+                a.copy_from_slice(&b);
+                a
+            }
+            None => {
+                return Ok(ZhtpResponse::error(
+                    ZhtpStatus::BadRequest,
+                    "client_did must be did:zhtp:<64-hex-char> form".to_string(),
+                ));
+            }
+        };
+
+        let mut records = match crate::runtime::blockchain_provider::get_global_blockchain().await {
+            Ok(bc_arc) => {
+                let bc = bc_arc.read().await;
+                bc.pouw_mint_index.get(&key_id).cloned().unwrap_or_default()
+            }
+            Err(_) => Vec::new(),
+        };
+        // Newest first.
+        records.sort_by(|a, b| b.block_height.cmp(&a.block_height));
+
+        let total_rewards = records.len();
+        let total_paid: u128 = records
             .iter()
-            .filter(|r| r.payout_status == crate::pouw::rewards::PayoutStatus::Paid)
-            .cloned()
-            .collect();
-        let total_paid: u128 = Self::checked_reward_sum(
-            &paid_rewards,
-            "total_paid",
-            &format!("client {}", client_did),
-        );
+            .map(|r| r.amount)
+            .fold(0u128, |acc, a| acc.saturating_add(a));
 
-        let total_rewards = rewards.len();
-        let page_rewards: Vec<_> = rewards.into_iter().skip(offset).take(limit).collect();
-
-        let reward_list: Vec<serde_json::Value> = page_rewards
+        let reward_list: Vec<serde_json::Value> = records
             .iter()
+            .skip(offset)
+            .take(limit)
             .map(|r| {
+                let tx_hex = hex::encode(r.tx_hash);
                 serde_json::json!({
-                    "reward_id": hex::encode(&r.reward_id),
-                    "epoch": r.epoch,
-                    "total_bytes": r.total_bytes,
-                    "raw_amount": r.raw_amount,
-                    "final_amount": r.final_amount,
-                    "payout_status": Self::payout_status_str(r.payout_status),
-                    "paid_at": r.paid_at,
-                    "tx_hash": r.tx_hash.as_ref().map(|h| hex::encode(h)),
+                    "reward_id": tx_hex,
+                    "epoch": serde_json::Value::Null,
+                    "total_bytes": 0,
+                    "raw_amount": r.amount,
+                    "final_amount": r.amount,
+                    "payout_status": "paid",
+                    "paid_at": serde_json::Value::Null,
+                    "block_height": r.block_height,
+                    "tx_hash": tx_hex,
                 })
             })
             .collect();
@@ -684,12 +711,13 @@ impl PouwHandler {
         let body = serde_json::json!({
             "client_did": client_did,
             "total_rewards": total_rewards,
-            "total_earned": total_earned,
+            "total_earned": total_paid,
             "total_paid": total_paid,
-            "pending": total_earned.saturating_sub(total_paid),
+            "pending": 0,
             "limit": limit,
             "offset": offset,
             "rewards": reward_list,
+            "source": "on-chain pouw:mint index",
         });
 
         Ok(ZhtpResponse::json(&body, None).map_err(|e| anyhow::anyhow!(e))?)


### PR DESCRIPTION
## Problem
`/api/v1/pouw/rewards/<did>` read the node-local `RewardCalculator` ledger (`rewards.dat`), which is **not replicated** — g1 had 53 reward records, g2-g5 had 0. The same user's reward counter flickered between a real number and 0 depending on which node answered.

## Fix — Option A (consensus-derived index)
Every PoUW reward payout is already an on-chain `TokenMint` tx with a `pouw:mint:<keyid>:<amount>` memo (`mint_sov_for_pouw`). That's a consensus-replicated, identical-on-every-node record. Derive reward history from it.

**lib-blockchain:**
- `PouwMintRecord { amount, block_height, tx_hash }`.
- `Blockchain.pouw_mint_index: HashMap<[u8;32], Vec<PouwMintRecord>>` keyed by recipient key_id. `#[serde(skip)]` — never persisted, always derived from blocks.
- `process_token_transactions`: records `pouw:mint:` TokenMints into the index (dedup by tx_hash) — the live-update path.
- `rebuild_pouw_mint_index()`: clears + scans all in-memory blocks. Called at the end of **both** `load_from_store` and `replay_from_store` — `load_from_store` deliberately skips token-tx processing, so the rebuild guarantees the full historical index regardless of load path.

**zhtp pouw handler:**
- `handle_get_client_rewards` reads `blockchain.pouw_mint_index` instead of the node-local calculator. Resolves recipient key_id from `did:zhtp:<64-hex>`; returns total + paginated history. Response keeps prior field names for app compat; adds `block_height` + `source`.
- Reports only **paid** rewards (a reward becomes on-chain when the payout task mints it). Pending-but-unpaid → 0 until next epoch payout: a ≤1-epoch lag, but **consistent across all nodes**, which the flickering node-local ledger never was.

Local: workspace build + zhtp-cli tests + DAO-READY gates all pass.