### PR TITLE
refactor(#2637): token_contracts field — sled-first read migration + footgun-safe facade

### DIFF
--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1047,6 +1047,30 @@ impl Blockchain {
             .unwrap_or(0))
     }
 
+    /// Sled-first iterator facade over all token contracts — **METADATA ONLY**
+    /// (#2637).
+    ///
+    /// Returns the authoritative contract set from the store when attached,
+    /// falling back to the in-memory map in store-less mode. Use for listing /
+    /// counting / finding tokens by name/symbol/decimals/supply.
+    ///
+    /// # ⚠️ Balances are NOT populated on these results
+    ///
+    /// Per-address balances live in a **separate** sled tree (`token_balances`),
+    /// not inside the serialized `TokenContract`. A contract deserialized from
+    /// sled has an **empty** `balances` map, so `c.balance_of(addr)` on a result
+    /// of this method **always returns 0**. The name encodes the contract: this
+    /// is metadata only. For balances call [`Self::token_balance`]. (This is the
+    /// footgun the renamed-from-`iter_token_contracts` CR flagged.)
+    pub fn iter_token_contract_metadata(&self) -> Vec<crate::contracts::TokenContract> {
+        if let Some(store) = self.get_store() {
+            if let Ok(iter) = store.iter_token_contracts() {
+                return iter.map(|(_, c)| c).collect();
+            }
+        }
+        self.token_contracts.values().cloned().collect()
+    }
+
     pub fn register_web4_contract(
         &mut self,
         contract_id: [u8; 32],

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -8,6 +8,43 @@ use super::*;
 use crate::storage::{Address, IdentityConsensus, SledStore, TokenId};
 use std::sync::Arc;
 
+/// #2637: iter_token_contract_metadata() is sled-first and surfaces the
+/// contract set (name/symbol/decimals/supply). It is METADATA ONLY — per its
+/// doc, per-address balances on the returned contracts are unreliable (the
+/// executor writes balances to a separate token_balances tree, so a contract it
+/// wrote has an empty balances map). Balances must be read via token_balance().
+#[test]
+fn iter_token_contract_metadata_lists_sled_contracts() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("facade_meta_store")).unwrap());
+
+    let creator = crate::integration::crypto_integration::PublicKey::new([1u8; 2592]);
+    let custom = crate::contracts::TokenContract::new(
+        [0xCC; 32],
+        "Meta".to_string(),
+        "MTA".to_string(),
+        8,
+        1_000_000,
+        false,
+        0,
+        creator,
+    );
+    store.begin_block(0).unwrap();
+    store.put_token_contract(&custom).unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+
+    let listed = bc.iter_token_contract_metadata();
+    let mta = listed
+        .iter()
+        .find(|c| c.symbol == "MTA")
+        .expect("MTA contract must be listed from sled");
+    assert_eq!(mta.name, "Meta");
+    assert_eq!(mta.max_supply, 1_000_000);
+}
+
 /// CR #2658 #2/#7: `token_balance` reads COMMITTED sled state. A write staged in
 /// an open block (`begin_block`..`commit_block`) is invisible until commit —
 /// `SledStore::set_token_balance` stages to `tx_batch` but `get_token_balance`

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1188,9 +1188,9 @@ impl BlockchainHandler {
         };
 
         let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
+        // #2637: get_token_contract() is the sled-first metadata facade.
         let total_supply = blockchain
-            .token_contracts
-            .get(&sov_token_id)
+            .get_token_contract(&sov_token_id)
             .map(|token| token.total_supply)
             .unwrap_or(0);
 
@@ -2445,14 +2445,15 @@ impl BlockchainHandler {
 
         let mut contracts = Vec::new();
         if contract_filter == "all" || contract_filter == "token" {
+            // #2637: iter_token_contract_metadata() is the sled-first list facade.
             contracts.extend(
                 blockchain
-                    .token_contracts
-                    .keys()
-                    .map(|id| ContractListItem {
-                        contract_id: hex::encode(id),
+                    .iter_token_contract_metadata()
+                    .into_iter()
+                    .map(|t| ContractListItem {
+                        contract_id: hex::encode(t.token_id),
                         contract_kind: "token".to_string(),
-                        block_height: blockchain.contract_blocks.get(id).copied(),
+                        block_height: blockchain.contract_blocks.get(&t.token_id).copied(),
                     }),
             );
         }

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -925,12 +925,10 @@ impl NetworkHandler {
                         // because PublicKey's Hash/PartialEq compare all fields (dilithium_pk,
                         // kyber_pk, key_id), so a synthetic PublicKey with zeroed crypto keys
                         // would never match a real entry in the balances HashMap.
+                        // #2637: token_balance() is sled-first and keyed by key_id.
                         let wallet_key_id = w.wallet_id.as_array();
                         let balance = blockchain
-                            .token_contracts
-                            .get(&sov_token_id)
-                            .and_then(|t| t.find_balance_by_key_id(&wallet_key_id))
-                            .map(|(_, bal)| bal)
+                            .token_balance(&sov_token_id, &wallet_key_id)
                             .unwrap_or(0);
                         (Some(wallet_id_hex), balance)
                     } else {

--- a/zhtp/src/api/handlers/oracle/mod.rs
+++ b/zhtp/src/api/handlers/oracle/mod.rs
@@ -430,8 +430,10 @@ impl OracleHandler {
                         // Epoch
                         "current_epoch": current_epoch,
                     })
-                } else if let Some(token) =
-                    bc.token_contracts.values().find(|t| t.symbol == cbe_symbol)
+                } else if let Some(token) = bc
+                    .iter_token_contract_metadata()
+                    .into_iter()
+                    .find(|t| t.symbol == cbe_symbol)
                 {
                     // CBE exists as a standard token contract without a bonding curve price.
                     json!({
@@ -623,8 +625,10 @@ impl OracleHandler {
                         "graduation_progress_percent": stats.graduation_progress_percent,
                         "can_graduate": stats.can_graduate,
                     })
-                } else if let Some(token) =
-                    bc.token_contracts.values().find(|t| t.symbol == cbe_symbol)
+                } else if let Some(token) = bc
+                    .iter_token_contract_metadata()
+                    .into_iter()
+                    .find(|t| t.symbol == cbe_symbol)
                 {
                     // CBE exists as a standard token contract; no bonding curve variation data.
                     json!({

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -564,11 +564,13 @@ impl TokenHandler {
     async fn handle_list_tokens(&self) -> Result<ZhtpResponse> {
         let blockchain = self.blockchain.read().await;
 
+        // #2637: iter_token_contract_metadata() is the sled-first list facade
+        // (metadata only — balances are not populated; this lists name/symbol/etc.).
         let mut tokens: Vec<TokenListItem> = blockchain
-            .token_contracts
-            .iter()
-            .map(|(id, token)| TokenListItem {
-                token_id: hex::encode(id),
+            .iter_token_contract_metadata()
+            .into_iter()
+            .map(|token| TokenListItem {
+                token_id: hex::encode(token.token_id),
                 name: token.name.clone(),
                 symbol: token.symbol.clone(),
                 decimals: token.decimals,
@@ -653,8 +655,8 @@ impl TokenHandler {
 
         // Check if any existing token uses this symbol (case-insensitive)
         let existing_token = blockchain
-            .token_contracts
-            .values()
+            .iter_token_contract_metadata()
+            .into_iter()
             .find(|token| token.symbol.to_uppercase() == symbol_upper);
 
         match existing_token {
@@ -779,9 +781,9 @@ impl TokenHandler {
             .iter()
             .any(|b| b.get("token_id").and_then(|v| v.as_str()) == Some(&native_token_id_hex));
         if !has_sov {
+            // #2637: get_token_contract() is the sled-first metadata facade.
             let (name, symbol, decimals) = blockchain
-                .token_contracts
-                .get(&native_token_id)
+                .get_token_contract(&native_token_id)
                 .map(|t| (t.name.clone(), t.symbol.clone(), t.decimals))
                 .unwrap_or_else(|| ("Sovereign".to_string(), "SOV".to_string(), 8));
 

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -381,23 +381,16 @@ impl WalletHandler {
                 let blockchain = self.blockchain.read().await;
                 let wallet_id_bytes_opt =
                     hex::decode(&wallet_id_hex).ok().filter(|b| b.len() == 32);
+                // #2637: token_balance() is sled-first and keyed by key_id. Also
+                // fixes a latent bug — the old synthetic PublicKey (zeroed
+                // dilithium/kyber) never matched balance_of's full-field key
+                // equality, so this path always returned 0.
                 wallet_id_bytes_opt
                     .as_ref()
-                    .and_then(|bytes| {
-                        blockchain
-                            .token_contracts
-                            .get(&sov_token_id)
-                            .and_then(|token| {
-                                let mut key_id = [0u8; 32];
-                                key_id.copy_from_slice(bytes);
-                                let wallet_key =
-                                    lib_blockchain::integration::crypto_integration::PublicKey {
-                                        dilithium_pk: [0u8; 2592],
-                                        kyber_pk: [0u8; 1568],
-                                        key_id,
-                                    };
-                                Some(token.balance_of(&wallet_key))
-                            })
+                    .map(|bytes| {
+                        let mut key_id = [0u8; 32];
+                        key_id.copy_from_slice(bytes);
+                        blockchain.token_balance(&sov_token_id, &key_id).unwrap_or(0)
                     })
                     .unwrap_or(0)
             };
@@ -531,34 +524,30 @@ impl WalletHandler {
                 let blockchain = self.blockchain.read().await;
                 let wallet_id_hex = hex::encode(summary.id.0);
                 if let Some(wallet_data) = blockchain.query_wallet(&wallet_id_hex) {
-                    if let Some(token) = blockchain
-                        .token_contracts
-                        .get(&lib_blockchain::contracts::utils::generate_lib_token_id())
-                    {
-                        let wallet_id_bytes = hex::decode(&wallet_id_hex).ok();
-                        let token_balance = if let Some(bytes) = wallet_id_bytes {
-                            if bytes.len() == 32 {
+                    // #2637: sled-first SOV balance. Gate on the contract existing
+                    // (preserves the prior "only override if SOV token present"
+                    // behavior), then read via token_balance() keyed by key_id —
+                    // the wallet_id for the 32-byte path (the SOV balance key the
+                    // executor uses), else the wallet public key's key_id. Also
+                    // fixes the synthetic-PublicKey balance_of bug that returned 0.
+                    let native_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
+                    if blockchain.get_token_contract(&native_token_id).is_some() {
+                        let addr: [u8; 32] = match hex::decode(&wallet_id_hex)
+                            .ok()
+                            .filter(|b| b.len() == 32)
+                        {
+                            Some(bytes) => {
                                 let mut key_id = [0u8; 32];
                                 key_id.copy_from_slice(&bytes);
-                                let wallet_key =
-                                    lib_blockchain::integration::crypto_integration::PublicKey {
-                                        dilithium_pk: [0u8; 2592],
-                                        kyber_pk: [0u8; 1568],
-                                        key_id,
-                                    };
-                                token.balance_of(&wallet_key)
-                            } else {
-                                token.balance_of(&lib_blockchain::integration::crypto_integration::PublicKey::new(
-                                    wallet_data.public_key.as_slice().try_into().unwrap_or([0u8; 2592])
-                                ))
+                                key_id
                             }
-                        } else {
-                            token.balance_of(
-                                &lib_blockchain::integration::crypto_integration::PublicKey::new(
-                                    wallet_data.public_key.as_slice().try_into().unwrap_or([0u8; 2592]),
-                                ),
+                            None => lib_blockchain::integration::crypto_integration::PublicKey::new(
+                                wallet_data.public_key.as_slice().try_into().unwrap_or([0u8; 2592]),
                             )
+                            .key_id,
                         };
+                        let token_balance =
+                            blockchain.token_balance(&native_token_id, &addr).unwrap_or(0);
                         if token_balance != available_balance {
                             tracing::debug!(
                                 "Using SOV token balance for wallet {}: {} (was {})",

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -396,18 +396,19 @@ impl Web4Handler {
                 key_id: owner_wallet_id.into(),
             };
 
-            // Check if SOV token contract exists
-            let sov_token = blockchain
-                .token_contracts
-                .get(&sov_token_id)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "SOV token contract not initialized. Network may still be bootstrapping."
-                    )
-                })?;
+            // #2637: keep the existence check, read the balance via sled-first
+            // token_balance() keyed by key_id. (Fixes the synthetic-PublicKey
+            // balance_of bug — owner_wallet_key has zeroed dilithium/kyber.)
+            if blockchain.get_token_contract(&sov_token_id).is_none() {
+                return Err(anyhow!(
+                    "SOV token contract not initialized. Network may still be bootstrapping."
+                ));
+            }
 
             // Check user's SOV balance
-            let user_sov_balance = sov_token.balance_of(&owner_wallet_key);
+            let user_sov_balance = blockchain
+                .token_balance(&sov_token_id, &owner_wallet_key.key_id)
+                .unwrap_or(0);
 
             info!(
                 " User SOV balance: {} SOV (need {} SOV)",


### PR DESCRIPTION
Closes #2637 (token_contracts reads). Field 2 of the redo, **field-atomic**.

> **Stacked on #2658** (`phase-1-facade-divergence`) — it provides `token_balance()` (sled-first, `Result`) and `get_token_contract()`. Merge #2658 first; I'll retarget to `development` after.

This is the corrected redo of the closed #2661: the aggregate facade is **renamed and documented** to kill the empty-balances footgun, and the callers handle `token_balance`'s `Result`.

## New facade — footgun fixed by naming + docs

`iter_token_contract_metadata()` (was `iter_token_contracts`): sled-first list, **metadata only**. The doc states prominently that per-address balances are **not reliable** on the returned contracts — the executor writes balances to a separate `token_balances` tree, so a contract it wrote deserializes with an **empty** balances map. `balance_of()` on a result is therefore unreliable; use `token_balance()`. (Verified empirically while writing the test: a *direct* `put_token_contract` does persist balances, but the *executor* path doesn't — so the only safe contract is "metadata only.")

## Migrated

| Kind | Facade | Sites |
|---|---|---|
| balance | `token_balance().unwrap_or(0)` | network, wallet (×2), web4/domains |
| metadata | `get_token_contract()` | token (name/symbol/decimals), blockchain (total_supply) |
| aggregate | `iter_token_contract_metadata()` | token (list, find-by-symbol), oracle (×2), blockchain (contract list) |

### 🐛 Bug fixed
Three balance reads built a synthetic `PublicKey` (zeroed dilithium/kyber, key_id only) and called `balance_of()` — which never matched `balance_of`'s full-field key equality, so they **silently returned 0**. `token_balance()` reads sled keyed by `key_id`. (Same class fixed in the blocks PR's neighbors.)

## Intentionally NOT migrated (Phase 3/4)
- SOV-init bootstrap clusters in `runtime/mod.rs` + `genesis_funding.rs` (`insert`/`get_mut`, also read `utxo_set`)
- `web4/domains.rs:1024` out-of-band fee debit (in-mem only, diverges from sled) → **filed #2667**; its coupled test (`:2415`) stays until the fee moves into block apply
- `tools/chain_audit.rs` balance-sum — needs a sled balance-iteration facade

## Verification
- **lib suite: 1878 passed / 0 failed** (incl. new `iter_token_contract_metadata_lists_sled_contracts`). lib-blockchain + zhtp build clean.

## Plan position
```
✓ #2657 inventory (merged) · #2658 facade+detector
✓ blocks  → #2666
✓ token_contracts → THIS
  validator_registry (consensus-critical) → next
  identity_registry (incl. BLOCKING gateway-auth site)
```