### PR TITLE
fix(lib-client): add stateful receive ratchet for envelope_open

### DIFF
--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -2496,9 +2496,12 @@ pub extern "C" fn zhtp_msg_seal_key_exchange(
 
 // ── Opening ─────────────────────────────────────────────────────────
 
-/// Decrypt a sealed envelope. `chain_key` must point to the 32-byte
-/// chain key for the relevant session; `envelope_bytes` is bincode bytes
-/// (the same shape `zhtp_msg_seal_*` produces). Returns plaintext bytes.
+/// Decrypt a sealed envelope **statelessly**. `chain_key` must already
+/// be ratcheted to the position matching `envelope.sequence`; this call
+/// does not advance any state and is intended for KeyExchange envelopes
+/// or callers that manage chain key advancement out-of-band. For normal
+/// in-session traffic use `zhtp_msg_envelope_open_with_session` which
+/// advances the receive ratchet in lockstep with the sender.
 #[no_mangle]
 pub extern "C" fn zhtp_msg_envelope_open(
     envelope_bytes: *const u8,
@@ -2519,6 +2522,111 @@ pub extern "C" fn zhtp_msg_envelope_open(
     key_arr.copy_from_slice(key_slice);
     match msg_mod::open_envelope(&envelope, &key_arr) {
         Ok(body) => vec_to_buffer(body),
+        Err(_) => empty_buffer(),
+    }
+}
+
+/// Decrypt a sealed envelope using a `MessagingSessionHandle`, advancing
+/// the receive ratchet in lockstep with the sender's send ratchet.
+/// Mirrors `zhtp_msg_seal_text` on the receive side.
+///
+/// Behaviour:
+/// - In-order (`envelope.sequence == session.counter`): decrypts and
+///   advances the chain key + counter.
+/// - Skip-forward (`envelope.sequence > session.counter`): buffers
+///   per-message keys for the skipped range in the session's
+///   `skipped_keys` map (bounded; over-limit skips are rejected) so
+///   they can still be opened if they arrive later, then decrypts the
+///   target and advances.
+/// - Out-of-order (`envelope.sequence < session.counter`): looks the
+///   key up in the skipped buffer and consumes it on success.
+///
+/// On any failure (epoch mismatch, replay outside the buffer, decrypt
+/// error, payload deserialize error) the session is left untouched.
+/// Returns plaintext on success; empty buffer on failure.
+#[no_mangle]
+pub extern "C" fn zhtp_msg_envelope_open_with_session(
+    handle: *mut MessagingSessionHandle,
+    envelope_bytes: *const u8,
+    envelope_len: usize,
+) -> ByteBuffer {
+    if handle.is_null() || envelope_bytes.is_null() {
+        return empty_buffer();
+    }
+    if envelope_len > 10 * 1024 * 1024 {
+        return empty_buffer();
+    }
+    let env_bytes = unsafe { borrow_slice(envelope_bytes, envelope_len) };
+    let envelope: msg_mod::MessageEnvelope = match bincode::deserialize(env_bytes) {
+        Ok(e) => e,
+        Err(_) => return empty_buffer(),
+    };
+    let session = unsafe { &mut (*handle).inner };
+
+    // Clone-then-commit so partial state changes don't leak on failure.
+    let mut session_copy = session.clone();
+    match msg_mod::open_envelope_with_session(&mut session_copy, &envelope) {
+        Ok(body) => {
+            *session = session_copy;
+            vec_to_buffer(body)
+        }
+        Err(_) => empty_buffer(),
+    }
+}
+
+/// Stateful + verified counterpart of `zhtp_msg_envelope_open_verified`.
+/// Verifies the Dilithium signature and the `sender_did` ↔ `peer_pk`
+/// binding, then decrypts via `zhtp_msg_envelope_open_with_session`'s
+/// ratchet semantics. `peer_dilithium_pk` is the sender's public key
+/// (2592 bytes). On any failure the session is left untouched.
+#[no_mangle]
+pub extern "C" fn zhtp_msg_envelope_open_verified_with_session(
+    handle: *mut MessagingSessionHandle,
+    envelope_bytes: *const u8,
+    envelope_len: usize,
+    peer_dilithium_pk: *const u8,
+    peer_dilithium_pk_len: usize,
+) -> ByteBuffer {
+    if handle.is_null() || envelope_bytes.is_null() || peer_dilithium_pk.is_null() {
+        return empty_buffer();
+    }
+    if peer_dilithium_pk_len != crypto::Dilithium5::PUBLIC_KEY_SIZE {
+        return empty_buffer();
+    }
+    if envelope_len > 10 * 1024 * 1024 {
+        return empty_buffer();
+    }
+
+    let env_bytes = unsafe { borrow_slice(envelope_bytes, envelope_len) };
+    let pk = unsafe { borrow_slice(peer_dilithium_pk, peer_dilithium_pk_len) };
+
+    let envelope: msg_mod::MessageEnvelope = match bincode::deserialize(env_bytes) {
+        Ok(e) => e,
+        Err(_) => return empty_buffer(),
+    };
+
+    // sender_did must equal `did:zhtp:` + blake3(pk)
+    let expected_did = format!(
+        "did:zhtp:{}",
+        hex::encode(crypto::Blake3::hash(pk))
+    );
+    if envelope.sender_did != expected_did {
+        return empty_buffer();
+    }
+
+    // Dilithium signature
+    match msg_mod::verify_envelope(&envelope, pk) {
+        Ok(true) => {}
+        _ => return empty_buffer(),
+    }
+
+    let session = unsafe { &mut (*handle).inner };
+    let mut session_copy = session.clone();
+    match msg_mod::open_envelope_with_session(&mut session_copy, &envelope) {
+        Ok(body) => {
+            *session = session_copy;
+            vec_to_buffer(body)
+        }
         Err(_) => empty_buffer(),
     }
 }

--- a/lib-client/src/messaging.rs
+++ b/lib-client/src/messaging.rs
@@ -21,10 +21,31 @@
 use crate::crypto::{Blake3, ChaCha20Poly1305Cipher, Dilithium5, Kyber1024};
 use crate::error::{ClientError, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Maximum number of skipped message keys a session will buffer for out-of-order
+/// delivery before refusing to ratchet further. Bounds memory and rate-limits a
+/// peer that floods with high sequence numbers to force key derivation.
+pub const MAX_SKIPPED_KEYS_PER_EPOCH: usize = 1024;
 
 // ── Session ────────────────────────────────────────────────────────
 
 /// A messaging session with a remote DID.
+///
+/// `chain_key` and `counter` advance in lockstep with the peer's matching
+/// session: the sender advances on `seal_*`, the receiver advances on
+/// `open_envelope_with_session`. Each session is therefore directional in
+/// practice — full-duplex callers maintain two sessions per peer.
+///
+/// `skipped_keys` buffers `(msg_key, nonce)` pairs for sequences the
+/// receiver had to walk past to decrypt a later message that arrived
+/// first. Both halves are needed because the sender derives the nonce
+/// from the chain key (which is discarded once we ratchet past it), so
+/// the receiver can't reconstruct the nonce later from the message key
+/// alone. Cleared on `rekey` / `accept_rekey`. Bounded by
+/// `MAX_SKIPPED_KEYS_PER_EPOCH`. `#[serde(skip)]` keeps the bincode wire
+/// format identical to v1 so previously persisted sessions deserialise
+/// unchanged.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct MessagingSession {
     pub local_did: String,
@@ -32,6 +53,8 @@ pub struct MessagingSession {
     pub chain_key: [u8; 32],
     pub counter: u64,
     pub epoch: u32,
+    #[serde(skip)]
+    pub skipped_keys: HashMap<u64, ([u8; 32], [u8; 12])>,
 }
 
 /// Initiate a session: Kyber encapsulate → shared secret → ratchet.
@@ -53,6 +76,7 @@ pub fn initiate_session(
             chain_key,
             counter: 0,
             epoch: 0,
+            skipped_keys: HashMap::new(),
         },
     ))
 }
@@ -74,6 +98,7 @@ pub fn accept_session(
         chain_key,
         counter: 0,
         epoch: 0,
+        skipped_keys: HashMap::new(),
     })
 }
 
@@ -89,6 +114,7 @@ pub fn rekey_session(
         Blake3::hash(&[&session.chain_key[..], &new_secret, b"rekey" as &[u8]].concat());
     session.epoch += 1;
     session.counter = 0;
+    session.skipped_keys.clear();
 
     Ok(ciphertext)
 }
@@ -105,6 +131,7 @@ pub fn accept_rekey(
         Blake3::hash(&[&session.chain_key[..], &new_secret, b"rekey" as &[u8]].concat());
     session.epoch += 1;
     session.counter = 0;
+    session.skipped_keys.clear();
 
     Ok(())
 }
@@ -262,7 +289,13 @@ fn seal_message(
     })
 }
 
-/// Open (decrypt) a received envelope. Returns the plaintext body bytes.
+/// Open (decrypt) a received envelope using a raw chain key. **Stateless** —
+/// does not advance any ratchet. The caller must supply the chain key that
+/// matches `envelope.sequence`, i.e. `chain_key_N` where
+/// `chain_key_{i+1} = H(chain_key_i || "next" || i)`. Useful for
+/// KeyExchange / first-contact envelopes or for callers that manage the
+/// chain key out-of-band; otherwise prefer `open_envelope_with_session`
+/// which mirrors the sender's ratchet and handles out-of-order delivery.
 pub fn open_envelope(
     envelope: &MessageEnvelope,
     chain_key: &[u8; 32],
@@ -280,6 +313,122 @@ pub fn open_envelope(
         .map_err(|e| ClientError::CryptoError(format!("Deserialize failed: {}", e)))?;
 
     Ok(content.body)
+}
+
+/// Advance `chain_key` one ratchet step — exact inverse of the step
+/// performed in `next_message_key`. Used by the receive ratchet to walk
+/// forward over delivered or skipped sequences.
+fn ratchet_chain_key(chain_key: &[u8; 32], counter: u64) -> [u8; 32] {
+    Blake3::hash(&[&chain_key[..], b"next", &counter.to_le_bytes()].concat())
+}
+
+/// Open (decrypt) a received envelope using a session, advancing the
+/// receive ratchet in lockstep with the sender's send ratchet.
+///
+/// Behaviour:
+/// - `envelope.sequence == session.counter` → derive `msg_key` at the
+///   current state, decrypt, then advance chain key + counter.
+/// - `envelope.sequence > session.counter` → ratchet forward, buffering
+///   message keys for skipped sequences in `session.skipped_keys` so they
+///   can still be opened if they arrive later. Skip distance is bounded
+///   by `MAX_SKIPPED_KEYS_PER_EPOCH` to prevent DoS.
+/// - `envelope.sequence < session.counter` → look up the message key in
+///   `session.skipped_keys`. Hit means out-of-order delivery, decrypt and
+///   evict the entry. Miss means replay or pre-rekey traffic — error.
+///
+/// `envelope.epoch` must match `session.epoch`; cross-epoch envelopes
+/// require a rekey first.
+///
+/// On decrypt failure the session is left untouched (clone-then-commit).
+pub fn open_envelope_with_session(
+    session: &mut MessagingSession,
+    envelope: &MessageEnvelope,
+) -> Result<Vec<u8>> {
+    if envelope.epoch != session.epoch {
+        return Err(ClientError::CryptoError(format!(
+            "envelope epoch {} != session epoch {}",
+            envelope.epoch, session.epoch
+        )));
+    }
+
+    // Out-of-order: a previously skipped sequence is being delivered now.
+    if envelope.sequence < session.counter {
+        let (msg_key, nonce) = session
+            .skipped_keys
+            .get(&envelope.sequence)
+            .copied()
+            .ok_or_else(|| {
+                ClientError::CryptoError(format!(
+                    "sequence {} below counter {} and not in skipped buffer (replay or pre-rekey)",
+                    envelope.sequence, session.counter
+                ))
+            })?;
+        let plaintext = ChaCha20Poly1305Cipher::decrypt(
+            &envelope.ciphertext,
+            &msg_key,
+            &nonce,
+            envelope.sender_did.as_bytes(),
+        )?;
+        let content: MessageContent = bincode::deserialize(&plaintext)
+            .map_err(|e| ClientError::CryptoError(format!("Deserialize failed: {}", e)))?;
+        // Only evict on full success so a malformed payload doesn't lose the key.
+        session.skipped_keys.remove(&envelope.sequence);
+        return Ok(content.body);
+    }
+
+    // In-order or skip-forward. Reject runaway skips before doing any work.
+    let skip = envelope.sequence.saturating_sub(session.counter);
+    if session.skipped_keys.len() as u64 + skip > MAX_SKIPPED_KEYS_PER_EPOCH as u64 {
+        return Err(ClientError::CryptoError(format!(
+            "skip of {} sequences would exceed max skipped-key buffer ({})",
+            skip, MAX_SKIPPED_KEYS_PER_EPOCH
+        )));
+    }
+
+    // Walk a local copy forward so a decrypt failure leaves the session intact.
+    let mut chain_key = session.chain_key;
+    let mut ctr = session.counter;
+    let mut pending_skipped: Vec<(u64, [u8; 32], [u8; 12])> = Vec::with_capacity(skip as usize);
+    while ctr < envelope.sequence {
+        let (msg_key, nonce, _epoch, leaf_counter) = derive_step(&chain_key, ctr);
+        pending_skipped.push((leaf_counter, msg_key, nonce));
+        chain_key = ratchet_chain_key(&chain_key, ctr);
+        ctr += 1;
+    }
+
+    let (msg_key, nonce, _epoch, _ctr) = derive_step(&chain_key, ctr);
+    let plaintext = ChaCha20Poly1305Cipher::decrypt(
+        &envelope.ciphertext,
+        &msg_key,
+        &nonce,
+        envelope.sender_did.as_bytes(),
+    )?;
+    let content: MessageContent = bincode::deserialize(&plaintext)
+        .map_err(|e| ClientError::CryptoError(format!("Deserialize failed: {}", e)))?;
+
+    // Decrypt succeeded — commit the walk.
+    for (seq, key, nonce) in pending_skipped {
+        session.skipped_keys.insert(seq, (key, nonce));
+    }
+    session.chain_key = ratchet_chain_key(&chain_key, ctr);
+    session.counter = envelope.sequence + 1;
+
+    Ok(content.body)
+}
+
+/// Same derivation `next_message_key` performs but without mutating
+/// session state — used by the receive walk. Returns
+/// `(msg_key, nonce, epoch_placeholder, counter)`; the epoch isn't read
+/// at this call site but the tuple shape mirrors `next_message_key`
+/// for symmetry.
+fn derive_step(chain_key: &[u8; 32], counter: u64) -> ([u8; 32], [u8; 12], u32, u64) {
+    let msg_key =
+        Blake3::hash(&[chain_key.as_slice(), b"msg", &counter.to_le_bytes()].concat());
+    let nonce_full =
+        Blake3::hash(&[chain_key.as_slice(), b"nonce", &counter.to_le_bytes()].concat());
+    let mut nonce = [0u8; 12];
+    nonce.copy_from_slice(&nonce_full[..12]);
+    (msg_key, nonce, 0, counter)
 }
 
 // ── Signing ────────────────────────────────────────────────────────
@@ -334,4 +483,109 @@ pub fn decode_envelope(hex_str: &str) -> Result<MessageEnvelope> {
         .map_err(|_| ClientError::CryptoError("Invalid hex".into()))?;
     bincode::deserialize(&bytes)
         .map_err(|e| ClientError::CryptoError(format!("Deserialize failed: {}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::Kyber1024;
+
+    fn pair() -> (MessagingSession, MessagingSession) {
+        let (recipient_pk, recipient_sk) = Kyber1024::generate_keypair().unwrap();
+        let (ct, send) =
+            initiate_session("did:zhtp:alice", "did:zhtp:bob", &recipient_pk).unwrap();
+        let recv =
+            accept_session("did:zhtp:bob", "did:zhtp:alice", &ct, &recipient_sk).unwrap();
+        (send, recv)
+    }
+
+    #[test]
+    fn stateful_open_handles_multiple_in_order_messages() {
+        let (mut send, mut recv) = pair();
+
+        for n in 0..5 {
+            let msg = format!("hello {}", n);
+            let env = seal_text_message(&mut send, &msg).unwrap();
+            assert_eq!(env.sequence, n as u64);
+
+            let body = open_envelope_with_session(&mut recv, &env).unwrap();
+            assert_eq!(body, msg.as_bytes());
+            assert_eq!(recv.counter, (n + 1) as u64);
+        }
+    }
+
+    #[test]
+    fn stateful_open_handles_skipped_then_delivered() {
+        let (mut send, mut recv) = pair();
+
+        let e0 = seal_text_message(&mut send, "zero").unwrap();
+        let e1 = seal_text_message(&mut send, "one").unwrap();
+        let e2 = seal_text_message(&mut send, "two").unwrap();
+
+        // Deliver out of order: 0, 2, 1.
+        assert_eq!(open_envelope_with_session(&mut recv, &e0).unwrap(), b"zero");
+        assert_eq!(open_envelope_with_session(&mut recv, &e2).unwrap(), b"two");
+        assert_eq!(recv.counter, 3);
+        assert_eq!(recv.skipped_keys.len(), 1);
+
+        assert_eq!(open_envelope_with_session(&mut recv, &e1).unwrap(), b"one");
+        assert!(recv.skipped_keys.is_empty());
+    }
+
+    #[test]
+    fn stateful_open_rejects_replay_of_consumed_sequence() {
+        let (mut send, mut recv) = pair();
+        let e0 = seal_text_message(&mut send, "first").unwrap();
+        let _ = open_envelope_with_session(&mut recv, &e0).unwrap();
+        let err = open_envelope_with_session(&mut recv, &e0).unwrap_err();
+        assert!(format!("{}", err).contains("not in skipped buffer"));
+    }
+
+    #[test]
+    fn stateful_open_rejects_epoch_mismatch() {
+        let (mut send, mut recv) = pair();
+        let mut e0 = seal_text_message(&mut send, "x").unwrap();
+        e0.epoch = 99;
+        let err = open_envelope_with_session(&mut recv, &e0).unwrap_err();
+        assert!(format!("{}", err).contains("epoch"));
+    }
+
+    #[test]
+    fn stateful_open_caps_skipped_keys_buffer() {
+        let (mut send, mut recv) = pair();
+        // Run sender far ahead.
+        let mut envs = Vec::new();
+        for _ in 0..(MAX_SKIPPED_KEYS_PER_EPOCH + 2) {
+            envs.push(seal_text_message(&mut send, "x").unwrap());
+        }
+        // Try to open the final envelope first — would require buffering
+        // MAX_SKIPPED_KEYS_PER_EPOCH+1 skipped keys.
+        let err =
+            open_envelope_with_session(&mut recv, envs.last().unwrap()).unwrap_err();
+        assert!(format!("{}", err).contains("max skipped-key buffer"));
+        // Session must be untouched.
+        assert_eq!(recv.counter, 0);
+    }
+
+    #[test]
+    fn stateless_and_stateful_open_agree_at_seq_zero() {
+        let (mut send, mut recv) = pair();
+        let chain_key_at_zero = recv.chain_key;
+        let env = seal_text_message(&mut send, "ping").unwrap();
+        let a = open_envelope(&env, &chain_key_at_zero).unwrap();
+        let b = open_envelope_with_session(&mut recv, &env).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn bincode_roundtrip_omits_skipped_keys() {
+        let (_send, mut recv) = pair();
+        recv.skipped_keys.insert(7, ([1u8; 32], [2u8; 12]));
+        let bytes = bincode::serialize(&recv).unwrap();
+        let restored: MessagingSession = bincode::deserialize(&bytes).unwrap();
+        // skipped_keys is #[serde(skip)] → not persisted across restart.
+        assert!(restored.skipped_keys.is_empty());
+        assert_eq!(restored.chain_key, recv.chain_key);
+        assert_eq!(restored.counter, recv.counter);
+    }
 }


### PR DESCRIPTION
## Summary

The lib-client decrypt FFI was stateless — receivers could decrypt seq=0 of a session and nothing after.

- `zhtp_msg_envelope_open` / `zhtp_msg_envelope_open_verified` took a raw 32-byte `chain_key` and called `open_envelope`, which uses `envelope.sequence` only as the per-message KDF leaf — it does **not** advance the chain key.
- `seal_text_signed` advances on the send side via `next_message_key`; there was no public counterpart on the receive side. To open seq=N the caller would have needed `chain_key_N = H(chain_key_{N-1} || "next" || N-1)`, and no public/FFI primitive performed that step.
- Visible symptom in the mobile app: `getSessionInfo(recvSession).counter` stayed at 0 forever, seq=1 decrypt failed, and the only thing that "fixed" it temporarily was an accidental per-message rehandshake making every message seq-0 of a fresh session.

This adds the missing stateful primitive plus FFI surface, mirroring `seal_text_signed`'s clone-then-commit pattern on the receive side.

### Changes

**`lib-client/src/messaging.rs`**
- `MessagingSession` gains `skipped_keys: HashMap<u64, ([u8;32], [u8;12])>` with `#[serde(skip)]` — bincode wire format unchanged, previously persisted sessions deserialise as-is.
- New `pub fn open_envelope_with_session(&mut session, &envelope)`:
  - in-order (`seq == counter`) → decrypt + advance chain key + counter
  - skip-forward (`seq > counter`) → ratchet forward, buffer `(msg_key, nonce)` per skipped sequence so they can still be opened if they arrive later, then decrypt the target and advance
  - out-of-order (`seq < counter`) → look the entry up in `skipped_keys`, decrypt, evict on success
  - bounded by `MAX_SKIPPED_KEYS_PER_EPOCH = 1024` (DoS bound)
  - epoch mismatch is rejected; decrypt failure leaves the session intact
- `rekey_session` / `accept_rekey` clear `skipped_keys` (new epoch invalidates them).
- `open_envelope` doc updated to mark it as the stateless / KeyExchange path.

**`lib-client/src/lib.rs`**
- `zhtp_msg_envelope_open_with_session(handle, env_bytes, env_len)` — stateful raw decrypt.
- `zhtp_msg_envelope_open_verified_with_session(handle, env_bytes, env_len, peer_pk, peer_pk_len)` — same plus Dilithium sig + `sender_did = did:zhtp:H(pk)` binding check, then routes through the stateful path.
- Both clone-then-commit so partial state can't leak on failure.
- Stateless `zhtp_msg_envelope_open*` retained for KeyExchange envelopes.

### Why `[u8;12]` is stored alongside the message key

The sender derives the nonce from the chain key (`H(chain_key || "nonce" || counter)`), and the chain key at that step is discarded once we ratchet past it. Storing only the message key and trying to re-derive the nonce later would break — both halves are kept.

### Migration for mobile / native callers

Add bindings that mirror `sealTextSigned` on the receive side:

```
envelopeOpenWithSession(sessionId, envelopeB64) -> bytes
    -> zhtp_msg_envelope_open_with_session

envelopeOpenVerifiedWithSession(sessionId, envelopeB64, peerDilithiumPkB64) -> bytes
    -> zhtp_msg_envelope_open_verified_with_session
```

Switch all Text/Binary decrypts to the `*WithSession` calls. Keep the stateless `envelopeOpen*` for KeyExchange envelopes only (no session yet). After this, `getSessionInfo(recvSession).counter` will advance on each successful decrypt.

## Test plan

- [x] `cargo test -p lib-client --lib` — 61/61 pass (7 new in `messaging::tests`)
  - `stateful_open_handles_multiple_in_order_messages`
  - `stateful_open_handles_skipped_then_delivered` (delivers 0,2,1 — verifies skipped buffer is used)
  - `stateful_open_rejects_replay_of_consumed_sequence`
  - `stateful_open_rejects_epoch_mismatch`
  - `stateful_open_caps_skipped_keys_buffer` (>1024 skip → reject, session untouched)
  - `stateless_and_stateful_open_agree_at_seq_zero`
  - `bincode_roundtrip_omits_skipped_keys` (wire-compat verified)
- [ ] Mobile-side: wire up the two new FFI symbols, confirm two-mobile message exchange succeeds for seq≥1 without a per-message rehandshake