### PR TITLE
refactor(#2637): Phase 2b — migrate token_contracts reads to facade

### DIFF
--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1032,6 +1032,22 @@ impl Blockchain {
             .unwrap_or(0)
     }
 
+    /// Sled-first iterator facade over all token contracts (#2637).
+    ///
+    /// Returns the authoritative set from the store when attached, falling back
+    /// to the in-memory map in store-less mode. Collected into a `Vec` so
+    /// callers get an owned, lifetime-free list to `.iter()` / `.len()` /
+    /// `.is_empty()` / `find()` over — the canonical replacement for direct
+    /// `token_contracts.values()` / `.keys()` / `.len()` reads.
+    pub fn iter_token_contracts(&self) -> Vec<crate::contracts::TokenContract> {
+        if let Some(store) = self.get_store() {
+            if let Ok(iter) = store.iter_token_contracts() {
+                return iter.map(|(_, c)| c).collect();
+            }
+        }
+        self.token_contracts.values().cloned().collect()
+    }
+
     pub fn register_web4_contract(
         &mut self,
         contract_id: [u8; 32],

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -32,6 +32,27 @@ fn token_balance_reads_sled_when_store_attached() {
 }
 
 #[test]
+fn iter_token_contracts_reads_sled() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("facade_iter_store")).unwrap());
+
+    let sov = crate::contracts::TokenContract::new_sov_native();
+    let sov_symbol = sov.symbol.clone();
+    store.begin_block(0).unwrap();
+    store.put_token_contract(&sov).unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+
+    let contracts = bc.iter_token_contracts();
+    assert!(
+        contracts.iter().any(|c| c.symbol == sov_symbol),
+        "iter_token_contracts must surface the sled-stored SOV contract"
+    );
+}
+
+#[test]
 fn identity_consensus_by_did_none_without_store() {
     let bc = Blockchain::new().expect("blockchain construct");
     assert!(bc.get_store().is_none(), "test assumes no store attached");

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1188,9 +1188,9 @@ impl BlockchainHandler {
         };
 
         let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
+        // #2637: get_token_contract() is the sled-first metadata facade.
         let total_supply = blockchain
-            .token_contracts
-            .get(&sov_token_id)
+            .get_token_contract(&sov_token_id)
             .map(|token| token.total_supply)
             .unwrap_or(0);
 
@@ -2445,14 +2445,16 @@ impl BlockchainHandler {
 
         let mut contracts = Vec::new();
         if contract_filter == "all" || contract_filter == "token" {
+            // #2637: iter_token_contracts() is the sled-first list facade.
+            // (contract_blocks is a separate metadata index, migrated later.)
             contracts.extend(
                 blockchain
-                    .token_contracts
-                    .keys()
-                    .map(|id| ContractListItem {
-                        contract_id: hex::encode(id),
+                    .iter_token_contracts()
+                    .into_iter()
+                    .map(|t| ContractListItem {
+                        contract_id: hex::encode(t.token_id),
                         contract_kind: "token".to_string(),
-                        block_height: blockchain.contract_blocks.get(id).copied(),
+                        block_height: blockchain.contract_blocks.get(&t.token_id).copied(),
                     }),
             );
         }

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -925,13 +925,11 @@ impl NetworkHandler {
                         // because PublicKey's Hash/PartialEq compare all fields (dilithium_pk,
                         // kyber_pk, key_id), so a synthetic PublicKey with zeroed crypto keys
                         // would never match a real entry in the balances HashMap.
+                        // #2637: token_balance() is sled-first and keyed by
+                        // key_id (the find_balance_by_key_id dance is now inside
+                        // the facade).
                         let wallet_key_id = w.wallet_id.as_array();
-                        let balance = blockchain
-                            .token_contracts
-                            .get(&sov_token_id)
-                            .and_then(|t| t.find_balance_by_key_id(&wallet_key_id))
-                            .map(|(_, bal)| bal)
-                            .unwrap_or(0);
+                        let balance = blockchain.token_balance(&sov_token_id, &wallet_key_id);
                         (Some(wallet_id_hex), balance)
                     } else {
                         (None, 0)

--- a/zhtp/src/api/handlers/oracle/mod.rs
+++ b/zhtp/src/api/handlers/oracle/mod.rs
@@ -430,8 +430,10 @@ impl OracleHandler {
                         // Epoch
                         "current_epoch": current_epoch,
                     })
-                } else if let Some(token) =
-                    bc.token_contracts.values().find(|t| t.symbol == cbe_symbol)
+                } else if let Some(token) = bc
+                    .iter_token_contracts()
+                    .into_iter()
+                    .find(|t| t.symbol == cbe_symbol)
                 {
                     // CBE exists as a standard token contract without a bonding curve price.
                     json!({
@@ -623,8 +625,10 @@ impl OracleHandler {
                         "graduation_progress_percent": stats.graduation_progress_percent,
                         "can_graduate": stats.can_graduate,
                     })
-                } else if let Some(token) =
-                    bc.token_contracts.values().find(|t| t.symbol == cbe_symbol)
+                } else if let Some(token) = bc
+                    .iter_token_contracts()
+                    .into_iter()
+                    .find(|t| t.symbol == cbe_symbol)
                 {
                     // CBE exists as a standard token contract; no bonding curve variation data.
                     json!({

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -564,11 +564,12 @@ impl TokenHandler {
     async fn handle_list_tokens(&self) -> Result<ZhtpResponse> {
         let blockchain = self.blockchain.read().await;
 
+        // #2637: iter_token_contracts() is the sled-first list facade.
         let mut tokens: Vec<TokenListItem> = blockchain
-            .token_contracts
-            .iter()
-            .map(|(id, token)| TokenListItem {
-                token_id: hex::encode(id),
+            .iter_token_contracts()
+            .into_iter()
+            .map(|token| TokenListItem {
+                token_id: hex::encode(token.token_id),
                 name: token.name.clone(),
                 symbol: token.symbol.clone(),
                 decimals: token.decimals,
@@ -653,8 +654,8 @@ impl TokenHandler {
 
         // Check if any existing token uses this symbol (case-insensitive)
         let existing_token = blockchain
-            .token_contracts
-            .values()
+            .iter_token_contracts()
+            .into_iter()
             .find(|token| token.symbol.to_uppercase() == symbol_upper);
 
         match existing_token {
@@ -779,9 +780,9 @@ impl TokenHandler {
             .iter()
             .any(|b| b.get("token_id").and_then(|v| v.as_str()) == Some(&native_token_id_hex));
         if !has_sov {
+            // #2637: get_token_contract() is the sled-first metadata facade.
             let (name, symbol, decimals) = blockchain
-                .token_contracts
-                .get(&native_token_id)
+                .get_token_contract(&native_token_id)
                 .map(|t| (t.name.clone(), t.symbol.clone(), t.decimals))
                 .unwrap_or_else(|| ("Sovereign".to_string(), "SOV".to_string(), 8));
 

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -381,23 +381,16 @@ impl WalletHandler {
                 let blockchain = self.blockchain.read().await;
                 let wallet_id_bytes_opt =
                     hex::decode(&wallet_id_hex).ok().filter(|b| b.len() == 32);
+                // #2637: token_balance() is sled-first and keyed by key_id. This
+                // also fixes a latent bug — the old synthetic PublicKey (zeroed
+                // dilithium/kyber, key_id only) never matched balance_of's
+                // full-field key equality, so this path returned 0.
                 wallet_id_bytes_opt
                     .as_ref()
-                    .and_then(|bytes| {
-                        blockchain
-                            .token_contracts
-                            .get(&sov_token_id)
-                            .and_then(|token| {
-                                let mut key_id = [0u8; 32];
-                                key_id.copy_from_slice(bytes);
-                                let wallet_key =
-                                    lib_blockchain::integration::crypto_integration::PublicKey {
-                                        dilithium_pk: [0u8; 2592],
-                                        kyber_pk: [0u8; 1568],
-                                        key_id,
-                                    };
-                                Some(token.balance_of(&wallet_key))
-                            })
+                    .map(|bytes| {
+                        let mut key_id = [0u8; 32];
+                        key_id.copy_from_slice(bytes);
+                        blockchain.token_balance(&sov_token_id, &key_id)
                     })
                     .unwrap_or(0)
             };
@@ -531,34 +524,29 @@ impl WalletHandler {
                 let blockchain = self.blockchain.read().await;
                 let wallet_id_hex = hex::encode(summary.id.0);
                 if let Some(wallet_data) = blockchain.query_wallet(&wallet_id_hex) {
-                    if let Some(token) = blockchain
-                        .token_contracts
-                        .get(&lib_blockchain::contracts::utils::generate_lib_token_id())
-                    {
-                        let wallet_id_bytes = hex::decode(&wallet_id_hex).ok();
-                        let token_balance = if let Some(bytes) = wallet_id_bytes {
-                            if bytes.len() == 32 {
+                    // #2637: sled-first SOV balance. Gate on the contract existing
+                    // (preserves the prior "only override if SOV token present"
+                    // behavior) then read via token_balance(), keyed by key_id.
+                    // The SOV balance is keyed by wallet_id (the normal 32-byte
+                    // path); fall back to the wallet public key's key_id otherwise.
+                    // This also fixes the old synthetic-PublicKey bug that returned 0.
+                    let native_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
+                    if blockchain.get_token_contract(&native_token_id).is_some() {
+                        let addr: [u8; 32] = match hex::decode(&wallet_id_hex)
+                            .ok()
+                            .filter(|b| b.len() == 32)
+                        {
+                            Some(bytes) => {
                                 let mut key_id = [0u8; 32];
                                 key_id.copy_from_slice(&bytes);
-                                let wallet_key =
-                                    lib_blockchain::integration::crypto_integration::PublicKey {
-                                        dilithium_pk: [0u8; 2592],
-                                        kyber_pk: [0u8; 1568],
-                                        key_id,
-                                    };
-                                token.balance_of(&wallet_key)
-                            } else {
-                                token.balance_of(&lib_blockchain::integration::crypto_integration::PublicKey::new(
-                                    wallet_data.public_key.as_slice().try_into().unwrap_or([0u8; 2592])
-                                ))
+                                key_id
                             }
-                        } else {
-                            token.balance_of(
-                                &lib_blockchain::integration::crypto_integration::PublicKey::new(
-                                    wallet_data.public_key.as_slice().try_into().unwrap_or([0u8; 2592]),
-                                ),
+                            None => lib_blockchain::integration::crypto_integration::PublicKey::new(
+                                wallet_data.public_key.as_slice().try_into().unwrap_or([0u8; 2592]),
                             )
+                            .key_id,
                         };
+                        let token_balance = blockchain.token_balance(&native_token_id, &addr);
                         if token_balance != available_balance {
                             tracing::debug!(
                                 "Using SOV token balance for wallet {}: {} (was {})",

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -396,18 +396,18 @@ impl Web4Handler {
                 key_id: owner_wallet_id.into(),
             };
 
-            // Check if SOV token contract exists
-            let sov_token = blockchain
-                .token_contracts
-                .get(&sov_token_id)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "SOV token contract not initialized. Network may still be bootstrapping."
-                    )
-                })?;
+            // #2637: keep the existence check, but read the balance via the
+            // sled-first token_balance() facade keyed by key_id. (Also fixes the
+            // synthetic-PublicKey balance_of bug that returned 0 — owner_wallet_key
+            // has zeroed dilithium/kyber, so it never matched balance_of.)
+            if blockchain.get_token_contract(&sov_token_id).is_none() {
+                return Err(anyhow!(
+                    "SOV token contract not initialized. Network may still be bootstrapping."
+                ));
+            }
 
             // Check user's SOV balance
-            let user_sov_balance = sov_token.balance_of(&owner_wallet_key);
+            let user_sov_balance = blockchain.token_balance(&sov_token_id, &owner_wallet_key.key_id);
 
             info!(
                 " User SOV balance: {} SOV (need {} SOV)",


### PR DESCRIPTION
Closes #2637 (token_contracts). Phase 2b of the #2645 state-unification migration.

> **Stacked PR.** Base is `phase-2a-blocks-migration` (PR #2659). Merge order: #2657 → #2658 → #2659 → this.

## What this does

Routes external `token_contracts` **reads** through sled-first facades so Phase 3 (#2640) can privatize the field. Adds one facade and **fixes three latent balance-read bugs** in passing.

## New facade

`Blockchain::iter_token_contracts() -> Vec<TokenContract>` — sled-first list, in-mem fallback when store-less. Canonical replacement for direct `.values()`/`.keys()`/`.iter()` reads. (`token_balance()` and `get_token_contract()` already existed.)

## Migrated

| Kind | Facade | Sites |
|---|---|---|
| balance | `token_balance()` | network, wallet (×2), web4/domains |
| metadata | `get_token_contract()` | token (name/symbol/decimals), blockchain (total_supply) |
| aggregate | `iter_token_contracts()` | token (list, find-by-symbol), oracle (×2 find-by-symbol), blockchain (contract list) |

### 🐛 Bug fixed: synthetic-key balances returned 0

Three balance reads built a synthetic `PublicKey { dilithium_pk: [0;2592], kyber_pk: [0;1568], key_id }` and called `balance_of()`. But `PublicKey`'s `Hash`/`Eq` compare **all** fields, so the synthetic key never matched the real entry in the balances map — **these reads silently returned 0**. `token_balance()` reads sled keyed by `key_id` (`Address`), so they now return the real balance. (One call site, `network/mod.rs`, had already worked around this with `find_balance_by_key_id` + a comment explaining the trap.) The web4/domains "SOV not initialized" error is preserved via a `get_token_contract().is_none()` guard.

## NOT migrated (intentional)

- **Mutations → Phase 3 / #2640**: `token_contracts.insert` / `get_mut` in the runtime SOV-init clusters, `genesis_funding`, and `web4/domains:1024` (a debit/credit that carries its own TODO admitting it diverges state and must move into block processing). The adjacent count/log reads that also touch `utxo_set` stay with them.
- **No-facade-yet**: `tools/chain_audit.rs` sums **all** balances of a token — needs a sled balance-iteration facade (sled keeps balances in a separate tree from the `TokenContract`), tracked as follow-up. Tool only.

## utxo (#2637+) — split to its own issue

`utxo_set` has **no facade**: in-mem `HashMap<Hash, TransactionOutput>` vs sled `OutPoint → Utxo` is a real type impedance (key shape *and* value type differ), deferred from Phase 1. Building it is genuine design, not a mechanical swap — so utxo migration gets its own issue rather than being rushed in here. **(Filing now; will link.)**

## Process note

The Phase 0 CSV **under-counted `token_contracts`** (~17 listed vs ~28 actual) because most accesses are multiline. Found by exhaustive per-file grep. Same lesson as 2a — grep per file, don't trust the CSV line list.

## Test plan

- [ ] CI green (builds clean: lib-blockchain + zhtp; 4 facade tests pass incl. new `iter_token_contracts_reads_sled`)
- [ ] With `ZHTP_DIVERGENCE_DETECT=1`, confirm token-balance reads agree with sled
- [ ] **Regression to verify the bug fix**: wallet/network balance endpoints now report real SOV balances where they previously may have shown 0

## Next in the stack

Phase 2c (#2638) — token nonce reads (small), then Phase 2d (#2639) validator+identity+wallet.