### PR TITLE
chore: add [opaque] section to genesis.toml + generator example

### DIFF
--- a/genesis.toml
+++ b/genesis.toml
@@ -35,6 +35,19 @@ genesis_time = "2026-05-01T00:00:00Z"
 # v1 supply is NOT carried over: cutover is a clean slate per CONS-606.
 initial_supply = 0
 
+[opaque]
+# OPAQUE lobby-auth server setup (ristretto255-sha512-argon2id-v1).
+# Generated once via `cargo run --example gen_opaque_server_setup -p lib-client --release`.
+# Loaded by `GenesisConfig::load_opaque_setup` on every node start; can be
+# rotated by regenerating and redeploying genesis (does NOT require a fork —
+# affects runtime auth state only, not block content).
+#
+# SECURITY: the serialized bytes contain the OPRF *private* seed. Anyone
+# holding these can offline-attack every credential ever registered. This
+# value is a throwaway testnet setup; replace with a fresh ceremony-generated
+# blob before mainnet and treat the production value as out-of-band material.
+server_setup_b64 = "cFfUtYcxbZD0BCFKPkbQN3tqMQRYsoCpRgoE3RcGIO44FnudtsdfrqSvUk/psxregbEG18pR8PdhBt5cLL3/2t1meFa920chRxaZ4oiRSQDDVhb9+IprqbCSJademegOSAQWEnNrL3dL3IH5kBsezgjkxs5QzSLD7L73JefTcTM="
+
 # [cbe_token] section intentionally absent — EPIC-001 Phase 1E.
 # CBE economic parameters live in
 #   lib-blockchain/src/contracts/bonding_curve/canonical.rs

--- a/lib-client/examples/gen_opaque_server_setup.rs
+++ b/lib-client/examples/gen_opaque_server_setup.rs
@@ -1,0 +1,20 @@
+//! One-shot OPAQUE server-setup generator for `genesis.toml`.
+//!
+//! Outputs a base64-encoded `ServerSetup<LobbyAuthCipherSuite>` blob to stdout.
+//! Pipe into the `[opaque] server_setup_b64 = ...` field of `genesis.toml`.
+//!
+//! Run:  `cargo run --example gen_opaque_server_setup -p lib-client --release`
+
+use base64::Engine as _;
+use opaque_ke::ServerSetup;
+use rand::rngs::OsRng;
+
+use zhtp_client::opaque::LobbyAuthCipherSuite;
+
+fn main() {
+    let mut rng = OsRng;
+    let setup: ServerSetup<LobbyAuthCipherSuite> = ServerSetup::<LobbyAuthCipherSuite>::new(&mut rng);
+    let bytes = setup.serialize();
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    println!("{}", b64);
+}


### PR DESCRIPTION
## Summary
Lobby-auth epic (#2554) never added the `[opaque]` section to v2 `genesis.toml`. Without it, `OpaqueAuthState::from_setup_bytes` is never reached and every OPAQUE endpoint returns 503 "Lobby auth not configured". Combined with PR #2616 (which wired the handler that was previously returning 404), this restores end-to-end OPAQUE register/login.

`apply_genesis_state` re-loads `opaque_server_setup` on every startup, so this enables lobby auth retroactively without a fork — the value only affects runtime auth state, not block content or replay.

Includes the generator (`cargo run --example gen_opaque_server_setup -p lib-client --release`) so the value can be regenerated. Per the `OpaqueConfig` doc, the committed setup is throwaway testnet material; the production network must regenerate via out-of-band ceremony before mainnet.

## Test plan
- [x] `cargo build --profile dev-release -p zhtp` clean
- [x] `strings target/dev-release/zhtp | grep cFfUtYcxbZD0` matches (server_setup embedded)
- [ ] After deploy: register/start on g1 returns 200 with RegisterStartResponse instead of 503