### PR TITLE
fix(observer): serve cold blocks via store fallback in /api/v1/blockchain/blocks/{from}/{to}

### DIFF
--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -2833,19 +2833,40 @@ impl BlockchainHandler {
             .map_err(|e| anyhow::anyhow!("Failed to get blockchain: {}", e))?;
         let blockchain = blockchain_arc.read().await;
 
-        if start as usize >= blockchain.query_block_count() {
+        // Use chain height for bounds, not `query_block_count` — the latter
+        // returns only the in-memory hot window (`self.blocks.len()`, capped
+        // around `block_window_size()` ≈ 128 by default). Past the hot
+        // window's lower edge, cold blocks live in the durable store and
+        // must be fetched via `get_block(h)` which has the sled fallback.
+        //
+        // Pre-fix: a chain past ~128 blocks rejected EVERY observer_sync
+        // range request below the hot window with 404 "Start block X beyond
+        // chain height Y" (where Y was reported as the actual height but
+        // the gate was checking against the window size). Gateways could
+        // never catch up because nearly every range they needed was cold.
+        let chain_height = blockchain.query_height();
+        if start > chain_height {
             return Ok(Err(ZhtpResponse::error(
                 ZhtpStatus::NotFound,
                 format!(
                     "Start block {} beyond chain height {}",
-                    start, blockchain.query_height()
+                    start, chain_height
                 ),
             )));
         }
 
-        let actual_end = std::cmp::min(end as usize, blockchain.query_block_count() - 1);
-        let blocks = blockchain.query_block_range(start, actual_end as u64);
-        Ok(Ok((actual_end as u64, blocks)))
+        let actual_end = std::cmp::min(end, chain_height);
+        // Per-height fetch through `get_block`, which serves hot blocks from
+        // the window and cold blocks from the store. Missing blocks (e.g.,
+        // pruned gaps) silently skip — the response stays well-formed and
+        // any gap surfaces on the receiver's `previous_hash` check.
+        let mut blocks = Vec::with_capacity((actual_end - start + 1) as usize);
+        for h in start..=actual_end {
+            if let Some(b) = blockchain.get_block(h) {
+                blocks.push(b);
+            }
+        }
+        Ok(Ok((actual_end, blocks)))
     }
 
     /// Get block range for incremental sync (e.g., /blocks/10/20 returns blocks 10-20)


### PR DESCRIPTION
## Summary

\`handle_get_block_range\` / \`load_block_range\` used \`Blockchain::query_block_count()\` (= \`self.blocks.len()\`) for bounds and \`query_block_range()\` to slice the response. Both read ONLY from the in-memory hot window, whose size is capped at \`block_window_size()\` ≈ 128 by default. Cold blocks live in the durable sled store and are only reachable via \`get_block(h)\`'s store fallback.

## Effect

Any chain past ~128 blocks rejected every observer_sync range request below the hot window with a misleading \`Start block X beyond chain height Y\` 404 (where Y was the actual height but the gate checked against window size). Gateways could not catch up. Observed on zhtp-gateway-1 (stuck at 21707) and zhtp-gateway-2 (stuck at 59683) while the validator chain advanced past 61614.

## Fix

Use \`blockchain.query_height()\` for bounds and iterate per-height via \`get_block(h)\` (hot → window, cold → sled store).

## Properties

- No wire-format change.
- Read-only path; no safety implications.
- Backwards compatible: pre-fix returned empty/404 for cold ranges; post-fix returns the requested blocks. Callers that retry on errors now succeed first try.

## Test plan

- [x] \`cargo build --profile dev-release -p zhtp\` clean
- [ ] After deploy: zhtp-gateway-1 and zhtp-gateway-2 catch up to validator tip and stay caught up