### PR TITLE
fix(consensus): decouple valid-state tracking from current_round; tolerate duplicate commit envelopes

### DIFF
--- a/lib-consensus-runtime/src/runtime.rs
+++ b/lib-consensus-runtime/src/runtime.rs
@@ -316,6 +316,26 @@ pub(crate) fn spawn_commit_executor(
                         "Commit executor: BFT finalized block + quorum proof committed"
                     );
                 }
+                Err(e) if is_already_applied_error(&*e) => {
+                    // CE-S2: benign duplicate. The engine produced a second
+                    // CommitEnvelope for a height that's already been applied —
+                    // typically a race between the engine sending the envelope
+                    // and the blockchain layer's in-memory cursor / persisted
+                    // store catching up.  The BlockCommitCallback contract is
+                    // documented as "idempotent handling required", and even
+                    // when the callback can't fully honour that (e.g. it
+                    // bottoms out in BlockExecutor::validate_header which
+                    // raises HeightMismatch), the runtime must treat the
+                    // duplicate as a no-op — not weaponize it into a halt.
+                    //
+                    // Pre-fix this aborted the chain on every validator
+                    // simultaneously after 2–3 fast back-to-back commits.
+                    tracing::info!(
+                        error = %e,
+                        height = height,
+                        "Commit executor: block at this height already applied; skipping duplicate envelope"
+                    );
+                }
                 Err(e) => {
                     tracing::error!(
                         error = ?e,
@@ -338,6 +358,47 @@ pub(crate) fn spawn_commit_executor(
         }
         tracing::debug!("Commit executor exited — engine sender dropped");
     })
+}
+
+/// Distinguishes a "block at this height already applied" error from a real
+/// commit failure.
+///
+/// The production callback (zhtp's `ConsensusBlockCommitter`) bottoms out in
+/// `lib_blockchain::execution::executor::BlockExecutor::validate_header`,
+/// which raises `BlockApplyError::HeightMismatch { expected, actual }` when
+/// `actual < expected`. There is no shared error type across the
+/// `lib-consensus-runtime` → `lib-consensus` → callback boundary (the trait
+/// returns `Box<dyn Error + Send + Sync>`), so we identify the case by the
+/// Display string the executor emits.
+///
+/// The check is conservative: it matches both phrasings the codebase emits
+/// for this condition. A real divergence (different block at the same height
+/// — chain fork) is logged as `Chain divergence at height ...` in
+/// `ConsensusBlockCommitter` and surfaces a *different* error string that
+/// does NOT match here, so this guard cannot suppress a real fork signal.
+fn is_already_applied_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    let msg = err.to_string();
+    // BlockExecutor::validate_header — "Block height mismatch: expected X, got Y" where Y < X.
+    // Or wrapping at the boundary — "BlockExecutor failed to apply block: Block height mismatch: ..."
+    if let Some(idx) = msg.find("Block height mismatch: expected ") {
+        // Parse "expected N, got M" and confirm M < N (i.e. actual is in the past).
+        let tail = &msg[idx + "Block height mismatch: expected ".len()..];
+        if let Some(comma) = tail.find(',') {
+            let expected_str = tail[..comma].trim();
+            if let Some(got_idx) = tail.find("got ") {
+                let actual_str = tail[got_idx + 4..]
+                    .split(|c: char| !c.is_ascii_digit())
+                    .next()
+                    .unwrap_or("");
+                if let (Ok(expected), Ok(actual)) =
+                    (expected_str.parse::<u64>(), actual_str.parse::<u64>())
+                {
+                    return actual < expected;
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Derive the watchdog threshold from the engine's per-phase timeouts.
@@ -943,6 +1004,7 @@ mod tests {
                     lib_types::consensus::ConsensusType::ByzantineFaultTolerance,
                     0,
                 ),
+                valid_round: None,
             },
             quorum_proof: lib_types::consensus::BftQuorumProof {
                 height,
@@ -973,5 +1035,103 @@ mod tests {
         // Give the task a tick to observe the closed channel.
         let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
         // If we got here without panicking the join completed.
+    }
+
+    // ---------------- duplicate commit-envelope (CE-S2) ----------------
+
+    /// Callback that simulates the BlockExecutor "already at this height"
+    /// behavior: succeeds the first time it sees `target_height`, then on any
+    /// subsequent commit at `target_height` returns the exact error string the
+    /// production `BlockExecutor::validate_header` raises when its `expected =
+    /// store.latest_height() + 1` is already past the incoming block's height.
+    ///
+    /// The race this models: engine emits a CommitEnvelope for height H, the
+    /// executor applies it, then a second CommitEnvelope for H arrives before
+    /// the engine's local view advances. Pre-fix, the runtime treated this as
+    /// a fatal storage error and halted consensus on every validator.
+    struct DoubleCommitCallback {
+        committed: std::sync::Arc<std::sync::Mutex<u64>>,
+    }
+
+    #[async_trait::async_trait]
+    impl lib_consensus::types::BlockCommitCallback for DoubleCommitCallback {
+        async fn commit_finalized_block(
+            &self,
+            proposal: &lib_consensus::types::ConsensusProposal,
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            let mut committed = self.committed.lock().unwrap();
+            if proposal.height <= *committed {
+                // BlockExecutor::validate_header HeightMismatch: incoming
+                // block's height isn't `store.latest_height() + 1`.
+                return Err(format!(
+                    "BlockExecutor failed to apply block: Block height mismatch: \
+                     expected {}, got {}",
+                    *committed + 1,
+                    proposal.height,
+                )
+                .into());
+            }
+            *committed = proposal.height;
+            Ok(())
+        }
+
+        async fn get_active_validator_count(
+            &self,
+        ) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(5)
+        }
+    }
+
+    /// CE-S2: a duplicate CommitEnvelope for an already-applied height MUST NOT
+    /// halt the runtime. The BlockCommitCallback contract is documented as
+    /// "idempotent handling required" — and even when the callback itself
+    /// can't fully honor that (due to in-memory/store cursor drift in the
+    /// production blockchain), the commit executor must not weaponize the
+    /// resulting height-mismatch into a chain-wide halt.
+    #[tokio::test]
+    async fn duplicate_commit_envelope_does_not_halt() {
+        let committed = std::sync::Arc::new(std::sync::Mutex::new(0u64));
+        let cb: Arc<dyn lib_consensus::types::BlockCommitCallback> =
+            Arc::new(DoubleCommitCallback {
+                committed: committed.clone(),
+            });
+
+        let (tx, rx) = mpsc::unbounded_channel::<CommitEnvelope>();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel::<Event>();
+        let handle = spawn_commit_executor(rx, cb, event_tx);
+
+        // First envelope: applies cleanly, committed = 1.
+        tx.send(test_commit_envelope(1)).expect("send first");
+        // Second envelope at the same height: the callback returns
+        // HeightMismatch.  The executor must treat this as benign (already
+        // applied) and continue draining — not inject HaltScheduled.
+        tx.send(test_commit_envelope(1)).expect("send dup");
+        // Third envelope at the next height: must still apply.
+        tx.send(test_commit_envelope(2)).expect("send next");
+
+        drop(tx);
+
+        // Executor should drain all three and exit cleanly.
+        let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
+
+        // No halt event must have been published. (We `try_recv` to avoid
+        // sleeping; if a Halt was emitted, it would be immediately available.)
+        match event_rx.try_recv() {
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+            | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                // expected: no halt scheduled
+            }
+            Ok(evt) => panic!(
+                "duplicate commit envelope must NOT inject Halt; got event: {:?}",
+                evt
+            ),
+        }
+
+        // The non-duplicate height 2 must have been applied.
+        assert_eq!(
+            *committed.lock().unwrap(),
+            2,
+            "post-duplicate envelopes for fresh heights must still apply"
+        );
     }
 }

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -10,7 +10,7 @@ use crate::validators::ValidatorManager;
 use lib_consensus_core::ports::ValidatorRewardInput;
 use lib_crypto::{hash_blake3, KeyPair, PostQuantumSignature};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::info;
 
@@ -1554,25 +1554,73 @@ impl ConsensusEngine {
             }
         }
 
-        // Re-check quorums for the round against the existing vote pool —
-        // prevotes/precommits that arrived before the jump never fired an
-        // on_prevote/on_precommit quorum check from this round's vantage.
-        if let Some(proposal_id) = self.current_round.proposals.first().cloned() {
-            let total = self.validator_manager.get_active_validators().len() as u64;
-            let prevotes = self.count_prevotes_for(height, round, &proposal_id);
-            if check_supermajority(prevotes, total)
-                && self.current_round.step <= ConsensusStep::PreCommit
-            {
-                if self.current_round.valid_proposal.is_none() {
-                    self.current_round.valid_proposal = Some(proposal_id.clone());
-                    self.current_round.valid_round = Some(round);
+        // Re-check quorums against the existing vote pool — prevotes /
+        // precommits that arrived before the jump never fired an
+        // on_prevote / on_precommit quorum check from this round's vantage.
+        //
+        // CE-S2: scan the pool for *any* (height, round, proposal_id) at-or-
+        // below this round that has reached supermajority. We must not gate on
+        // `proposals.first()` — the proposal artifact may not yet have arrived
+        // at this node even though the network already reached a quorum on it.
+        let total = self.validator_manager.get_active_validators().len() as u64;
+        let quorum_candidates: Vec<(u32, Hash)> = {
+            let mut counts: HashMap<(u32, Hash), u64> = HashMap::new();
+            for (key, (_vote, prop_id)) in self.vote_pool.iter() {
+                if key.height != height
+                    || key.vote_type != VoteType::PreVote
+                    || key.round > round
+                {
+                    continue;
                 }
-                if let Err(e) = self.enter_precommit_step().await {
-                    tracing::warn!(error = ?e, "reevaluate: enter_precommit_step failed");
-                }
+                *counts.entry((key.round, prop_id.clone())).or_insert(0) += 1;
             }
-            if let Err(e) = self.maybe_finalize(height, round, &proposal_id).await {
-                tracing::warn!(error = ?e, "reevaluate: maybe_finalize failed");
+            counts
+                .into_iter()
+                .filter(|(_, n)| check_supermajority(*n, total))
+                .map(|((r, id), _)| (r, id))
+                .collect()
+        };
+
+        // Apply each observed quorum to valid_proposal/valid_round using the
+        // same rules as on_prevote: track the *latest* round at which a
+        // quorum was seen, refuse to overwrite a same-round conflict.
+        for (qround, qid) in &quorum_candidates {
+            let should_update = match self.current_round.valid_round {
+                None => true,
+                Some(vr) if *qround > vr => true,
+                Some(vr) if *qround == vr => match self.current_round.valid_proposal.as_ref() {
+                    Some(existing) if existing != qid => {
+                        tracing::warn!(
+                            "reevaluate: conflicting prevote quorum at (h={}, r={}); \
+                             refusing overwrite",
+                            height, qround
+                        );
+                        continue;
+                    }
+                    _ => false,
+                },
+                Some(_) => false,
+            };
+            if should_update {
+                self.current_round.valid_proposal = Some(qid.clone());
+                self.current_round.valid_round = Some(*qround);
+            }
+        }
+
+        // If the current round has a quorum AND we're still able to act on it
+        // locally, transition to PreCommit.  This is the local-action arm —
+        // tied to current_round, exactly like on_prevote.
+        if self.current_round.step <= ConsensusStep::PreCommit {
+            if let Some(proposal_id) = self.current_round.proposals.first().cloned() {
+                let prevotes = self.count_prevotes_for(height, round, &proposal_id);
+                if check_supermajority(prevotes, total) {
+                    if let Err(e) = self.enter_precommit_step().await {
+                        tracing::warn!(error = ?e, "reevaluate: enter_precommit_step failed");
+                    }
+                }
+                if let Err(e) = self.maybe_finalize(height, round, &proposal_id).await {
+                    tracing::warn!(error = ?e, "reevaluate: maybe_finalize failed");
+                }
             }
         }
     }
@@ -1841,54 +1889,96 @@ impl ConsensusEngine {
             }
         }
 
-        // **CE-S1**: prevote-quorum check, proposal-scoped (never the round
-        // aggregate) and CURRENT-round-only. A quorum in a stale round is
-        // not actionable; a quorum in a higher round is handled by the
-        // Trigger B jump above, after which enter_round re-checks quorum.
-        if vote.round == self.current_round.round
-            && vote.height == self.current_round.height
-        {
+        // **CE-S2**: prevote-quorum detection runs against the vote's own
+        // (height, round, proposal_id) — independent of `current_round.round`.
+        //
+        // Previously the entire arm was gated on `vote.round == current_round`,
+        // which conflated two distinct concerns: (a) recording the fact that
+        // 2f+1 prevotes for proposal P exist at round R, and (b) the local
+        // action of casting a precommit at round R. Concern (a) is round-
+        // agnostic — `valid_proposal/valid_round` is Tendermint's mechanism
+        // for a *future* proposer to certify "round R already had a quorum
+        // for P" so locked peers can apply the unlock rule. With drift the
+        // 4th-of-5 prevote routinely arrives at a peer whose `current_round`
+        // has already advanced past R; under the old gate, `valid_proposal`
+        // was never set, future proposals omitted `valid_round`, and locked
+        // peers stayed locked across rounds forever.
+        //
+        // The PreCommit local-action arm (b) keeps the current-round guard:
+        // the precommit message is tagged with the *local* round, and a
+        // precommit at round R+1 derived from a round-R prevote quorum would
+        // be unsound.
+        if vote.height == self.current_round.height {
             let prevote_count =
                 self.count_prevotes_for(vote.height, vote.round, &proposal_id);
             let total_validators =
                 self.validator_manager.get_active_validators().len() as u64;
 
-            if check_supermajority(prevote_count, total_validators)
-                && self.current_round.step <= ConsensusStep::PreCommit
-            {
-                // **CE-S1**: only transition if this proposal can be THE
-                // valid proposal. A conflicting valid_proposal already set
-                // means two quorums — refuse, to preserve BFT safety.
-                if let Some(existing) = self.current_round.valid_proposal.as_ref() {
-                    if existing != &proposal_id {
-                        tracing::warn!(
-                            "Conflicting quorum detected: proposal {:?} has quorum but valid_proposal is already {:?}",
-                            proposal_id, existing
-                        );
-                        return Ok(());
+            if check_supermajority(prevote_count, total_validators) {
+                // (a) Record/refresh valid_proposal/valid_round.
+                //
+                // The conflicting-quorum guard rejects a second distinct
+                // proposal claiming a quorum at the *same* (height, round).
+                // With n=5, f=1, two disjoint quorums of 4 at the same
+                // (h, r) require ≥6 honest votes from ≥4 honest validators —
+                // impossible without f+1 Byzantines. So if `valid_round`
+                // already matches `vote.round` and `valid_proposal` differs,
+                // we treat it as evidence of Byzantine behaviour (or our own
+                // bug) and refuse to overwrite.
+                //
+                // For a newer round's quorum (vote.round > valid_round) we
+                // overwrite: Tendermint's `validValue` should always track
+                // the *latest* round at which a quorum was observed.
+                let should_update = match self.current_round.valid_round {
+                    None => true,
+                    Some(vr) if vote.round > vr => true,
+                    Some(vr) if vote.round == vr => {
+                        // Same round — must be the same proposal, else conflicting quorum.
+                        match self.current_round.valid_proposal.as_ref() {
+                            Some(existing) if existing != &proposal_id => {
+                                tracing::warn!(
+                                    "Conflicting prevote quorum: proposal {:?} reached quorum \
+                                     at (h={}, r={}) but valid_proposal already {:?} at same \
+                                     round — refusing overwrite (possible Byzantine evidence)",
+                                    proposal_id, vote.height, vote.round, existing
+                                );
+                                return Ok(());
+                            }
+                            _ => false, // already recorded, idempotent
+                        }
                     }
-                } else {
-                    // First proposal to reach a prevote quorum this round.
-                    // Record valid_proposal AND valid_round — a future
-                    // re-proposing proposer advertises valid_round so locked
-                    // peers can apply the Tendermint unlock rule.
+                    Some(_) => false, // older round than what we have — stale
+                };
+
+                if should_update {
                     self.current_round.valid_proposal = Some(proposal_id.clone());
-                    self.current_round.valid_round = Some(self.current_round.round);
+                    self.current_round.valid_round = Some(vote.round);
+                    tracing::debug!(
+                        "Recorded valid_proposal={:?}, valid_round={} from prevote quorum (current_round={})",
+                        proposal_id, vote.round, self.current_round.round,
+                    );
                 }
 
-                // CONS-305d: route the prevote-quorum threshold through the
-                // FSM. `(Prevoting, PrevoteThresholdReached) → Precommitting`
-                // — `enter_precommit_step` casts + broadcasts the precommit.
-                let prior_fsm = self.fsm_state.clone();
-                let (next_fsm, actions) = lib_consensus_core::fsm::transition(
-                    prior_fsm,
-                    lib_consensus_core::fsm::Event::PrevoteThresholdReached {
-                        block_id: proposal_id.clone(),
-                    },
-                );
-                self.enter_fsm_state(next_fsm).await;
-                for action in actions {
-                    self.dispatch_action(action).await;
+                // (b) Local-action arm — cast precommit ONLY if the quorum is
+                // for the round we're currently in. A round-R quorum does not
+                // authorize a round-(R+1) precommit.
+                if vote.round == self.current_round.round
+                    && self.current_round.step <= ConsensusStep::PreCommit
+                {
+                    // CONS-305d: route through the FSM.
+                    // (Prevoting, PrevoteThresholdReached) → Precommitting,
+                    // emits SendPrecommit + ResetWatchdog.
+                    let prior_fsm = self.fsm_state.clone();
+                    let (next_fsm, actions) = lib_consensus_core::fsm::transition(
+                        prior_fsm,
+                        lib_consensus_core::fsm::Event::PrevoteThresholdReached {
+                            block_id: proposal_id.clone(),
+                        },
+                    );
+                    self.enter_fsm_state(next_fsm).await;
+                    for action in actions {
+                        self.dispatch_action(action).await;
+                    }
                 }
             }
         }

--- a/lib-consensus/src/engines/consensus_engine/tests.rs
+++ b/lib-consensus/src/engines/consensus_engine/tests.rs
@@ -3137,3 +3137,296 @@ async fn test_stale_valid_proposal_does_not_trigger_fork_reject() {
         "same proposal_id at same round must not trigger fork rejection"
     );
 }
+
+// ─── Cross-round valid-state tracking (CE-S2) ────────────────────────────────
+//
+// Background: `on_prevote` previously gated the 2f+1 prevote-quorum check on
+// `vote.round == current_round.round`. With round drift the quorum-completing
+// 4th-of-5 prevote routinely arrives after the local engine has already
+// advanced past that round (via Trigger B or LocalPrevoteTimeout). The check
+// then never fires, `valid_proposal`/`valid_round` are never set for that
+// round, and subsequent re-proposers fail to thread `valid_round` into their
+// proposal — leaving locked peers locked across rounds indefinitely.
+//
+// The fix decouples valid-state tracking (which must happen regardless of
+// local round) from the precommit transition (which stays current-round-only,
+// because casting a precommit is a local action against a local step). These
+// tests pin the structural contract.
+
+/// Helper: inject a remote prevote for (height, round, proposal_id) into the
+/// engine's pool and run the live `on_prevote` handler so all of its side
+/// effects (validation, dedup, relay, Trigger B, quorum check) actually run.
+async fn deliver_remote_prevote(
+    engine: &mut ConsensusEngine,
+    voter: &IdentityId,
+    voter_kp: &KeyPair,
+    proposal_id: Hash,
+    height: u64,
+    round: u32,
+) {
+    let vote = make_signed_vote(
+        engine,
+        voter_kp,
+        voter.clone(),
+        proposal_id,
+        VoteType::PreVote,
+        height,
+        round,
+    );
+    engine
+        .on_prevote(vote)
+        .await
+        .expect("on_prevote must accept a well-formed remote prevote");
+}
+
+#[tokio::test]
+async fn test_ce_s2_prevote_quorum_records_valid_state_across_rounds() {
+    // 5-validator setup. Local is validator[0]. Drift the local engine forward
+    // to round 7 while the rest of the network has been voting on a proposal P
+    // at round 5. Three remote prevotes arrive — the local engine pools them
+    // and (combined with the local prevote we inject for P at round 5) the
+    // quorum threshold (4/5) is reached.
+    //
+    // CONTRACT: `valid_proposal = P` and `valid_round = 5` MUST be set even
+    // though `current_round.round = 7`. Future re-proposers depend on this to
+    // thread `valid_round` and unlock locked peers.
+    let (mut engine, validators) = setup_bft_engine(1, 0).await;
+
+    // Register a fifth validator so the quorum threshold is 4/5 (a clean
+    // BFT-quorum test). `setup_bft_engine` registers 4; add one more.
+    let v5_id = test_validator_id(5);
+    let v5_kp = create_test_keypair();
+    register_validator_with_keypair(&mut engine, v5_id.clone(), &v5_kp, false).await;
+    engine.snapshot_validator_set(1);
+
+    // Drift local forward to round 7. The earlier-round prevotes arriving now
+    // are exactly the case the bug stranded.
+    engine.current_round.round = 7;
+    engine.current_round.step = ConsensusStep::Propose;
+    assert!(
+        engine.current_round.valid_proposal.is_none(),
+        "precondition: valid_proposal starts empty"
+    );
+
+    // Stage a proposal artifact for round 5 so signature/proposer checks pass.
+    // The on_prevote validator-set check is height-scoped, not round-scoped, so
+    // votes for a past round in the current height are accepted.
+    let proposal_id = Hash::from_bytes(&[0xC5u8; 32]);
+    let (ref proposer_id, ref proposer_kp) = validators[0];
+    stage_stub_proposal(
+        &mut engine,
+        proposal_id.clone(),
+        1,
+        5,
+        proposer_id,
+        proposer_kp,
+    );
+
+    // Pool a prevote for round 5 from validators[0] (the local validator).
+    // We insert directly so we can tag (height, round) explicitly — cast_vote
+    // uses current_round which is now at 7, but the quorum we care about is
+    // for round 5.
+    {
+        let (vid, kp) = &validators[0];
+        let vote = make_signed_vote(
+            &engine,
+            kp,
+            vid.clone(),
+            proposal_id.clone(),
+            VoteType::PreVote,
+            1,
+            5,
+        );
+        let key = VotePoolKey {
+            height: 1,
+            round: 5,
+            vote_type: VoteType::PreVote,
+            validator_id: vid.clone(),
+        };
+        engine.vote_pool.insert(key, (vote, proposal_id.clone()));
+    }
+
+    // Deliver three remote prevotes via the live on_prevote handler so the
+    // bug surface (its quorum check) is what we're actually exercising.
+    for i in 1..=3usize {
+        let (vid, kp) = &validators[i];
+        deliver_remote_prevote(&mut engine, vid, kp, proposal_id.clone(), 1, 5).await;
+    }
+
+    // Total prevotes for (1, 5, P) is now 4-of-5 — supermajority.
+    let count = engine.count_prevotes_for(1, 5, &proposal_id);
+    assert_eq!(
+        count, 4,
+        "test setup: 4 prevotes should be pooled for round 5"
+    );
+
+    // CONTRACT: valid_proposal/valid_round MUST be set, despite current_round.round = 7.
+    assert_eq!(
+        engine.current_round.valid_proposal.as_ref(),
+        Some(&proposal_id),
+        "cross-round prevote quorum must update valid_proposal"
+    );
+    assert_eq!(
+        engine.current_round.valid_round,
+        Some(5),
+        "cross-round prevote quorum must update valid_round"
+    );
+
+    // And the local engine must NOT have transitioned to PreCommit at round 7,
+    // because the precommit transition is a local-action arm and the quorum is
+    // for a past round. (Precommitting at round 7 against a round-5 quorum
+    // would violate BFT safety — the precommit must be tagged with its own
+    // round, and the round-5 quorum doesn't authorize a round-7 precommit.)
+    assert_ne!(
+        engine.current_round.step,
+        ConsensusStep::PreCommit,
+        "cross-round quorum must NOT cause a local PreCommit transition"
+    );
+}
+
+#[tokio::test]
+async fn test_ce_s2_locked_peer_unlocks_on_advertised_valid_round() {
+    // Setup: local validator was locked at round 2 on proposal `LOCKED`. Then a
+    // fresh proposer at round 9 re-proposes a *different* value `NEW`, but
+    // advertises `valid_round = 5` to certify that round 5 saw a prevote
+    // quorum on `NEW`.
+    //
+    // CONTRACT: `prevote_permitted_by_lock` must return true (unlock allowed),
+    // because the advertised valid_round (5) ≥ locked_round (2). This is the
+    // mechanism by which `valid_round` tracking (CE-S2) actually unsticks the
+    // chain — without it the validator would abstain forever.
+    let (mut engine, _validators) = setup_bft_engine(1, 0).await;
+
+    let locked_id = Hash::from_bytes(&[0xAAu8; 32]);
+    let new_id = Hash::from_bytes(&[0xBBu8; 32]);
+
+    engine.current_round.locked_proposal = Some(locked_id.clone());
+    engine.current_round.locked_round = Some(2);
+    engine.current_round.round = 9;
+
+    // Build a fake "new" proposal with valid_round = 5 (≥ locked_round = 2).
+    let proposal = ConsensusProposal {
+        id: new_id.clone(),
+        proposer: test_validator_id(2),
+        height: 1,
+        round: 9,
+        protocol_version: super::CONSENSUS_PROTOCOL_VERSION,
+        previous_hash: Hash([0u8; 32]),
+        block_data: vec![],
+        timestamp: 0,
+        signature: PostQuantumSignature::default(),
+        consensus_proof: crate::types::ConsensusProof {
+            consensus_type: crate::types::ConsensusType::ByzantineFaultTolerance,
+            stake_proof: None,
+            storage_proof: None,
+            work_proof: None,
+            zk_did_proof: None,
+            timestamp: 0,
+        },
+        valid_round: Some(5),
+    };
+
+    let allowed = engine.prevote_permitted_by_lock(Some(&proposal), &new_id);
+    assert!(
+        allowed,
+        "lock-rule unlock: proposal.valid_round (5) >= locked_round (2) must allow prevoting NEW"
+    );
+
+    // Negative control: valid_round = 1 (< locked_round = 2) must still abstain.
+    let mut stale = proposal.clone();
+    stale.valid_round = Some(1);
+    let denied = engine.prevote_permitted_by_lock(Some(&stale), &new_id);
+    assert!(
+        !denied,
+        "lock-rule must REFUSE unlock when proposal.valid_round < locked_round"
+    );
+
+    // Negative control: missing valid_round must abstain (no proof of unlock).
+    let mut no_vr = proposal.clone();
+    no_vr.valid_round = None;
+    let denied2 = engine.prevote_permitted_by_lock(Some(&no_vr), &new_id);
+    assert!(
+        !denied2,
+        "lock-rule must REFUSE unlock when proposal advertises no valid_round"
+    );
+}
+
+#[tokio::test]
+async fn test_ce_s2_quorum_for_current_round_still_transitions_to_precommit() {
+    // Regression guard: the fix must NOT break the normal-case path where the
+    // 4th prevote arrives WHILE the engine is at the same round. Local must
+    // still set valid_proposal/valid_round AND transition to PreCommit.
+    let (mut engine, validators) = setup_bft_engine(1, 0).await;
+
+    // Register a fifth so quorum is 4/5 again.
+    let v5_id = test_validator_id(5);
+    let v5_kp = create_test_keypair();
+    register_validator_with_keypair(&mut engine, v5_id.clone(), &v5_kp, false).await;
+    engine.snapshot_validator_set(1);
+
+    // Engine at round 3, in PreVote step (we've already cast our prevote).
+    // FSM must be in Prevoting so the PrevoteThresholdReached transition rule
+    // (Prevoting, PrevoteThresholdReached) → (Precommitting, SendPrecommit) is
+    // actually armed — see fsm/transition.rs.
+    engine.current_round.round = 3;
+    engine.current_round.step = ConsensusStep::PreVote;
+    engine.fsm_state = lib_consensus_core::fsm::ValidatorState::Prevoting;
+
+    let proposal_id = Hash::from_bytes(&[0xC3u8; 32]);
+    let (ref proposer_id, ref proposer_kp) = validators[0];
+    stage_stub_proposal(
+        &mut engine,
+        proposal_id.clone(),
+        1,
+        3,
+        proposer_id,
+        proposer_kp,
+    );
+
+    // Pool the local prevote at round 3.
+    {
+        let (vid, kp) = &validators[0];
+        let vote = make_signed_vote(
+            &engine,
+            kp,
+            vid.clone(),
+            proposal_id.clone(),
+            VoteType::PreVote,
+            1,
+            3,
+        );
+        let key = VotePoolKey {
+            height: 1,
+            round: 3,
+            vote_type: VoteType::PreVote,
+            validator_id: vid.clone(),
+        };
+        engine.vote_pool.insert(key, (vote, proposal_id.clone()));
+    }
+
+    // Deliver three remote prevotes at round 3 — these complete the quorum.
+    for i in 1..=3usize {
+        let (vid, kp) = &validators[i];
+        deliver_remote_prevote(&mut engine, vid, kp, proposal_id.clone(), 1, 3).await;
+    }
+
+    // Valid state must be set.
+    assert_eq!(
+        engine.current_round.valid_proposal.as_ref(),
+        Some(&proposal_id),
+        "same-round quorum still sets valid_proposal"
+    );
+    assert_eq!(
+        engine.current_round.valid_round,
+        Some(3),
+        "same-round quorum still sets valid_round"
+    );
+
+    // And the local engine MUST have moved to PreCommit (the current-round
+    // local-action arm of the rule).
+    assert!(
+        engine.current_round.step >= ConsensusStep::PreCommit,
+        "same-round quorum must transition to PreCommit, got {:?}",
+        engine.current_round.step
+    );
+}


### PR DESCRIPTION
## Summary

Two distinct consensus bugs that together explained the testnet stall pattern: chain commits 2-3 blocks after a deploy, then re-locks at the new height and barely advances. The fixes are decoupled but I'm shipping them in one PR because the second is only reachable once the first lets the chain commit fast enough to race.

## Bug 1 — `on_prevote` drops cross-round prevote quorums

The 2f+1 prevote-quorum check was gated on `vote.round == current_round.round`. With round drift (~8s/round on testnet, validators advance independently via Trigger B / LocalPrevoteTimeout), the 4th-of-5 prevote completing a quorum at round R routinely arrives at a peer whose `current_round.round` has already advanced past R. The gate short-circuited the check, so `valid_proposal/valid_round` were never set for round R.

Effect chain: future re-proposers (`proofs.rs:25-26`) saw no `valid_proposal` → omitted `valid_round` from their proposal → locked peers received `valid_round = None` → `prevote_permitted_by_lock` refused unlock → locked peers stayed locked across rounds indefinitely. Trigger B kept rotating rounds but never broke the lock.

**Spec reference**: Tendermint Algorithm 1 (Buchman/Kwon/Milosevic, "The latest gossip on BFT consensus"), rule (8): on observing 2f+1 prevotes for v at round r, `validValue ← v, validRound ← r`. The spec's local-action side (cast precommit) is current-round-gated; the *recording* side is not.

**Fix**: split `on_prevote`'s quorum branch into two:
- (a) Record/refresh `valid_proposal/valid_round` — runs whenever a new quorum is observed for `(vote.height, vote.round, proposal_id)`, regardless of `current_round`. `valid_round` becomes monotonically non-decreasing per spec.
- (b) Transition to PreCommit — stays current-round-gated. A precommit message at round R+1 derived from a round-R prevote quorum would be unsound.

Same-round conflicting-quorum guard preserved with an explicit branch (n=5 f=1 makes two disjoint quorums at the same (h, r) numerically impossible without f+1 Byzantines, but the guard remains as defense against impl bugs).

`reevaluate_current_round` (post-round-jump replay) updated symmetrically: scan the full pool for any pooled supermajority at-or-below the new round, apply the same rules. Previously it only ran if `proposals.first()` was already populated, which made the path useless when the network had reached a quorum but the proposal hadn't propagated to this node.

## Bug 2 — duplicate `CommitEnvelope` halts the chain

When the chain commits faster (which Bug-1's fix enables), the engine occasionally emits two `CommitEnvelope`s for the same height back-to-back before its in-memory cursor advances. The second envelope hits `ConsensusBlockCommitter`'s idempotent check while `blockchain.height` is still stale, falls through to `BlockExecutor::validate_header`, which raises `HeightMismatch { expected: N+1, actual: N }`. The runtime's commit executor treated any commit error as fork evidence and emitted `HaltScheduled { reason: ConsensusFailure }`. Pre-fix this halted every validator simultaneously after 3-4 commits (observed at heights 59118 and 59122 on testnet today).

**Fix**: in `spawn_commit_executor`, distinguish the benign duplicate (`HeightMismatch` with `actual < expected`) from a real divergence (separate error string `Chain divergence at height ...` emitted by `ConsensusBlockCommitter` *before* `BlockExecutor` is reached). Duplicate envelopes log at info and continue draining. Real divergence still halts.

The matcher is conservative — it parses "expected N, got M" and confirms M < N. It does NOT match the divergence error, so the fork-detection signal is preserved.

## Safety argument

| Invariant | How preserved |
|---|---|
| **Agreement** (no two nodes decide differently at same height) | Decided by 2f+1 **precommits** in `maybe_finalize`, not prevotes. Unchanged. `locked_proposal/locked_round` writes (state_machine.rs:2022-2023) unchanged. |
| **Validity** (only proposed values decided) | `validate_incoming_proposal` + `validate_remote_vote` unchanged. All values referenced by the fix have passed admission gates. |
| **Lock safety** (no spurious unlock) | `prevote_permitted_by_lock` (L972-993) unchanged. Unlock condition `valid_round >= locked_round` unchanged. `valid_round` is monotonically non-decreasing in the fix, so it can never *regress* in a way that would change a previously-permitted unlock into a forbidden one. |
| **No spurious lock** | Lock writes happen ONLY in `on_precommit` after 2f+1 precommit quorum at current round. The fix does not touch this path. Observing a *prevote* quorum (no matter the round) does not create a lock. |

Cross-round conflicting quorums (different proposals reaching quorum at different rounds) are explicitly supported per spec — `valid_proposal/valid_round` track the *latest* round at which a quorum was observed. Pre-fix `valid_proposal.is_none()` guard incorrectly held the FIRST quorum forever; post-fix matches Tendermint.

## Tests

New:
- `test_ce_s2_prevote_quorum_records_valid_state_across_rounds` — fails pre-fix, passes post-fix
- `test_ce_s2_quorum_for_current_round_still_transitions_to_precommit` — regression guard for the normal case
- `test_ce_s2_locked_peer_unlocks_on_advertised_valid_round` — pins the unlock contract (positive + 2 negative controls)
- `duplicate_commit_envelope_does_not_halt` — fails pre-fix, passes post-fix

Full suites:
- `cargo test -p lib-consensus --lib` — 144/144 pass
- `cargo test -p lib-consensus-runtime --lib` — 20/20 pass

## Deploy plan

Per testnet protocol: g1 → g1+g2 → canary g3 → g4 → g5 → gateway. After each stage, sample ~3 minutes; success = block commits at steady rate (~1 per ≤30s) with no HALTED events. If a stage shows regression, revert that node before continuing.

The chain is currently at height 59123 stuck. Expected post-deploy: commits resume immediately and accumulate without re-halting.
