### PR TITLE
fix(identity): bridge device QUIC key to canonical DID + bidirectional owner relation

### DIFF
--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -3387,6 +3387,15 @@ impl BlockExecutor {
             TransactionType::RegisterCredential
             | TransactionType::UpdateCredentialPassword => Ok(TxOutcome::LegacySystem),
 
+            // Domain lifecycle — state applied by process_domain_transactions()
+            // in finish_block_processing(). Same pattern as credentials above.
+            // Was missing this arm: when block 67027 (testnet 2026-05-22) carried
+            // a DomainRegistration the executor crashed at TxApplyError::UnsupportedType
+            // and all 4 validators halted to prevent a fork — even though the validator
+            // pre-check and Phase 2 allow-list both passed it.
+            TransactionType::DomainRegistration
+            | TransactionType::DomainUpdate => Ok(TxOutcome::LegacySystem),
+
             TransactionType::TreasuryAllocation => {
                 self.apply_treasury_allocation(mutator, tx)?;
                 Ok(TxOutcome::TreasuryAllocation)

--- a/lib-identity/src/identity/manager.rs
+++ b/lib-identity/src/identity/manager.rs
@@ -352,6 +352,21 @@ impl IdentityManager {
     }
 
     /// Determine the relationship between a principal and a subject identity.
+    ///
+    /// Mobile clients authenticate to QUIC with a per-device Dilithium key
+    /// (e.g. `did:zhtp:53c47662…`) which is registered as its own identity
+    /// whose `owner_identity_id` points back at the user's primary identity
+    /// (e.g. `did:zhtp:e0b97576…`). Domain registration and any other
+    /// owner-gated endpoint must recognise that link so the device can act
+    /// on behalf of its owning user.
+    ///
+    /// We accept the `Owner` relation in **either** direction:
+    /// - `identity.owner_identity_id == principal_id`
+    ///   (legacy "this identity is owned by the principal" form — kept so
+    ///   existing tests and any single-identity setup keep working).
+    /// - `principal_identity.owner_identity_id == identity.id`
+    ///   (mobile device → user form: principal is a device identity whose
+    ///   owner is the subject identity).
     fn determine_relation(
         &self,
         principal: &SecurityPrincipal,
@@ -363,9 +378,25 @@ impl IdentityManager {
 
         // Parse principal DID to IdentityId for owner comparison.
         if let Ok(principal_id) = crate::did::parse_did_to_identity_id(&principal.did) {
+            // Direction 1 — subject identity declares the principal as its
+            // owner (e.g. principal is a user identity, subject is its
+            // owned device or wallet identity).
             if let Some(ref owner_id) = identity.owner_identity_id {
                 if principal_id == *owner_id {
                     return SubjectRelation::Owner;
+                }
+            }
+
+            // Direction 2 — principal identity declares the subject as its
+            // owner. This is the mobile-device → owning-user case: the
+            // QUIC transport key is the device identity, whose
+            // `owner_identity_id` field points at the user identity whose
+            // domain / wallet the request is operating on.
+            if let Some(principal_identity) = self.identities.get(&principal_id) {
+                if let Some(ref principal_owner_id) = principal_identity.owner_identity_id {
+                    if *principal_owner_id == identity.id {
+                        return SubjectRelation::Owner;
+                    }
                 }
             }
         }
@@ -1541,6 +1572,41 @@ mod access_control_tests {
         assert!(
             matches!(view, Some(IdentityView::Full(_))),
             "Self DID lookup should return Full view"
+        );
+    }
+
+    #[test]
+    fn test_device_principal_acting_on_owning_user_gets_owner_view() {
+        // Mobile device authenticates QUIC as the device identity, but
+        // the request operates on the user identity whose
+        // `owner_identity_id` it carries. The view must come back at
+        // device-owner level (Full or DeviceOwner) — never Public — or
+        // every owner-gated endpoint 403s.
+        let mut manager = IdentityManager::new();
+
+        // User identity — the subject of the request (e.g. domain owner).
+        let user = test_identity();
+        let user_id = user.id.clone();
+        let user_did = user.did.clone();
+        manager.add_identity(user);
+
+        // Device identity — the QUIC transport principal. Its
+        // `owner_identity_id` points back at the user identity.
+        let mut device = test_identity();
+        device.owner_identity_id = Some(user_id.clone());
+        let device_did = device.did.clone();
+        manager.add_identity(device);
+
+        let device_principal =
+            SecurityPrincipal::new(&device_did, Role::Citizen, NodeType::FullNode);
+        let view = manager.get_identity_view_by_did(&device_principal, &user_did);
+
+        assert!(
+            !matches!(view, Some(IdentityView::Public(_)) | None),
+            "Device principal acting on its owning user must NOT be \
+             Public/None (got {:?}). This is the exact case that 403s \
+             /api/v1/web4/domains/register from mobile clients.",
+            view.as_ref().map(|v| std::mem::discriminant(v))
         );
     }
 }

--- a/lib-identity/src/identity/manager.rs
+++ b/lib-identity/src/identity/manager.rs
@@ -1445,12 +1445,16 @@ mod access_control_tests {
     use lib_types::NodeType;
 
     fn test_identity() -> ZhtpIdentity {
+        test_identity_with_seed([0u8; 64])
+    }
+
+    fn test_identity_with_seed(seed: [u8; 64]) -> ZhtpIdentity {
         ZhtpIdentity::new_unified(
             IdentityType::Human,
             Some(30),
             Some("US".to_string()),
             "laptop",
-            Some([0u8; 64]),
+            Some(seed),
         )
         .unwrap()
     }
@@ -1580,33 +1584,82 @@ mod access_control_tests {
         // Mobile device authenticates QUIC as the device identity, but
         // the request operates on the user identity whose
         // `owner_identity_id` it carries. The view must come back at
-        // device-owner level (Full or DeviceOwner) — never Public — or
-        // every owner-gated endpoint 403s.
+        // device-owner level (DeviceOwner) — never Public — or every
+        // owner-gated endpoint 403s.
+        //
+        // User and device need distinct seeds so they end up with
+        // distinct DIDs/ids — same seed collapses them into the same
+        // identity and the test would pass for the wrong reason (Self_
+        // relation instead of direction-2 Owner).
         let mut manager = IdentityManager::new();
 
         // User identity — the subject of the request (e.g. domain owner).
-        let user = test_identity();
+        let user = test_identity_with_seed([0x11u8; 64]);
         let user_id = user.id.clone();
         let user_did = user.did.clone();
         manager.add_identity(user);
 
         // Device identity — the QUIC transport principal. Its
         // `owner_identity_id` points back at the user identity.
-        let mut device = test_identity();
+        let mut device = test_identity_with_seed([0x22u8; 64]);
         device.owner_identity_id = Some(user_id.clone());
         let device_did = device.did.clone();
         manager.add_identity(device);
+        assert_ne!(user_did, device_did, "test setup: user/device DIDs must differ");
 
+        // Role::Device is the production role for mobile QUIC principals;
+        // get_identity_view's DeviceOwner branch is gated on it.
         let device_principal =
-            SecurityPrincipal::new(&device_did, Role::Citizen, NodeType::FullNode);
+            SecurityPrincipal::new(&device_did, Role::Device, NodeType::FullNode);
         let view = manager.get_identity_view_by_did(&device_principal, &user_did);
 
         assert!(
-            !matches!(view, Some(IdentityView::Public(_)) | None),
-            "Device principal acting on its owning user must NOT be \
-             Public/None (got {:?}). This is the exact case that 403s \
-             /api/v1/web4/domains/register from mobile clients.",
-            view.as_ref().map(|v| std::mem::discriminant(v))
+            matches!(view, Some(IdentityView::DeviceOwner(_))),
+            "Device principal acting on its owning user must get \
+             DeviceOwner view (got {view:?}). This is the exact case \
+             that 403s /api/v1/web4/domains/register from mobile clients."
+        );
+    }
+
+    #[test]
+    fn test_device_principal_acting_on_unrelated_identity_gets_public() {
+        // Sanity: the bidirectional check must not grant Owner to a
+        // device principal that doesn't actually own the subject.
+        let mut manager = IdentityManager::new();
+
+        let user = test_identity_with_seed([0x11u8; 64]);
+        let user_did = user.did.clone();
+        manager.add_identity(user);
+
+        // Device with NO owner link to user.
+        let device = test_identity_with_seed([0x22u8; 64]);
+        let device_did = device.did.clone();
+        manager.add_identity(device);
+
+        // A third, unrelated identity acts as the subject.
+        let other = test_identity_with_seed([0x33u8; 64]);
+        let other_did = other.did.clone();
+        manager.add_identity(other);
+
+        let device_principal =
+            SecurityPrincipal::new(&device_did, Role::Device, NodeType::FullNode);
+
+        let unrelated_view =
+            manager.get_identity_view_by_did(&device_principal, &other_did);
+        assert!(
+            matches!(unrelated_view, Some(IdentityView::Public(_))),
+            "Device principal with no owner link must only see Public \
+             view of an unrelated identity (got {unrelated_view:?})"
+        );
+
+        // And the user (subject from previous test) without the owner
+        // link wired up must also be Public.
+        let user_view =
+            manager.get_identity_view_by_did(&device_principal, &user_did);
+        assert!(
+            matches!(user_view, Some(IdentityView::Public(_))),
+            "Device principal without owner_identity_id wired to user \
+             must only see Public view (got {user_view:?})"
         );
     }
 }

--- a/zhtp/src/api/handlers/credentials/opaque.rs
+++ b/zhtp/src/api/handlers/credentials/opaque.rs
@@ -773,13 +773,26 @@ impl OpaqueHandlers {
         // re-established on the next login. No chain transaction or schema
         // change is required.
         if let Some(req_id) = request.requester.as_ref() {
-            self.session_manager
-                .bind_device_to_canonical_did(req_id.0, did.clone())
-                .await;
-            tracing::debug!(
-                "OPAQUE device-bind: key_id {} → {}",
-                hex::encode(&req_id.0[..8]),
-                &did[..20.min(did.len())]
+            if did.is_empty() {
+                tracing::warn!(
+                    "OPAQUE login_finish: cannot bind device {} — canonical DID resolved to empty string (credential_registry lookup failed for username '{}')",
+                    hex::encode(&req_id.0[..8]),
+                    pending.username
+                );
+            } else {
+                self.session_manager
+                    .bind_device_to_canonical_did(req_id.0, did.clone())
+                    .await;
+                tracing::info!(
+                    "OPAQUE device-bind: key_id {} → {}",
+                    hex::encode(&req_id.0[..8]),
+                    &did[..did.len().min(28)]
+                );
+            }
+        } else {
+            tracing::warn!(
+                "OPAQUE login_finish for '{}' completed but request.requester is None — no device→canonical DID binding written",
+                pending.username
             );
         }
 

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -155,29 +155,78 @@ impl Web4Handler {
             format!("did:zhtp:{}", simple_request.owner)
         };
 
-        // Look up owner identity using boundary-safe DID API
-        // This is the correct layer: accept DID, use get_identity_by_did()
-        let identity_mgr = self.identity_manager.read().await;
-        let view = identity_mgr.get_identity_view_by_did(principal, &owner_did);
-
-        // Domain registration requires at least device-owner level access.
-        match view {
-            Some(IdentityView::Public(_)) | None => {
-                return Ok(ZhtpResponse::error(
-                    ZhtpStatus::Forbidden,
-                    "Access denied: cannot register domain for this identity".to_string(),
-                ));
-            }
-            _ => {}
+        // Access gate: principal (the QUIC peer, resolved to its canonical
+        // chain DID by `extract_principal_from_request`) must be the owner
+        // of the identity it's registering for. We use a direct string
+        // match here rather than `IdentityManager::get_identity_view_by_did`
+        // because IdentityManager is only populated from QUIC handshakes
+        // for the *device* identity — chain identities loaded via
+        // `IdentityRegistration` txes never make it into that in-memory
+        // map, so the view-based check was 403'ing every legitimate mobile
+        // registration. The on-chain `DomainRegistration` tx verification
+        // path (`validation.rs:548` and `:2108`) is the real authz boundary
+        // — it checks the tx signature against the owner DID's chain pubkey
+        // — and is unaffected by this gate.
+        if principal.did != owner_did {
+            tracing::warn!(
+                "domain/register: principal {} attempted to register for owner {} — refused (chain still enforces sig at tx-apply time)",
+                &principal.did[..principal.did.len().min(28)],
+                &owner_did[..owner_did.len().min(28)]
+            );
+            return Ok(ZhtpResponse::error(
+                ZhtpStatus::Forbidden,
+                "Access denied: cannot register domain for this identity".to_string(),
+            ));
         }
 
-        let owner_identity = identity_mgr.get_identity_by_did(&owner_did)
-            .ok_or_else(|| anyhow!(
-                "Owner identity not found: {}. Please register this identity first using /api/v1/identity/create",
-                owner_did
-            ))?
-            .clone();
-        drop(identity_mgr);
+        // Try IdentityManager first (covers the rare case where the owner
+        // identity was also auto-registered from a QUIC handshake), then
+        // fall back to chain.identity_registry, which is the authoritative
+        // store for everything else.
+        let owner_identity = {
+            let identity_mgr = self.identity_manager.read().await;
+            if let Some(found) = identity_mgr.get_identity_by_did(&owner_did) {
+                found.clone()
+            } else {
+                drop(identity_mgr);
+                let bc_arc = crate::runtime::blockchain_provider::get_global_blockchain()
+                    .await
+                    .map_err(|e| anyhow!("Blockchain unavailable: {}", e))?;
+                let bc = bc_arc.read().await;
+                let chain_id = bc.identity_registry.get(&owner_did).ok_or_else(|| {
+                    anyhow!(
+                        "Owner identity not found on chain: {}. Register this identity first.",
+                        owner_did
+                    )
+                })?;
+                let pk = chain_id.public_key.clone();
+                drop(bc);
+
+                let pubkey = lib_crypto::PublicKey::new(
+                    pk.as_slice().try_into().map_err(|_| {
+                        anyhow!("Chain identity public_key is not Dilithium5 size (2592)")
+                    })?,
+                );
+                // `IdentityTransactionData` doesn't carry device_id/node_id —
+                // those are local-only fields populated when we see a peer
+                // over QUIC. For a chain-loaded owner identity we hand in
+                // empty placeholders; the downstream domain-registration
+                // path only reads `did`, `public_key`, and (optionally)
+                // `wallet_manager.wallets`/`metadata`, none of which depend
+                // on device_id/node_id.
+                let identity = lib_identity::ZhtpIdentity::from_observed_handshake(
+                    owner_did.clone(),
+                    pubkey,
+                    String::new(),
+                    lib_identity::types::NodeId::default(),
+                )
+                .map_err(|e| anyhow!("Failed to construct owner identity from chain: {}", e))?;
+
+                let mut identity_mgr = self.identity_manager.write().await;
+                identity_mgr.add_identity(identity.clone());
+                identity
+            }
+        };
 
         // DEBUG: Check wallet state right after retrieval
         info!("  WALLET DEBUG (after IdentityManager retrieval):");

--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -87,15 +87,69 @@ fn resolve_role_for_did(did: &str) -> Role {
 /// point (the request itself arrived through tokio), so the cost is
 /// bounded to a single map read.
 fn resolve_canonical_did(device_key: [u8; 32], raw_did: String) -> String {
-    let manager = match crate::session_manager::session_manager_handle() {
-        Some(m) => m,
-        None => return raw_did,
+    let device_key_hex = hex::encode(&device_key);
+
+    // (1) Session-bound device map (set by OPAQUE login_finish — only works
+    //     for flows that authenticate over an already-v2 session, which is
+    //     why OPAQUE itself can't populate it: login_finish runs on a
+    //     public read-only QUIC connection where request.requester is None).
+    if let Some(manager) = crate::session_manager::session_manager_handle() {
+        let lookup = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async move {
+                manager.canonical_did_for_quic_key(&device_key).await
+            })
+        });
+        if let Some(canonical) = lookup {
+            if !canonical.is_empty() {
+                tracing::debug!(
+                    "principal: device {} → canonical {} (via SessionManager binding)",
+                    &device_key_hex[..16],
+                    &canonical[..canonical.len().min(28)]
+                );
+                return canonical;
+            }
+        }
+    }
+
+    // (2) + (3) — chain identity_registry lookup. Same resolver
+    // `msg/receive` uses (messaging/handler.rs:279-326). This is the path
+    // that actually unblocks mobile after OPAQUE login because the
+    // SessionManager binding can never be populated by the OPAQUE flow
+    // itself (the public read-only QUIC connection has no peer_did).
+    let provider = match crate::runtime::blockchain_provider::get_global_blockchain_provider() {
+        Some(p) => p,
+        None => {
+            tracing::debug!(
+                "principal: no blockchain provider — using raw DID for device {}",
+                &device_key_hex[..16]
+            );
+            return raw_did;
+        }
     };
 
-    let lookup = tokio::task::block_in_place(|| {
-        tokio::runtime::Handle::current()
-            .block_on(async move { manager.canonical_did_for_quic_key(&device_key).await })
+    let resolved = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(async move {
+            provider
+                .resolve_device_key_to_canonical_did(&device_key)
+                .await
+        })
     });
 
-    lookup.unwrap_or(raw_did)
+    match resolved {
+        Some(canonical) => {
+            tracing::info!(
+                "principal: device {} → canonical {} (via identity_registry)",
+                &device_key_hex[..16],
+                &canonical[..canonical.len().min(28)]
+            );
+            canonical
+        }
+        None => {
+            tracing::info!(
+                "principal: no chain identity binds device {} — using raw DID",
+                &device_key_hex[..16]
+            );
+            raw_did
+        }
+    }
 }

--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -10,11 +10,22 @@ use lib_types::NodeType;
 /// Authenticated DIDs are checked against the on-chain council member list
 /// to assign `Role::Council` vs `Role::Citizen`. If the blockchain lock is
 /// contended, defaults to `Role::Citizen` (safe: never elevates on failure).
+///
+/// Mobile clients sign QUIC bytes with a per-device Dilithium key
+/// (`53c47662…`) which is *different by design* from the user's canonical
+/// chain DID (`e0b97576…`); the OPAQUE login flow binds the two in the
+/// in-memory `SessionManager` map (see PR #2626). The previous version of
+/// this function turned `request.requester.0` directly into
+/// `did:zhtp:<device-key-hex>` — the device-DID — which made every
+/// owner-gated endpoint 403 even immediately after a successful OPAQUE
+/// login. We now consult the binding first and only fall back to the raw
+/// device DID when no binding exists (i.e. pre-OPAQUE-login traffic).
 pub fn extract_principal_from_request(request: &ZhtpRequest) -> SecurityPrincipal {
     // If the transport/session layer has already authenticated the caller
     // and set request.requester, use that DID directly.
     if let Some(ref identity_id) = request.requester {
-        let did = format!("did:zhtp:{}", hex::encode(&identity_id.0));
+        let raw_did = format!("did:zhtp:{}", hex::encode(&identity_id.0));
+        let did = resolve_canonical_did(identity_id.0, raw_did);
         let role = resolve_role_for_did(&did);
         return SecurityPrincipal::new(&did, role, NodeType::FullNode);
     }
@@ -58,4 +69,33 @@ fn resolve_role_for_did(did: &str) -> Role {
         Some(true) => Role::Council,
         _ => Role::Citizen, // Not council, not initialized, or lock contended
     }
+}
+
+/// Resolve a 32-byte device QUIC key to the canonical chain DID it was
+/// bound to at OPAQUE login, falling back to `raw_did` (the stub
+/// `did:zhtp:<device-key-hex>`) when no binding exists.
+///
+/// The binding lives in `SessionManager.device_quic_key_canonical_did`
+/// (in-memory only, cleared on restart, populated by
+/// `handle_login_finish`). This is the same map `/msg/receive` already
+/// consults; surfacing it here means *every* owner-gated endpoint sees
+/// the canonical DID instead of the device-DID.
+///
+/// Performed in a `block_in_place` shim because the principal extractor
+/// is called from sync code paths but the binding map is guarded by an
+/// async `RwLock`. We've already paid for the async runtime at this
+/// point (the request itself arrived through tokio), so the cost is
+/// bounded to a single map read.
+fn resolve_canonical_did(device_key: [u8; 32], raw_did: String) -> String {
+    let manager = match crate::session_manager::session_manager_handle() {
+        Some(m) => m,
+        None => return raw_did,
+    };
+
+    let lookup = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current()
+            .block_on(async move { manager.canonical_did_for_quic_key(&device_key).await })
+    });
+
+    lookup.unwrap_or(raw_did)
 }

--- a/zhtp/src/runtime/blockchain_provider.rs
+++ b/zhtp/src/runtime/blockchain_provider.rs
@@ -66,6 +66,55 @@ impl BlockchainProvider {
         Some(bc.is_council_member(did))
     }
 
+    /// Resolve a 32-byte QUIC device key (the `request.requester` blob set by
+    /// `quic_handler.rs:729` from `session.peer_did()`) to the canonical chain
+    /// DID it represents. Mirrors the resolver `/msg/receive` uses
+    /// (`messaging/handler.rs:279-326`) so every owner-gated endpoint sees the
+    /// same canonical DID instead of the per-device peer_did.
+    ///
+    /// Resolution order:
+    /// 1. Direct match — chain has identity registered under
+    ///    `did:zhtp:<device_key_hex>`.
+    /// 2. Public-key hash match — iterate identities, hash each public key
+    ///    (and combined Dilithium+Kyber bytes) and look for a match against
+    ///    the device key id.
+    ///
+    /// Returns the canonical DID on hit, `None` on miss.
+    pub async fn resolve_device_key_to_canonical_did(
+        &self,
+        device_key: &[u8; 32],
+    ) -> Option<String> {
+        let arc = self.blockchain.read().await.as_ref().cloned()?;
+        let bc = arc.read().await;
+        let key_id_hex = hex::encode(device_key);
+        let key_id_did = format!("did:zhtp:{}", key_id_hex);
+
+        // (1) Direct match — same DID is registered.
+        if bc.identity_registry.contains_key(&key_id_did) {
+            return Some(key_id_did);
+        }
+
+        // (2) Hash-of-public-key match (Dilithium alone, then Dilithium+Kyber).
+        for (canonical_did, identity) in bc.identity_registry.iter() {
+            if identity.public_key.len() < 32 {
+                continue;
+            }
+            let dil_hash = hex::encode(lib_crypto::hash_blake3(&identity.public_key));
+            if dil_hash == key_id_hex {
+                return Some(canonical_did.clone());
+            }
+            if !identity.kyber_public_key.is_empty() {
+                let combined = [&identity.public_key[..], &identity.kyber_public_key[..]].concat();
+                let combined_hash = hex::encode(lib_crypto::hash_blake3(&combined));
+                if combined_hash == key_id_hex {
+                    return Some(canonical_did.clone());
+                }
+            }
+        }
+
+        None
+    }
+
     /// Configure blockchain mutation access mode.
     pub async fn set_access_mode(&self, access_mode: BlockchainAccessMode) {
         *self.access_mode.write().await = access_mode;

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -359,6 +359,15 @@ impl ZhtpUnifiedServer {
         // Initialize session manager first
         let _session_manager = Arc::new(SessionManager::new());
         _session_manager.start_cleanup_task();
+        // Publish the same instance as the global handle so consumers that
+        // can't easily take an `Arc<SessionManager>` constructor argument
+        // — `extract_principal_from_request` and the `/msg/receive`
+        // resolver among them — pick up the binding written by
+        // `handle_login_finish`. PR #2626 added `session_manager_handle()`
+        // but never wired this call, so the singleton stayed empty and
+        // every owner-gated endpoint silently fell back to the device DID
+        // and 403'd.
+        crate::session_manager::set_global_session_manager(_session_manager.clone());
 
         // Initialize discovery coordinator (Phase 3 consolidation)
         // Create DiscoveryConfig from runtime bootstrap peers (ARCHITECTURE: Runtime topology, not Environment defaults)


### PR DESCRIPTION
## Summary

Two complementary fixes for the same root issue — mobile clients can't act on their own user identity because the QUIC transport key and the chain DID are distinct by design and neither layer bridges them for non-messaging endpoints.

Was verified live: domain registration from a mobile client returned 403 *"Access denied: cannot register domain for this identity"* even though OPAQUE login had succeeded 12 seconds earlier and bound the device key to the canonical DID in `SessionManager`. The binding was in place; nothing read it.

(Commit 1 — already pushed; commit 2 incoming on this branch with the bridge.)

## Commit 1 — `determine_relation` accepts bidirectional `owner_identity_id`

Mobile clients store a device identity (QUIC transport key) and a primary user identity (the one the UI shows, owns wallets/domains). The device identity's `owner_identity_id` points at the user identity. The previous `determine_relation` only matched one direction (`identity.owner_identity_id == principal_id` — *"subject identity declares principal as its owner"*) so the device→user case fell through to `External` → `Public` view → 403.

This adds the inverse direction (`principal_identity.owner_identity_id == identity.id`) so a device principal acting on its owning user gets `Owner` view.

Regression test included: `test_device_principal_acting_on_owning_user_gets_owner_view`.

## Commit 2 — bridge `SessionManager` binding into `extract_principal_from_request` (coming next)

`extract_principal_from_request` (`zhtp/src/api/principal.rs`) was building `did:zhtp:<hex(requester.0)>` directly from the QUIC ephemeral key, completely ignoring the `SessionManager.device_quic_key_canonical_did` map that PR #2626 added. Result: every authenticated request — except `/msg/receive`, which has its own resolver — uses the device DID as the principal, never the canonical DID.

Bridges the principal extractor to consult the SessionManager binding when present, falling back to the raw key as before if no OPAQUE login has happened yet.

## Verification

- `cargo test -p lib-identity --lib access_control_tests` — new test passes; pre-existing `test_council_principal_gets_council_view` failure is unrelated (fails on clean development, confirmed via `git stash` + rerun).
- Will deploy + retest domain register from mobile after commit 2 lands.

## Test plan

- [x] New regression test for direction-2 relation
- [ ] Principal extractor reads binding when available
- [ ] End-to-end mobile domain register passes after redeploy