### PR TITLE
refactor(#2636): Phase 2a — migrate blocks read sites to facade

### DIFF
--- a/zhtp-cli/src/commands/genesis.rs
+++ b/zhtp-cli/src/commands/genesis.rs
@@ -29,7 +29,9 @@ fn cmd_build(config: Option<PathBuf>, output: Option<PathBuf>) -> Result<()> {
     let bc = cfg
         .build_block0()
         .context("Failed to build genesis block")?;
-    let block0 = bc.blocks.first().context("No genesis block")?;
+    // #2636: get_block(0) is the facade for "genesis" — correct even on a
+    // store-backed chain where the in-memory window no longer starts at height 0.
+    let block0 = bc.get_block(0).context("No genesis block")?;
     let hash = block0.header.block_hash;
     let hash_hex = hex::encode(hash.as_bytes());
 

--- a/zhtp/src/api/server.rs
+++ b/zhtp/src/api/server.rs
@@ -300,10 +300,12 @@ impl ZhtpServer {
 
         let blockchain_stats = {
             let blockchain = self.blockchain.read().await;
-            let block_count = blockchain.blocks.len();
+            // #2636: block_count() is the full chain length; iter_blocks() sums
+            // transactions across the whole chain (hot window + sled), not just
+            // the in-memory window the previous `blocks` reads saw.
+            let block_count = blockchain.block_count() as usize;
             let transaction_count = blockchain
-                .blocks
-                .iter()
+                .iter_blocks()
                 .map(|block| block.transactions.len())
                 .sum::<usize>();
             (block_count, transaction_count)

--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -857,7 +857,7 @@ impl Component for BlockchainComponent {
         if let Ok(global) = global_blockchain {
             let blockchain = global.read().await;
             metrics.insert("chain_height".to_string(), blockchain.height as f64);
-            metrics.insert("total_blocks".to_string(), blockchain.blocks.len() as f64);
+            metrics.insert("total_blocks".to_string(), blockchain.block_count() as f64);
             metrics.insert(
                 "pending_transactions".to_string(),
                 blockchain.pending_transactions.len() as f64,
@@ -869,20 +869,25 @@ impl Component for BlockchainComponent {
             );
             metrics.insert("total_work".to_string(), blockchain.total_work as f64);
 
-            let avg_block_size = if blockchain.blocks.len() > 0 {
-                blockchain
-                    .blocks
-                    .iter()
-                    .map(|b| b.transactions.len())
-                    .sum::<usize>() as f64
-                    / blockchain.blocks.len() as f64
-            } else {
-                0.0
+            let avg_block_size = {
+                // #2636: full-chain average via iter_blocks() (hot window + sled).
+                // The previous `blocks.len()` only averaged the in-memory window;
+                // block_count() is the cheap full-chain denominator.
+                let total = blockchain.block_count();
+                if total > 0 {
+                    blockchain
+                        .iter_blocks()
+                        .map(|b| b.transactions.len())
+                        .sum::<usize>() as f64
+                        / total as f64
+                } else {
+                    0.0
+                }
             };
             metrics.insert("avg_transactions_per_block".to_string(), avg_block_size);
         } else if let Some(ref blockchain) = *self.blockchain.read().await {
             metrics.insert("chain_height".to_string(), blockchain.height as f64);
-            metrics.insert("total_blocks".to_string(), blockchain.blocks.len() as f64);
+            metrics.insert("total_blocks".to_string(), blockchain.block_count() as f64);
             metrics.insert(
                 "pending_transactions".to_string(),
                 blockchain.pending_transactions.len() as f64,
@@ -894,15 +899,20 @@ impl Component for BlockchainComponent {
             );
             metrics.insert("total_work".to_string(), blockchain.total_work as f64);
 
-            let avg_block_size = if blockchain.blocks.len() > 0 {
-                blockchain
-                    .blocks
-                    .iter()
-                    .map(|b| b.transactions.len())
-                    .sum::<usize>() as f64
-                    / blockchain.blocks.len() as f64
-            } else {
-                0.0
+            let avg_block_size = {
+                // #2636: full-chain average via iter_blocks() (hot window + sled).
+                // The previous `blocks.len()` only averaged the in-memory window;
+                // block_count() is the cheap full-chain denominator.
+                let total = blockchain.block_count();
+                if total > 0 {
+                    blockchain
+                        .iter_blocks()
+                        .map(|b| b.transactions.len())
+                        .sum::<usize>() as f64
+                        / total as f64
+                } else {
+                    0.0
+                }
             };
             metrics.insert("avg_transactions_per_block".to_string(), avg_block_size);
         } else {

--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -1409,15 +1409,16 @@ impl lib_consensus::types::ConsensusBlockchainProvider for ConsensusBlockchainAd
         drop(slot);
 
         let blockchain = blockchain_arc.read().await;
-        if blockchain.blocks.is_empty() {
-            // No blocks yet - genesis
-            Ok(lib_crypto::Hash([0u8; 32]))
-        } else {
-            let latest_block = blockchain.blocks.last().unwrap();
+        // #2636: latest_block() is the facade form of `blocks.last()` (identical
+        // semantics — the in-memory hot-window tip).
+        if let Some(latest_block) = blockchain.latest_block() {
             // Convert lib_blockchain::Hash to lib_crypto::Hash
             let block_hash = latest_block.header.hash();
             let hash_bytes = block_hash.as_array();
             Ok(lib_crypto::Hash(hash_bytes))
+        } else {
+            // No blocks yet - genesis
+            Ok(lib_crypto::Hash([0u8; 32]))
         }
     }
 
@@ -1511,7 +1512,7 @@ impl lib_consensus::types::ConsensusBlockchainProvider for ConsensusBlockchainAd
         if let Some(blockchain_arc) = slot.as_ref() {
             // Blockchain is wired and ready
             if let Ok(blockchain) = blockchain_arc.try_read() {
-                return !blockchain.blocks.is_empty() || blockchain.height == 0;
+                return blockchain.latest_block().is_some() || blockchain.height == 0;
             }
         }
         false

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -2464,7 +2464,11 @@ impl RuntimeOrchestrator {
                     // Log the genesis block hash for verification/debugging.
                     // Note: Full hash verification against CANONICAL_GENESIS_HASH is done
                     // inside lib_blockchain::Blockchain::new() -> GenesisConfig::verify_hash().
-                    if let Some(genesis_block) = bc.blocks.first() {
+                    // #2636: get_block(0) is the facade for genesis. The chain was
+                    // just built in memory (single genesis block) with an empty
+                    // store, so this resolves to the in-memory genesis we are about
+                    // to persist below.
+                    if let Some(genesis_block) = bc.get_block(0) {
                         let genesis_hash = hex::encode(genesis_block.header.block_hash.as_bytes());
                         info!("🔗 Genesis block hash: {}", genesis_hash);
 
@@ -2475,7 +2479,7 @@ impl RuntimeOrchestrator {
                         store_ref
                             .begin_block(0)
                             .map_err(|e| anyhow::anyhow!("Failed to begin genesis block: {}", e))?;
-                        store_ref.append_block(genesis_block).map_err(|e| {
+                        store_ref.append_block(&genesis_block).map_err(|e| {
                             anyhow::anyhow!("Failed to append genesis block: {}", e)
                         })?;
                         store_ref.commit_block().map_err(|e| {
@@ -5425,9 +5429,9 @@ impl RuntimeOrchestrator {
 
 fn canonical_genesis_hash() -> Result<lib_blockchain::Hash> {
     let bc = lib_blockchain::genesis::GenesisConfig::from_embedded()?.build_block0()?;
+    // #2636: get_block(0) facade (store-less chain → in-memory genesis).
     let genesis = bc
-        .blocks
-        .first()
+        .get_block(0)
         .ok_or_else(|| anyhow::anyhow!("embedded genesis config produced no block 0"))?;
     Ok(genesis.header.calculate_hash())
 }
@@ -5437,9 +5441,10 @@ fn validate_local_restore_compatibility(
     allow_genesis_mismatch: bool,
 ) -> Result<()> {
     let expected_genesis_hash = canonical_genesis_hash()?;
+    // #2636: get_block(0) facade. dat_bc was loaded from a .dat snapshot with no
+    // store attached, so this reads the in-memory genesis (block 0).
     let actual_genesis_hash = dat_bc
-        .blocks
-        .first()
+        .get_block(0)
         .ok_or_else(|| anyhow::anyhow!("blockchain.dat contains no genesis block"))?
         .header
         .calculate_hash();

--- a/zhtp/src/runtime/shared_blockchain.rs
+++ b/zhtp/src/runtime/shared_blockchain.rs
@@ -100,11 +100,12 @@ impl SharedBlockchainService {
             } => {
                 let result = {
                     let blockchain = blockchain_arc.read().await;
-                    if height < blockchain.blocks.len() as u64 {
-                        Ok(Some(blockchain.blocks[height as usize].clone()))
-                    } else {
-                        Ok(None)
-                    }
+                    // #2636: get_block(height) resolves by absolute height across
+                    // the hot window AND sled. The previous `blocks[height]`
+                    // indexed the in-memory window by absolute height, which
+                    // silently returned the wrong block (or None) once the window
+                    // slid past genesis on a store-backed node.
+                    Ok(blockchain.get_block(height))
                 };
                 let _ = response_tx.send(result);
             }
@@ -112,9 +113,12 @@ impl SharedBlockchainService {
             BlockchainOperation::GetTransaction { hash, response_tx } => {
                 let result = {
                     let blockchain = blockchain_arc.read().await;
-                    // Search for transaction in all blocks
+                    // Search for transaction in all blocks.
+                    // #2636: iter_blocks() walks the full chain (hot window + sled),
+                    // so this no longer misses transactions in blocks that have
+                    // aged out of the in-memory window on a store-backed node.
                     let mut found_tx = None;
-                    for block in &blockchain.blocks {
+                    for block in blockchain.iter_blocks() {
                         for tx in &block.transactions {
                             if format!("{:?}", tx.hash()) == hash {
                                 found_tx = Some(tx.clone());
@@ -183,10 +187,9 @@ impl SharedBlockchainService {
                         let header = BlockHeader::new(
                             1, // version
                             blockchain
-                                .blocks
-                                .last()
+                                .latest_block()
                                 .map(|b| b.hash())
-                                .unwrap_or_default(), // previous hash
+                                .unwrap_or_default(), // previous hash (#2636: facade form of blocks.last())
                             Hash::default(), // data helix root (simplified)
                             timestamp,
                             blockchain.height + 1, // height

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -1145,9 +1145,10 @@ impl ZhtpUnifiedServer {
         };
         let pouw_genesis_timestamp = {
             let blockchain_guard = blockchain.read().await;
+            // #2636: get_block(0) is the facade for the genesis timestamp —
+            // correct even when the in-memory window no longer holds height 0.
             blockchain_guard
-                .blocks
-                .first()
+                .get_block(0)
                 .map(|b| b.header.timestamp)
                 .unwrap_or_else(|| {
                     SystemTime::now()
@@ -2125,7 +2126,8 @@ impl ZhtpUnifiedServer {
     pub async fn get_blockchain_stats(&self) -> Result<serde_json::Value> {
         let blockchain = self.blockchain.read().await;
         Ok(serde_json::json!({
-            "block_count": blockchain.blocks.len(),
+            // #2636: block_count() is the full chain length, not the window size.
+            "block_count": blockchain.block_count(),
             "pending_transactions": blockchain.pending_transactions.len(),
             "identity_count": blockchain.identity_registry.len(),
             "server_id": self.server_id


### PR DESCRIPTION
Closes #2636. Phase 2a of the #2645 state-unification migration.

> **Stacked PR.** Base is `phase-1-facade-divergence` (PR #2658). Merge order: #2657 → #2658 → this. I'll retarget to `development` as the stack merges down.

## What this does

Routes external `blocks` reads through the Phase 1 facade so Phase 3 (#2640) can privatize the field. `Blockchain.blocks` is a **hot window** (oldest blocks are dropped once a store is attached), so reads that assumed it was the full chain were latent bugs — three are fixed here in passing.

## Migrated — 18 read sites / 7 files

| Facade | Sites | Why |
|---|---|---|
| `block_count()` | server.rs, components/blockchain.rs (×2), unified_server.rs | `blocks.len()` was the **window size**, not chain length |
| `latest_block()` | consensus.rs (×2), shared_blockchain.rs | behavior-identical to `blocks.last()` / `is_empty()` |
| `get_block(0)` | cli genesis, mod.rs (×3), unified_server.rs | `.first()` returned the window head, **not genesis**, once the window slid |
| `get_block(height)` | shared_blockchain.rs GetBlock | **bug fix**: `blocks[height]` indexed the window by absolute height |
| `iter_blocks()` | shared_blockchain.rs GetTransaction, server.rs, blockchain.rs avg | **bug fix**: window-only scans/sums under-counted the chain |

## Bugs fixed in passing

1. **`GetBlock` operation** indexed the in-memory window by absolute height (`blocks[height]`) → returned the wrong block or `None` once the window slid past genesis on a store-backed node. Now `get_block(height)` (window + sled).
2. **`GetTransaction` operation** scanned only the window → silently missed transactions in aged-out blocks. Now `iter_blocks()` walks the full chain.
3. **genesis reads via `.first()`** returned the window head, not genesis, on a windowed chain. Now `get_block(0)`.

## Deliberately NOT migrated — 5 sites (Phase 3 / #2640)

These are **mutations or bootstrap-source reads**, not facade-able reads:
- `genesis_funding.rs:123/127` — `&mut blocks[0]` mutates the genesis block in place during genesis funding (+ its `is_empty` guard)
- `mod.rs:2243/2271` — emergency restore migrates the in-memory `.dat` snapshot **into** a freshly-attached empty store. `iter_blocks()` would read **from** the empty store and migrate nothing — in-memory is the source here. (This is precisely the breakage a blind mechanical migration would have introduced.)
- `mod.rs:6276` — a test bumps a block header version in place

They keep direct field access; Phase 3 gives them dedicated methods (a genesis mutator, an in-memory-snapshot iterator) before privatizing `blocks`. The Phase 0 CSV already flags them as Mutate rows for #2640.

## Process note

The Phase 0 read-site CSV **missed 4 multiline `.blocks` accesses** (the grep required `binding.blocks` on a single line). Found here by exhaustive per-file grep. The later phases (2b–2d) should grep per-file rather than trust the CSV line list alone — I'll do that.

## Test plan

- [ ] CI green (builds clean locally: `zhtp` + `zhtp-cli`)
- [ ] With `ZHTP_DIVERGENCE_DETECT=1` (from #2658), confirm no divergence after these reads flip — they read the same sled the detector samples
- [ ] Soak: block explorer / stats endpoints return full-chain counts (not window size); tx lookup finds txs in old blocks

## Next in the stack

Phase 2b (#2637 + #2637+) — token balance + utxo read sites, using the `token_balance()` facade from #2658.