### PR TITLE
fix(consensus): cross-round precommit-quorum detection (CE-S2 part 2)

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -2159,43 +2159,76 @@ impl ConsensusEngine {
             }
         }
 
-        // **CE-S1**: precommit-quorum check — proposal-scoped, current-round
-        // only. A higher-round quorum is reached via the Trigger C jump
-        // above; a stale-round quorum is not actionable for locking.
-        if vote.round == self.current_round.round
-            && vote.height == self.current_round.height
-        {
-            let precommit_count =
-                self.count_precommits_for(vote.height, vote.round, &proposal_id);
+        // **CE-S2 part 2**: precommit-quorum detection must run against the
+        // vote's own (height, round, proposal_id) and ALSO across all rounds
+        // at this height — not be gated on `vote.round == current_round`.
+        //
+        // Symmetric to the prevote fix (CE-S2) shipped in PR #2620. The
+        // previous current-round-only gate left precommits in the same
+        // drift-induced limbo: with each validator advancing rounds on its
+        // own clock, the 4th-of-5 precommit at round R routinely landed at
+        // peers whose `current_round.round` had moved past R, skipping the
+        // quorum check, never transitioning to Commit step, never casting a
+        // Commit vote, and never letting `maybe_finalize`'s commit-quorum
+        // path run (it needs Commit votes, which depend on this transition).
+        //
+        // The 2f+1 precommit count is taken across ALL rounds at this height
+        // (same as count_commits_for) — BFT safety holds because two
+        // proposals cannot each receive 2f+1 distinct precommits at the same
+        // height without f+1 Byzantine validators (counting argument with
+        // n=5, f=1: 4+4 ≤ 5 distinct + Byzantine doubles would require
+        // f+1 = 2 Byzantine validators).
+        if vote.height == self.current_round.height {
+            // Cross-round count for (height, proposal_id) — proposal-scoped.
+            let precommit_count: u64 = self
+                .vote_pool
+                .iter()
+                .filter(|(k, (_, voted_id))| {
+                    k.height == vote.height
+                        && k.vote_type == VoteType::PreCommit
+                        && voted_id == &proposal_id
+                })
+                .count() as u64;
             let total_validators =
                 self.validator_manager.get_active_validators().len() as u64;
 
             if check_supermajority(precommit_count, total_validators)
                 && self.current_round.step <= ConsensusStep::Commit
             {
-                // **CE-S1**: only lock if this proposal can BE the lock. A
-                // conflicting locked_proposal means two precommit quorums —
-                // refuse, to preserve BFT safety.
+                // Conflicting-quorum guard (CE-S1 / CE-S2):
+                // - same-locked-proposal: idempotent, no overwrite.
+                // - different locked_proposal: in honest operation with n=5
+                //   f=1 this is unreachable (see counting argument above);
+                //   if observed, prefer the FIRST lock seen and log loudly.
                 if let Some(existing) = self.current_round.locked_proposal.as_ref() {
                     if existing != &proposal_id {
                         tracing::warn!(
-                            "Conflicting precommit quorum detected: proposal {:?} has quorum but locked_proposal is already {:?}",
-                            proposal_id, existing
+                            "Conflicting precommit quorum: proposal {:?} reached quorum \
+                             at height {} but locked_proposal is already {:?} — refusing \
+                             overwrite (possible Byzantine evidence)",
+                            proposal_id, vote.height, existing
                         );
                         return Ok(());
                     }
+                    // Same proposal — idempotent, fall through to FSM
+                    // transition so a late-arriving precommit can still
+                    // drive the Commit step on a node that previously
+                    // observed the quorum but had not yet stepped to Commit.
                 } else {
-                    // First proposal to reach a precommit quorum this round.
-                    // Record locked_proposal AND locked_round — the prevote
-                    // lock rule needs both to decide whether a conflicting
-                    // proposal in a later round may be prevoted.
                     self.current_round.locked_proposal = Some(proposal_id.clone());
-                    self.current_round.locked_round = Some(self.current_round.round);
+                    // Record locked_round as the round the QUORUM was observed
+                    // at (vote.round) — that is the round whose precommit set
+                    // formed the lock. Tendermint's lock-unlock rule reads
+                    // locked_round to decide if a later proposal's
+                    // `valid_round >= locked_round` is sufficient to unlock.
+                    self.current_round.locked_round = Some(vote.round);
                 }
 
-                // CONS-305c: route the precommit-quorum threshold through
-                // the FSM. `enter_commit_step` (via SendCommit) casts the
-                // commit vote.
+                // CONS-305c: drive the Commit-step transition via FSM.
+                // `enter_commit_step` (via SendCommit) casts the Commit vote
+                // tagged with the LOCAL current_round, which the cross-round
+                // commit count then aggregates with peers' Commit votes
+                // (also tagged with each peer's own round).
                 let prior_fsm = self.fsm_state.clone();
                 let (next_fsm, actions) = lib_consensus_core::fsm::transition(
                     prior_fsm,

--- a/lib-consensus/src/engines/consensus_engine/tests.rs
+++ b/lib-consensus/src/engines/consensus_engine/tests.rs
@@ -3648,3 +3648,209 @@ fn test_ce_s3_bft_quorum_count_values() {
     assert_eq!(bft_quorum_count(10), 7);
     assert_eq!(bft_quorum_count(100), 67);
 }
+
+// ─── Cross-round precommit-quorum detection (CE-S2 part 2) ──────────────────
+//
+// Symmetric to the prevote fix shipped in PR #2620: on_precommit's quorum
+// check was current-round-only. With drift, 2f+1 precommits accumulate
+// across different rounds but no single engine ever sees them all at its
+// CURRENT round, so the Commit-step transition never fires, no Commit vote
+// is cast, and the chain stalls AFTER prevote-quorum was reached.
+//
+// Observable on the testnet at height 61615 (2026-05-21): all 5 validators
+// entered PreCommit step 87 times in 10 minutes via the CE-S2 prevote path,
+// but 0 ever transitioned to Commit step — precommit-quorum detection was
+// still gated to current_round.
+
+/// Helper: insert a Commit-step vote (PreCommit) into the pool at a specific
+/// (height, round) with a valid signature.
+fn pool_precommit(
+    engine: &mut ConsensusEngine,
+    validator_id: IdentityId,
+    keypair: &KeyPair,
+    proposal_id: Hash,
+    height: u64,
+    round: u32,
+) {
+    let vote = make_signed_vote(
+        engine,
+        keypair,
+        validator_id.clone(),
+        proposal_id.clone(),
+        VoteType::PreCommit,
+        height,
+        round,
+    );
+    let key = VotePoolKey {
+        height,
+        round,
+        vote_type: VoteType::PreCommit,
+        validator_id,
+    };
+    engine.vote_pool.insert(key, (vote, proposal_id));
+}
+
+/// Helper: build a 5-validator engine where the validator set snapshot
+/// includes all 5 at the given height (setup_bft_engine seals the snapshot
+/// with only 4, and snapshot_validator_set is write-once per height).
+async fn setup_bft_engine_5(
+    height: u64,
+    round: u32,
+) -> (ConsensusEngine, Vec<(IdentityId, KeyPair)>) {
+    let config = ConsensusConfig {
+        development_mode: true,
+        ..Default::default()
+    };
+    let broadcaster: Arc<dyn MessageBroadcaster> = Arc::new(MockMessageBroadcaster::new());
+    let mut engine = ConsensusEngine::new(config, broadcaster).expect("create engine");
+
+    let mut validators = Vec::new();
+    for i in 1..=5u8 {
+        let vid = test_validator_id(i);
+        let kp = create_test_keypair();
+        register_validator_with_keypair(&mut engine, vid.clone(), &kp, i == 1).await;
+        validators.push((vid, kp));
+    }
+
+    engine.validator_identity = Some(validators[0].0.clone());
+    engine
+        .set_validator_keypair(validators[0].1.clone())
+        .expect("set keypair");
+
+    engine.current_round.height = height;
+    engine.current_round.round = round;
+    engine.current_round.step = ConsensusStep::Propose;
+    engine.snapshot_validator_set(height);
+
+    if let Some(proposer) = engine.compute_proposer_for_round(height, round) {
+        engine.current_round.proposer = Some(proposer);
+    }
+
+    (engine, validators)
+}
+
+#[tokio::test]
+async fn test_ce_s2p2_precommit_quorum_detected_across_rounds() {
+    // 5-validator engine. Local is validators[0] at round 7. Pool precommits
+    // from validators[1..4] at round 5 (different from local round). Engine
+    // delivers a fresh precommit from validator 5 at round 5 via on_precommit
+    // and must detect a cross-round quorum: 4 distinct validators have
+    // precommitted for the same proposal at height H.
+    //
+    // CONTRACT: the engine MUST transition into the Commit step (or set the
+    // step to >= Commit / set locked_proposal) once 2f+1 precommits exist
+    // for (height, proposal_id), regardless of which rounds individual
+    // precommits came from. Otherwise the chain cannot commit when rounds
+    // drift between validators.
+    let (mut engine, validators) = setup_bft_engine_5(1, 7).await;
+
+    let proposal_id = Hash::from_bytes(&[0xE5u8; 32]);
+    let (ref proposer_id, ref proposer_kp) = validators[0];
+    stage_stub_proposal(
+        &mut engine,
+        proposal_id.clone(),
+        1,
+        7,
+        proposer_id,
+        proposer_kp,
+    );
+
+    // Local validator's perspective: it has cast its own prevote and is in
+    // PreCommit step at round 7 (where it would cast a precommit), but the
+    // network reached precommit-quorum a couple of rounds earlier.
+    engine.current_round.step = ConsensusStep::PreCommit;
+    engine.fsm_state = lib_consensus_core::fsm::ValidatorState::Precommitting;
+
+    // Pool 3 remote precommits at round 5 (the "early" quorum window).
+    for i in 1..=3usize {
+        let (vid, kp) = &validators[i];
+        pool_precommit(&mut engine, vid.clone(), kp, proposal_id.clone(), 1, 5);
+    }
+
+    // Deliver the 4th precommit at round 5 via the live handler — completes
+    // the quorum at round 5, but the local engine is at round 7.
+    let (ref v5_id, ref v5_kp) = validators[4];
+    let v5_vote = make_signed_vote(
+        &engine,
+        v5_kp,
+        v5_id.clone(),
+        proposal_id.clone(),
+        VoteType::PreCommit,
+        1,
+        5,
+    );
+    engine
+        .on_precommit(v5_vote)
+        .await
+        .expect("on_precommit must accept the 4th remote precommit");
+
+    let precommits_at_round_5 =
+        engine.count_precommits_for(1, 5, &proposal_id);
+    assert_eq!(
+        precommits_at_round_5, 4,
+        "test setup: 4 precommits should be pooled for round 5"
+    );
+
+    // CONTRACT: cross-round precommit-quorum must move the local step toward
+    // Commit AND/OR record the lock. Without the fix this stays at PreCommit
+    // forever because the current-round-only gate skips the quorum check
+    // (vote.round=5 vs current_round.round=7).
+    assert!(
+        engine.current_round.step >= ConsensusStep::Commit
+            || engine.current_round.locked_proposal.as_ref() == Some(&proposal_id),
+        "cross-round precommit quorum must record the lock and/or advance \
+         to Commit step. got step={:?}, locked={:?}",
+        engine.current_round.step, engine.current_round.locked_proposal,
+    );
+}
+
+#[tokio::test]
+async fn test_ce_s2p2_same_round_precommit_quorum_still_advances() {
+    // Regression guard: the fix must NOT break the normal-case path where
+    // 2f+1 precommits arrive at the engine's CURRENT round. Local should
+    // still set locked state and transition to Commit step.
+    let (mut engine, validators) = setup_bft_engine_5(1, 4).await;
+
+    let proposal_id = Hash::from_bytes(&[0xE6u8; 32]);
+    let (ref proposer_id, ref proposer_kp) = validators[0];
+    stage_stub_proposal(
+        &mut engine,
+        proposal_id.clone(),
+        1,
+        4,
+        proposer_id,
+        proposer_kp,
+    );
+
+    engine.current_round.step = ConsensusStep::PreCommit;
+    engine.fsm_state = lib_consensus_core::fsm::ValidatorState::Precommitting;
+
+    // Pool 3 same-round precommits.
+    for i in 1..=3usize {
+        let (vid, kp) = &validators[i];
+        pool_precommit(&mut engine, vid.clone(), kp, proposal_id.clone(), 1, 4);
+    }
+
+    // Deliver the 4th — completes quorum at current round.
+    let (ref v5_id, ref v5_kp) = validators[4];
+    let v5_vote = make_signed_vote(
+        &engine,
+        v5_kp,
+        v5_id.clone(),
+        proposal_id.clone(),
+        VoteType::PreCommit,
+        1,
+        4,
+    );
+    engine.on_precommit(v5_vote).await.expect("on_precommit");
+
+    assert_eq!(
+        engine.current_round.locked_proposal.as_ref(),
+        Some(&proposal_id),
+        "same-round precommit quorum must set locked_proposal"
+    );
+    assert!(
+        engine.current_round.step >= ConsensusStep::Commit,
+        "same-round precommit quorum must advance to Commit step"
+    );
+}


### PR DESCRIPTION
## Summary

Symmetric to PR #2620's prevote fix. \`on_precommit\`'s quorum check was gated on \`vote.round == self.current_round.round\`. With round drift the 4th-of-5 precommit completing a quorum at round R routinely arrives at peers whose \`current_round.round\` has advanced past R, the gate skips the check, engine never transitions to Commit step, never casts a Commit vote, no commit-quorum ever forms.

## Observable

Testnet 2026-05-21 at height 61615 after the PR #2620 recovery: 87 PreCommit-step entries on g1 in 10 min, 0 Commit-step entries, 0 \`BFT BLOCK COMMITTED\`. The CE-S2 prevote fix unblocked the prevote phase; this unblocks precommit.

## Fix

\`on_precommit\` counts precommits **across all rounds** at this height for this proposal — same shape as \`count_commits_for\`. Safety: two proposals cannot each receive 2f+1 distinct precommits at the same height without f+1 Byzantines (counting: n=5, f=1, 4+4 ≤ 5 distinct + Byzantine doubles needs 2 Byzantines).

\`locked_round\` is now recorded as \`vote.round\` (the round the quorum was observed at) — that's what \`prevote_permitted_by_lock\`'s \`valid_round >= locked_round\` actually consults.

Commit-step transition still goes through the FSM. The Commit vote is tagged with the local current_round, which \`maybe_finalize\`'s already-cross-round commit aggregation handles.

## Tests

- \`test_ce_s2p2_precommit_quorum_detected_across_rounds\` — engine at round 7, precommit quorum at round 5. Asserts locked_proposal/step advance. **Fails on main.**
- \`test_ce_s2p2_same_round_precommit_quorum_still_advances\` — regression guard. Passes on main + post-fix.

149/149 lib-consensus tests pass.

## Safety

\`bft_quorum_root\` determinism (PR #2620) untouched. Lock-unlock rule untouched. \`maybe_finalize\`'s commit aggregation untouched. The fix changes WHEN the local engine recognizes a precommit-quorum, not what counts as one. Each honest validator that observes 2f+1 distinct precommits at this height for the same proposal_id now transitions to Commit and casts a Commit vote — exactly the BFT safety guarantee.