### PR TITLE
refactor(storage): blockchain state tiering — epic design + Phase 1 (table-keyed WAL)

### DIFF
--- a/docs/epics/blockchain-state-tiering-epic.md
+++ b/docs/epics/blockchain-state-tiering-epic.md
@@ -1,0 +1,211 @@
+# EPIC — Blockchain State Tiering (`Blockchain` struct → hot working set + `BlockchainStore`)
+
+**Status:** Approved — open questions resolved & decisions locked 2026-05-19; Phase 1 gated on PR #2589
+**Owner:** TBD
+**Date:** 2026-05-19
+**Companion work:** PR #2589 (`storage_atomic_commit` — WAL crash-atomic block commits). Phase 1 of this epic supersedes and simplifies the `PendingBatch`/WAL structure introduced there; sequence accordingly.
+
+**Decision context:** `Blockchain` (`lib-blockchain/src/blockchain.rs:114`) is an ~80-field monolithic in-memory database. It holds the chain-tip working set *and* all history — every block, every transaction receipt, per-height UTXO and contract-state snapshots, the fork audit trail, and economic event logs. The whole struct is cloned, `bincode`-serialized, and held under one `Arc<RwLock<>>`. Memory grows unbounded with chain length; a clone or save touches the entire history. This epic separates the **hot working set** (state needed to validate block `H+1`) from **cold state** (history / receipts / snapshots / archival blocks) and moves the cold tier behind `BlockchainStore`.
+
+---
+
+## Outcome (Definition of Done)
+
+When this epic ships:
+
+1. **`Blockchain` holds only the hot working set** — the indexes required to validate and apply the next block. Memory footprint is bounded by *state size*, not *chain length*.
+2. **Cold state lives behind `BlockchainStore`** — receipts, `contract_state_history`, `utxo_snapshots`, `fork_points`, `economics_transactions`, and archival blocks are read through the store, not held in the struct.
+3. **A generic `Table<K, V>` abstraction exists** — adding a persisted dataset is one `impl Table` declaration, not a `get/put/delete/iter` method quadruple plus wiring in six places.
+4. **`PendingBatch` / WAL is table-driven** — the 24 hand-listed fields, the 24-arm `tree_by_name` match, and the per-tree `to_wal_record` lines collapse to iteration over a registry.
+5. **Block access is a hot-window cache + store-backed cold reads** — recent blocks stay in memory; older blocks come from the store. Tip and recent-block access stay effectively infallible on consensus hot paths.
+6. **No `bincode(Blockchain)` whole-history serialization on the live path** — the deprecated `.dat` format is drained into the store on load and retired.
+
+---
+
+## Principle: what is "hot" vs "cold"
+
+> **Hot** = state read or mutated while validating/applying block `H+1`. **Cold** = historical, audit, or snapshot data read only by queries, recovery, or export.
+
+| Tier | Fields (representative) | Rationale |
+|---|---|---|
+| **Hot — stays in `Blockchain`** | `height`, `total_work`, `difficulty*`, `tx_fee_config*`; `utxo_set`, `nullifier_set`, `pending_transactions`; all registries (`identity_*`, `wallet_*`, `validator_*`, `gateway_*`, `token_contracts`, `web4_contracts`, `nft_collections`, `domain_registry`, `dao_registry_index`, `credential_registry`, `did_to_username`, `token_nonces`, `ubi_*`, `observer_registry`, `welfare_services`, `bonding_curve_registry`, `amm_pools`, `contract_states`); DAO/treasury/governance state incl. `executed_dao_proposals`; `oracle_state`, `exchange_state`, `onramp_state`, `token_pricing_state`, `fee_router`; `#[serde(skip)]` runtime handles | Needed to validate the next block, or process-local handles |
+| **Cold — moves behind `BlockchainStore`** | `blocks` (archival portion), `receipts`, `contract_state_history`, `utxo_snapshots`, `fork_points`, `economics_transactions`, `oracle_slash_events`, `welfare_audit_trail`, `finalized_blocks` | History / audit / per-height snapshots; grow with chain length; never read to validate `H+1` |
+
+**Explicitly out of scope (future, Stage 4+):** the large mutable registries (`identity_registry`, `utxo_set`, …) are *hot* but also grow unbounded. Tiering them (e.g. an LRU index over a store-backed map) is a separate epic — this one stops at history/receipts/snapshots/blocks, matching the review finding.
+
+**Deliberately kept hot — `executed_dao_proposals`:** although bounded-ish, governance execution reads it for replay protection, execution dedup, proposal-state transitions, and treasury-action idempotency. Moving it cold now would push store reads onto the governance execution hot path and couple consensus to the store prematurely, while governance is already the most stateful and dangerous subsystem. It stays hot until governance execution semantics and the proposal lifecycle are formally modelled; only *finalized/expired* governance history moves cold later, keeping the active-proposal index hot. `finalized_blocks`, by contrast, is pure consensus-audit history (never read to validate `H+1`) and moves cold in Phase 2.
+
+---
+
+## Phase Map
+
+| Phase | Theme | Shippable as |
+|---|---|---|
+| 0 | Design lock (this document) | — |
+| 1 | Generic `Table` abstraction; migrate existing store types; collapse `PendingBatch`/WAL repetition | 1 PR |
+| 2 | Cold-state offload — receipts, snapshots, histories, fork points become `Table`s; removed from `Blockchain` | 1–2 PRs |
+| 3 | Archival blocks — hot-window cache + store-backed cold reads; migrate the 123 `self.blocks` sites | 2–3 PRs |
+| 4 | (future, not this epic) Registry tiering | separate epic |
+
+Phases are strictly ordered: 2 depends on 1; 3 depends on 1 (and is independent of 2).
+
+---
+
+# Phase 0 — Decisions & Setup
+
+## BST-001 · Lock the design
+
+This document. Sign-off required before Phase 1 code.
+
+## BST-002 · `store` becomes mandatory for cold access
+
+Today `Blockchain.store: Option<Arc<dyn BlockchainStore>>`. Cold-state reads cannot be `Option`-gated on a hot path. Decision: cold-state accessors require a store; constructors that build a store-less `Blockchain` (`new_runtime_state`, test fixtures) either (a) attach an in-memory `SledStore` (`open_temporary`) by default, or (b) the cold accessors return a typed "no store" error. Phase 1 picks (a) — every `Blockchain` gets a store. Recorded as **AD-005**.
+
+---
+
+# Phase 1 — Generic `Table` abstraction
+
+The current `BlockchainStore` is a fat trait: one `get_X`/`put_X`/`delete_X`/`iter_X` quadruple per dataset, each wired into a `SledStore` tree field, `from_db`, the 24-field `PendingBatch`, the 24-arm `tree_by_name`, `to_wal_record`, and `apply_post_image`. Adding a dataset means writing that boilerplate ~6 times. Phase 1 removes the multiplier.
+
+## BST-101 · Introduce the `Table` trait
+
+```rust
+/// A typed, transactional key→value dataset backed by one storage keyspace.
+pub trait Table {
+    /// Stable on-disk keyspace name (sled tree). Protocol — never changes.
+    const NAME: &'static str;
+    /// Schema version of `Value`. Bumped on any incompatible change; drives
+    /// the startup migration registry (BST-104 / AD-009).
+    const VERSION: u32;
+    type Key: AsKeyBytes;
+    type Value: Serialize + DeserializeOwned;
+}
+```
+
+Generic, written once on `BlockchainStore`:
+`get<T: Table>(&T::Key) -> StorageResult<Option<T::Value>>`,
+`stage<T: Table>(batch, &T::Key, &T::Value)`, `stage_delete<T: Table>(batch, &T::Key)`,
+`iter<T: Table>() -> impl Iterator<Item = (T::Key, T::Value)>`.
+
+## BST-102 · Migrate existing datasets to `Table` declarations
+
+UTXOs, token contracts/supply, identities, wallet projections, pending transactions, observer records, etc. each become a zero-sized `struct XTable; impl Table for XTable`. The bespoke `get_utxo`/`put_utxo`/… methods are deleted or become thin shims during migration, then removed. Bespoke non-KV methods (UTXO Merkle root/proof) stay as-is.
+
+## BST-103 · Make `PendingBatch` and the WAL table-driven
+
+`PendingBatch` becomes `BTreeMap<&'static str, TreeBatch>` (tree name → ops). `commit_block`, `to_wal_record`, `apply_post_image`, and `tree_by_name` iterate the map — the 24 hand-listed fields, the 24 `add(...)` lines, and the 24-arm match all collapse. New tables require **no** edits to the WAL path. This directly simplifies the code added in PR #2589.
+
+## BST-104 · Table schema versioning + startup migration registry
+
+Removing `bincode(Blockchain)` (AD-006) also removes its implicit "free" whole-struct migration: once cold datasets are independent tables, each owns its own forward compatibility. Each `Table` declares `const VERSION`; a startup migration registry runs per-table upgrade hooks against on-disk data before first read and records the applied version in a `meta` key. Built **now**, while there are ~6 tables — retrofitting versioning across 50+ tables later is not viable. See AD-009.
+
+**Exit criteria:** existing storage tests green; `BlockchainStore` trait surface reduced; adding a table touches one file; every table is version-tagged and the migration registry runs on open.
+
+---
+
+# Phase 2 — Cold-state offload
+
+With `Table` in place, each cold dataset is one declaration.
+
+## BST-201 · Receipts → `ReceiptsTable`
+
+`receipts: HashMap<Hash, TransactionReceipt>` removed from `Blockchain`. `create_receipt` stages into the table; `get_receipt`/finality updates read/rewrite through it. ~6 call sites (`blockchain.rs:5599–5679`).
+
+## BST-202 · Per-height snapshots → `UtxoSnapshotTable`, `ContractStateHistoryTable`
+
+`utxo_snapshots` and `contract_state_history` (`BTreeMap<u64, …>`) become height-keyed tables. Pruning (existing `remove(&key)` logic) becomes range-delete on the table. ~10 call sites (`blockchain.rs:5964–6075`).
+
+## BST-203 · Audit logs & finalized-block history → tables
+
+`fork_points` (~4 sites), `economics_transactions` (~9 sites), `finalized_blocks`, `oracle_slash_events`, and `welfare_audit_trail` become append/scan tables — they share one shape: monotonically-growing audit history. `finalized_blocks` is historical consensus-audit material — block `H+1` is validated from the tip, validator state, fork-choice, and the current finality frontier, never from ancient finalized metadata, so it belongs cold.
+
+## BST-204 · Drain legacy `.dat` cold fields into the store on load
+
+`load_from_file` currently rehydrates these fields into the struct. Instead, on load, drain them into the store, then leave the struct fields gone. `BlockchainStorageV3` keeps the fields for *reading* old files; `to_blockchain` writes them to the store. New saves no longer carry them.
+
+**Exit criteria:** every Phase-2 cold field (receipts, the two per-height snapshot maps, fork points, economic log, finalized blocks, the audit logs) no longer exists on `Blockchain`; queries go through the store; `.dat` migration covered by a test.
+
+---
+
+# Phase 3 — Archival blocks
+
+`blocks: Vec<Block>` has **123 call sites** and is on consensus hot paths. It is already mirrored into `BlockchainStore` (`append_block`/`get_block_by_height`), so the in-memory `Vec` is a redundant full copy.
+
+## BST-301 · Hot-window block cache
+
+`Blockchain` keeps a bounded window of the most recent `W` blocks in a `VecDeque<Block>`, where:
+
+```
+W = max(finality_depth * 2, MIN_WINDOW)   // MIN_WINDOW = 128
+```
+
+The size **derives from consensus rollback/finality guarantees, not an arbitrary constant** (AD-004). Older blocks are evicted; they remain in the store.
+
+## BST-302 · Block access API
+
+Introduce explicit accessors and migrate the 123 sites by category:
+
+| Pattern | Today | After |
+|---|---|---|
+| tip | `self.blocks.last()` | `self.tip()` — always in-window, infallible |
+| count | `self.blocks.len()` | `self.height + 1` |
+| recent (`h ≥ height − W`) | `self.blocks[h]` | `self.recent_block(h)` — in-window, infallible |
+| arbitrary historical | `self.blocks[h]` | `self.block_at(h) -> StorageResult<Option<Block>>` — window then store |
+| full scan (replay/export) | `self.blocks.iter()` | `self.store.iter_blocks()` |
+
+Consensus hot paths only ever touch tip + recent → stay infallible. Only genuine historical reads become fallible.
+
+## BST-303 · Migrate call sites + delete the field
+
+Convert all 123 sites, then remove `blocks: Vec<Block>` from `Blockchain`. `replay_from_store` and chain export switch to store iteration.
+
+**Exit criteria:** `Blockchain` memory is bounded by `W` blocks + state size, independent of chain length.
+
+---
+
+## Architectural Decisions
+
+- **AD-001 · Hot/cold split by next-block-validation.** A field is hot iff validating/applying block `H+1` reads or writes it. Everything else is cold.
+- **AD-002 · One generic `Table` abstraction, not per-dataset trait methods.** Removes the `get/put/delete/iter`-quadruple multiplier and the six-place wiring.
+- **AD-003 · `PendingBatch`/WAL is table-driven.** A name-keyed map replaces the 24 hand-listed fields and the `tree_by_name` match; new tables need no WAL edits.
+- **AD-004 · Archival blocks via bounded hot-window + store cold reads.** Window `W = max(finality_depth * 2, 128)`. **Window size derives from consensus rollback/finality guarantees, not an arbitrary constant** — validation, mempool rebasing, rollback, and recovery paths routinely reach beyond strict finality depth, so the window must track `finality_depth` (the `*2` margin), and a future change (`finality_depth = 256`, optimistic-execution windows, delayed attestations, wider mesh-partition reconciliation) must not silently invalidate the cache assumption. A fixed `128` would become a latent consensus bug. Tip and recent access stay infallible; only historical reads return `Result<Option<Block>>`.
+- **AD-005 · `store` is mandatory.** Every `Blockchain` carries a `BlockchainStore` (real or `open_temporary`); cold accessors do not branch on `Option`.
+- **AD-006 · `.dat` is retired in this epic — store + WAL is the sole runtime authority.** The moment the WAL exists, the authoritative model is `sled + WAL`, never "`sled` + maybe `.dat` + maybe memory" — `.dat` as shadow authority cannot survive the transition. Cold fields drain into the store on load. `save_to_file` is removed from all runtime paths; new nodes never emit `.dat`. `load_from_file` survives **only** as read-only one-time migration / import / offline-recovery input — never as live persistence. No `bincode(Blockchain)` whole-history serialization remains on any live path.
+- **AD-007 · Registry tiering is out of scope.** `identity_registry`, `utxo_set`, etc. are hot but unbounded; tiering them is a separate future epic.
+- **AD-008 · Sequence after PR #2589.** Phase 1 rewrites the WAL `PendingBatch` structure; land #2589 first so Phase 1 *simplifies* it rather than colliding. The strict order is: (1) make commits crash-safe, (2) abstract storage, (3) move cold state, (4) shrink memory — never collapsed into one PR stream.
+- **AD-009 · Tables are schema-versioned (BST-104).** Removing `bincode(Blockchain)` removes its implicit free whole-struct migration, so every table owns its forward compatibility: a `const VERSION`, optional per-table migration hooks, and a startup migration registry that upgrades on-disk data before first read. Established in Phase 1, *before* the table count grows — versioning is the difference between this storage layer being evolvable and being schema-by-copy-paste.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Block access becoming fallible leaks into consensus hot paths | AD-004 — window keeps tip/recent infallible; only historical reads are `Result` |
+| Cold reads hitting sled add latency to queries | Cold data is query-path only, not consensus; acceptable. Window absorbs the hot case |
+| Migration of existing on-disk data (`.dat` and current sled) | BST-204 drain + a migration test; sled cold tables are additive |
+| Phase 1 conflicts with in-review PR #2589 | AD-008 — strict ordering; Phase 1 deletes #2589's repetition |
+| 123-site `blocks` migration is large and consensus-adjacent | Phase 3 split into 2–3 PRs by call-site category (BST-302 table); each independently testable |
+| Behavioral drift in receipts/snapshot semantics | Phase 2 keeps existing logic, only changes the backing store; covered by existing tests + `.dat` migration test |
+
+---
+
+## Sign-off — open questions resolved (2026-05-19)
+
+1. **Hot-window size `W`** → `W = max(finality_depth * 2, 128)`. Derived from consensus guarantees, not a fixed constant — see AD-004.
+2. **`executed_dao_proposals` / `finalized_blocks`** → `finalized_blocks` cold (Phase 2, BST-203); `executed_dao_proposals` stays **hot** until governance execution semantics are formally modelled — see the hot/cold note above.
+3. **`.dat` format** → retired in this epic; `save_to_file` removed from runtime, `load_from_file` kept read-only for migration/import/recovery — see AD-006.
+
+## Future work (explicitly not this epic)
+
+Once archival blocks are cold (Phase 3), full `replay_from_store` becomes the bootstrap cost and grows with chain length — eventually multi-hour, making node bootstrap and federation nodes impractical. Before that bites, a follow-up epic must add:
+
+- **Periodic canonical checkpoints / state snapshots** — a verifiable state root plus the serialized hot working set at epoch boundaries.
+- **Fast-sync bootstrap** — new nodes load the latest checkpoint and replay only the tail, instead of replaying from genesis.
+- **Pruning epochs** — bounded retention for cold tables that are pure audit history.
+
+Also future (AD-007): tiering the large hot registries (`identity_registry`, `utxo_set`, …). Flagged here so they are designed *for*, not discovered later.
+
+---
+
+*This epic is not a bug fix — it converts the chain from monolithic process-state into a storage-backed blockchain architecture: composable, evolvable, and bounded in memory. The four ordered moves are: commits safe → storage abstracted → cold state moved → memory bounded.*

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -39,6 +39,7 @@
 
 pub mod keys;
 pub mod sled_store;
+pub mod table;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -47,6 +48,7 @@ use thiserror::Error;
 
 // Re-export the store implementation
 pub use sled_store::SledStore;
+pub use table::{Table, TableAccess};
 
 // Import ALL canonical types from lib-types
 // These are the authoritative definitions for consensus-critical types
@@ -1591,5 +1593,48 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
         _policy: &lib_types::ObserverAdmissionPolicy,
     ) -> StorageResult<()> {
         Ok(())
+    }
+
+    // =========================================================================
+    // Generic Table Access (blockchain-state-tiering epic, BST-101)
+    // =========================================================================
+    // Object-safe byte-level primitives. The typed, generic API is layered on
+    // top by the `TableAccess` extension trait — see `storage::table`. A
+    // dataset declares one `impl Table` instead of a bespoke get/put/delete/
+    // iter method quadruple.
+    //
+    // Default impls error: a store that has not opted into generic table
+    // access does not support it. `SledStore` overrides all three.
+    // =========================================================================
+
+    /// Read a raw value from keyspace `tree`.
+    fn get_raw(&self, _tree: &'static str, _key: &[u8]) -> StorageResult<Option<Vec<u8>>> {
+        Err(StorageError::Database(
+            "generic table access not supported by this store".to_string(),
+        ))
+    }
+
+    /// Stage a raw write (`Some` = insert, `None` = delete) into keyspace
+    /// `tree`. MUST be called within `begin_block`/`commit_block`.
+    fn stage_raw(
+        &self,
+        _tree: &'static str,
+        _key: &[u8],
+        _value: Option<&[u8]>,
+    ) -> StorageResult<()> {
+        Err(StorageError::Database(
+            "generic table access not supported by this store".to_string(),
+        ))
+    }
+
+    /// Iterate every `(key, value)` pair in keyspace `tree`.
+    #[allow(clippy::type_complexity)]
+    fn iter_raw(
+        &self,
+        _tree: &'static str,
+    ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(Vec<u8>, Vec<u8>)>> + '_>> {
+        Err(StorageError::Database(
+            "generic table access not supported by this store".to_string(),
+        ))
     }
 }

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1957,6 +1957,57 @@ impl BlockchainStore for SledStore {
     }
 
     // =========================================================================
+    // Generic Table Access (BST-101)
+    // =========================================================================
+
+    fn get_raw(&self, tree: &'static str, key: &[u8]) -> StorageResult<Option<Vec<u8>>> {
+        let t = self.tree_by_name(tree).ok_or_else(|| {
+            StorageError::Database(format!("unknown table keyspace '{}'", tree))
+        })?;
+        match t.get(key) {
+            Ok(Some(v)) => Ok(Some(v.to_vec())),
+            Ok(None) => Ok(None),
+            Err(e) => Err(StorageError::Database(e.to_string())),
+        }
+    }
+
+    fn stage_raw(
+        &self,
+        tree: &'static str,
+        key: &[u8],
+        value: Option<&[u8]>,
+    ) -> StorageResult<()> {
+        self.require_transaction()?;
+        if self.tree_by_name(tree).is_none() {
+            return Err(StorageError::Database(format!(
+                "unknown table keyspace '{}'",
+                tree
+            )));
+        }
+        let mut batch_guard = self.tx_batch.lock().unwrap();
+        if let Some(ref mut batch) = *batch_guard {
+            match value {
+                Some(v) => batch.tree(tree).insert(key, v),
+                None => batch.tree(tree).remove(key),
+            }
+        }
+        Ok(())
+    }
+
+    fn iter_raw(
+        &self,
+        tree: &'static str,
+    ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(Vec<u8>, Vec<u8>)>> + '_>> {
+        let t = self.tree_by_name(tree).ok_or_else(|| {
+            StorageError::Database(format!("unknown table keyspace '{}'", tree))
+        })?;
+        Ok(Box::new(t.iter().map(|r| {
+            r.map(|(k, v)| (k.to_vec(), v.to_vec()))
+                .map_err(|e| StorageError::Database(e.to_string()))
+        })))
+    }
+
+    // =========================================================================
     // Bonding Curve Operations
     // =========================================================================
 
@@ -3258,5 +3309,72 @@ mod tests {
         assert_eq!(store.latest_height().unwrap(), 0);
         assert!(store.get_block_by_height(0).unwrap().is_some());
         assert!(store.wal.get(WAL_PENDING_KEY).unwrap().is_none());
+    }
+
+    // =========================================================================
+    // Generic Table abstraction (BST-101)
+    // =========================================================================
+
+    /// A `Table` declared purely for the round-trip test, backed by the (empty
+    /// in a fresh store) `dao_stakes` keyspace.
+    struct TableProbe;
+    impl crate::storage::Table for TableProbe {
+        const NAME: &'static str = TREE_DAO_STAKES;
+        const VERSION: u32 = 1;
+        type Key = [u8; 8];
+        type Value = u64;
+        fn encode_key(key: &[u8; 8]) -> Vec<u8> {
+            key.to_vec()
+        }
+    }
+
+    /// One `impl Table` yields typed `get` / `stage` / `stage_delete` / `iter`
+    /// with no bespoke store methods — staged writes land atomically with the
+    /// block commit, exactly like every other tree.
+    #[test]
+    fn test_generic_table_round_trip() {
+        use crate::storage::TableAccess;
+
+        let store = SledStore::open_temporary().unwrap();
+        let block0 = create_test_block(0, Hash::default());
+
+        store.begin_block(0).unwrap();
+        store.append_block(&block0).unwrap();
+        store.stage::<TableProbe>(&1u64.to_be_bytes(), &111u64).unwrap();
+        store.stage::<TableProbe>(&2u64.to_be_bytes(), &222u64).unwrap();
+        // Staged writes are not visible until the block commits.
+        assert_eq!(store.get::<TableProbe>(&1u64.to_be_bytes()).unwrap(), None);
+        store.commit_block().unwrap();
+
+        assert_eq!(store.get::<TableProbe>(&1u64.to_be_bytes()).unwrap(), Some(111));
+        assert_eq!(store.get::<TableProbe>(&2u64.to_be_bytes()).unwrap(), Some(222));
+        assert_eq!(store.get::<TableProbe>(&9u64.to_be_bytes()).unwrap(), None);
+
+        let mut all = store.iter::<TableProbe>().unwrap();
+        all.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].1, 111);
+        assert_eq!(all[1].1, 222);
+
+        // stage_delete also lands with the block commit.
+        let block1 = create_test_block(1, block0.header.block_hash);
+        store.begin_block(1).unwrap();
+        store.append_block(&block1).unwrap();
+        store.stage_delete::<TableProbe>(&1u64.to_be_bytes()).unwrap();
+        store.commit_block().unwrap();
+        assert_eq!(store.get::<TableProbe>(&1u64.to_be_bytes()).unwrap(), None);
+        assert_eq!(store.get::<TableProbe>(&2u64.to_be_bytes()).unwrap(), Some(222));
+    }
+
+    /// Generic table writes outside `begin_block` are rejected, like every
+    /// other staged write.
+    #[test]
+    fn test_generic_table_stage_requires_transaction() {
+        use crate::storage::TableAccess;
+        let store = SledStore::open_temporary().unwrap();
+        assert!(matches!(
+            store.stage::<TableProbe>(&1u64.to_be_bytes(), &1u64),
+            Err(StorageError::NoActiveTransaction)
+        ));
     }
 }

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -172,109 +172,47 @@ struct WalRecord {
     trees: Vec<(String, Vec<(Vec<u8>, Option<Vec<u8>>)>)>,
 }
 
-/// Buffered changes for atomic commit.
+/// Buffered changes for one atomic commit.
+///
+/// Per-tree write batches are keyed by tree name in a single map, so adding a
+/// storage tree needs no new struct field, no `new()` initializer, and no
+/// `to_wal_record` line — the WAL path iterates the map generically.
 struct PendingBatch {
-    blocks_by_height: TreeBatch,
-    blocks_by_hash: TreeBatch,
-    utxos: TreeBatch,
-    accounts: TreeBatch,
-    wallets: TreeBatch,
-    token_balances: TreeBatch,
-    token_nonces: TreeBatch, // Nonce for token transfers
-    token_contracts: TreeBatch,
-    token_supply: TreeBatch,     // Total supply tracking
-    contract_code: TreeBatch,    // Contract code storage
-    contract_storage: TreeBatch, // Contract key-value storage
-    identities: TreeBatch,
-    identity_metadata: TreeBatch,
-    identity_by_owner: TreeBatch,
-    bonding_curves: TreeBatch,
-    bonding_curve_symbols: TreeBatch,
-    cbe_accounts: TreeBatch,
-    dao_stakes: TreeBatch,
-    observer_registry: TreeBatch,
-    utxo_merkle_leaves: TreeBatch,
-    utxo_merkle_index: TreeBatch,
-    utxo_merkle_meta: TreeBatch,
-    utxo_merkle_nodes: TreeBatch,
+    /// Tree name → buffered key writes. Only touched trees get an entry.
+    trees: std::collections::BTreeMap<&'static str, TreeBatch>,
     /// Hash of the block staged via `append_block` (recorded in the WAL).
     block_hash: Option<[u8; 32]>,
     /// In-transaction cache of outpoints → leaf_index for the current block.
     utxo_merkle_indexed: std::collections::HashMap<[u8; 36], u64>,
     /// In-transaction cache of Merkle internal nodes for path updates.
     utxo_merkle_nodes_cache: std::collections::HashMap<[u8; 12], [u8; 32]>,
-    meta: TreeBatch,
 }
 
 impl PendingBatch {
     fn new() -> Self {
         Self {
-            blocks_by_height: TreeBatch::default(),
-            blocks_by_hash: TreeBatch::default(),
-            utxos: TreeBatch::default(),
-            accounts: TreeBatch::default(),
-            wallets: TreeBatch::default(),
-            token_balances: TreeBatch::default(),
-            token_nonces: TreeBatch::default(),
-            token_contracts: TreeBatch::default(),
-            token_supply: TreeBatch::default(),
-            contract_code: TreeBatch::default(),
-            contract_storage: TreeBatch::default(),
-            identities: TreeBatch::default(),
-            identity_metadata: TreeBatch::default(),
-            identity_by_owner: TreeBatch::default(),
-            bonding_curves: TreeBatch::default(),
-            bonding_curve_symbols: TreeBatch::default(),
-            cbe_accounts: TreeBatch::default(),
-            dao_stakes: TreeBatch::default(),
-            observer_registry: TreeBatch::default(),
-            utxo_merkle_leaves: TreeBatch::default(),
-            utxo_merkle_index: TreeBatch::default(),
-            utxo_merkle_meta: TreeBatch::default(),
-            utxo_merkle_nodes: TreeBatch::default(),
+            trees: std::collections::BTreeMap::new(),
             block_hash: None,
             utxo_merkle_indexed: std::collections::HashMap::new(),
             utxo_merkle_nodes_cache: std::collections::HashMap::new(),
-            meta: TreeBatch::default(),
         }
     }
 
+    /// Buffer for tree `name`, created empty on first use. `name` must be one
+    /// of the canonical `TREE_*` constants (`tree_by_name` maps it back).
+    fn tree(&mut self, name: &'static str) -> &mut TreeBatch {
+        self.trees.entry(name).or_default()
+    }
+
     /// Build the durable WAL record for committing block `height`.
-    ///
-    /// Empty per-tree batches are omitted to keep the record compact. The
-    /// tree names are the canonical `TREE_*` constants — `tree_by_name` maps
-    /// them back to live trees during apply/recovery.
+    /// Empty per-tree batches are omitted to keep the record compact.
     fn to_wal_record(&self, height: u64) -> WalRecord {
-        let mut trees = Vec::new();
-        let mut add = |name: &str, batch: &TreeBatch| {
-            if !batch.is_empty() {
-                trees.push((name.to_string(), batch.to_post_image()));
-            }
-        };
-        add(TREE_BLOCKS_BY_HEIGHT, &self.blocks_by_height);
-        add(TREE_BLOCKS_BY_HASH, &self.blocks_by_hash);
-        add(TREE_UTXOS, &self.utxos);
-        add(TREE_ACCOUNTS, &self.accounts);
-        add(TREE_WALLETS, &self.wallets);
-        add(TREE_TOKEN_BALANCES, &self.token_balances);
-        add(TREE_TOKEN_NONCES, &self.token_nonces);
-        add(TREE_TOKEN_CONTRACTS, &self.token_contracts);
-        add(TREE_TOKEN_SUPPLY, &self.token_supply);
-        add(TREE_CONTRACT_CODE, &self.contract_code);
-        add(TREE_CONTRACT_STORAGE, &self.contract_storage);
-        add(TREE_IDENTITIES, &self.identities);
-        add(TREE_IDENTITY_METADATA, &self.identity_metadata);
-        add(TREE_IDENTITY_BY_OWNER, &self.identity_by_owner);
-        add(TREE_BONDING_CURVES, &self.bonding_curves);
-        add(TREE_BONDING_CURVE_SYMBOLS, &self.bonding_curve_symbols);
-        add(TREE_CBE_ACCOUNTS, &self.cbe_accounts);
-        add(TREE_DAO_STAKES, &self.dao_stakes);
-        add(TREE_OBSERVER_REGISTRY, &self.observer_registry);
-        add(TREE_UTXO_MERKLE_LEAVES, &self.utxo_merkle_leaves);
-        add(TREE_UTXO_MERKLE_INDEX, &self.utxo_merkle_index);
-        add(TREE_UTXO_MERKLE_META, &self.utxo_merkle_meta);
-        add(TREE_UTXO_MERKLE_NODES, &self.utxo_merkle_nodes);
-        add(TREE_META, &self.meta);
+        let trees = self
+            .trees
+            .iter()
+            .filter(|(_, b)| !b.is_empty())
+            .map(|(name, b)| (name.to_string(), b.to_post_image()))
+            .collect();
         WalRecord {
             height,
             block_hash: self.block_hash.unwrap_or([0u8; 32]),
@@ -498,7 +436,7 @@ impl SledStore {
         let value = Self::serialize(record)?;
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.wallets.insert(wallet_id.as_ref(), value);
+            batch.tree(TREE_WALLETS).insert(wallet_id.as_ref(), value);
         }
 
         Ok(())
@@ -510,7 +448,7 @@ impl SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.wallets.remove(wallet_id.as_ref());
+            batch.tree(TREE_WALLETS).remove(wallet_id.as_ref());
         }
 
         Ok(())
@@ -646,7 +584,7 @@ impl SledStore {
         for level in 0..lib_proofs::transaction::circuit::MERKLE_DEPTH as u32 {
             let key = Self::merkle_node_key(level, current_index);
             batch.utxo_merkle_nodes_cache.insert(key, current_hash);
-            batch.utxo_merkle_nodes.insert(key.as_ref(), current_hash.as_ref());
+            batch.tree(TREE_UTXO_MERKLE_NODES).insert(key.as_ref(), current_hash.as_ref());
 
             let sibling_index = current_index ^ 1;
             let sibling_hash = self.get_merkle_node(batch, level, sibling_index)?;
@@ -662,8 +600,8 @@ impl SledStore {
         let depth = lib_proofs::transaction::circuit::MERKLE_DEPTH as u32;
         let root_key = Self::merkle_node_key(depth, 0);
         batch.utxo_merkle_nodes_cache.insert(root_key, current_hash);
-        batch.utxo_merkle_nodes.insert(root_key.as_ref(), current_hash.as_ref());
-        batch.utxo_merkle_meta.insert(
+        batch.tree(TREE_UTXO_MERKLE_NODES).insert(root_key.as_ref(), current_hash.as_ref());
+        batch.tree(TREE_UTXO_MERKLE_META).insert(
             keys::meta::UTXO_MERKLE_ROOT,
             current_hash.as_ref(),
         );
@@ -940,9 +878,9 @@ impl BlockchainStore for SledStore {
             // TreeBatch::insert mirrors sled Batch::insert (Into<IVec> for K and V),
             // so fixed-size arrays are converted to slices.
             batch
-                .blocks_by_height
+                .tree(TREE_BLOCKS_BY_HEIGHT)
                 .insert(height_key.as_ref(), block_hash.as_bytes().as_ref());
-            batch.blocks_by_hash.insert(hash_key.as_ref(), block_bytes);
+            batch.tree(TREE_BLOCKS_BY_HASH).insert(hash_key.as_ref(), block_bytes);
             // Record the block hash for the write-ahead commit record.
             batch.block_hash = Some(hash_bytes);
         }
@@ -1014,7 +952,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.utxos.insert(key.as_ref(), value);
+            batch.tree(TREE_UTXOS).insert(key.as_ref(), value);
         }
 
         Ok(())
@@ -1027,7 +965,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.utxos.remove(key.as_ref());
+            batch.tree(TREE_UTXOS).remove(key.as_ref());
         }
 
         Ok(())
@@ -1059,9 +997,9 @@ impl BlockchainStore for SledStore {
         let next_index = self.tx_utxo_merkle_next_index.fetch_add(1, Ordering::SeqCst);
         let index_bytes = next_index.to_be_bytes();
 
-        batch.utxo_merkle_leaves.insert(index_bytes.as_ref(), &leaf[..]);
-        batch.utxo_merkle_index.insert(op_key.as_ref(), index_bytes.as_ref());
-        batch.utxo_merkle_meta.insert(
+        batch.tree(TREE_UTXO_MERKLE_LEAVES).insert(index_bytes.as_ref(), &leaf[..]);
+        batch.tree(TREE_UTXO_MERKLE_INDEX).insert(op_key.as_ref(), index_bytes.as_ref());
+        batch.tree(TREE_UTXO_MERKLE_META).insert(
             keys::meta::UTXO_MERKLE_NEXT_INDEX,
             (next_index + 1).to_be_bytes().as_ref(),
         );
@@ -1092,8 +1030,8 @@ impl BlockchainStore for SledStore {
         };
 
         if let Some(bytes) = index_bytes {
-            batch.utxo_merkle_leaves.insert(bytes.as_slice(), &[0u8; 32][..]);
-            batch.utxo_merkle_index.remove(op_key.as_ref());
+            batch.tree(TREE_UTXO_MERKLE_LEAVES).insert(bytes.as_slice(), &[0u8; 32][..]);
+            batch.tree(TREE_UTXO_MERKLE_INDEX).remove(op_key.as_ref());
             let idx = u64::from_be_bytes([
                 bytes[0], bytes[1], bytes[2], bytes[3],
                 bytes[4], bytes[5], bytes[6], bytes[7],
@@ -1260,7 +1198,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.token_contracts.insert(key.as_ref(), value);
+            batch.tree(TREE_TOKEN_CONTRACTS).insert(key.as_ref(), value);
         }
 
         Ok(())
@@ -1296,7 +1234,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.token_supply.insert(key.as_ref(), value.as_ref());
+            batch.tree(TREE_TOKEN_SUPPLY).insert(key.as_ref(), value.as_ref());
         }
 
         Ok(())
@@ -1319,7 +1257,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.contract_code.insert(contract_id, code);
+            batch.tree(TREE_CONTRACT_CODE).insert(contract_id, code);
         }
 
         Ok(())
@@ -1356,7 +1294,7 @@ impl BlockchainStore for SledStore {
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
             batch
-                .contract_storage
+                .tree(TREE_CONTRACT_STORAGE)
                 .insert(IVec::from(composite_key), value);
         }
 
@@ -1372,7 +1310,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.contract_storage.remove(IVec::from(composite_key));
+            batch.tree(TREE_CONTRACT_STORAGE).remove(IVec::from(composite_key));
         }
 
         Ok(())
@@ -1395,7 +1333,7 @@ impl BlockchainStore for SledStore {
         let value = Self::serialize(snapshot)?;
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.meta.insert(keys::meta::TOKEN_STATE_SNAPSHOT, value);
+            batch.tree(TREE_META).insert(keys::meta::TOKEN_STATE_SNAPSHOT, value);
         }
 
         Ok(())
@@ -1518,7 +1456,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.accounts.insert(key.as_ref(), value);
+            batch.tree(TREE_ACCOUNTS).insert(key.as_ref(), value);
         }
 
         Ok(())
@@ -1554,9 +1492,9 @@ impl BlockchainStore for SledStore {
         if let Some(ref mut batch) = *batch_guard {
             if v == 0 {
                 // Optionally delete zero balances to save space
-                batch.token_balances.remove(key.as_ref());
+                batch.tree(TREE_TOKEN_BALANCES).remove(key.as_ref());
             } else {
-                batch.token_balances.insert(key.as_ref(), &v.to_be_bytes());
+                batch.tree(TREE_TOKEN_BALANCES).insert(key.as_ref(), &v.to_be_bytes());
             }
         }
 
@@ -1656,10 +1594,10 @@ impl BlockchainStore for SledStore {
         if let Some(ref mut batch) = *batch_guard {
             if nonce == 0 {
                 // Delete zero nonces to save space
-                batch.token_nonces.remove(key.as_ref());
+                batch.tree(TREE_TOKEN_NONCES).remove(key.as_ref());
             } else {
                 batch
-                    .token_nonces
+                    .tree(TREE_TOKEN_NONCES)
                     .insert(key.as_ref(), &nonce.to_be_bytes());
             }
         }
@@ -1689,7 +1627,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.identities.insert(did_hash.as_ref(), value);
+            batch.tree(TREE_IDENTITIES).insert(did_hash.as_ref(), value);
         }
 
         Ok(())
@@ -1700,7 +1638,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.identities.remove(did_hash.as_ref());
+            batch.tree(TREE_IDENTITIES).remove(did_hash.as_ref());
         }
 
         Ok(())
@@ -1732,7 +1670,7 @@ impl BlockchainStore for SledStore {
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
             batch
-                .identity_by_owner
+                .tree(TREE_IDENTITY_BY_OWNER)
                 .insert(key.as_ref(), did_hash.as_ref());
         }
 
@@ -1746,7 +1684,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.identity_by_owner.remove(key.as_ref());
+            batch.tree(TREE_IDENTITY_BY_OWNER).remove(key.as_ref());
         }
 
         Ok(())
@@ -1781,7 +1719,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.identity_metadata.insert(did_hash.as_ref(), value);
+            batch.tree(TREE_IDENTITY_METADATA).insert(did_hash.as_ref(), value);
         }
 
         Ok(())
@@ -1792,7 +1730,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.identity_metadata.remove(did_hash.as_ref());
+            batch.tree(TREE_IDENTITY_METADATA).remove(did_hash.as_ref());
         }
 
         Ok(())
@@ -1996,19 +1934,19 @@ impl BlockchainStore for SledStore {
                 .ok_or(StorageError::NoActiveTransaction)?
         };
 
-        // Apply supplementary index batches only — no block data, no
-        // latest_height update. This path is not WAL-protected: it writes
-        // rebuildable identity indexes, not block-commit consensus state.
-        apply_tree_post_image(&self.identities, &batch.identities.to_post_image())?;
-        apply_tree_post_image(
-            &self.identity_metadata,
-            &batch.identity_metadata.to_post_image(),
-        )?;
-        apply_tree_post_image(
-            &self.identity_by_owner,
-            &batch.identity_by_owner.to_post_image(),
-        )?;
-        apply_tree_post_image(&self.accounts, &batch.accounts.to_post_image())?;
+        // Apply whatever index trees were staged (identities/metadata/owner/
+        // accounts) — no block data, no latest_height update. This path is not
+        // WAL-protected: it writes rebuildable identity indexes, not
+        // block-commit consensus state.
+        for (name, tree_batch) in &batch.trees {
+            let tree = self.tree_by_name(name).ok_or_else(|| {
+                StorageError::CorruptedData(format!(
+                    "metadata write staged unknown tree '{}'",
+                    name
+                ))
+            })?;
+            apply_tree_post_image(tree, &tree_batch.to_post_image())?;
+        }
 
         // Flush to ensure identity writes are durable before the next block commit.
         self.db
@@ -2049,7 +1987,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.bonding_curves.insert(key, value);
+            batch.tree(TREE_BONDING_CURVES).insert(key, value);
         }
 
         Ok(())
@@ -2060,7 +1998,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.bonding_curves.remove(token_id.as_ref());
+            batch.tree(TREE_BONDING_CURVES).remove(token_id.as_ref());
         }
 
         Ok(())
@@ -2129,7 +2067,7 @@ impl BlockchainStore for SledStore {
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
             batch
-                .bonding_curve_symbols
+                .tree(TREE_BONDING_CURVE_SYMBOLS)
                 .insert(symbol.as_bytes(), token_id.as_ref());
         }
 
@@ -2141,7 +2079,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.bonding_curve_symbols.remove(symbol.as_bytes());
+            batch.tree(TREE_BONDING_CURVE_SYMBOLS).remove(symbol.as_bytes());
         }
 
         Ok(())
@@ -2171,7 +2109,7 @@ impl BlockchainStore for SledStore {
         let value = Self::serialize(state)?;
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.meta.insert(keys::meta::CBE_ECONOMIC_STATE, value);
+            batch.tree(TREE_META).insert(keys::meta::CBE_ECONOMIC_STATE, value);
         }
 
         Ok(())
@@ -2204,7 +2142,7 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.cbe_accounts.insert(key.as_ref(), value);
+            batch.tree(TREE_CBE_ACCOUNTS).insert(key.as_ref(), value);
         }
 
         Ok(())
@@ -2265,7 +2203,7 @@ impl BlockchainStore for SledStore {
         let value = Self::serialize(record)?;
         let mut batch_guard = self.tx_batch.lock().unwrap();
         let batch = batch_guard.as_mut().ok_or(StorageError::NoActiveTransaction)?;
-        batch.dao_stakes.insert(key.as_ref(), value);
+        batch.tree(TREE_DAO_STAKES).insert(key.as_ref(), value);
         Ok(())
     }
 
@@ -2278,7 +2216,7 @@ impl BlockchainStore for SledStore {
         let key = keys::dao_stake_key(sector_dao_key_id, staker);
         let mut batch_guard = self.tx_batch.lock().unwrap();
         let batch = batch_guard.as_mut().ok_or(StorageError::NoActiveTransaction)?;
-        batch.dao_stakes.remove(key.as_ref());
+        batch.tree(TREE_DAO_STAKES).remove(key.as_ref());
         Ok(())
     }
 
@@ -2328,7 +2266,7 @@ impl BlockchainStore for SledStore {
             StorageError::Database(format!("lock poisoned in put_observer_record: {e}"))
         })?;
         if let Some(batch) = guard.as_mut() {
-            batch.observer_registry.insert(did_hash.as_slice(), bytes);
+            batch.tree(TREE_OBSERVER_REGISTRY).insert(did_hash.as_slice(), bytes);
             Ok(())
         } else {
             Err(StorageError::Database(
@@ -2342,7 +2280,7 @@ impl BlockchainStore for SledStore {
             StorageError::Database(format!("lock poisoned in delete_observer_record: {e}"))
         })?;
         if let Some(batch) = guard.as_mut() {
-            batch.observer_registry.remove(did_hash.as_slice());
+            batch.tree(TREE_OBSERVER_REGISTRY).remove(did_hash.as_slice());
             Ok(())
         } else {
             Err(StorageError::Database(

--- a/lib-blockchain/src/storage/table.rs
+++ b/lib-blockchain/src/storage/table.rs
@@ -1,0 +1,87 @@
+//! Generic typed `Table` abstraction over `BlockchainStore` keyspaces.
+//!
+//! Blockchain-state-tiering epic, BST-101 (`docs/epics/blockchain-state-tiering-epic.md`).
+//!
+//! Before this, every persisted dataset needed its own bespoke
+//! `get_X`/`put_X`/`delete_X`/`iter_X` quadruple on `BlockchainStore`, each
+//! wired through the `SledStore` trees, the WAL, and migration code. A new
+//! dataset is now a single `impl Table` declaration: it names a keyspace,
+//! a key encoding, and a value type, and gets typed CRUD for free via the
+//! `TableAccess` extension trait.
+//!
+//! The store side stays object-safe — `BlockchainStore` exposes only the
+//! byte-level `get_raw`/`stage_raw`/`iter_raw` primitives, and `TableAccess`
+//! layers the generic typed API on top with a blanket impl.
+
+use super::{BlockchainStore, StorageError, StorageResult};
+
+/// A typed, versioned key→value dataset backed by one storage keyspace.
+pub trait Table {
+    /// Stable on-disk keyspace name (a `SledStore` tree). Protocol — once a
+    /// table ships, its `NAME` never changes.
+    const NAME: &'static str;
+
+    /// Schema version of `Value`. Bump on any incompatible change to the
+    /// serialized form; drives the future per-table migration registry
+    /// (BST-104). New tables start at `1`.
+    const VERSION: u32;
+
+    /// Logical key type. `?Sized` so `[u8]` / `str` keys work directly.
+    type Key: ?Sized;
+
+    /// Stored value — serialized with bincode.
+    type Value: serde::Serialize + serde::de::DeserializeOwned;
+
+    /// Encode a key to its on-disk byte form.
+    fn encode_key(key: &Self::Key) -> Vec<u8>;
+}
+
+/// Typed CRUD over any [`BlockchainStore`], built on the object-safe
+/// `*_raw` primitives. Blanket-implemented — callers just `use TableAccess`
+/// and call `store.get::<SomeTable>(&key)`.
+pub trait TableAccess {
+    /// Read and decode the value for `key`.
+    fn get<T: Table>(&self, key: &T::Key) -> StorageResult<Option<T::Value>>;
+
+    /// Stage an insert of `value` for `key`. Must run within
+    /// `begin_block`/`commit_block`; lands atomically with the block.
+    fn stage<T: Table>(&self, key: &T::Key, value: &T::Value) -> StorageResult<()>;
+
+    /// Stage a delete of `key`. Must run within `begin_block`/`commit_block`.
+    fn stage_delete<T: Table>(&self, key: &T::Key) -> StorageResult<()>;
+
+    /// Decode every `(raw_key, value)` pair in the table.
+    fn iter<T: Table>(&self) -> StorageResult<Vec<(Vec<u8>, T::Value)>>;
+}
+
+impl<S: BlockchainStore + ?Sized> TableAccess for S {
+    fn get<T: Table>(&self, key: &T::Key) -> StorageResult<Option<T::Value>> {
+        match self.get_raw(T::NAME, &T::encode_key(key))? {
+            Some(bytes) => Ok(Some(decode::<T>(&bytes)?)),
+            None => Ok(None),
+        }
+    }
+
+    fn stage<T: Table>(&self, key: &T::Key, value: &T::Value) -> StorageResult<()> {
+        let bytes =
+            bincode::serialize(value).map_err(|e| StorageError::Serialization(e.to_string()))?;
+        self.stage_raw(T::NAME, &T::encode_key(key), Some(&bytes))
+    }
+
+    fn stage_delete<T: Table>(&self, key: &T::Key) -> StorageResult<()> {
+        self.stage_raw(T::NAME, &T::encode_key(key), None)
+    }
+
+    fn iter<T: Table>(&self) -> StorageResult<Vec<(Vec<u8>, T::Value)>> {
+        let mut out = Vec::new();
+        for entry in self.iter_raw(T::NAME)? {
+            let (raw_key, raw_value) = entry?;
+            out.push((raw_key, decode::<T>(&raw_value)?));
+        }
+        Ok(out)
+    }
+}
+
+fn decode<T: Table>(bytes: &[u8]) -> StorageResult<T::Value> {
+    bincode::deserialize(bytes).map_err(|e| StorageError::Serialization(e.to_string()))
+}


### PR DESCRIPTION
Stacked on #2589 (`storage_atomic_commit`) — review/merge that first; this rebases onto `development` afterward.

## What this delivers

**1. The epic design** — `docs/epics/blockchain-state-tiering-epic.md`. The `Blockchain` struct (`blockchain.rs:114`) is an ~80-field monolithic in-memory database holding the chain-tip working set *and* all history. The doc locks the hot/cold split, the generic `Table` abstraction, the archival-block hot-window, schema versioning, and a 3-phase plan. Open questions resolved and decisions recorded (AD-001…009).

**2. Phase 1, BST-103 — table-keyed `PendingBatch`.** The repetition flagged in review: `PendingBatch` had 24 hand-listed `TreeBatch` fields, and `new()` / `to_wal_record()` / the staging sites each repeated the per-tree pattern. Replaced the 24 fields with one `BTreeMap<&'static str, TreeBatch>`:

- `PendingBatch::tree(name)` returns the buffer, created on first use.
- `to_wal_record()` iterates the map — 24 hand-written `add()` lines gone.
- `commit_metadata_write()` applies whatever trees were staged.

Adding a storage tree no longer needs a struct field, an initializer, or a `to_wal_record` line. ~75 lines of pure repetition removed; the ~45 staging sites route through `tree(TREE_*)`.

## Scope / sequencing

This is the first slice of Phase 1. Per AD-008 the remaining work lands as follow-up PRs so each is reviewable:

- **Next** — the typed `Table<K, V>` trait + generic `get`/`stage`/`iter` store API + schema versioning (BST-101/102/104).
- **Then** — Phase 2 cold-state offload (receipts, snapshots, histories leave the `Blockchain` struct) and Phase 3 archival blocks.

## Verification

`cargo check` clean; all 23 `storage::sled_store` tests pass, including the WAL crash-recovery suite — behavior is unchanged, this is a pure de-duplication refactor.