### PR TITLE
fix(#2639): migrate kyber/device-key identity reads to sled facade (#58)

### DIFF
--- a/lib-blockchain/src/blockchain/identity.rs
+++ b/lib-blockchain/src/blockchain/identity.rs
@@ -237,6 +237,80 @@ impl Blockchain {
             .map(|id| id.did.clone())
     }
 
+    /// Resolve the canonical DID for a device key-id fingerprint, sled-first (#58).
+    ///
+    /// The messaging / device-key layer fingerprints an identity two ways
+    /// (see `zhtp` reverse lookups), and this resolver mirrors both exactly:
+    ///   * `blake3(dilithium_public_key)` — the Dilithium-only key id (also the
+    ///     DID suffix), and
+    ///   * `blake3(dilithium_public_key ++ kyber_public_key)` — the combined
+    ///     post-quantum device key.
+    /// `key_id_hex` is the lowercase hex of that 32-byte blake3 hash; the hash is
+    /// computed with `lib_crypto::hash_blake3`, byte-identical to the callers, so
+    /// this is a behavior-preserving drop-in for the open-coded `identity_registry`
+    /// scans it replaces.
+    ///
+    /// Resolution order, mirroring the prior in-memory logic:
+    ///   1. direct match — `did:zhtp:{key_id_hex}` is itself a registered DID
+    ///      (sled-first via `identity_exists`); then
+    ///   2. a hash match over the durable `identity_metadata` set, which carries
+    ///      `kyber_public_key` from schema v2 (#2679).
+    /// Reading durable metadata is what lets a store-backed node resolve a
+    /// recipient after a restart, when the in-memory `identity_registry` is empty.
+    /// Falls back to the in-memory shadow only when sled has no match or the scan
+    /// errors (store-less mode, or a pending pre-commit registration). Returns
+    /// `None` when no identity matches.
+    pub fn did_by_device_key_id(&self, key_id_hex: &str) -> Option<String> {
+        // (1) Direct match — the key id is itself a registered DID suffix.
+        let candidate = format!("did:zhtp:{key_id_hex}");
+        if self.identity_exists(&candidate) {
+            return Some(candidate);
+        }
+
+        // (2) Hash match: Dilithium-only key id, then the combined Dilithium+Kyber
+        //     device key. Identical derivation on both the sled and in-mem paths.
+        let matches_key_id = |public_key: &[u8], kyber: &[u8]| -> bool {
+            if public_key.len() < 32 {
+                return false;
+            }
+            if hex::encode(lib_crypto::hash_blake3(public_key)) == key_id_hex {
+                return true;
+            }
+            if !kyber.is_empty() {
+                let combined = [public_key, kyber].concat();
+                if hex::encode(lib_crypto::hash_blake3(&combined)) == key_id_hex {
+                    return true;
+                }
+            }
+            false
+        };
+
+        if let Some(store) = self.get_store() {
+            match store.iter_identity_metadata() {
+                Ok(iter) => {
+                    if let Some(meta) = iter
+                        .into_iter()
+                        .find(|m| matches_key_id(&m.public_key, &m.kyber_public_key))
+                    {
+                        return Some(meta.did);
+                    }
+                    // No metadata match — fall through to the in-mem shadow.
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "did_by_device_key_id: iter_identity_metadata failed; falling back to in-memory shadow (may be empty after restart on store-backed node)"
+                    );
+                }
+            }
+        }
+
+        self.identity_registry
+            .values()
+            .find(|id| matches_key_id(&id.public_key, &id.kyber_public_key))
+            .map(|id| id.did.clone())
+    }
+
     /// Full Dilithium public key for a DID, sled-first and consensus-pinned (#2639).
     ///
     /// The full key bytes live only in the (non-consensus) `IdentityMetadata`

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -481,3 +481,95 @@ fn identity_controlled_nodes_reads_sled_metadata() {
         "unknown DID -> None"
     );
 }
+
+/// did_by_device_key_id() resolves a canonical DID from a device key-id
+/// fingerprint — `blake3(dilithium)` or `blake3(dilithium || kyber)` — by
+/// scanning sled metadata even when the in-memory shadow is empty (the restart
+/// case). This is the read the messaging / device-key reverse lookups depend on
+/// (#58); the combined-hash arm exercises the schema-v2 `kyber_public_key` the
+/// migration persists (#2679). It is a fingerprint resolver (NOT consensus
+/// signature verification), so it is not consensus-pinned.
+#[test]
+fn did_by_device_key_id_reads_sled_metadata() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("did_by_devkey")).unwrap());
+
+    let did = "did:zhtp:device-owner";
+    let did_hash = crate::storage::did_to_hash(did);
+    let pk = vec![0x9u8; 2592];
+    let kyber = vec![0x7u8; 1568];
+
+    store.begin_block(0).unwrap();
+    store
+        .put_identity(
+            &did_hash,
+            &IdentityConsensus { did_hash, ..Default::default() },
+        )
+        .unwrap();
+    store
+        .put_identity_metadata(
+            &did_hash,
+            &IdentityMetadata {
+                did: did.to_string(),
+                display_name: "D".to_string(),
+                public_key: pk.clone(),
+                kyber_public_key: kyber.clone(),
+                ownership_proof: vec![],
+                controlled_nodes: vec![],
+                owned_wallets: vec![],
+                attributes: vec![],
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().unwrap();
+    bc.set_store(store.clone());
+    assert!(
+        !bc.identity_registry.contains_key(did)
+            && !bc.identity_registry.values().any(|i| i.public_key == pk),
+        "test premise: this identity is sled-only (absent from the in-mem shadow, like after restart)"
+    );
+
+    // (a) Dilithium-only key id. Computed with lib_crypto::hash_blake3 exactly
+    //     as the facade does, so the hashes are byte-identical.
+    let dil_key_id = hex::encode(lib_crypto::hash_blake3(&pk));
+    assert_eq!(
+        bc.did_by_device_key_id(&dil_key_id),
+        Some(did.to_string()),
+        "resolves DID from blake3(dilithium) over sled metadata"
+    );
+
+    // (b) Combined Dilithium+Kyber device key id (the schema-v2 kyber path).
+    let combined = [&pk[..], &kyber[..]].concat();
+    let combined_key_id = hex::encode(lib_crypto::hash_blake3(&combined));
+    assert_eq!(
+        bc.did_by_device_key_id(&combined_key_id),
+        Some(did.to_string()),
+        "resolves DID from blake3(dilithium || kyber) over sled metadata"
+    );
+
+    // (c) Unknown fingerprint -> None (no match, and the constructed
+    //     did:zhtp:{key_id} is not a registered DID either).
+    assert_eq!(
+        bc.did_by_device_key_id(&"de".repeat(32)),
+        None,
+        "unknown device key id -> None"
+    );
+
+    // (d) Direct match: the key id is itself a registered DID suffix, resolved
+    //     via the sled-first existence check (not the hash scan).
+    let direct_did = "did:zhtp:abcd1234";
+    let direct_hash = crate::storage::did_to_hash(direct_did);
+    put_sled_identity(
+        &store,
+        1,
+        direct_did,
+        IdentityConsensus { did_hash: direct_hash, ..Default::default() },
+    );
+    assert_eq!(
+        bc.did_by_device_key_id("abcd1234"),
+        Some(direct_did.to_string()),
+        "direct DID-suffix match resolves via identity_exists"
+    );
+}

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1717,40 +1717,17 @@ impl IdentityHandler {
 
         let did: String = {
             let blockchain = blockchain_arc.read().await;
-            let key_id_did = format!("did:zhtp:{}", requester_key_id);
-            if blockchain.identity_registry.contains_key(&key_id_did) {
-                key_id_did
-            } else {
-                let found = blockchain
-                    .identity_registry
-                    .iter()
-                    .find(|(_, id)| {
-                        if id.public_key.len() < 32 {
-                            return false;
-                        }
-                        let dil_hash =
-                            hex::encode(lib_crypto::hash_blake3(&id.public_key));
-                        if dil_hash == requester_key_id {
-                            return true;
-                        }
-                        if !id.kyber_public_key.is_empty() {
-                            let combined =
-                                [&id.public_key[..], &id.kyber_public_key[..]].concat();
-                            let combined_hash =
-                                hex::encode(lib_crypto::hash_blake3(&combined));
-                            return combined_hash == requester_key_id;
-                        }
-                        false
-                    })
-                    .map(|(did, _)| did.clone());
-                match found {
-                    Some(d) => d,
-                    None => {
-                        return Ok(ZhtpResponse::error(
-                            ZhtpStatus::NotFound,
-                            "Authenticated identity not found on chain".to_string(),
-                        ));
-                    }
+            // #58: sled-first direct-match + Dilithium / Dilithium+Kyber hash
+            // resolution via the facade, which reads durable `identity_metadata`
+            // so it survives a restart (the in-memory `identity_registry` is
+            // empty then).
+            match blockchain.did_by_device_key_id(&requester_key_id) {
+                Some(d) => d,
+                None => {
+                    return Ok(ZhtpResponse::error(
+                        ZhtpStatus::NotFound,
+                        "Authenticated identity not found on chain".to_string(),
+                    ));
                 }
             }
         };

--- a/zhtp/src/api/handlers/pouw/mod.rs
+++ b/zhtp/src/api/handlers/pouw/mod.rs
@@ -276,7 +276,6 @@ impl PouwHandler {
         if requester_key_id.is_empty() {
             return None;
         }
-        let key_id_did = format!("did:zhtp:{}", requester_key_id);
 
         let blockchain_arc =
             crate::runtime::blockchain_provider::get_global_blockchain()
@@ -284,34 +283,11 @@ impl PouwHandler {
                 .ok()?;
         let blockchain = blockchain_arc.read().await;
 
-        // Fast path: the QUIC identity_id is itself the canonical DID.
-        if blockchain.identity_registry.contains_key(&key_id_did) {
-            return Some(key_id_did);
-        }
-        // Slow path: scan, matching dilithium-only and dilithium||kyber.
-        blockchain
-            .identity_registry
-            .iter()
-            .find(|(_, id)| {
-                if id.public_key.len() < 32 {
-                    return false;
-                }
-                let dil_hash = hex::encode(lib_crypto::hash_blake3(&id.public_key));
-                if dil_hash == requester_key_id {
-                    return true;
-                }
-                if !id.kyber_public_key.is_empty() {
-                    let combined =
-                        [&id.public_key[..], &id.kyber_public_key[..]].concat();
-                    let combined_hash =
-                        hex::encode(lib_crypto::hash_blake3(&combined));
-                    if combined_hash == requester_key_id {
-                        return true;
-                    }
-                }
-                false
-            })
-            .map(|(did, _)| did.clone())
+        // #58: sled-first direct-match + Dilithium / Dilithium+Kyber hash
+        // resolution via the facade, which reads durable `identity_metadata` so
+        // it survives a restart (the in-memory `identity_registry` is empty
+        // then). Returns None when no identity matches, as before.
+        blockchain.did_by_device_key_id(&requester_key_id)
     }
 
     async fn check_reward_query_access(

--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -101,18 +101,25 @@ impl MessagingHandler {
             format!("did:zhtp:{}", req.recipient)
         };
 
-        // Get recipient's identity (including Kyber key)
-        let identity = match blockchain.query_identity(&recipient_did) {
-            Some(id) => id.clone(),
+        // Get recipient's keys, sled-first (#58). The Dilithium key is the
+        // existence signal — `identity_public_key` is consensus-pinned, so it
+        // serves the durable key and refuses a metadata↔consensus drift. The
+        // Kyber key drives the encrypted-session error path. Both read durable
+        // `identity_metadata`, so a store-backed node still resolves the
+        // recipient after a restart (the in-memory registry is empty then).
+        let dilithium_public_key = match blockchain.identity_public_key(&recipient_did) {
+            Some(pk) => pk,
             None => return Ok(error_resp(ZhtpStatus::NotFound, "Recipient DID not found")),
         };
-
-        if identity.kyber_public_key.is_empty() {
-            return Ok(error_resp(
-                ZhtpStatus::BadRequest,
-                "Recipient has no Kyber public key — cannot establish encrypted session",
-            ));
-        }
+        let kyber_public_key = match blockchain.identity_kyber_public_key(&recipient_did) {
+            Some(k) => k,
+            None => {
+                return Ok(error_resp(
+                    ZhtpStatus::BadRequest,
+                    "Recipient has no Kyber public key — cannot establish encrypted session",
+                ))
+            }
+        };
 
         // Get username if available
         let username = blockchain.did_to_username.get(&recipient_did).cloned();
@@ -121,8 +128,8 @@ impl MessagingHandler {
             "status": "success",
             "recipient_did": recipient_did,
             "recipient_username": username,
-            "kyber_public_key": hex::encode(&identity.kyber_public_key),
-            "dilithium_public_key": hex::encode(&identity.public_key),
+            "kyber_public_key": hex::encode(&kyber_public_key),
+            "dilithium_public_key": hex::encode(&dilithium_public_key),
         }))
     }
 
@@ -292,36 +299,14 @@ impl MessagingHandler {
                 did
             } else {
                 let blockchain = self.blockchain.read().await;
-                // (2) Direct match.
-                if blockchain.identity_registry.contains_key(&key_id_did) {
-                    key_id_did.clone()
-                } else {
-                    // (3) Public-key hash match.
-                    blockchain
-                        .identity_registry
-                        .iter()
-                        .find(|(_, id)| {
-                            if id.public_key.len() < 32 {
-                                return false;
-                            }
-                            let dil_hash = hex::encode(lib_crypto::hash_blake3(&id.public_key));
-                            if dil_hash == requester_key_id {
-                                return true;
-                            }
-                            if !id.kyber_public_key.is_empty() {
-                                let combined =
-                                    [&id.public_key[..], &id.kyber_public_key[..]].concat();
-                                let combined_hash =
-                                    hex::encode(lib_crypto::hash_blake3(&combined));
-                                if combined_hash == requester_key_id {
-                                    return true;
-                                }
-                            }
-                            false
-                        })
-                        .map(|(did, _)| did.clone())
-                        .unwrap_or(key_id_did)
-                }
+                // #58: sled-first direct-match + Dilithium / Dilithium+Kyber hash
+                // resolution. Reads durable `identity_metadata` so a store-backed
+                // node resolves the requester after a restart (the in-memory
+                // `identity_registry` is empty then). Falls back to the raw
+                // key-id DID when no identity matches, as before.
+                blockchain
+                    .did_by_device_key_id(&requester_key_id)
+                    .unwrap_or(key_id_did)
             }
         };
 

--- a/zhtp/src/messaging/inbound_stream.rs
+++ b/zhtp/src/messaging/inbound_stream.rs
@@ -34,30 +34,16 @@ async fn resolve_recipient_did(requester_key_id: &str) -> Option<String> {
         crate::runtime::blockchain_provider::get_global_blockchain().await.ok()?;
     let blockchain = blockchain_arc.read().await;
 
+    // #58: sled-first direct-match + Dilithium / Dilithium+Kyber resolution via
+    // the facade, which reads durable `identity_metadata` so this survives a
+    // restart (the in-memory `identity_registry` is empty then). Falls back to
+    // the raw key_id DID suffix when no identity matches, as before.
     let key_id_did = format!("did:zhtp:{}", requester_key_id);
-    if blockchain.identity_registry.contains_key(&key_id_did) {
-        return Some(key_id_did);
-    }
-
-    for (did, id) in blockchain.identity_registry.iter() {
-        if id.public_key.len() < 32 {
-            continue;
-        }
-        let dil_hash = hex::encode(lib_crypto::hash_blake3(&id.public_key));
-        if dil_hash == requester_key_id {
-            return Some(did.clone());
-        }
-        if !id.kyber_public_key.is_empty() {
-            let combined = [&id.public_key[..], &id.kyber_public_key[..]].concat();
-            let combined_hash = hex::encode(lib_crypto::hash_blake3(&combined));
-            if combined_hash == requester_key_id {
-                return Some(did.clone());
-            }
-        }
-    }
-
-    // Fallback: assume the raw key_id is itself the canonical DID suffix
-    Some(key_id_did)
+    Some(
+        blockchain
+            .did_by_device_key_id(requester_key_id)
+            .unwrap_or(key_id_did),
+    )
 }
 
 /// Write a single framed envelope to the send stream.

--- a/zhtp/src/runtime/blockchain_provider.rs
+++ b/zhtp/src/runtime/blockchain_provider.rs
@@ -87,32 +87,13 @@ impl BlockchainProvider {
         let arc = self.blockchain.read().await.as_ref().cloned()?;
         let bc = arc.read().await;
         let key_id_hex = hex::encode(device_key);
-        let key_id_did = format!("did:zhtp:{}", key_id_hex);
 
-        // (1) Direct match — same DID is registered.
-        if bc.identity_registry.contains_key(&key_id_did) {
-            return Some(key_id_did);
-        }
-
-        // (2) Hash-of-public-key match (Dilithium alone, then Dilithium+Kyber).
-        for (canonical_did, identity) in bc.identity_registry.iter() {
-            if identity.public_key.len() < 32 {
-                continue;
-            }
-            let dil_hash = hex::encode(lib_crypto::hash_blake3(&identity.public_key));
-            if dil_hash == key_id_hex {
-                return Some(canonical_did.clone());
-            }
-            if !identity.kyber_public_key.is_empty() {
-                let combined = [&identity.public_key[..], &identity.kyber_public_key[..]].concat();
-                let combined_hash = hex::encode(lib_crypto::hash_blake3(&combined));
-                if combined_hash == key_id_hex {
-                    return Some(canonical_did.clone());
-                }
-            }
-        }
-
-        None
+        // #58: sled-first resolution. The facade does the same direct-match +
+        // Dilithium / Dilithium+Kyber hash scan this used to open-code over the
+        // in-memory `identity_registry`, but reads the durable `identity_metadata`
+        // set so a store-backed node still resolves the recipient after a restart
+        // (the in-memory registry is empty then).
+        bc.did_by_device_key_id(&key_id_hex)
     }
 
     /// Configure blockchain mutation access mode.


### PR DESCRIPTION
## What

Completes the **#58** read-migration half of the kyber persistence work. The kyber *persistence* (#2679) and metadata *iterator* (#2678) foundations have merged; this migrates the **reads** onto the sled-authoritative facade.

## Why

Device-key → DID resolution (matching a `blake3(dilithium)` or `blake3(dilithium||kyber)` fingerprint) was open-coded as an in-memory `identity_registry` scan in **five** zhtp sites. On a store-backed node the in-memory registry is **empty after a restart**, so every one of those scans silently failed to resolve a recipient/requester — the exact post-restart masking #2645 exists to eliminate.

## Changes

**lib-blockchain**
- `Blockchain::did_by_device_key_id(key_id_hex)` — one sled-first resolver: direct DID-suffix existence match, then Dilithium-only and Dilithium+Kyber hash scan over the durable `identity_metadata` set, with the in-memory shadow as the store-less / pending-pre-commit fallback. Hashing via `lib_crypto::hash_blake3`, byte-identical to the call sites → behavior-preserving drop-in. Not consensus-pinned (fingerprint resolver, not signature verification).
- Test `did_by_device_key_id_reads_sled_metadata`: Dilithium-only, Dilithium+Kyber, unknown, and direct-suffix paths against an empty in-mem shadow (restart simulation).

**zhtp — replace open-coded scans with the facade**
- `messaging/handler.rs`: reverse lookup → facade; **and** the resolve endpoint's forward read off `query_identity` → `identity_public_key` (consensus-pinned) + `identity_kyber_public_key`, preserving the NotFound vs no-Kyber error paths.
- `messaging/inbound_stream.rs`, `api/handlers/pouw`, `api/handlers/identity`, `runtime/blockchain_provider`: reverse lookups → facade.

Net **-153** duplicated lines.

## Out of scope (separate follow-up)

The two `blockchain/mod.rs` forward `query_identity` reads return full `IdentityTransactionData` fields (`identity_type`/`registration_fee`/`created_at`) that are **not** in `IdentityMetadata`, and are blocked on the `query_identity`-returns-a-borrow problem. They do **not** read kyber.

## Test

- `cargo test -p lib-blockchain --lib`: **1892 pass / 0 fail**
- `cargo build -p zhtp`: clean

## Operational note

The schema-v2 kyber migration these reads depend on runs automatically on node startup (`replay_from_store` → `migrate_identity_metadata_schema`); it's idempotent and version-gated, so no manual step is required.