### PR TITLE
fix(identity): Council role gets CouncilView, not FullIdentityView

### DIFF
--- a/lib-identity/src/identity/manager.rs
+++ b/lib-identity/src/identity/manager.rs
@@ -304,8 +304,8 @@ impl IdentityManager {
         // Council was previously in this branch under a "testnet:
         // council has full access" comment, which bypassed the
         // dedicated `CouncilView` and gave every council member
-        // unrestricted access to wallet manifests, credentials,
-        // attestations, and `owner_identity_id` — a privilege
+        // unrestricted access to private identity fields (metadata,
+        // device_node_ids, credentials, attestations, and `owner_identity_id`) — a privilege
         // escalation past the scoped investigation surface the access
         // policy documents. Council is now handled exclusively by the
         // `Council + Investigate` branch a few lines below, which

--- a/lib-identity/src/identity/manager.rs
+++ b/lib-identity/src/identity/manager.rs
@@ -299,14 +299,26 @@ impl IdentityManager {
             dao_member_id: identity.dao_member_id.clone(),
         };
 
-        // Full view: self, system, emergency, or council (testnet: council has full access).
+        // Full view: self, system, or emergency override only.
+        //
+        // Council was previously in this branch under a "testnet:
+        // council has full access" comment, which bypassed the
+        // dedicated `CouncilView` and gave every council member
+        // unrestricted access to wallet manifests, credentials,
+        // attestations, and `owner_identity_id` — a privilege
+        // escalation past the scoped investigation surface the access
+        // policy documents. Council is now handled exclusively by the
+        // `Council + Investigate` branch a few lines below, which
+        // returns the intended `CouncilView`. The regression test
+        // `test_council_principal_gets_council_view` exercises this
+        // and was failing on `cargo test -p lib-identity` because of
+        // this bug.
         let has_emergency_override = principal.role == lib_access_control::Role::Emergency
             && principal
                 .capabilities
                 .contains(&lib_access_control::Capability::EmergencyOverride);
         if matches!(relation, SubjectRelation::Self_)
             || principal.role == lib_access_control::Role::System
-            || principal.role == lib_access_control::Role::Council
             || has_emergency_override
         {
             return Some(IdentityView::Full(FullIdentityView {


### PR DESCRIPTION
## Summary

Removes Council from the `FullIdentityView` branch in `IdentityManager::get_identity_view` (`lib-identity/src/identity/manager.rs:309`). Council members were receiving unrestricted `IdentityView::Full` — wallet manifests, credentials, attestations, `owner_identity_id` — instead of the scoped `CouncilView` the access policy is documented to grant. That's a privilege escalation past the investigation surface.

The fix is one condition: drop `|| principal.role == lib_access_control::Role::Council` from the early-return branch that produces `FullIdentityView`. Council is then handled by the dedicated `Council + Investigate` branch a few lines below, which already returns `CouncilView`. The previous code was carrying a `testnet: council has full access` shortcut that should have been narrowed when CouncilView landed.

## Test

`test_council_principal_gets_council_view` (`lib-identity/src/identity/manager.rs:1494`) had been failing on `cargo test -p lib-identity` because of this bug.

```
running 1 test
test identity::manager::access_control_tests::test_council_principal_gets_council_view ... ok
```

## Credit

Originally identified by **Harley Ross / @officialredroleplays-ui** in #2651 and re-flagged in #2656. Both of those PRs bundled the fix with a large amount of unrelated changes (62 files in #2656 including duplicate definitions that don't compile, plus a GitHub project-board automation script). Re-doing here as a clean focused change so it can land.

## Test plan

- [x] `cargo test -p lib-identity --lib test_council_principal_gets_council_view` passes
- [x] No other files touched; the test that was failing on `development` now passes