### PR TITLE
fix: per-broadcast Propose message_id so re-broadcasts pass dedup

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -29,8 +29,22 @@ use tracing::info;
 /// receiver's TOFU path special-cases empty signatures, and Mainnet would
 /// reject — same conservative semantics as the rest of the broadcast path.
 fn wrap_propose(proposal: ConsensusProposal, keypair: Option<&KeyPair>) -> ValidatorMessage {
-    let message_id = proposal.id.clone();
+    // Per-broadcast message_id (matches wrap_vote): receiver-side dedup keys
+    // off message_id, so reusing `proposal.id` here meant a locked validator
+    // re-proposing the SAME proposal in every round produced an identical
+    // message_id, and every re-broadcast after the first was silently dropped
+    // network-wide as a duplicate — blocking the lock-recovery path.
     let proposer = proposal.proposer.clone();
+    let message_id = {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let nonce = lib_crypto::generate_nonce();
+        let mut data = format!("propose_bcast_{}", ts).into_bytes();
+        data.extend_from_slice(&nonce);
+        lib_crypto::Hash::from_bytes(&hash_blake3(&data))
+    };
     let mut msg = ProposeMessage {
         message_id,
         proposer,


### PR DESCRIPTION
## Summary
\`wrap_propose\` set \`message_id = proposal.id\` (deterministic from proposal content). ValidatorProtocol's network-level dedup cache keys off \`message_id\`, so a locked validator re-proposing the same proposal in every round produced an identical message_id and **every re-broadcast after the first was silently dropped network-wide as a duplicate** — blocking the lock-recovery path.

## Symptom
Chain unsticks for 2–3 blocks after a deploy then re-locks at the new height because lock-recovery proposals never reach unlocked peers. g1 logs showed the same message_id (e.g. \`fccfd36e48358f6e\`) appearing in "Ignoring duplicate" 10× in 90s while the underlying validator was the locked proposer trying to re-broadcast.

## Fix
\`wrap_vote\` already mints a fresh per-broadcast \`message_id\` from \`SystemTime::now() + generate_nonce()\`; apply the same pattern to \`wrap_propose\`. The signature is computed AFTER \`message_id\` is set so signature verification still holds — the signed envelope just changes each broadcast.

## Test plan
- [x] \`cargo build --profile dev-release -p lib-consensus\` clean
- [x] \`cargo build --profile dev-release -p zhtp\` clean
- [ ] Deploy + verify \`"Ignoring duplicate"\` rate drops to near-zero and chain commits beyond 59120