### PR TITLE
fix(consensus): scope same-round fork check to valid_proposal set this round

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/tests.rs
+++ b/lib-consensus/src/engines/consensus_engine/tests.rs
@@ -3093,3 +3093,47 @@ async fn test_round_sync_lagging_proposer_does_not_propose() {
         "a behind proposer must NOT enqueue a proposal artifact"
     );
 }
+
+/// Regression: `validate_no_fork_proposal` must not treat a `valid_proposal`
+/// carried over from an earlier round as a same-round fork.
+///
+/// Before this fix, the round-sync work that preserves `valid_proposal` /
+/// `valid_round` across round jumps (Tendermint unlock-rule semantics)
+/// caused every legitimate next-round proposal to be rejected as a fork
+/// against the stale `valid_proposal` — deadlocking the chain.
+#[tokio::test]
+async fn test_stale_valid_proposal_does_not_trigger_fork_reject() {
+    let (mut engine, _) = setup_bft_engine(5, 10).await;
+
+    let stale_id = Hash::from_bytes(&[1u8; 32]);
+    let fresh_id = Hash::from_bytes(&[2u8; 32]);
+
+    // Stale state: a prevote quorum was observed in an earlier round, so
+    // valid_proposal / valid_round persist (per Tendermint unlock rule) but
+    // they belong to round 5, not the current round 10.
+    engine.current_round.valid_proposal = Some(stale_id.clone());
+    engine.current_round.valid_round = Some(5);
+
+    let result = engine.validate_no_fork_proposal(5, 10, &fresh_id);
+    assert!(
+        result.is_ok(),
+        "stale valid_proposal (from an earlier round) must NOT trigger a \
+         same-round fork rejection of a new round's legitimate proposal"
+    );
+
+    // Real same-round conflict: valid_proposal was set IN the current round,
+    // and a different proposal_id arrives for that same round.
+    engine.current_round.valid_round = Some(10);
+    let result = engine.validate_no_fork_proposal(5, 10, &fresh_id);
+    assert!(
+        result.is_err(),
+        "same-round conflicting proposal must still trigger a fork rejection"
+    );
+
+    // Same-round, same proposal_id: no conflict, no rejection.
+    let result = engine.validate_no_fork_proposal(5, 10, &stale_id);
+    assert!(
+        result.is_ok(),
+        "same proposal_id at same round must not trigger fork rejection"
+    );
+}

--- a/lib-consensus/src/engines/consensus_engine/validation.rs
+++ b/lib-consensus/src/engines/consensus_engine/validation.rs
@@ -590,25 +590,24 @@ impl ConsensusEngine {
             )));
         }
 
-        // If the proposal targets the current round height but there is already an
-        // agreed-upon proposal (valid_proposal) at this height with a different hash,
-        // reject it as a fork.
+        // Same-round fork check: if this proposal is for the current round AND
+        // a conflicting proposal was already agreed upon in THIS round (a prevote
+        // quorum observed this round), reject it as a Byzantine same-round fork.
         //
-        // This can happen if consensus committed a block in a prior round but the
-        // engine has not yet advanced to the next height. Any conflicting proposal
-        // at the same height is a fork and MUST be rejected.
-        // Same-round fork check: if this proposal is for the current round and a
-        // conflicting proposal was already agreed upon in this round, reject it.
+        // `valid_proposal` and `valid_round` PERSIST across rounds — that is the
+        // Tendermint unlock-rule contract (`validValue`/`validRound`). A stale
+        // `valid_proposal` from an earlier round is NOT a same-round conflict:
+        // the elected proposer for the current round may legitimately propose a
+        // different value. The `valid_round == Some(current.round)` gate scopes
+        // the fork check to genuine same-round agreement.
         //
-        // This check is scoped to SAME-ROUND proposals only. A proposal for a different
-        // round is not a fork — each round has its own designated proposer and legitimately
-        // produces a different block. Different-round proposals may arrive while
-        // `valid_proposal` is still set from the local node's current round; treating those
-        // as same-round forks would deadlock timeout-driven round progression.
+        // Without this gate, the check spuriously rejects every legitimate
+        // next-round proposal once `valid_proposal` is set in any round —
+        // deadlocking the chain.
         if proposal_height == self.current_round.height
             && proposal_round == self.current_round.round
+            && self.current_round.valid_round == Some(self.current_round.round)
         {
-            // Two different proposals for the same (height, round) — genuine Byzantine fork.
             if let Some(committed_id) = &self.current_round.valid_proposal {
                 if committed_id != proposal_id {
                     return Err(ConsensusError::ByzantineFault(format!(


### PR DESCRIPTION
## Summary

Fix a regression from **#2591** (Tendermint round synchronization). The fork-rejection logs that have been blocking commits on the stuck testnet (height 59117) trace to **`validate_no_fork_proposal` rejecting every legitimate next-round proposal against a stale `valid_proposal`**.

### Before #2591
`on_round_timeout` cleared `valid_proposal = None` on every round bump, so the same-round fork check was implicitly round-scoped — it only fired against a `valid_proposal` set in the current round.

### After #2591
The new \`enter_round\` deliberately **preserves** \`valid_proposal\` / \`valid_round\` across round jumps — that's the Tendermint unlock-rule contract (\`validValue\` / \`validRound\` are how a locked validator decides whether to prevote a conflicting proposal in a later round). Correct in isolation.

### What I missed
`validate_no_fork_proposal` (`validation.rs:608-623`) only gated on `proposal_round == current.round` and `valid_proposal.is_some()` — it **never checked `valid_round`**. With #2591 preserving `valid_proposal` past its own round, the check now spuriously fires:

```
Round R: prevote quorum for Y → valid_proposal = Y, valid_round = R.
Round R+1: legitimate proposer rotates, proposes X.
Receiver: proposal.round (R+1) == current.round (R+1) ✓
         valid_proposal = Some(Y) (stale), Y != X → FORK REJECTED (spurious).
```

That's exactly the `FORK REJECTED ... conflicts with already-agreed proposal Y at height 59117 round 3944` errors we see in production. Every subsequent round's legitimate proposal is rejected. Chain can't commit.

### Fix
Add `valid_round == Some(current.round)` to the same-round fork predicate. Only treat `valid_proposal` as a fork candidate when it was set in the current round. Stale carry-over from earlier rounds is ignored for the fork check (and is still authoritative for the unlock rule consumed in `prevote_permitted_by_lock` — the path that genuinely needs it).

The fix's own comment block now explains the persistence contract and why the gate is necessary.

## Test plan

- [x] New regression test: `test_stale_valid_proposal_does_not_trigger_fork_reject` — asserts stale carry-over is not a fork, real same-round conflicts still are, same-id same-round is no-op.
- [x] Full `cargo test -p lib-consensus --lib` — 141 / 141 pass.
- [x] `cargo build --workspace --locked` — clean.
- [x] All 17 DAO-ready release gates pass.

## Deploy

Same protocol version (v3), no rolling concerns from a protocol bump. Drop-in binary swap (with `halt-consensus` if the chain is actually producing — it isn't right now, so `systemctl stop`/swap/start staged is safe).