### PR TITLE
fix: prune utxo_snapshots on every commit — was unbounded leak

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -1244,6 +1244,10 @@ impl Blockchain {
         self.height += 1;
         self.update_utxo_set(&block)?;
         self.save_utxo_snapshot(self.height)?;
+        // BST-202: snapshots accumulate without bound otherwise — RSS grew to
+        // 12 GB / 123k snapshots on validators. Retention matches the hot
+        // block window, since reorg cannot exceed it anyway.
+        self.prune_utxo_history(self.block_window_size() as u64);
         self.adjust_difficulty()?;
 
         // Remove processed transactions from pending pool


### PR DESCRIPTION
## Summary
- `save_utxo_snapshot` ran on every block commit, cloning the full UTXO set into `utxo_snapshots: BTreeMap<height, HashMap<Hash, Output>>`. `prune_utxo_history` existed but was never called.
- O(N × |UTXO|) growth → g1 RSS 12 GB / 123k snapshots after 1d21h. Cluster-wide leak driving kernel OOM on 8 GB validators (g5 SSH banner timeout root cause).
- Fix: prune to `block_window_size()` immediately after each save — matches the in-memory hot block window (BST-301), since reorg cannot exceed that depth.

## Risk
- `get_utxo_set_at_height` / `restore_utxo_set_from_snapshot` have **zero callers** in the live tree (verified by grep). The snapshot subsystem is currently write-only dead weight; trimming retention to the block window is strictly safe.
- Retention matches `blocks` cache; symmetry with the rest of the windowed state.

## Test plan
- [ ] Build cleanly with `cargo build --profile dev-release -p zhtp`
- [ ] Deploy to g1 canary; verify RSS plateau within ~10 minutes
- [ ] Continue staged rollout per HALT-BEFORE-DEPLOY protocol
- [ ] Monitor RSS across cluster for 24h — should stay flat instead of climbing linearly