### PR TITLE
fix: harmonize mesh UNI receive limit to 4 MiB across both paths

### DIFF
--- a/lib-network/src/protocols/quic_mesh.rs
+++ b/lib-network/src/protocols/quic_mesh.rs
@@ -81,6 +81,15 @@ pub const DEFAULT_TLS_CERT_PATH: &str = "./data/tls/server.crt";
 /// Default path for TLS private key
 pub const DEFAULT_TLS_KEY_PATH: &str = "./data/tls/server.key";
 
+/// Max bytes a single mesh UNI message is allowed to occupy on the wire.
+/// Sized to fit a consensus proposal carrying a full block (MAX_BLOCK_SIZE = 4 MiB)
+/// plus encryption/framing overhead. Both receive paths (`spawn_receive_loop`
+/// and the inbound-acceptor in `start_receiving`) must agree on this value —
+/// any divergence causes silent truncation of large messages on whichever path
+/// uses the smaller limit, which manifests as proposals being dropped while
+/// smaller messages (votes, heartbeats) pass through.
+pub const MAX_MESH_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
+
 /// Trust policy for QUIC TLS verification.
 #[derive(Clone, Debug)]
 pub enum QuicTrustMode {
@@ -1138,8 +1147,7 @@ impl QuicMeshProtocol {
             loop {
                 match conn.accept_uni().await {
                     Ok(mut stream) => {
-                        match stream.read_to_end(4 * 1024 * 1024).await {
-                            // 4MB max (consensus proposals include block data up to MAX_BLOCK_SIZE + overhead)
+                        match stream.read_to_end(MAX_MESH_MESSAGE_BYTES).await {
                             Ok(encrypted) => {
                                 match decrypt_data(&encrypted, &session_key) {
                                     Ok(decrypted) => {
@@ -1395,7 +1403,7 @@ impl QuicMeshProtocol {
                                         loop {
                                             match quic_conn_clone.accept_uni().await {
                                                 Ok(mut stream) => {
-                                                    match stream.read_to_end(1024 * 1024).await {
+                                                    match stream.read_to_end(MAX_MESH_MESSAGE_BYTES).await {
                                                         Ok(encrypted) => {
                                                             match decrypt_data(
                                                                 &encrypted,
@@ -1439,9 +1447,11 @@ impl QuicMeshProtocol {
                                                                 ),
                                                             }
                                                         }
-                                                        Err(e) => debug!(
-                                                            "Failed to read UNI stream: {}",
-                                                            e
+                                                        Err(e) => warn!(
+                                                            peer = %node_id_hex,
+                                                            error = %e,
+                                                            "Failed to read UNI stream (message dropped); \
+                                                             if this is `TooLong`, raise MAX_MESH_MESSAGE_BYTES"
                                                         ),
                                                     }
                                                 }
@@ -1939,7 +1949,7 @@ impl PqcQuicConnection {
 
         // Receive from QUIC (TLS 1.3 decryption automatic)
         let mut stream = self.quic_conn.accept_uni().await?;
-        let encrypted = stream.read_to_end(1024 * 1024).await?; // 1MB max message size
+        let encrypted = stream.read_to_end(MAX_MESH_MESSAGE_BYTES).await?;
 
         // Decrypt using master key (nonce is embedded in encrypted data by lib-crypto)
         let decrypted = decrypt_data(&encrypted, &session_key)?;


### PR DESCRIPTION
## Summary
- Two parallel mesh UNI receive loops disagreed on the per-message size cap (4 MiB vs 1 MiB). The 1 MiB path silently truncated large messages (consensus proposals carry block_data up to MAX_BLOCK_SIZE = 4 MiB) while votes and heartbeats squeaked through. Failure logged only at `debug`, so the drop was invisible.
- Introduces `MAX_MESH_MESSAGE_BYTES = 4 MiB` as the single source of truth, used by every `read_to_end` call site in `quic_mesh.rs`. Promotes the inbound-acceptor read-failure log from `debug` to `warn`.

## Root cause
Chain stuck at height 59117. A freshly-restarted validator (g1) received heartbeats + votes from all 5 validators but proposals from only 2 of 4 remote peers despite all 5 logging `proposal_created` 16–18 times in 5 min. Same broadcaster, same wrapper, same wire format on both sides. Difference: connections accepted by `start_receiving` ran the 1 MiB receive loop (bypassing `register_peer`'s 4 MiB loop), so any proposal larger than 1 MiB on that side was silently dropped while smaller payloads (votes, heartbeats) made it through.

## Test plan
- [x] `cargo build --profile dev-release -p lib-network` clean
- [x] `cargo build --profile dev-release -p zhtp` clean
- [ ] Post-merge: staged rollout g1 → g1+g2 → canary → majority → full; verify g1 sees proposals from all 4 remote validators and `BFT BLOCK COMMITTED` resumes