### PR TITLE
fix(network): WARN-only NodeId verification + accept bootstrap validators as registered

### DIFF
--- a/lib-network/src/handshake/mod.rs
+++ b/lib-network/src/handshake/mod.rs
@@ -1063,19 +1063,31 @@ impl ClientHello {
             return Err(anyhow!("Channel binding mismatch"));
         }
 
-        // 4. CRITICAL: Verify NodeId derivation (prevent collision attacks)
+        // 4. Verify NodeId derivation (collision protection).
+        //
+        // WARN-ONLY mode: a deployed mobile-app build computes NodeId via a
+        // derivation that doesn't match the server-side
+        // `NodeId::from_did_device` rule. Strict rejection here cuts the app
+        // off the network entirely (no path to ship a hotfix before app-store
+        // review). The downstream Dilithium signature check at step 8 still
+        // verifies the client's signature against the public_key embedded in
+        // the ClientHello — that's the real impersonation gate. NodeId
+        // derivation collision-protection is weakened but not bypassable for
+        // identity spoofing without holding the matching private key. Restore
+        // strict rejection once the app build derives NodeId per the canonical
+        // Blake3(DID || device_id) rule and is the only one in the wild.
         if let Err(e) = self.identity.verify_node_id() {
             let metrics = ctx.metrics_snapshot(timer.elapsed_micros(), self.protocol_version);
             ctx.observer.on_event(
                 HandshakeEvent::NodeIdVerificationFailed,
                 Some(metrics.clone()),
             );
-            ctx.observer.on_failure(
-                HandshakeEvent::ClientHelloVerificationFailed,
-                FailureReason::NodeIdVerificationFailed,
-                Some(metrics),
+            tracing::warn!(
+                "NodeId verification failed (WARN-ONLY for app compat): did={} device_id={} err={}",
+                &self.identity.did[..self.identity.did.len().min(24)],
+                &self.identity.device_id[..self.identity.device_id.len().min(16)],
+                e,
             );
-            return Err(e);
         }
 
         // 5. CRITICAL: Validate timestamp (prevent replay attacks)
@@ -1401,8 +1413,15 @@ impl ServerHello {
             return Err(anyhow!("Channel binding mismatch"));
         }
 
-        // 4. CRITICAL: Verify NodeId derivation
-        self.identity.verify_node_id()?;
+        // 4. Verify NodeId derivation — WARN-ONLY for app-compat (see ClientHello::verify_signature step 4).
+        if let Err(e) = self.identity.verify_node_id() {
+            tracing::warn!(
+                "ServerHello: NodeId verification failed (WARN-ONLY for app compat): did={} device_id={} err={}",
+                &self.identity.did[..self.identity.did.len().min(24)],
+                &self.identity.device_id[..self.identity.device_id.len().min(16)],
+                e,
+            );
+        }
 
         // 5. CRITICAL: Validate timestamp
         validate_timestamp(self.timestamp, &ctx.timestamp_config)?;
@@ -1591,10 +1610,16 @@ impl ClientFinish {
         }
 
         // === MUTUAL AUTHENTICATION: Verify server before completing handshake ===
-        server_hello
-            .identity
-            .verify_node_id()
-            .map_err(|e| anyhow!("Server NodeId verification failed: {}", e))?;
+        // NodeId derivation check is WARN-ONLY for app-compat (see
+        // ClientHello::verify_signature step 4 for rationale).
+        if let Err(e) = server_hello.identity.verify_node_id() {
+            tracing::warn!(
+                "ClientFinish: server NodeId verification failed (WARN-ONLY for app compat): did={} device_id={} err={}",
+                &server_hello.identity.did[..server_hello.identity.did.len().min(24)],
+                &server_hello.identity.device_id[..server_hello.identity.device_id.len().min(16)],
+                e,
+            );
+        }
 
         validate_timestamp(server_hello.timestamp, &ctx.timestamp_config)
             .map_err(|e| anyhow!("Server timestamp validation failed: {}", e))?;

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -952,10 +952,21 @@ impl NetworkHandler {
         let blocks_count = blockchain.query_block_count();
         let pending_count = blockchain.query_pending_count();
 
+        // A node DID may be present in `validator_registry` (seeded from
+        // bootstrap config at startup) without a corresponding entry in
+        // `identity_registry` (which is only populated by on-chain
+        // IdentityRegistration transactions). Validator/observer nodes that
+        // come from bootstrap config legitimately don't have an on-chain
+        // identity tx and shouldn't report themselves as
+        // `identity_not_registered` — that label is for fresh nodes that
+        // haven't completed their first-time setup yet.
+        let node_is_known_validator = blockchain.query_validator(&node_did).is_some();
+        let identity_known_to_chain = identity_registered || node_is_known_validator;
+
         // Determine detailed node state
         let state = if node_did == "not_initialized" {
             "setup_required"
-        } else if !identity_registered {
+        } else if !identity_known_to_chain {
             "identity_not_registered"
         } else if chain_height == 0 {
             "connecting"


### PR DESCRIPTION
## Summary

Two production fixes deployed today during the mobile-app incident response (clients couldn't reach any node):

1. **`lib-network/src/handshake/mod.rs`** — switch the four `verify_node_id()` checks (ClientHello step 4, ServerHello step 4, ClientFinish server check) from `return Err` to `tracing::warn!`. Deployed mobile-app builds compute NodeId via a derivation that doesn't match the server-side `NodeId::from_did_device` rule, so every handshake was being rejected. The downstream Dilithium signature check at step 8 still verifies the client's signature against the public_key embedded in the ClientHello — that's the real impersonation gate; NodeId derivation collision-protection is weakened but not bypassable for identity spoofing without holding the matching private key.

2. **`zhtp/src/api/handlers/network/mod.rs`** — `/api/v1/node/status` was returning `state: "identity_not_registered"` on every validator because the resolver only consulted `identity_registry` (populated by on-chain `IdentityRegistration` txes). Bootstrap-seeded validators legitimately don't have one and are known via `validator_registry` instead. The mobile app was reading `state` to decide reachability and treating every validator as unreachable. Accept `blockchain.query_validator(&node_did).is_some()` as also satisfying the "identity known to chain" condition.

## Status

Both fixes were live-deployed today to g1/g2/g3/g5 and verified working. This PR brings development in sync with the deployed binary so the next non-stashed deploy doesn't regress mobile connectivity.

## Follow-up

The NodeId WARN-only mode is temporary. Restore strict rejection once the app build derives NodeId per the canonical `Blake3(DID || device_id)` rule and is the only build in the wild.

## Test plan

- [x] Builds clean (`cargo build --profile dev-release -p zhtp`)
- [x] Live verified on g1/g2/g3/g5