### PR TITLE
fix(consensus): make BftQuorumProof deterministic across validators (post-restart 3-way fork)

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -161,6 +161,125 @@ fn now_secs() -> u64 {
         .as_secs()
 }
 
+/// Assemble the canonical, **deterministic** `BftQuorumProof` for a finalized
+/// proposal.
+///
+/// ## Why this exists
+///
+/// The block header commits to `bft_quorum_root = compute_bft_quorum_root(&proof)`,
+/// which feeds into `block.hash()` (header serialization). For all validators
+/// finalizing the same logical block to produce the same `block.hash()`, they
+/// must each construct an **identical** `BftQuorumProof.attestations` vec.
+///
+/// `compute_bft_quorum_root` already sorts + dedups by `validator_id`, so
+/// ordering is not the risk — set membership is. Without this helper's
+/// truncation step, each validator's proof contained every commit attestation
+/// it had locally observed. A peer that observed one extra attestation
+/// produced a different set, and therefore a different root, and therefore
+/// a different `block.hash()`, and therefore the next height's `previous_hash`
+/// check rejected the rest of the network's proposals. That was the testnet
+/// fork-after-restart bug observed at heights 59118–59123 on 2026-05-20.
+///
+/// ## Contract
+///
+/// 1. `process_committed_block` only reaches this helper after verifying that
+///    `count_commits_for(height, _, proposal_id) >= quorum_count(n)`. So this
+///    helper can assume the pool contains at least `quorum_count(n)` distinct
+///    commit attestations for `proposal_id` at `height`.
+/// 2. The attestations included in the returned proof are the
+///    `quorum_count(n)` **lowest-`validator_id`** distinct commit attestations
+///    for `proposal_id` at `height`. Any extras observed only by some
+///    validators are excluded.
+/// 3. Determinism: given any two `vote_pool` snapshots that both satisfy
+///    contract (1) for the same `proposal_id` and `height`, this helper
+///    returns proofs whose `attestations` vecs compare equal — and therefore
+///    `compute_bft_quorum_root` returns identical roots.
+pub(super) fn build_quorum_proof(
+    vote_pool: &HashMap<VotePoolKey, (ConsensusVote, Hash)>,
+    height: u64,
+    proposal_id: &Hash,
+    total_validators: u64,
+) -> lib_types::consensus::BftQuorumProof {
+    let mut attestations: Vec<lib_types::consensus::CommitAttestation> = vote_pool
+        .iter()
+        .filter(|(k, (_, voted_id))| {
+            k.height == height
+                && k.vote_type == VoteType::Commit
+                && voted_id == proposal_id
+        })
+        .filter_map(|(_, (vote, _))| {
+            // Convert Vec<u8> signature to fixed-size Dilithium5 array.
+            // Skip votes with wrong-sized signatures (e.g. test stubs).
+            let signature: [u8; 4595] =
+                vote.signature.signature.as_slice().try_into().ok()?;
+            Some(lib_types::consensus::CommitAttestation {
+                validator_id: vote.voter.0,
+                vote_id: vote.id.0,
+                proposal_id: vote.proposal_id.0,
+                round: vote.round,
+                signature,
+                public_key: vote.signature.public_key.dilithium_pk,
+            })
+        })
+        .collect();
+
+    // Sort by (validator_id, round) so that within each validator_id group
+    // the LOWEST-round attestation comes first. `sort_by` is stable; ties
+    // (same validator_id and same round) keep insertion order, but in normal
+    // operation a validator never produces two commits at the same round
+    // (`enter_commit_step`'s `already_committed` guard at L2882+ now blocks
+    // double-commit cross-round too).
+    //
+    // The secondary `round` sort matters because peers can transiently hold
+    // commit attestations from a validator at multiple rounds — e.g. when a
+    // peer was on the wire before this node's `already_committed` fix
+    // shipped, or during an in-flight upgrade. Picking the lowest-round
+    // attestation deterministically ensures all upgraded peers agree even
+    // when they have different supersets in their pools.
+    attestations.sort_by(|a, b| {
+        a.validator_id
+            .cmp(&b.validator_id)
+            .then_with(|| a.round.cmp(&b.round))
+    });
+
+    // Dedup: keep the FIRST entry per validator_id, which after the sort above
+    // is the lowest-round attestation. All upgraded peers converge on the
+    // same choice for each validator_id.
+    attestations.dedup_by_key(|a| a.validator_id);
+
+    // Truncate to exactly `quorum_count(n)` so the attestation SET is identical
+    // on every validator that has at least quorum_count observations. Extra
+    // attestations from validators with lexicographically-higher `validator_id`
+    // are excluded uniformly. See "Contract" note above.
+    let threshold = bft_quorum_count(total_validators) as usize;
+    if attestations.len() > threshold {
+        attestations.truncate(threshold);
+    }
+
+    lib_types::consensus::BftQuorumProof {
+        height,
+        proposal_id: proposal_id.0,
+        total_validators: total_validators as u32,
+        attestations,
+    }
+}
+
+/// Smallest `k` such that `has_supermajority(k, n)` holds.
+///
+/// `has_supermajority` is a `>= 6667 bps` predicate; this returns the integer
+/// vote count that satisfies it. For n=5 → 4, n=4 → 3, n=3 → 3.
+///
+/// Used by `build_quorum_proof` to truncate the attestation set to a
+/// deterministic subset.
+pub(super) fn bft_quorum_count(total_validators: u64) -> u64 {
+    if total_validators == 0 {
+        return 0;
+    }
+    // ceil(n * 6667 / 10000). Integer math.
+    const BPS: u64 = lib_types::consensus::threshold::BFT_SUPERMAJORITY_BPS;
+    ((total_validators * BPS) + 9_999) / 10_000
+}
+
 /// Why the engine is entering a new round.
 ///
 /// Round progress is network-evidence-driven (Tendermint-style round
@@ -1128,55 +1247,16 @@ impl ConsensusEngine {
         self.validate_committed_block(&proposal).await?;
 
         // Build the BFT quorum proof from the commit votes in the vote pool.
-        // Collect across ALL rounds: validators may cast commit votes in different rounds
-        // (due to timing skew) but they all agree on the same proposal_id, which is what
-        // matters for safety. Round-scoped filtering was the root cause of commit quorum
-        // never being reached when validators entered the Commit step at different times.
-        //
-        // DETERMINISM: attestations must be sorted and deduplicated by validator_id so that
-        // all nodes compute the same quorum_root, which is embedded in the block header.
-        // A non-deterministic quorum_root causes each node to store a different block hash,
-        // breaking the previous_hash chain validation for the next height.
-        let quorum_proof = {
-            let mut attestations: Vec<lib_types::consensus::CommitAttestation> = self
-                .vote_pool
-                .iter()
-                .filter(|(k, (_, voted_id))| {
-                    k.height == self.current_round.height
-                        && k.vote_type == VoteType::Commit
-                        && voted_id == proposal_id
-                })
-                .filter_map(|(_, (vote, _))| {
-                    // Convert Vec<u8> signature to fixed-size Dilithium5 array.
-                    // Skip votes with wrong-sized signatures (e.g. test stubs).
-                    let signature: [u8; 4595] = vote.signature.signature.as_slice()
-                        .try_into().ok()?;
-                    Some(lib_types::consensus::CommitAttestation {
-                        validator_id: vote.voter.0,
-                        vote_id: vote.id.0,
-                        proposal_id: vote.proposal_id.0,
-                        round: vote.round,
-                        signature,
-                        public_key: vote.signature.public_key.dilithium_pk,
-                    })
-                })
-                .collect();
-
-            // Sort by validator_id for deterministic ordering across all nodes.
-            attestations.sort_by_key(|a| a.validator_id);
-            // Deduplicate: keep only the first (lowest-round, since pool was round-sorted) entry
-            // per validator. A validator may have cast commit votes at multiple rounds if the
-            // local round advanced after the initial cast; only one attestation per validator
-            // should contribute to the quorum root so the hash is identical on all nodes.
-            attestations.dedup_by_key(|a| a.validator_id);
-
-            lib_types::consensus::BftQuorumProof {
-                height: self.current_round.height,
-                proposal_id: proposal_id.0,
-                total_validators: total_validators as u32,
-                attestations,
-            }
-        };
+        // See `build_quorum_proof` for the determinism contract — the
+        // attestation set must be identical on every node that finalizes
+        // this block, or the `bft_quorum_root` (and therefore `block.hash()`)
+        // diverges and the chain forks at the next height.
+        let quorum_proof = build_quorum_proof(
+            &self.vote_pool,
+            self.current_round.height,
+            proposal_id,
+            total_validators,
+        );
 
         // Apply block to state with its quorum proof.
         // The callback persists the proof alongside the block so catch-up sync
@@ -2814,16 +2894,29 @@ impl ConsensusEngine {
             .cloned();
 
         if let Some(proposal_id) = commit_target {
-            // Skip if we already cast a commit vote for this round.
+            // Skip if we already cast a commit vote for this proposal at this
+            // height — **at any round**, not just the current one.
+            //
+            // CE-S3: the previous "current-round-only" guard let a single
+            // validator emit MULTIPLE commit votes across rounds (one per
+            // round in which precommit-quorum was observed). Each commit's
+            // signature is bound to its round (see serialize_vote_data L412),
+            // so peers received distinct g3-at-r5 and g3-at-r6 attestations.
+            // When validator A's vote_pool happened to hold g3@r5 and
+            // validator B's held g3@r6, their quorum proofs differed and the
+            // `bft_quorum_root` (which feeds block.hash) diverged → fork at
+            // the next height. The investigation that produced this fix
+            // traced exactly that mechanism through the testnet stall at
+            // heights 59118–59123 on 2026-05-20.
             let already_committed = self
                 .validator_identity
                 .as_ref()
                 .map(|id| {
-                    self.vote_pool.contains_key(&VotePoolKey {
-                        height: self.current_round.height,
-                        round: self.current_round.round,
-                        vote_type: VoteType::Commit,
-                        validator_id: id.clone(),
+                    self.vote_pool.iter().any(|(k, (_, voted_id))| {
+                        k.height == self.current_round.height
+                            && k.vote_type == VoteType::Commit
+                            && k.validator_id == *id
+                            && voted_id == &proposal_id
                     })
                 })
                 .unwrap_or(false);

--- a/lib-consensus/src/engines/consensus_engine/tests.rs
+++ b/lib-consensus/src/engines/consensus_engine/tests.rs
@@ -3430,3 +3430,221 @@ async fn test_ce_s2_quorum_for_current_round_still_transitions_to_precommit() {
         engine.current_round.step
     );
 }
+
+// ─── Quorum-proof determinism (CE-S3) ────────────────────────────────────────
+//
+// Background: the block header commits to `bft_quorum_root = compute_bft_quorum_root(&proof)`,
+// which is part of `block.hash()` via `BlockHeader::hash`. For all validators
+// finalizing the same logical block to compute identical block hashes — and
+// therefore for height H+1's `previous_hash` check to pass — every validator
+// must construct an IDENTICAL `BftQuorumProof.attestations` vec.
+//
+// Pre-fix, each validator built the proof from whatever commit votes it had
+// locally observed at finalization time. A validator that observed one extra
+// attestation produced a different attestation SET, a different root, and
+// therefore a different block hash. After a network restart from a unanimous
+// height-H state, three groups of validators independently committed three
+// distinct versions of block H+1 — exactly because their local observations
+// of the commit quorum differed by one or two attestations.
+//
+// The fix: after sort_by_key + dedup_by_key, truncate to exactly the
+// `bft_quorum_count(n)` lowest-`validator_id` attestations. Every validator
+// that has at least `bft_quorum_count(n)` distinct observations now produces
+// the same prefix → same root → same block hash.
+
+/// Helper: build a CommitAttestation-bearing signed commit vote and insert it
+/// into the engine's vote_pool at the given (height, round) for the given
+/// proposal. Uses a fresh keypair per validator_id so signatures are length-
+/// correct (the proof helper skips zero-length / stub signatures).
+fn pool_commit(
+    engine: &mut ConsensusEngine,
+    validator_id: IdentityId,
+    keypair: &KeyPair,
+    proposal_id: Hash,
+    height: u64,
+    round: u32,
+) {
+    let vote = make_signed_vote(
+        engine,
+        keypair,
+        validator_id.clone(),
+        proposal_id.clone(),
+        VoteType::Commit,
+        height,
+        round,
+    );
+    let key = VotePoolKey {
+        height,
+        round,
+        vote_type: VoteType::Commit,
+        validator_id,
+    };
+    engine.vote_pool.insert(key, (vote, proposal_id));
+}
+
+#[tokio::test]
+async fn test_ce_s3_quorum_proof_root_identical_with_extra_observations() {
+    // Two engines A and B at the same height with 5 validators registered.
+    // A observed 4 commit attestations (the BFT threshold). B observed all 5
+    // (one extra — modeling normal late-arriving commits). Both must produce
+    // the SAME quorum proof attestations and therefore the SAME quorum_root.
+    use lib_types::consensus::compute_bft_quorum_root;
+
+    let (mut engine_a, validators) = setup_bft_engine(1, 0).await;
+    let v5_id = test_validator_id(5);
+    let v5_kp = create_test_keypair();
+    register_validator_with_keypair(&mut engine_a, v5_id.clone(), &v5_kp, false).await;
+    engine_a.snapshot_validator_set(1);
+
+    let (mut engine_b, _) = setup_bft_engine(1, 0).await;
+    register_validator_with_keypair(&mut engine_b, v5_id.clone(), &v5_kp, false).await;
+    engine_b.snapshot_validator_set(1);
+
+    let proposal_id = Hash::from_bytes(&[0xC5u8; 32]);
+
+    // A: 4 commits (validators 1..=4) — exactly the BFT threshold for n=5.
+    for i in 0..4 {
+        let (vid, kp) = &validators[i];
+        pool_commit(&mut engine_a, vid.clone(), kp, proposal_id.clone(), 1, 0);
+    }
+    // B: same 4 commits PLUS validator 5 — superset.
+    for i in 0..4 {
+        let (vid, kp) = &validators[i];
+        pool_commit(&mut engine_b, vid.clone(), kp, proposal_id.clone(), 1, 0);
+    }
+    pool_commit(&mut engine_b, v5_id, &v5_kp, proposal_id.clone(), 1, 0);
+
+    // Build proofs via the same module helper the engine uses internally.
+    let proof_a = super::state_machine::build_quorum_proof(
+        &engine_a.vote_pool,
+        1,
+        &proposal_id,
+        5,
+    );
+    let proof_b = super::state_machine::build_quorum_proof(
+        &engine_b.vote_pool,
+        1,
+        &proposal_id,
+        5,
+    );
+
+    assert_eq!(
+        proof_a.attestations.len(),
+        proof_b.attestations.len(),
+        "attestation count must match across subset/superset observations \
+         (both must truncate to bft_quorum_count(5) = 4)"
+    );
+    let a_ids: Vec<_> = proof_a.attestations.iter().map(|a| a.validator_id).collect();
+    let b_ids: Vec<_> = proof_b.attestations.iter().map(|a| a.validator_id).collect();
+    assert_eq!(
+        a_ids, b_ids,
+        "attestation validator_id sets must match — both must include the \
+         same lowest-validator_id prefix"
+    );
+
+    let root_a = compute_bft_quorum_root(&proof_a);
+    let root_b = compute_bft_quorum_root(&proof_b);
+    assert_eq!(
+        root_a, root_b,
+        "bft_quorum_root MUST be identical across validators that observed \
+         different numbers of attestations (this is the fork-after-restart bug)"
+    );
+}
+
+#[tokio::test]
+async fn test_ce_s3_quorum_proof_root_dedups_double_commits_to_lowest_round() {
+    // Upgrade-race scenario: with `enter_commit_step`'s `already_committed`
+    // guard in place, validators cast exactly ONE commit per (height,
+    // proposal). But the network may still hold redundant double-commits
+    // from before the guard shipped, or from a peer running a legacy build.
+    // build_quorum_proof must deterministically pick ONE attestation per
+    // validator_id — specifically the lowest-round one — so an "upgraded"
+    // peer and a peer who only observed the legacy double-commit still
+    // converge on the same quorum_root.
+    use lib_types::consensus::compute_bft_quorum_root;
+
+    let (mut engine_clean, validators) = setup_bft_engine(1, 5).await;
+    let v5_id = test_validator_id(5);
+    let v5_kp = create_test_keypair();
+    register_validator_with_keypair(&mut engine_clean, v5_id.clone(), &v5_kp, false).await;
+    engine_clean.snapshot_validator_set(1);
+
+    let (mut engine_with_dup, _) = setup_bft_engine(1, 5).await;
+    register_validator_with_keypair(&mut engine_with_dup, v5_id.clone(), &v5_kp, false).await;
+    engine_with_dup.snapshot_validator_set(1);
+
+    let proposal_id = Hash::from_bytes(&[0xD5u8; 32]);
+
+    // Clean view: each of the first 4 validators committed once, at round 4.
+    for i in 0..4 {
+        let (vid, kp) = &validators[i];
+        pool_commit(&mut engine_with_dup, vid.clone(), kp, proposal_id.clone(), 1, 4);
+        pool_commit(&mut engine_clean, vid.clone(), kp, proposal_id.clone(), 1, 4);
+    }
+    // engine_with_dup also holds REDUNDANT commits at round 5 from g1 and g2 —
+    // modeling commits that landed in the pool before the
+    // `already_committed`-across-rounds guard was deployed. After dedup these
+    // must vanish in favour of the round-4 entries.
+    pool_commit(
+        &mut engine_with_dup,
+        validators[0].0.clone(),
+        &validators[0].1,
+        proposal_id.clone(),
+        1,
+        5,
+    );
+    pool_commit(
+        &mut engine_with_dup,
+        validators[1].0.clone(),
+        &validators[1].1,
+        proposal_id.clone(),
+        1,
+        5,
+    );
+
+    let proof_clean = super::state_machine::build_quorum_proof(
+        &engine_clean.vote_pool,
+        1,
+        &proposal_id,
+        5,
+    );
+    let proof_with_dup = super::state_machine::build_quorum_proof(
+        &engine_with_dup.vote_pool,
+        1,
+        &proposal_id,
+        5,
+    );
+
+    let root_clean = compute_bft_quorum_root(&proof_clean);
+    let root_with_dup = compute_bft_quorum_root(&proof_with_dup);
+    assert_eq!(
+        root_clean, root_with_dup,
+        "build_quorum_proof must dedup double-commits by keeping the LOWEST \
+         round per validator, so an upgraded peer (clean) and a peer with \
+         redundant pre-fix commits (with_dup) compute the same quorum_root"
+    );
+    // And the chosen rounds must indeed be the lowest-per-validator (round 4).
+    for att in proof_with_dup.attestations.iter() {
+        assert_eq!(
+            att.round, 4,
+            "with_dup: dedup must pick lowest-round attestation per validator"
+        );
+    }
+}
+
+#[test]
+fn test_ce_s3_bft_quorum_count_values() {
+    // Pin the threshold function. These are the (n, k) pairs the BFT protocol
+    // requires; any change here is a wire-format / safety change.
+    use super::state_machine::bft_quorum_count;
+    assert_eq!(bft_quorum_count(0), 0);
+    assert_eq!(bft_quorum_count(1), 1);
+    assert_eq!(bft_quorum_count(2), 2);
+    assert_eq!(bft_quorum_count(3), 3);
+    assert_eq!(bft_quorum_count(4), 3);
+    assert_eq!(bft_quorum_count(5), 4);
+    assert_eq!(bft_quorum_count(6), 5);
+    assert_eq!(bft_quorum_count(7), 5);
+    assert_eq!(bft_quorum_count(10), 7);
+    assert_eq!(bft_quorum_count(100), 67);
+}


### PR DESCRIPTION
## Summary

Root cause of the post-restart 3-way fork at height 59118-59123 (2026-05-20). After restoring 5 validators from a unanimous height-59117 sled backup, each independently committed a *different* block at height 59118. No fork-detection halt fired because the divergence happened locally: each validator's stored `block.hash()` differed because each computed a different `bft_quorum_root` from a different attestation SET.

## Trace

`block.header.bft_quorum_root` participates in `BlockHeader::hash`. It is computed from `BftQuorumProof.attestations`. The proof is assembled per-validator from the local vote_pool at finalization time. Three independent non-determinism sources combined:

1. **Multiple commits per validator across rounds.** `enter_commit_step`'s `already_committed` guard was current-round-only. When a validator's round advanced between observations of precommit-quorum, it emitted a second commit with a different round-bound signature. Peers received both.
2. **HashMap iteration order.** After filtering pool entries for `(height, proposal_id)`, the order is non-deterministic. `sort_by_key(validator_id) + dedup_by_key(validator_id)` made *ordering* stable but did not pick a deterministic round per validator when multiple commits from the same peer were in the pool.
3. **Superset inclusion.** Different validators observed different numbers of attestations (4 vs 5 for n=5). The proof included every observed attestation, so subset/superset peers produced different roots even when no validator had ever double-committed.

## Fix

Three coordinated changes in `lib-consensus/src/engines/consensus_engine/state_machine.rs`:

- (a) Tighten `enter_commit_step`'s `already_committed` guard to scan the pool at **any round** at this height for this proposal. Closes the multi-round-signature source.
- (b) Extract proof assembly into a pure `build_quorum_proof` helper. Sort attestations by `(validator_id, round) ASCENDING`, then dedup by `validator_id`. Keeps the lowest-round attestation per validator deterministically — required for the upgrade-race window where redundant pre-fix commits may still be in the pool.
- (c) Truncate to exactly `bft_quorum_count(n)` attestations after sort+dedup. All validators with ≥threshold distinct observations now include the same lowest-validator_id subset.

New helper `bft_quorum_count(n)`: smallest `k` such that `has_supermajority(k, n)` holds. n=5→4, n=4→3.

## Tests

| Test | Demonstrates |
|---|---|
| `test_ce_s3_quorum_proof_root_identical_with_extra_observations` | subset (4) vs superset (5) → same root |
| `test_ce_s3_quorum_proof_root_dedups_double_commits_to_lowest_round` | upgrade-race convergence (clean peer = peer-with-legacy-double-commit) |
| `test_ce_s3_bft_quorum_count_values` | pins (n, k) for n ∈ {0..7, 10, 100} |

All 147 lib-consensus tests pass.

## Safety

`bft_quorum_root` continues to bind a block to the set of validator IDs that authorized it. Each attestation in the proof still carries a valid signature against `serialize_vote_data(h, r, ...)`; `verify_quorum_proof` still checks each one; `verify_quorum_root_binding` still checks `compute_bft_quorum_root(&proof) == header.bft_quorum_root`. The fix changes only WHICH attestations are SELECTED into the proof, not how the proof is verified once selected.

Cross-validator agreement now reduces to: "do you have the BFT threshold of distinct commit attestations from the same lowest-validator_id peers" — exactly the Tendermint convergence guarantee.

Wire-format compatibility: `BftQuorumProof`, `CommitAttestation`, and `compute_bft_quorum_root` are unchanged. Existing on-chain block hashes remain valid.

## Deploy plan

The testnet is currently a 3-way fork that the previous PRs cannot heal. This PR plus a one-time forced re-sync from the canonical 12:00 backup on g1 unsticks it. Staged: g1 → g1+g2 → canary g3 → g4 → g5 → gateway, ≥3 minutes observation per stage. Success = sustained block production at ≥1 commit per 30s with no `HALTED` events and no new `Invalid previous hash` admission rejects.