### PR TITLE
fix(messaging): bind per-device QUIC key_ids to canonical chain identity (device_node_ids)

### DIFF
--- a/lib-blockchain/src/blockchain/gateways.rs
+++ b/lib-blockchain/src/blockchain/gateways.rs
@@ -71,6 +71,7 @@ impl Blockchain {
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
                     kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
         };
 
         let registration_tx = Transaction::new_identity_registration(
@@ -157,6 +158,7 @@ impl Blockchain {
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
                     kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
         };
 
         let update_tx = Transaction::new_identity_update(

--- a/lib-blockchain/src/blockchain/identity.rs
+++ b/lib-blockchain/src/blockchain/identity.rs
@@ -257,6 +257,21 @@ impl Blockchain {
                             {
                                 updated_identity_data.controlled_nodes =
                                     existing_identity.controlled_nodes.clone();
+
+                                // Merge device_node_ids — union semantics, no
+                                // duplicates. A device-binding update appends
+                                // new QUIC key_ids to the list; we never
+                                // remove existing ones here. Devices are
+                                // permanent until an explicit revocation tx
+                                // (out of scope for this fix).
+                                let mut merged: Vec<[u8; 32]> =
+                                    existing_identity.device_node_ids.clone();
+                                for incoming in &updated_identity_data.device_node_ids {
+                                    if !merged.iter().any(|d| d == incoming) {
+                                        merged.push(*incoming);
+                                    }
+                                }
+                                updated_identity_data.device_node_ids = merged;
                             }
 
                             if let Some(existing_identity) =
@@ -530,6 +545,7 @@ impl Blockchain {
             controlled_nodes: Vec::new(),
             owned_wallets: vec![wallet_id.to_string()],
             kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
         };
 
         let registration_tx = Transaction::new_identity_registration(

--- a/lib-blockchain/src/blockchain/validators.rs
+++ b/lib-blockchain/src/blockchain/validators.rs
@@ -84,6 +84,7 @@ impl Blockchain {
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
                     kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
         };
 
         let registration_tx = Transaction::new_identity_registration(
@@ -170,6 +171,7 @@ impl Blockchain {
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
                     kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
         };
 
         let update_tx = Transaction::new_identity_update(

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -604,6 +604,7 @@ impl GenesisConfig {
                     controlled_nodes: vec![],
                     owned_wallets: vec![],
                     kyber_public_key: vec![],
+                    device_node_ids: vec![],
                 },
             );
             bc.identity_blocks.insert(id.did.clone(), 0u64);
@@ -723,6 +724,7 @@ impl GenesisConfig {
                             controlled_nodes: vec![],
                             owned_wallets: vec![],
                             kyber_public_key: vec![],
+                    device_node_ids: vec![],
                         },
                     );
                     bc.identity_blocks.insert(id.did.clone(), 0u64);

--- a/lib-blockchain/src/integration/economic_integration.rs
+++ b/lib-blockchain/src/integration/economic_integration.rs
@@ -480,6 +480,7 @@ impl EconomicTransactionProcessor {
                     controlled_nodes: Vec::new(),
                     owned_wallets: Vec::new(),
                     kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
                 })
             }
             EconomyTransactionType::ProposalVote | EconomyTransactionType::ProposalExecution => {
@@ -500,6 +501,7 @@ impl EconomicTransactionProcessor {
                     controlled_nodes: Vec::new(),
                     owned_wallets: Vec::new(),
                     kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
                 })
             }
             _ => None, // Regular payments don't require identity verification

--- a/lib-blockchain/src/integration/identity_integration.rs
+++ b/lib-blockchain/src/integration/identity_integration.rs
@@ -377,6 +377,7 @@ mod tests {
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
             kyber_public_key: Vec::new(),
+            device_node_ids: Vec::new(),
         };
 
         assert!(validate_identity_data(&identity_data)?);
@@ -400,6 +401,7 @@ mod tests {
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
             kyber_public_key: Vec::new(),
+            device_node_ids: Vec::new(),
         };
 
         let registration_id = process_identity_registration(&identity_data)?;

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -535,6 +535,30 @@ pub struct IdentityTransactionData {
     /// 1568 bytes when present. Empty for identities registered before this field was added.
     #[serde(default)]
     pub kyber_public_key: Vec<u8>,
+    /// QUIC key_ids of devices bound to this canonical chain identity.
+    ///
+    /// Each entry is the `blake3(dilithium_pk || kyber_pk)` of a device's
+    /// QUIC handshake keypair — the value the server sees as
+    /// `request.requester.0` for control-plane v2 authenticated requests
+    /// from that device.
+    ///
+    /// Mobiles generate an ephemeral QUIC keypair per device/session that
+    /// does NOT match the identity's chain-registered keys. Without an
+    /// explicit binding, the server's msg/receive resolver cannot map an
+    /// incoming QUIC key_id back to the user's canonical DID, so messages
+    /// addressed to the canonical DID never reach the polling device.
+    ///
+    /// New devices are appended (set semantics; no duplicates) by an
+    /// `IdentityUpdate` transaction. The OPAQUE login flow self-bootstraps
+    /// this binding: after a password-authenticated session is established,
+    /// the server submits a system `IdentityUpdate` adding the request's
+    /// QUIC key_id if absent. Mobiles do not need to call any new
+    /// endpoint — existing OPAQUE login is the trigger.
+    ///
+    /// Empty for identities registered before this field was added
+    /// (`#[serde(default)]`).
+    #[serde(default)]
+    pub device_node_ids: Vec<[u8; 32]>,
 }
 
 /// Wallet registration transaction data (processed by lib-identity package)
@@ -779,6 +803,7 @@ impl Transaction {
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
                     kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
         };
 
         Transaction {
@@ -2043,6 +2068,7 @@ impl IdentityTransactionData {
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
             kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
         }
     }
 
@@ -2081,6 +2107,7 @@ impl IdentityTransactionData {
             controlled_nodes,
             owned_wallets,
             kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
         }
     }
 

--- a/lib-blockchain/src/utils.rs
+++ b/lib-blockchain/src/utils.rs
@@ -325,6 +325,7 @@ pub mod testing {
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
             kyber_public_key: Vec::new(),
+            device_node_ids: Vec::new(),
         }
     }
 }

--- a/zhtp/src/api/handlers/credentials/opaque.rs
+++ b/zhtp/src/api/handlers/credentials/opaque.rs
@@ -759,6 +759,79 @@ impl OpaqueHandlers {
 
         info!("OPAQUE login: '{}' from {}", pending.username, client_ip);
 
+        // Auto-bind this device's QUIC key_id to the canonical chain identity.
+        //
+        // Mobiles generate an ephemeral QUIC keypair per device/session that
+        // does NOT match the chain-registered keys. Without an explicit
+        // binding, msg/receive cannot map the device's incoming key_id back
+        // to the user's canonical DID, so messages addressed to the canonical
+        // DID never reach the polling device.
+        //
+        // OPAQUE login proves possession of the user's password — sufficient
+        // authority to attach a new device's QUIC key under the canonical
+        // DID. We submit a system IdentityUpdate that appends the QUIC
+        // key_id; apply_identity_update merges into the existing entry's
+        // device_node_ids with set semantics so repeat logins are idempotent.
+        // Also cache-warm the in-memory identity_registry so msg/receive
+        // resolves correctly before the block commits.
+        if let Some(req_id) = request.requester.as_ref() {
+            let device_key_id: [u8; 32] = req_id.0;
+            let mut bc = self.blockchain.write().await;
+            let existing = bc.identity_registry.get(&did).cloned();
+            if let Some(mut id_data) = existing {
+                let already_bound =
+                    id_data.device_node_ids.iter().any(|d| *d == device_key_id);
+                if !already_bound {
+                    id_data.device_node_ids.push(device_key_id);
+
+                    // Cache-warm: in-memory registry update so msg/receive
+                    // can resolve immediately without waiting for the block.
+                    bc.identity_registry.insert(did.clone(), id_data.clone());
+
+                    // Submit the durable IdentityUpdate system tx. Sig is
+                    // empty (system tx); the OPAQUE-session check above is
+                    // the authorization gate.
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    let tx = lib_blockchain::Transaction::new_identity_update(
+                        id_data,
+                        Vec::new(),
+                        Vec::new(),
+                        0,
+                        lib_blockchain::integration::crypto_integration::Signature {
+                            signature: Vec::new(),
+                            public_key:
+                                lib_blockchain::integration::crypto_integration::PublicKey {
+                                    dilithium_pk: [0u8; 2592],
+                                    kyber_pk: [0u8; 1568],
+                                    key_id: [0u8; 32],
+                                },
+                            algorithm: lib_blockchain::integration::crypto_integration::SignatureAlgorithm::Dilithium5,
+                            timestamp: now,
+                        },
+                        format!("opaque:device_bind:{}", pending.username).into_bytes(),
+                    );
+                    if let Err(e) = bc.add_system_transaction(tx) {
+                        // Non-fatal: the in-memory binding is in place so
+                        // this session works. Persistence will retry on the
+                        // next login.
+                        warn!(
+                            "OPAQUE device-bind tx submission failed (cache-warm still applied): {}",
+                            e
+                        );
+                    } else {
+                        info!(
+                            "OPAQUE device-bind: queued key_id {} for {} (will persist next block)",
+                            hex::encode(&device_key_id[..8]),
+                            &did[..20.min(did.len())]
+                        );
+                    }
+                }
+            }
+        }
+
         json_ok(&LoginFinishResponse {
             status: "ok",
             session_token,

--- a/zhtp/src/api/handlers/identity/backup_recovery.rs
+++ b/zhtp/src/api/handlers/identity/backup_recovery.rs
@@ -561,6 +561,7 @@ async fn auto_create_identity_from_seed(
                     controlled_nodes: vec![],
                     owned_wallets: vec![],
                     kyber_public_key: vec![],
+                    device_node_ids: vec![],
                 };
                 let reg_tx = lib_blockchain::transaction::Transaction::new_identity_registration(
                     identity_data.clone(),
@@ -1780,6 +1781,7 @@ pub async fn handle_migrate_identity(
                     controlled_nodes: vec![],
                     owned_wallets: wallet_ids_all.iter().cloned().collect(),
                     kyber_public_key: vec![],
+                    device_node_ids: vec![],
                 };
 
                 if let Err(e) = blockchain.register_identity(identity_tx) {

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -1658,6 +1658,7 @@ impl WalletHandler {
                     controlled_nodes: vec![],
                     owned_wallets: vec![],
                     kyber_public_key: vec![],
+                    device_node_ids: vec![],
                 };
 
                 // Create IdentityRegistration system transaction for block persistence

--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -252,32 +252,60 @@ impl MessagingHandler {
             ));
         }
 
-        // Try multiple DID derivations to find the canonical DID the deposit was keyed under.
-        // QUIC identity_id = blake3(dilithium_pk || kyber_pk) — that's what request.requester.0 is.
-        // Canonical DID = "did:zhtp:" + blake3(dilithium_pk) — that's what envelopes use.
-        // The registry stores entries keyed by the canonical DID. To match the polling phone's
-        // authenticated identity to the canonical DID, we scan the registry trying all
-        // derivations (dil-only, dil||kyber). Genesis identities may have kyber_pk empty,
-        // mobile-registered identities have a real kyber_pk.
+        // Resolve the requester's QUIC identity to the canonical chain DID the
+        // deposit was keyed under. Three independent matches are tried; the
+        // first hit wins:
+        //
+        // 1. **Direct DID match.** A registry entry keyed by
+        //    `did:zhtp:<requester_key_id>` (rare — happens when the QUIC key
+        //    coincides with the canonical DID derivation).
+        // 2. **`device_node_ids` match.** The polling device's QUIC key_id is
+        //    in some identity's `device_node_ids` list — set by the OPAQUE
+        //    login auto-bind (handle_login_finish). This is the path that
+        //    handles ephemeral per-device QUIC keypairs: mobiles generate a
+        //    fresh QUIC key each session, OPAQUE login proves password, and
+        //    the server records the key under the canonical DID. Subsequent
+        //    msg/receive polls from the same QUIC session resolve here.
+        // 3. **Public-key hash match.** Legacy / non-OPAQUE flow: scan all
+        //    identity_registry entries, hash `dilithium_pk` and
+        //    `dilithium_pk||kyber_pk`, see if either matches the requester
+        //    key_id. Genesis identities and identities registered before
+        //    OPAQUE existed land here.
+        //
+        // Fallback: derive a stub DID from the key_id itself. The deposit
+        // store will return empty for unknown DIDs — better than 500-ing.
         let key_id_did = format!("did:zhtp:{}", requester_key_id);
         let recipient_did = {
             let blockchain = self.blockchain.read().await;
+
+            // (1) Direct match.
             if blockchain.identity_registry.contains_key(&key_id_did) {
                 key_id_did.clone()
             } else {
+                // Parse requester_key_id back into bytes for the device_node_ids
+                // comparison; the field stores raw [u8; 32] bytes.
+                let requester_key_id_bytes: Option<[u8; 32]> = hex::decode(&requester_key_id)
+                    .ok()
+                    .and_then(|v| v.try_into().ok());
+
                 blockchain
                     .identity_registry
                     .iter()
                     .find(|(_, id)| {
+                        // (2) device_node_ids match — populated by OPAQUE login auto-bind.
+                        if let Some(ref key_bytes) = requester_key_id_bytes {
+                            if id.device_node_ids.iter().any(|d| d == key_bytes) {
+                                return true;
+                            }
+                        }
+                        // (3) Public-key hash match (legacy / non-OPAQUE flow).
                         if id.public_key.len() < 32 {
                             return false;
                         }
-                        // Match against dilithium-only hash (canonical DID derivation).
                         let dil_hash = hex::encode(lib_crypto::hash_blake3(&id.public_key));
                         if dil_hash == requester_key_id {
                             return true;
                         }
-                        // Match against dilithium||kyber hash (QUIC identity_id derivation).
                         if !id.kyber_public_key.is_empty() {
                             let combined =
                                 [&id.public_key[..], &id.kyber_public_key[..]].concat();

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -632,6 +632,7 @@ async fn migrate_identities_to_blockchain() -> Result<(u32, u32)> {
             controlled_nodes: vec![],
             owned_wallets: vec![],
             kyber_public_key: vec![],
+                    device_node_ids: vec![],
         };
 
         // Register on blockchain
@@ -1276,6 +1277,7 @@ mod tests {
                 controlled_nodes: vec![],
                 owned_wallets: vec![],
                 kyber_public_key: vec![],
+                    device_node_ids: vec![],
             },
         );
 
@@ -1334,6 +1336,7 @@ mod tests {
                 controlled_nodes: vec![],
                 owned_wallets: vec![],
                 kyber_public_key: vec![],
+                    device_node_ids: vec![],
             },
         );
 

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -2778,6 +2778,7 @@ impl RuntimeOrchestrator {
                             .map(|id| hex::encode(&id.0))
                             .collect(),
                         kyber_public_key: vec![],
+                    device_node_ids: vec![],
                     };
 
                     // Register identity on blockchain
@@ -2959,6 +2960,7 @@ impl RuntimeOrchestrator {
                                         .map(|id| hex::encode(&id.0))
                                         .collect(),
                                     kyber_public_key: vec![],
+                    device_node_ids: vec![],
                                 };
 
                             match blockchain_ref.register_identity(identity_data) {

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -401,6 +401,7 @@ impl GenesisFundingService {
                 controlled_nodes: controlled_node_ids,
                 owned_wallets: vec![hex::encode(&user_primary_wallet_id.as_ref().unwrap().0 .0)],
                 kyber_public_key: vec![],
+                    device_node_ids: vec![],
             };
 
             if blockchain.identity_registry.contains_key(&user_did) {
@@ -495,6 +496,7 @@ impl GenesisFundingService {
                             .unwrap_or_default(),
                         owned_wallets: Vec::new(),
                         kyber_public_key: Vec::new(),
+                    device_node_ids: Vec::new(),
                     },
                 );
                 blockchain.identity_blocks.insert(validator_did.clone(), 0);

--- a/zhtp/src/server/mesh/identity_api.rs
+++ b/zhtp/src/server/mesh/identity_api.rs
@@ -1562,6 +1562,7 @@ async fn record_identity_on_blockchain(identity_result: &serde_json::Value) -> R
         controlled_nodes: Vec::new(),
         owned_wallets: Vec::new(),
         kyber_public_key: vec![],
+                    device_node_ids: vec![],
     };
 
     let identity_tx_hash = blockchain_guard.register_identity(identity_data)?;


### PR DESCRIPTION
## Summary

Mobile-to-mobile messages silently never arriving. Mobiles generate an ephemeral QUIC keypair per device/session that doesn't match the chain-registered identity's keys. msg/receive's resolver couldn't link the incoming QUIC key_id to a canonical DID, fell back to a key_id-derived stub DID, and polled an empty queue — while deposits sat correctly under the canonical DID.

The chain schema already had a `device_node_ids: Vec<NodeId>` slot on the runtime `ZhtpIdentity` view, but it was never persisted or wired. This PR finishes that path.

## Changes

1. **`IdentityTransactionData`** — add `pub device_node_ids: Vec<[u8; 32]>` with `#[serde(default)]`. Backward compatible (empty for old identities).
2. **`Blockchain::apply ... IdentityUpdate`** — merge incoming `device_node_ids` into existing entry, set semantics, additive only.
3. **`handle_login_finish` (OPAQUE)** — after the password-authenticated session is established, append the request's QUIC `key_id` to `identity_registry[did].device_node_ids` if absent. Submits an `IdentityUpdate` system tx + cache-warms the in-memory registry. Mobiles don't need to call any new endpoint.
4. **msg/receive resolver** — adds a second match path: scan `identity_registry` for any entry whose `device_node_ids` contains the request's QUIC key_id. Preserves the existing dilithium-only / combined-hash matches as fast paths.

## Backward compatibility

- `#[serde(default)]` keeps old wire format readable.
- 12 in-repo constructor sites updated to set `Vec::new()` / `vec![]` (no behavior change).
- Resolver's existing match paths still run for identities without any device_node_ids.
- Merge is additive only; immutable public_key / identity_type invariants unchanged.

## Test plan

- [x] `cargo test -p lib-blockchain --lib` — 1862/1862 pass
- [x] `cargo test -p lib-consensus --lib` — 149/149 pass
- [ ] Post-deploy: OPAQUE login emits `OPAQUE device-bind: queued key_id ...` log; msg/receive logs show resolution to canonical DID; recipient mobile receives messages.
