### PR TITLE
fix: wire CredentialsHandler into unified_server (404 on lobby auth)

### DIFF
--- a/zhtp/src/api/handlers/mod.rs
+++ b/zhtp/src/api/handlers/mod.rs
@@ -36,6 +36,7 @@ pub mod zkp;
 pub use bearer_auth::BearerAuthMiddleware;
 pub use blockchain::BlockchainHandler;
 pub use cbe::CbeHandler;
+pub use credentials::CredentialsHandler;
 pub use crypto::CryptoHandler;
 pub use dao::DaoHandler;
 pub use dht::DhtHandler;

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -53,9 +53,9 @@ const QUIC_PORT: u16 = 9334;
 
 // Import our comprehensive API handlers
 use crate::api::handlers::{
-    BearerAuthMiddleware, BlockchainHandler, CbeHandler, DaoHandler, DhtHandler, DnsHandler,
-    IdentityHandler, MobileAuthHandler, ProtocolHandler, StorageHandler, TokenHandler,
-    WalletHandler, Web4Handler,
+    BearerAuthMiddleware, BlockchainHandler, CbeHandler, CredentialsHandler, DaoHandler,
+    DhtHandler, DnsHandler, IdentityHandler, MobileAuthHandler, ProtocolHandler, StorageHandler,
+    TokenHandler, WalletHandler, Web4Handler,
 };
 use crate::config::environment::detect_environment;
 use crate::session_manager::SessionManager;
@@ -1219,6 +1219,22 @@ impl ZhtpUnifiedServer {
         );
         // Transaction delegation endpoints (#2153, #2154) — auth handled internally
         zhtp_router.register_handler("/api/v1/tx".to_string(), mobile_auth_handler);
+
+        // Credentials + OPAQUE lobby-auth endpoints (epic #2554).
+        // Serves /api/v1/auth/credentials/{register,signin,recover} and
+        // /api/v1/auth/opaque/{register,login}/{start,finish}.
+        let credentials_handler: Arc<dyn ZhtpRequestHandler> = Arc::new(CredentialsHandler::new(
+            blockchain.clone(),
+            _session_manager.clone(),
+        ));
+        zhtp_router.register_handler(
+            "/api/v1/auth/credentials".to_string(),
+            credentials_handler.clone(),
+        );
+        zhtp_router.register_handler(
+            "/api/v1/auth/opaque".to_string(),
+            credentials_handler,
+        );
 
         info!("✅ All API handlers registered successfully on ZHTP router");
         Ok((pouw_validator_arc, pouw_calculator))


### PR DESCRIPTION
## Summary
- `CredentialsHandler` was implemented and the OPAQUE endpoint paths sat in the lobby ACL, but no code path instantiated the handler in `unified_server.rs`. Result: every `/api/v1/auth/credentials/*` and `/api/v1/auth/opaque/*` request returned 404 on every node. The mobile app's JS treats 404 from this endpoint as "request timed out", which is why the user saw a fast bogus timeout.
- Dead module wasn't even reaching the deployed binary — `strings /opt/zhtp/zhtp | grep opaque` returned zero matches. Linker eliminated the unused module.

## Fix
Re-exports `CredentialsHandler` from `crate::api::handlers`, then registers an instance in `unified_server.rs` under both `/api/v1/auth/credentials` and `/api/v1/auth/opaque` prefixes (router does prefix matching, longest-first).

## Test plan
- [x] `cargo build --profile dev-release -p zhtp` clean
- [x] `strings target/dev-release/zhtp | grep opaque/register/start` now matches
- [ ] After deploy: `POST /api/v1/auth/opaque/register/start` returns either 200 with `RegisterStartResponse` or 503 "Lobby auth not configured" (not 404)