### PR TITLE
fix(#2636): blocks field — windowing-correct reads, internal + external (field-atomic)

### DIFF
--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -93,7 +93,12 @@ impl Blockchain {
     pub fn rebuild_pouw_mint_index(&mut self) {
         self.pouw_mint_index.clear();
         let mut total = 0usize;
-        for block in &self.blocks {
+        // #2636: materialize the full chain (window + sled) up front. iter_blocks()
+        // borrows &self, but the loop body mutates self.pouw_mint_index, so we
+        // can't iterate it lazily here; the previous `&self.blocks` scan also
+        // silently bounded the rebuild to the hot window on a pruned node.
+        let blocks: Vec<crate::block::Block> = self.iter_blocks().collect();
+        for block in &blocks {
             let height = block.height();
             for tx in &block.transactions {
                 if tx.transaction_type != TransactionType::TokenMint {
@@ -784,7 +789,11 @@ impl Blockchain {
     }
 
     pub(super) fn reprocess_contract_executions(&mut self) -> Result<()> {
-        let block_count = self.blocks.len();
+        // #2636: full chain (window + sled), materialized up front since the
+        // loop mutates self. The previous `self.blocks` scan only reprocessed
+        // the hot window on a pruned node.
+        let blocks: Vec<crate::block::Block> = self.iter_blocks().collect();
+        let block_count = blocks.len();
         if block_count == 0 {
             return Ok(());
         }
@@ -797,7 +806,7 @@ impl Blockchain {
         let mut tokens_found = 0;
         let mut contract_txs_found = 0;
 
-        for block in &self.blocks.clone() {
+        for block in &blocks {
             for transaction in &block.transactions {
                 if transaction.transaction_type == TransactionType::ContractExecution {
                     contract_txs_found += 1;

--- a/lib-blockchain/src/blockchain/dao.rs
+++ b/lib-blockchain/src/blockchain/dao.rs
@@ -207,12 +207,13 @@ impl Blockchain {
     }
 
     pub fn get_dao_proposals(&self) -> Vec<crate::transaction::DaoProposalData> {
-        self.blocks
-            .iter()
-            .flat_map(|block| &block.transactions)
+        // #2636: iter_blocks() walks the full chain (window + sled); scanning
+        // self.blocks only saw the hot window, silently truncating DAO history
+        // on a store-backed node.
+        self.iter_blocks()
+            .flat_map(|block| block.transactions)
             .filter(|tx| tx.transaction_type == TransactionType::DaoProposal)
-            .filter_map(|tx| tx.dao_proposal_data())
-            .cloned()
+            .filter_map(|tx| tx.dao_proposal_data().cloned())
             .collect()
     }
 
@@ -220,46 +221,42 @@ impl Blockchain {
         &self,
         proposal_id: &Hash,
     ) -> Option<crate::transaction::DaoProposalData> {
-        self.blocks
-            .iter()
-            .flat_map(|block| &block.transactions)
+        // #2636: full-chain scan via iter_blocks() (window + sled).
+        self.iter_blocks()
+            .flat_map(|block| block.transactions)
             .filter(|tx| tx.transaction_type == TransactionType::DaoProposal)
-            .filter_map(|tx| tx.dao_proposal_data())
+            .filter_map(|tx| tx.dao_proposal_data().cloned())
             .find(|proposal| &proposal.proposal_id == proposal_id)
-            .cloned()
     }
 
     pub fn get_dao_votes_for_proposal(
         &self,
         proposal_id: &Hash,
     ) -> Vec<crate::transaction::DaoVoteData> {
-        self.blocks
-            .iter()
-            .flat_map(|block| &block.transactions)
+        // #2636: full-chain scan via iter_blocks() (window + sled).
+        self.iter_blocks()
+            .flat_map(|block| block.transactions)
             .filter(|tx| tx.transaction_type == TransactionType::DaoVote)
-            .filter_map(|tx| tx.dao_vote_data())
+            .filter_map(|tx| tx.dao_vote_data().cloned())
             .filter(|vote| &vote.proposal_id == proposal_id)
-            .cloned()
             .collect()
     }
 
     pub fn get_all_dao_votes(&self) -> Vec<crate::transaction::DaoVoteData> {
-        self.blocks
-            .iter()
-            .flat_map(|block| &block.transactions)
+        // #2636: full-chain scan via iter_blocks() (window + sled).
+        self.iter_blocks()
+            .flat_map(|block| block.transactions)
             .filter(|tx| tx.transaction_type == TransactionType::DaoVote)
-            .filter_map(|tx| tx.dao_vote_data())
-            .cloned()
+            .filter_map(|tx| tx.dao_vote_data().cloned())
             .collect()
     }
 
     pub fn get_dao_executions(&self) -> Vec<crate::transaction::DaoExecutionData> {
-        self.blocks
-            .iter()
-            .flat_map(|block| &block.transactions)
+        // #2636: full-chain scan via iter_blocks() (window + sled).
+        self.iter_blocks()
+            .flat_map(|block| block.transactions)
             .filter(|tx| tx.transaction_type == TransactionType::DaoExecution)
-            .filter_map(|tx| tx.dao_execution_data())
-            .cloned()
+            .filter_map(|tx| tx.dao_execution_data().cloned())
             .collect()
     }
 
@@ -343,7 +340,9 @@ impl Blockchain {
 
     pub fn rebuild_dao_registry_index(&mut self) {
         let mut rebuilt: HashMap<[u8; 32], DaoRegistryIndexEntry> = HashMap::new();
-        for block in &self.blocks {
+        // #2636: full-chain scan via iter_blocks() (window + sled) so the index
+        // rebuild isn't silently bounded to the hot window on a pruned node.
+        for block in self.iter_blocks() {
             for tx in &block.transactions {
                 if let Some(entry) = Self::dao_registry_entry_from_tx(tx, block.header.height) {
                     rebuilt.entry(entry.dao_id).or_insert(entry);

--- a/lib-blockchain/src/blockchain/test_utils.rs
+++ b/lib-blockchain/src/blockchain/test_utils.rs
@@ -48,7 +48,7 @@ impl Blockchain {
             Signature::default(),
             vec![],
         );
-        self.blocks.push(Self::make_minimal_test_block(vec![tx]));
+        self.push_test_block(vec![tx]);
     }
 
     /// Push a governance-parameter-update DAO proposal into `self.blocks` for test use.
@@ -89,7 +89,7 @@ impl Blockchain {
             Signature::default(),
             vec![],
         );
-        self.blocks.push(Self::make_minimal_test_block(vec![tx]));
+        self.push_test_block(vec![tx]);
     }
 
     /// Push a minimal DAO vote into `self.blocks` for test use.
@@ -112,7 +112,7 @@ impl Blockchain {
             Signature::default(),
             vec![],
         );
-        self.blocks.push(Self::make_minimal_test_block(vec![tx]));
+        self.push_test_block(vec![tx]);
     }
 
     /// Credit SOV directly to the DAO treasury wallet.
@@ -221,6 +221,19 @@ impl Blockchain {
             },
             transactions,
         }
+    }
+
+    /// Append a minimal test block at the next height AND bump `self.height`,
+    /// keeping the blocks/height invariant that production maintains. Required
+    /// because the facade scans (`get_dao_*`, etc.) now walk the chain via
+    /// `iter_blocks()` (`0..=height`) — pushing to `self.blocks` without
+    /// updating `height` leaves the block invisible to those scans (#2636).
+    fn push_test_block(&mut self, transactions: Vec<Transaction>) {
+        let next_height = self.height + 1;
+        let mut block = Self::make_minimal_test_block(transactions);
+        block.header.height = next_height;
+        self.blocks.push(block);
+        self.height = next_height;
     }
 
 }

--- a/lib-blockchain/src/blockchain/tests/replay_contract_execution_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/replay_contract_execution_tests.rs
@@ -306,6 +306,9 @@ fn dao_registry_index_incremental_matches_rebuild() {
     }
 
     let mut rebuilt = Blockchain::default();
+    // Keep blocks/height consistent as production does — rebuild now walks the
+    // chain via iter_blocks() (0..=height), not the raw blocks Vec (#2636).
+    rebuilt.height = block2.header.height;
     rebuilt.blocks.push(block1);
     rebuilt.blocks.push(block2);
     rebuilt.rebuild_dao_registry_index();

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -142,7 +142,10 @@ impl Blockchain {
             return true;
         }
 
-        self.blocks.iter().any(|block| {
+        // #2636: scan the full chain (window + sled). The previous self.blocks
+        // scan only saw the hot window, so a wallet registered in an aged-out
+        // block was wrongly reported as absent from canonical history.
+        self.iter_blocks().any(|block| {
             block.transactions.iter().any(|tx| {
                 tx.wallet_data()
                     .map(|wallet_data| wallet_data.wallet_id == *wallet_id)

--- a/lib-blockchain/src/integration/storage_integration.rs
+++ b/lib-blockchain/src/integration/storage_integration.rs
@@ -801,8 +801,11 @@ impl BlockchainStorageManager {
         results.push(state_result);
 
         // 2. Backup individual blocks
-        for block in &blockchain.blocks {
-            match self.store_block(block).await {
+        // #2636: iter_blocks() backs up the FULL chain (window + sled); the
+        // previous `blockchain.blocks` loop silently backed up only the hot
+        // window on a pruned node.
+        for block in blockchain.iter_blocks() {
+            match self.store_block(&block).await {
                 Ok(result) => results.push(result),
                 Err(e) => {
                     error!(
@@ -1595,7 +1598,7 @@ mod tests {
         let mut manager = BlockchainStorageManager::new(config).await?;
 
         let blockchain = Blockchain::new()?;
-        let genesis_block = blockchain.blocks[0].clone();
+        let genesis_block = blockchain.get_block(0).expect("genesis block"); // #2636
         drop(blockchain); // Free the massive Blockchain struct early
 
         // Store block

--- a/lib-blockchain/src/query_impl.rs
+++ b/lib-blockchain/src/query_impl.rs
@@ -15,7 +15,9 @@ impl BlockchainQuery for Blockchain {
     }
 
     fn query_block_count(&self) -> usize {
-        self.blocks.len()
+        // #2636: full chain length, not the hot-window size (`self.blocks.len()`
+        // under-counts once the window slides on a store-backed node).
+        self.block_count() as usize
     }
 
     fn query_block(&self, height: u64) -> Option<Block> {
@@ -155,12 +157,16 @@ impl BlockchainQuery for Blockchain {
     }
 
     fn query_block_range(&self, start: u64, end: u64) -> Vec<Block> {
-        let start = start as usize;
-        let end = (end as usize).min(self.blocks.len().saturating_sub(1));
-        if start >= self.blocks.len() || start > end {
+        // #2636: `start`/`end` are ABSOLUTE heights. `self.blocks` is only the
+        // hot window, so `self.blocks[start..=end]` indexed it by absolute
+        // height — returning the wrong blocks (or empty) once the window slid
+        // past genesis on a store-backed node. get_block(h) resolves each height
+        // across the window AND sled.
+        let end = end.min(self.height);
+        if start > end {
             return Vec::new();
         }
-        self.blocks[start..=end].to_vec()
+        (start..=end).filter_map(|h| self.get_block(h)).collect()
     }
 }
 

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -2247,7 +2247,7 @@ impl<'a> StatefulTransactionValidator<'a> {
         if transaction.transaction_type == TransactionType::TokenMint {
             if let Some(blockchain) = self.blockchain {
                 if blockchain.height == 0
-                    && blockchain.blocks.is_empty()
+                    && blockchain.latest_block().is_none() // #2636: facade form of blocks.is_empty()
                     && transaction.signature.signature.is_empty()
                 {
                     skip_signature = true; // Allow genesis TokenMint without signature

--- a/zhtp-cli/src/commands/genesis.rs
+++ b/zhtp-cli/src/commands/genesis.rs
@@ -29,7 +29,9 @@ fn cmd_build(config: Option<PathBuf>, output: Option<PathBuf>) -> Result<()> {
     let bc = cfg
         .build_block0()
         .context("Failed to build genesis block")?;
-    let block0 = bc.blocks.first().context("No genesis block")?;
+    // #2636: get_block(0) is the facade for "genesis" — correct even on a
+    // store-backed chain where the in-memory window no longer starts at height 0.
+    let block0 = bc.get_block(0).context("No genesis block")?;
     let hash = block0.header.block_hash;
     let hash_hex = hex::encode(hash.as_bytes());
 

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1113,8 +1113,13 @@ impl BlockchainHandler {
         let blockchain_arc = self.get_blockchain().await?;
         let blockchain = blockchain_arc.read().await;
 
-        // #2636: full chain via iter_blocks(); query_blocks() summed only the window.
-        let total: usize = blockchain.iter_blocks().map(|b| b.transactions.len()).sum();
+        // #2636: materialize the full chain once (window + sled), then both
+        // count and iterate over the same vector. iter_blocks() on a
+        // store-backed node calls get_block(h) per block; doing it twice
+        // (once for total, once for the loop) doubles the sled work per
+        // request — measurable latency hit on long chains.
+        let all_blocks: Vec<_> = blockchain.iter_blocks().collect();
+        let total: usize = all_blocks.iter().map(|b| b.transactions.len()).sum();
         let total_pages = if total == 0 {
             0
         } else {
@@ -1125,8 +1130,6 @@ impl BlockchainHandler {
         let mut skipped = 0usize;
         let mut transactions = Vec::new();
 
-        // #2636: materialize the full chain (window + sled), then iterate newest-first.
-        let all_blocks: Vec<_> = blockchain.iter_blocks().collect();
         for block in all_blocks.iter().rev() {
             for tx in block.transactions.iter().rev() {
                 if skipped < offset {

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1113,7 +1113,8 @@ impl BlockchainHandler {
         let blockchain_arc = self.get_blockchain().await?;
         let blockchain = blockchain_arc.read().await;
 
-        let total: usize = blockchain.query_blocks().iter().map(|b| b.transactions.len()).sum();
+        // #2636: full chain via iter_blocks(); query_blocks() summed only the window.
+        let total: usize = blockchain.iter_blocks().map(|b| b.transactions.len()).sum();
         let total_pages = if total == 0 {
             0
         } else {
@@ -1124,7 +1125,9 @@ impl BlockchainHandler {
         let mut skipped = 0usize;
         let mut transactions = Vec::new();
 
-        for block in blockchain.query_blocks().iter().rev() {
+        // #2636: materialize the full chain (window + sled), then iterate newest-first.
+        let all_blocks: Vec<_> = blockchain.iter_blocks().collect();
+        for block in all_blocks.iter().rev() {
             for tx in block.transactions.iter().rev() {
                 if skipped < offset {
                     skipped += 1;
@@ -1177,7 +1180,9 @@ impl BlockchainHandler {
 
         let avg_block_time_secs = if blockchain.query_block_count() >= 2 {
             let mut total_delta = 0u64;
-            for window in blockchain.query_blocks().windows(2) {
+            // #2636: full chain (window + sled), materialized for windows(2).
+            let all_blocks: Vec<_> = blockchain.iter_blocks().collect();
+            for window in all_blocks.windows(2) {
                 let a = window[0].header.timestamp;
                 let b = window[1].header.timestamp;
                 total_delta = total_delta.saturating_add(b.saturating_sub(a));
@@ -1281,7 +1286,9 @@ impl BlockchainHandler {
                 }));
             }
 
-            for block in blockchain.query_blocks().iter().rev() {
+            // #2636: full chain (window + sled), newest-first.
+            let all_blocks: Vec<_> = blockchain.iter_blocks().collect();
+            for block in all_blocks.iter().rev() {
                 if let Some(tx) = block.transactions.iter().find(|tx| tx.hash() == tx_hash) {
                     let confirmations = latest_height.saturating_sub(block.header.height) + 1;
                     return Some(serde_json::json!({
@@ -1978,7 +1985,7 @@ impl BlockchainHandler {
         }
 
         // Search through all blocks for the transaction
-        for (_block_index, block) in blockchain.query_blocks().iter().enumerate() {
+        for (_block_index, block) in blockchain.iter_blocks().enumerate() {
             if let Some(confirmed_tx) = block.transactions.iter().find(|tx| tx.hash() == tx_hash) {
                 let transaction_info = Self::tx_to_info(confirmed_tx);
 
@@ -2297,7 +2304,7 @@ impl BlockchainHandler {
         }
 
         // Fallback: Search through all blocks for the transaction (for backward compatibility)
-        for (_block_index, block) in blockchain.query_blocks().iter().enumerate() {
+        for (_block_index, block) in blockchain.iter_blocks().enumerate() {
             if let Some((tx_index, confirmed_tx)) = block
                 .transactions
                 .iter()

--- a/zhtp/src/api/handlers/dao/mod.rs
+++ b/zhtp/src/api/handlers/dao/mod.rs
@@ -614,8 +614,10 @@ impl DaoHandler {
         }
 
         // Slow path: rebuild and cache
+        // #2636: iter_blocks() walks the full chain (window + sled); query_blocks()
+        // returned only the in-memory hot window, truncating DAO history.
         let mut registry = DAORegistry::new();
-        for block in blockchain.query_blocks() {
+        for block in blockchain.iter_blocks() {
             for tx in &block.transactions {
                 Self::apply_registry_registration_from_tx(&mut registry, tx, block.header.height);
             }

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -1338,7 +1338,8 @@ impl WalletHandler {
         let mut tx_by_hash: HashMap<String, TransactionRecord> = HashMap::new();
 
         // Search through all blocks for transactions
-        for block in blockchain.query_blocks() {
+        // #2636: iter_blocks() (full chain) — query_blocks() saw only the window.
+        for block in blockchain.iter_blocks() {
             for tx in &block.transactions {
                 if Self::tx_involves_identity(
                     tx,

--- a/zhtp/src/api/server.rs
+++ b/zhtp/src/api/server.rs
@@ -300,10 +300,12 @@ impl ZhtpServer {
 
         let blockchain_stats = {
             let blockchain = self.blockchain.read().await;
-            let block_count = blockchain.blocks.len();
+            // #2636: block_count() is the full chain length; iter_blocks() sums
+            // transactions across the whole chain (hot window + sled), not just
+            // the in-memory window the previous `blocks` reads saw.
+            let block_count = blockchain.block_count() as usize;
             let transaction_count = blockchain
-                .blocks
-                .iter()
+                .iter_blocks()
                 .map(|block| block.transactions.len())
                 .sum::<usize>();
             (block_count, transaction_count)

--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -857,7 +857,7 @@ impl Component for BlockchainComponent {
         if let Ok(global) = global_blockchain {
             let blockchain = global.read().await;
             metrics.insert("chain_height".to_string(), blockchain.height as f64);
-            metrics.insert("total_blocks".to_string(), blockchain.blocks.len() as f64);
+            metrics.insert("total_blocks".to_string(), blockchain.block_count() as f64);
             metrics.insert(
                 "pending_transactions".to_string(),
                 blockchain.pending_transactions.len() as f64,
@@ -869,20 +869,25 @@ impl Component for BlockchainComponent {
             );
             metrics.insert("total_work".to_string(), blockchain.total_work as f64);
 
-            let avg_block_size = if blockchain.blocks.len() > 0 {
-                blockchain
-                    .blocks
-                    .iter()
-                    .map(|b| b.transactions.len())
-                    .sum::<usize>() as f64
-                    / blockchain.blocks.len() as f64
-            } else {
-                0.0
+            let avg_block_size = {
+                // #2636: full-chain average via iter_blocks() (hot window + sled).
+                // The previous `blocks.len()` only averaged the in-memory window;
+                // block_count() is the cheap full-chain denominator.
+                let total = blockchain.block_count();
+                if total > 0 {
+                    blockchain
+                        .iter_blocks()
+                        .map(|b| b.transactions.len())
+                        .sum::<usize>() as f64
+                        / total as f64
+                } else {
+                    0.0
+                }
             };
             metrics.insert("avg_transactions_per_block".to_string(), avg_block_size);
         } else if let Some(ref blockchain) = *self.blockchain.read().await {
             metrics.insert("chain_height".to_string(), blockchain.height as f64);
-            metrics.insert("total_blocks".to_string(), blockchain.blocks.len() as f64);
+            metrics.insert("total_blocks".to_string(), blockchain.block_count() as f64);
             metrics.insert(
                 "pending_transactions".to_string(),
                 blockchain.pending_transactions.len() as f64,
@@ -894,15 +899,20 @@ impl Component for BlockchainComponent {
             );
             metrics.insert("total_work".to_string(), blockchain.total_work as f64);
 
-            let avg_block_size = if blockchain.blocks.len() > 0 {
-                blockchain
-                    .blocks
-                    .iter()
-                    .map(|b| b.transactions.len())
-                    .sum::<usize>() as f64
-                    / blockchain.blocks.len() as f64
-            } else {
-                0.0
+            let avg_block_size = {
+                // #2636: full-chain average via iter_blocks() (hot window + sled).
+                // The previous `blocks.len()` only averaged the in-memory window;
+                // block_count() is the cheap full-chain denominator.
+                let total = blockchain.block_count();
+                if total > 0 {
+                    blockchain
+                        .iter_blocks()
+                        .map(|b| b.transactions.len())
+                        .sum::<usize>() as f64
+                        / total as f64
+                } else {
+                    0.0
+                }
             };
             metrics.insert("avg_transactions_per_block".to_string(), avg_block_size);
         } else {

--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -1409,15 +1409,16 @@ impl lib_consensus::types::ConsensusBlockchainProvider for ConsensusBlockchainAd
         drop(slot);
 
         let blockchain = blockchain_arc.read().await;
-        if blockchain.blocks.is_empty() {
-            // No blocks yet - genesis
-            Ok(lib_crypto::Hash([0u8; 32]))
-        } else {
-            let latest_block = blockchain.blocks.last().unwrap();
+        // #2636: latest_block() is the facade form of `blocks.last()` (identical
+        // semantics — the in-memory hot-window tip).
+        if let Some(latest_block) = blockchain.latest_block() {
             // Convert lib_blockchain::Hash to lib_crypto::Hash
             let block_hash = latest_block.header.hash();
             let hash_bytes = block_hash.as_array();
             Ok(lib_crypto::Hash(hash_bytes))
+        } else {
+            // No blocks yet - genesis
+            Ok(lib_crypto::Hash([0u8; 32]))
         }
     }
 
@@ -1511,7 +1512,7 @@ impl lib_consensus::types::ConsensusBlockchainProvider for ConsensusBlockchainAd
         if let Some(blockchain_arc) = slot.as_ref() {
             // Blockchain is wired and ready
             if let Ok(blockchain) = blockchain_arc.try_read() {
-                return !blockchain.blocks.is_empty() || blockchain.height == 0;
+                return blockchain.latest_block().is_some() || blockchain.height == 0;
             }
         }
         false

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -2463,7 +2463,11 @@ impl RuntimeOrchestrator {
                     // Log the genesis block hash for verification/debugging.
                     // Note: Full hash verification against CANONICAL_GENESIS_HASH is done
                     // inside lib_blockchain::Blockchain::new() -> GenesisConfig::verify_hash().
-                    if let Some(genesis_block) = bc.blocks.first() {
+                    // #2636: get_block(0) is the facade for genesis. The chain was
+                    // just built in memory (single genesis block) with an empty
+                    // store, so this resolves to the in-memory genesis we are about
+                    // to persist below.
+                    if let Some(genesis_block) = bc.get_block(0) {
                         let genesis_hash = hex::encode(genesis_block.header.block_hash.as_bytes());
                         info!("🔗 Genesis block hash: {}", genesis_hash);
 
@@ -2474,7 +2478,7 @@ impl RuntimeOrchestrator {
                         store_ref
                             .begin_block(0)
                             .map_err(|e| anyhow::anyhow!("Failed to begin genesis block: {}", e))?;
-                        store_ref.append_block(genesis_block).map_err(|e| {
+                        store_ref.append_block(&genesis_block).map_err(|e| {
                             anyhow::anyhow!("Failed to append genesis block: {}", e)
                         })?;
                         store_ref.commit_block().map_err(|e| {
@@ -5415,9 +5419,9 @@ impl RuntimeOrchestrator {
 
 fn canonical_genesis_hash() -> Result<lib_blockchain::Hash> {
     let bc = lib_blockchain::genesis::GenesisConfig::from_embedded()?.build_block0()?;
+    // #2636: get_block(0) facade (store-less chain → in-memory genesis).
     let genesis = bc
-        .blocks
-        .first()
+        .get_block(0)
         .ok_or_else(|| anyhow::anyhow!("embedded genesis config produced no block 0"))?;
     Ok(genesis.header.calculate_hash())
 }
@@ -5427,9 +5431,10 @@ fn validate_local_restore_compatibility(
     allow_genesis_mismatch: bool,
 ) -> Result<()> {
     let expected_genesis_hash = canonical_genesis_hash()?;
+    // #2636: get_block(0) facade. dat_bc was loaded from a .dat snapshot with no
+    // store attached, so this reads the in-memory genesis (block 0).
     let actual_genesis_hash = dat_bc
-        .blocks
-        .first()
+        .get_block(0)
         .ok_or_else(|| anyhow::anyhow!("blockchain.dat contains no genesis block"))?
         .header
         .calculate_hash();

--- a/zhtp/src/runtime/shared_blockchain.rs
+++ b/zhtp/src/runtime/shared_blockchain.rs
@@ -100,11 +100,12 @@ impl SharedBlockchainService {
             } => {
                 let result = {
                     let blockchain = blockchain_arc.read().await;
-                    if height < blockchain.blocks.len() as u64 {
-                        Ok(Some(blockchain.blocks[height as usize].clone()))
-                    } else {
-                        Ok(None)
-                    }
+                    // #2636: get_block(height) resolves by absolute height across
+                    // the hot window AND sled. The previous `blocks[height]`
+                    // indexed the in-memory window by absolute height, which
+                    // silently returned the wrong block (or None) once the window
+                    // slid past genesis on a store-backed node.
+                    Ok(blockchain.get_block(height))
                 };
                 let _ = response_tx.send(result);
             }
@@ -112,9 +113,12 @@ impl SharedBlockchainService {
             BlockchainOperation::GetTransaction { hash, response_tx } => {
                 let result = {
                     let blockchain = blockchain_arc.read().await;
-                    // Search for transaction in all blocks
+                    // Search for transaction in all blocks.
+                    // #2636: iter_blocks() walks the full chain (hot window + sled),
+                    // so this no longer misses transactions in blocks that have
+                    // aged out of the in-memory window on a store-backed node.
                     let mut found_tx = None;
-                    for block in &blockchain.blocks {
+                    for block in blockchain.iter_blocks() {
                         for tx in &block.transactions {
                             if format!("{:?}", tx.hash()) == hash {
                                 found_tx = Some(tx.clone());
@@ -183,10 +187,9 @@ impl SharedBlockchainService {
                         let header = BlockHeader::new(
                             1, // version
                             blockchain
-                                .blocks
-                                .last()
+                                .latest_block()
                                 .map(|b| b.hash())
-                                .unwrap_or_default(), // previous hash
+                                .unwrap_or_default(), // previous hash (#2636: facade form of blocks.last())
                             Hash::default(), // data helix root (simplified)
                             timestamp,
                             blockchain.height + 1, // height

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -1145,9 +1145,10 @@ impl ZhtpUnifiedServer {
         };
         let pouw_genesis_timestamp = {
             let blockchain_guard = blockchain.read().await;
+            // #2636: get_block(0) is the facade for the genesis timestamp —
+            // correct even when the in-memory window no longer holds height 0.
             blockchain_guard
-                .blocks
-                .first()
+                .get_block(0)
                 .map(|b| b.header.timestamp)
                 .unwrap_or_else(|| {
                     SystemTime::now()
@@ -2125,7 +2126,8 @@ impl ZhtpUnifiedServer {
     pub async fn get_blockchain_stats(&self) -> Result<serde_json::Value> {
         let blockchain = self.blockchain.read().await;
         Ok(serde_json::json!({
-            "block_count": blockchain.blocks.len(),
+            // #2636: block_count() is the full chain length, not the window size.
+            "block_count": blockchain.block_count(),
             "pending_transactions": blockchain.pending_transactions.len(),
             "identity_count": blockchain.identity_registry.len(),
             "server_id": self.server_id


### PR DESCRIPTION
Closes #2636. The **`blocks` field, done field-atomically** — every read of the hot window (`Blockchain.blocks`), internal `lib-blockchain` **and** external `zhtp`, in one PR. This is the redo of the closed #2659, which was scoped external-only and missed the dangerous internal reads.

`Blockchain.blocks` is a **hot window** (oldest blocks dropped once a store is attached), so reads that assumed it was the full chain silently truncated on a pruned/store-backed node.

## Commit 1 — internal correctness bugs (the part #2659 missed)

**Real bugs fixed:**
- `query_block_range`: indexed the window by **absolute height** (`self.blocks[start..=end]`) → returned the wrong blocks / empty once the window slid. Now `get_block(h)` per height.
- `query_block_count`: returned window size, not chain length → `block_count()`.

**Full-chain scans → `iter_blocks()` (window + sled):**
- `dao.rs` — all 6 DAO scans (`get_dao_proposals`/`_proposal`/`_votes_for_proposal`/`get_all_dao_votes`/`get_dao_executions`/`rebuild_dao_registry_index`). DAO history was bounded to the window, so validators at different heights could derive different DAO state.
- `wallets.rs::wallet_exists_in_canonical_history` — a wallet in an aged-out block was wrongly reported absent.
- `contracts.rs::rebuild_pouw_mint_index` + `reprocess_contract_executions`, `storage_integration.rs` backup loop, `validation.rs` genesis guard.

**Verified the reviewer's claims — not all were bugs:**
- `snapshot.rs::compute_state_hash` is **NOT a fork vector**: the Snapshot's blocks come from `collect_blocks(store, 0..=height)` — sled, full chain — not the windowed `blockchain.blocks`. Left unchanged rather than "fixing" a non-bug.

## Commit 2 — external zhtp reads

- Raw `.blocks` reads → `block_count()` / `latest_block()` / `get_block(h)` / `iter_blocks()` (incl. the `GetBlock` window-index bug and `GetTransaction` window-only scan in `shared_blockchain.rs`).
- 8 `query_blocks()` callers (the window-slice API) → `iter_blocks()` (materialized to a Vec where `.rev()`/`.windows()` need a slice).

## Intentionally left (Phase 3 / #2640 — mutations & bootstrap source, not reads)
- `runtime/mod.rs:2242` emergency restore (in-mem `.dat` is the **source**, written into an empty store — `iter_blocks()` would read *from* the empty store)
- `runtime/mod.rs:6266` test version-bump mutation; `genesis_funding.rs:127` genesis in-place mutation
- `persistence.rs` `.dat` serialization — already `#[deprecated]`; serializes the window; sled is the durable truth

## Verification
- **lib suite: 1866 passed / 0 failed.** `token_regression`: 24/24. zhtp + zhtp-cli build clean.
- One test (`dao_registry_index_incremental_matches_rebuild`) set up blocks at heights 10/11 with chain height 0 — impossible in production; fixed to keep blocks/height consistent (rebuild now walks `0..=height`).

## Note
Built on the corrected #2657 inventory + #2658 facade/detector foundation. Field-atomic, internal + external, verified for windowing — the discipline that was missing the first time.