### PR TITLE
fix(messaging): bind device QUIC key_ids to canonical DIDs via in-memory SessionManager map

### DIFF
--- a/zhtp/src/api/handlers/credentials/opaque.rs
+++ b/zhtp/src/api/handlers/credentials/opaque.rs
@@ -759,6 +759,30 @@ impl OpaqueHandlers {
 
         info!("OPAQUE login: '{}' from {}", pending.username, client_ip);
 
+        // Bind this device's QUIC key_id to the canonical chain DID.
+        //
+        // Mobiles generate an ephemeral QUIC keypair per session that does
+        // NOT match the chain-registered identity's keys. Without an
+        // explicit binding, msg/receive cannot map the polling device's
+        // incoming key_id back to the user's canonical DID, so messages
+        // addressed to the canonical DID never reach the polling device.
+        //
+        // OPAQUE login proves possession of the password — sufficient
+        // authority to attach this connection's QUIC key under the canonical
+        // DID. Recorded per-server, in-memory only; cleared on restart and
+        // re-established on the next login. No chain transaction or schema
+        // change is required.
+        if let Some(req_id) = request.requester.as_ref() {
+            self.session_manager
+                .bind_device_to_canonical_did(req_id.0, did.clone())
+                .await;
+            tracing::debug!(
+                "OPAQUE device-bind: key_id {} → {}",
+                hex::encode(&req_id.0[..8]),
+                &did[..20.min(did.len())]
+            );
+        }
+
         json_ok(&LoginFinishResponse {
             status: "ok",
             session_token,

--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -252,45 +252,76 @@ impl MessagingHandler {
             ));
         }
 
-        // Try multiple DID derivations to find the canonical DID the deposit was keyed under.
-        // QUIC identity_id = blake3(dilithium_pk || kyber_pk) — that's what request.requester.0 is.
-        // Canonical DID = "did:zhtp:" + blake3(dilithium_pk) — that's what envelopes use.
-        // The registry stores entries keyed by the canonical DID. To match the polling phone's
-        // authenticated identity to the canonical DID, we scan the registry trying all
-        // derivations (dil-only, dil||kyber). Genesis identities may have kyber_pk empty,
-        // mobile-registered identities have a real kyber_pk.
+        // Resolve the polling device's QUIC identity to the canonical chain
+        // DID the deposit was keyed under. Three paths, first hit wins:
+        //
+        // (1) **Session-bound device map.** OPAQUE login records
+        //     (quic_key_id → canonical_did) in SessionManager via
+        //     `bind_device_to_canonical_did`. Handles mobiles that generate
+        //     an ephemeral QUIC keypair per session (the dominant case):
+        //     mobile logs in with password → server binds this connection's
+        //     QUIC key under the user's canonical DID → /msg/receive on the
+        //     same connection (or any future connection whose key has been
+        //     bound) resolves correctly.
+        //
+        // (2) **Direct DID match.** A registry entry keyed by
+        //     `did:zhtp:<requester_key_id>` (rare — happens when the QUIC
+        //     key coincides with the canonical DID derivation).
+        //
+        // (3) **Public-key hash match.** Legacy / non-OPAQUE flow: scan all
+        //     identity_registry entries, hash `dilithium_pk` and
+        //     `dilithium_pk||kyber_pk`, see if either matches the requester
+        //     key_id. Genesis identities and identities registered before
+        //     OPAQUE existed land here.
+        //
+        // Fallback: derive a stub DID from the key_id itself. Deposit store
+        // returns empty for unknown DIDs — better than 500-ing.
         let key_id_did = format!("did:zhtp:{}", requester_key_id);
         let recipient_did = {
-            let blockchain = self.blockchain.read().await;
-            if blockchain.identity_registry.contains_key(&key_id_did) {
-                key_id_did.clone()
+            // (1) Session-bound device map.
+            let bound = match (
+                crate::session_manager::session_manager_handle(),
+                request.requester.as_ref(),
+            ) {
+                (Some(mgr), Some(req_id)) => {
+                    mgr.canonical_did_for_quic_key(&req_id.0).await
+                }
+                _ => None,
+            };
+            if let Some(did) = bound {
+                did
             } else {
-                blockchain
-                    .identity_registry
-                    .iter()
-                    .find(|(_, id)| {
-                        if id.public_key.len() < 32 {
-                            return false;
-                        }
-                        // Match against dilithium-only hash (canonical DID derivation).
-                        let dil_hash = hex::encode(lib_crypto::hash_blake3(&id.public_key));
-                        if dil_hash == requester_key_id {
-                            return true;
-                        }
-                        // Match against dilithium||kyber hash (QUIC identity_id derivation).
-                        if !id.kyber_public_key.is_empty() {
-                            let combined =
-                                [&id.public_key[..], &id.kyber_public_key[..]].concat();
-                            let combined_hash =
-                                hex::encode(lib_crypto::hash_blake3(&combined));
-                            if combined_hash == requester_key_id {
+                let blockchain = self.blockchain.read().await;
+                // (2) Direct match.
+                if blockchain.identity_registry.contains_key(&key_id_did) {
+                    key_id_did.clone()
+                } else {
+                    // (3) Public-key hash match.
+                    blockchain
+                        .identity_registry
+                        .iter()
+                        .find(|(_, id)| {
+                            if id.public_key.len() < 32 {
+                                return false;
+                            }
+                            let dil_hash = hex::encode(lib_crypto::hash_blake3(&id.public_key));
+                            if dil_hash == requester_key_id {
                                 return true;
                             }
-                        }
-                        false
-                    })
-                    .map(|(did, _)| did.clone())
-                    .unwrap_or(key_id_did)
+                            if !id.kyber_public_key.is_empty() {
+                                let combined =
+                                    [&id.public_key[..], &id.kyber_public_key[..]].concat();
+                                let combined_hash =
+                                    hex::encode(lib_crypto::hash_blake3(&combined));
+                                if combined_hash == requester_key_id {
+                                    return true;
+                                }
+                            }
+                            false
+                        })
+                        .map(|(did, _)| did.clone())
+                        .unwrap_or(key_id_did)
+                }
             }
         };
 

--- a/zhtp/src/session_manager.rs
+++ b/zhtp/src/session_manager.rs
@@ -74,6 +74,28 @@ pub struct SessionManager {
     /// Highest `X-OPAQUE-Seq` value seen for each OPAQUE-bound session.
     /// Strict monotonic — server rejects seq ≤ last seen as replay (S6).
     opaque_last_seq: Arc<RwLock<HashMap<String, u64>>>,
+    /// Device QUIC key_id → canonical chain DID bindings.
+    ///
+    /// Mobiles generate an ephemeral QUIC keypair per device/session that
+    /// does NOT match the chain-registered identity's keys. The msg/receive
+    /// resolver scans identity_registry for entries whose
+    /// `blake3(dilithium_pk)` or `blake3(dilithium_pk||kyber_pk)` match the
+    /// requester's QUIC key_id — neither matches for ephemeral keys, so
+    /// messages addressed to the canonical DID never reach the polling
+    /// device.
+    ///
+    /// This map is populated on a successful OPAQUE login (password proves
+    /// authority over the canonical DID; the QUIC key_id of the login
+    /// connection is recorded as a device of that DID). The msg/receive
+    /// resolver consults this map BEFORE the existing hash-based scan, so
+    /// every subsequent /msg/* request on the same QUIC session (or any
+    /// future session whose key_id has been bound) resolves to the
+    /// canonical DID.
+    ///
+    /// Per-server state, in-memory only — cleared on restart. Mobile
+    /// re-logs in OPAQUE on next session start, which re-establishes the
+    /// binding. No chain transaction or schema change is needed.
+    device_quic_key_canonical_did: Arc<RwLock<HashMap<[u8; 32], String>>>,
 }
 
 impl SessionManager {
@@ -86,7 +108,40 @@ impl SessionManager {
             max_sessions_per_identity: 5,
             opaque_session_keys: Arc::new(RwLock::new(HashMap::new())),
             opaque_last_seq: Arc::new(RwLock::new(HashMap::new())),
+            device_quic_key_canonical_did: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Record that QUIC key_id `device_key` belongs to canonical chain DID
+    /// `canonical_did`. Called from `handle_login_finish` after a successful
+    /// OPAQUE login: the password proves authority, the QUIC key of the
+    /// login connection is recorded as a device of that DID. Idempotent;
+    /// repeat logins from the same device are no-ops.
+    pub async fn bind_device_to_canonical_did(
+        &self,
+        device_key: [u8; 32],
+        canonical_did: String,
+    ) {
+        let mut map = self.device_quic_key_canonical_did.write().await;
+        map.insert(device_key, canonical_did);
+    }
+
+    /// Look up the canonical chain DID for a given QUIC key_id. Returns
+    /// `None` if no OPAQUE login has bound this device key.
+    ///
+    /// Used by `/api/v1/msg/receive`'s recipient resolver to map an
+    /// incoming polling device's ephemeral QUIC identity to the user's
+    /// canonical DID, so messages addressed to the canonical DID reach the
+    /// device.
+    pub async fn canonical_did_for_quic_key(
+        &self,
+        device_key: &[u8; 32],
+    ) -> Option<String> {
+        self.device_quic_key_canonical_did
+            .read()
+            .await
+            .get(device_key)
+            .cloned()
     }
 
     /// S6: atomically verify and advance the per-session monotonic sequence
@@ -419,6 +474,7 @@ impl SessionManager {
             max_sessions_per_identity: self.max_sessions_per_identity,
             opaque_session_keys: Arc::clone(&self.opaque_session_keys),
             opaque_last_seq: Arc::clone(&self.opaque_last_seq),
+            device_quic_key_canonical_did: Arc::clone(&self.device_quic_key_canonical_did),
         };
 
         tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Redo of PR #2623 (reverted in #2624) using a per-server in-memory map instead of a chain-schema change. The original PR added a new field to `IdentityTransactionData` with `#[serde(default)]`, which works for fresh serde state but breaks bincode-serialized sled blobs that lack the new field's bytes — every node hit EOF on startup. This approach avoids any wire-format change.

## Root cause (unchanged)

Mobiles generate an ephemeral QUIC keypair per device/session. The msg/receive resolver maps the polling QUIC key_id to a canonical DID by hashing each identity_registry entry's keys. Neither `blake3(dilithium)` nor `blake3(dilithium||kyber)` matches an ephemeral per-session key. Resolver falls back to a stub DID, polling finds empty queues, deposits sit correctly under the canonical DID.

## Fix

1. `SessionManager` gains `device_quic_key_canonical_did: HashMap<[u8; 32], String>` plus two accessors.
2. `handle_login_finish` records `(request.requester.0, did)` after a successful OPAQUE login.
3. `msg/receive` resolver checks the map FIRST. Existing identity_registry hash scans become fallbacks for legacy / non-OPAQUE flows.

## Properties

- **No wire-format change.** No chain schema, no migration, no sled rewrite.
- **Per-server in-memory.** Bindings clear on restart, re-established on next OPAQUE login. Mobile flow unchanged.
- **No chain consensus.** Each server independently observes the OPAQUE logins it serves. A mobile that hops between servers re-binds on each. Fine for messaging — sessions typically stick to one entry point.

## Tests

- [x] 149/149 lib-consensus tests pass
- [x] 20/20 lib-consensus-runtime tests pass
- [ ] After deploy: OPAQUE login emits `OPAQUE device-bind: key_id ...` at debug level; msg/receive resolves to canonical DID; mobile-to-mobile messaging works.