### PR TITLE
fix(CONS-512): engine owns consensus height; storage is downstream

### DIFF
--- a/docs/epics/cons-512-engine-owns-height.md
+++ b/docs/epics/cons-512-engine-owns-height.md
@@ -2,7 +2,7 @@
 
 **Status.** Draft (2026-06-03). Drafted in response to the 2026-06-03 stall at H=123008/123009 where two of five validators wedged because their engine's `current_round.height` and `blockchain.height` drifted by one.
 
-**Branch.** `fix/synchronous-commit-path-cons508`
+**Branch.** `fix/synchronous-commit-path-cons508` (branch name predates the CONS-512 ticket assignment — the synchronous-commit work was originally scoped under CONS-508's "delete legacy lib-consensus" umbrella before being scoped down to this surgical change. Kept as-is to preserve PR continuity; future references should use CONS-512.)
 
 **Tracks.** CONS-307, CONS-504, CONS-505. Supersedes the "wire a `ConsensusEvent::NewBlock` event" patch sketch.
 
@@ -42,13 +42,20 @@ In BFT, a block is final the moment 2/3+1 commit votes are observed. Persistence
 
 ### 2. `sync_height_with_blockchain` becomes boot-only.
 
-Renamed to `init_height_from_storage`. Called only from `run_consensus_loop` start. Removed from `on_round_timeout(Commit)`, removed from `handle_consensus_event(ConsensusEvent::NewBlock)`, removed from the mode transition.
+Called only from `run_consensus_loop` start. Removed from `on_round_timeout(Commit)`, removed from the Bootstrap→BFT mode transition, removed from the (vestigial) `handle_consensus_event(ConsensusEvent::NewBlock)` handler.
 
-The new name makes the intent explicit: storage is the source of truth *at boot* (recovering from a crash), and never again at runtime.
+The function name is unchanged in this PR — the rename to `init_height_from_storage` was considered to make the intent explicit but deferred to keep the diff focused on the safety-critical behavior change. The doc comment now spells out the boot-only contract in unambiguous terms, and any future caller addition is required to justify itself as a non-regression in the PR description.
 
-### 3. `ConsensusEvent::NewBlock` is deleted.
+### 3. `ConsensusEvent::NewBlock` — kept, but neutered.
 
-It has no production constructors and the only handler now belongs to a code path we're removing. Removing it deletes ~30 lines of dead state-machine code plus the unused variant.
+Grep confirms zero production constructors of this variant; only test code builds it. We considered deleting both the variant and its handler in this PR but kept them, for two reasons:
+
+- The handler does post-block bookkeeping (governance callback, byzantine fault detection, reward callback) that is duplicated in `process_committed_block`. Cleanly de-duplicating is a separate, scoped refactor, and bundling it into a safety-critical change is the kind of scope creep that turns a 4-file diff into a 20-file diff with a wider blast radius.
+- The handler is a plausible attachment point for a future external block-ingest path (archive-node replay, fast-sync apply).
+
+What this PR *does* change in the handler: the `sync_height_with_blockchain()` call inside it is removed, and a CONS-512 contract comment is added stating that re-adding it would re-introduce the engine ↔ storage drift bug.
+
+Deletion of the variant + handler is tracked as a follow-up cleanup, not a prerequisite for the CONS-512 contract.
 
 ### 4. Storage write stays async (CONS-307 unchanged).
 

--- a/docs/epics/cons-512-engine-owns-height.md
+++ b/docs/epics/cons-512-engine-owns-height.md
@@ -1,0 +1,100 @@
+# CONS-512 · Engine owns consensus height; storage is downstream
+
+**Status.** Draft (2026-06-03). Drafted in response to the 2026-06-03 stall at H=123008/123009 where two of five validators wedged because their engine's `current_round.height` and `blockchain.height` drifted by one.
+
+**Branch.** `fix/synchronous-commit-path-cons508`
+
+**Tracks.** CONS-307, CONS-504, CONS-505. Supersedes the "wire a `ConsensusEvent::NewBlock` event" patch sketch.
+
+---
+
+## What's broken
+
+Right now there are two height counters in one process:
+
+- `ConsensusEngine.current_round.height` — what the engine is voting on.
+- `Blockchain.height` — what's actually persisted in sled.
+
+They are coordinated via `sync_height_with_blockchain()`, which reads `blockchain.height` and sets `engine.current_round.height = blockchain.height + 1`. **The engine derives its height from storage.**
+
+`sync_height_with_blockchain` is called from exactly four places:
+
+1. `run_consensus_loop` start (boot)
+2. `handle_consensus_event(ConsensusEvent::NewBlock)` — *event never constructed in production code* (grep-verified: only constructed in tests)
+3. `on_round_timeout(Commit)` — only fires if the engine is sitting in the `Commit` step when the timer fires
+4. Bootstrap → BFT mode transition
+
+If anything causes the engine to leave the `Commit` step at height N before its timer fires — a stale-round vote from a slow peer, a round-bump, anything — and the engine then falls into PreVote/PreCommit timeouts at H=N (because no peer will vote for N anymore, they've all moved on), **the engine has no recovery path.** PreVote timeouts don't sync height. The engine spins at H=N forever while `blockchain.height` quietly sits at N too. They look the same to the API (both report N) but the engine is voting for N when it should be voting for N+1.
+
+This is exactly what happened to g2 and g3 today. They committed H=123008 in the morning, something kicked them out of Commit step before the timer fired, and they've been spinning PreVote rounds at H=123008 for 11 hours.
+
+## Why this design exists
+
+CONS-307 explicitly made the commit path async fire-and-forget to fix the "storage blocks consensus" hang (epic line 575-589). That change is correct *for storage*. What CONS-307 got wrong was treating engine *height advancement* as a downstream consequence of the storage write, instead of an immediate consequence of the consensus decision.
+
+In BFT, a block is final the moment 2/3+1 commit votes are observed. Persistence is a separate concern. The engine should advance its height the instant BFT decides, not when sled finishes writing.
+
+## What we change
+
+### 1. Engine owns its height.
+
+`process_committed_block` advances `current_round.height` synchronously, in the same call frame, right after `apply_block_to_state_with_proof().await` returns. Same code that `advance_to_next_round()` already implements — just called from the commit success path, not from `on_round_timeout(Commit)`.
+
+### 2. `sync_height_with_blockchain` becomes boot-only.
+
+Renamed to `init_height_from_storage`. Called only from `run_consensus_loop` start. Removed from `on_round_timeout(Commit)`, removed from `handle_consensus_event(ConsensusEvent::NewBlock)`, removed from the mode transition.
+
+The new name makes the intent explicit: storage is the source of truth *at boot* (recovering from a crash), and never again at runtime.
+
+### 3. `ConsensusEvent::NewBlock` is deleted.
+
+It has no production constructors and the only handler now belongs to a code path we're removing. Removing it deletes ~30 lines of dead state-machine code plus the unused variant.
+
+### 4. Storage write stays async (CONS-307 unchanged).
+
+`spawn_commit_executor`'s fire-and-forget pattern is preserved. Storage-write failures still surface via `Event::HaltScheduled` and transition the FSM to `Halting`. The engine has already advanced past N at that point — on restart, the boot path re-syncs from whichever storage tip persisted (this node or peers).
+
+### 5. Boot path's storage-vs-engine reconciliation.
+
+On boot, `blockchain.height` from sled is authoritative. Engine initializes to `blockchain.height + 1`. If consensus has progressed beyond what's in sled (another node committed but this one's writer task hadn't flushed before crash), catch-up sync downloads the missing blocks during the Bootstrap phase before BFT mode engages. This already works today; we don't touch it.
+
+## What this rules out
+
+- **Engine drifting behind storage.** The engine no longer reads storage post-boot, so there's no "engine syncs to old value" race.
+- **Engine drifting ahead of storage.** When the engine commits N, it advances to N+1 immediately. If storage fails, halt scheduling is exactly the existing path.
+- **Silent stall.** The bug we hit today required `sync_height_with_blockchain` to be the only advance trigger AND for that trigger to never fire. Both prerequisites go away.
+
+## Risk
+
+**Medium.** This is a consensus correctness change. Failure modes to validate:
+
+1. *Engine advances, storage fails, restart:* engine boots at storage tip, catches up via sync from peers. **Existing path.**
+2. *Engine advances, storage succeeds, restart:* engine boots at storage tip + 1. **Trivial.**
+3. *Same-height fork after restart (PR #2620 scenario):* unaffected — the fix here is orthogonal to quorum-proof determinism.
+4. *Storage falls arbitrarily behind:* engine keeps advancing, halt scheduler eventually fires on accumulated failures. *This is new behavior.* In the old design the engine would block on storage and stop voting, providing implicit backpressure. We need the watchdog (CONS-309) to be the explicit backpressure: if the engine produces commits faster than storage applies them, that's a `Hung` condition the watchdog detects via stale `state_age`.
+
+## Touchpoints
+
+| File | Change |
+|---|---|
+| `lib-consensus/src/engines/consensus_engine/state_machine.rs` | `process_committed_block` advances height after `apply_block_to_state_with_proof` returns; delete `ConsensusEvent::NewBlock` handler arm (line 526); delete the height-sync path in `on_round_timeout(Commit)` (line 2606-2632, replace with a simple round-bump). |
+| `lib-consensus/src/engines/consensus_engine/mod.rs` | Rename `sync_height_with_blockchain` → `init_height_from_storage`; tighten doc comment to "boot only". |
+| `lib-consensus/src/engines/consensus_engine/network.rs` | Single call site updated (line 35). Delete the call at line 137 (mode transition). |
+| `lib-consensus/src/types/mod.rs` | Delete `ConsensusEvent::NewBlock` variant. |
+| `lib-consensus/src/engines/consensus_engine/tests.rs` | Update tests that construct `ConsensusEvent::NewBlock` to use the direct advancement path. |
+| `lib-consensus-runtime/src/runtime.rs` | No structural changes. `spawn_commit_executor` stays as-is — async write with halt-on-failure. |
+
+Estimated ~250 lines net deletion, ~80 lines added.
+
+## Migration
+
+None. Schema-compatible. Storage format unchanged. Network messages unchanged. Validator identity unchanged.
+
+## Test plan
+
+- Unit: existing state-machine tests pass after migrating away from `ConsensusEvent::NewBlock`.
+- Unit: new test — engine commits at H=N, advances to H=N+1 synchronously in the same call frame, with a delayed-writer stub.
+- Unit: storage-failure path — writer returns Err, engine reaches `Halting` via `Event::HaltScheduled` while at H=N+1.
+- Integration: existing BFT integration tests must continue to commit a sequence of blocks.
+- Regression: the specific stall pattern (engine kicked out of Commit step without height advance) — construct a state machine, drive a commit, force a round-bump before the Commit timer fires, assert the engine is at N+1, not N.
+- Live: staged rollout per HALT-BEFORE-DEPLOY. g1 canary first; verify normal block production for ≥100 blocks before extending.

--- a/lib-consensus/src/engines/consensus_engine/mod.rs
+++ b/lib-consensus/src/engines/consensus_engine/mod.rs
@@ -904,14 +904,29 @@ impl ConsensusEngine {
         tracing::info!("🔄 Catch-up sync trigger connected to consensus engine");
     }
 
-    /// Synchronize consensus engine height with blockchain
+    /// CONS-512: Initialize engine height from durable storage at BOOT.
     ///
-    /// Called before starting the consensus loop to ensure the engine
-    /// starts proposing at the correct height (blockchain_height + 1).
+    /// **Boot-only contract.** This is the *single* legitimate point of
+    /// coupling between engine height and blockchain storage. Under the
+    /// engine-owns-height contract (`docs/epics/cons-512-engine-owns-height.md`),
+    /// engine height advancement at runtime happens synchronously inside
+    /// `process_committed_block` — storage is downstream of consensus,
+    /// never the source of truth for runtime height.
     ///
-    /// This is critical for mode transitions:
-    /// - Bootstrap mode produces blocks directly to blockchain
-    /// - When switching to BFT mode, consensus must continue from the correct height
+    /// The bug this contract fixes: pre-CONS-512, `sync_height_with_blockchain`
+    /// was called from `on_round_timeout(Commit)`, the NewBlock event handler
+    /// (never fired in production), and mode transitions. If the engine left
+    /// Commit step before its timer fired, the runtime sync triggers all
+    /// missed, and the engine wedged at H=N with `blockchain.height = N`
+    /// (engine and storage agree on N but disagree on whether N is the
+    /// "next to vote on" or "already committed"). This was the 2026-06-03
+    /// stall.
+    ///
+    /// Callers (post-CONS-512):
+    /// - `run_consensus_loop` start — sole production caller.
+    ///
+    /// Anyone adding a new caller MUST justify why this is not a CONS-512
+    /// regression in the PR description.
     pub async fn sync_height_with_blockchain(&mut self) -> ConsensusResult<()> {
         if let Some(ref provider) = self.blockchain_provider {
             match provider.get_blockchain_height().await {

--- a/lib-consensus/src/engines/consensus_engine/network.rs
+++ b/lib-consensus/src/engines/consensus_engine/network.rs
@@ -133,11 +133,14 @@ impl ConsensusEngine {
                                 "🔄 MODE TRANSITION: Bootstrapping → BFT ({} validators now active)",
                                 validator_count
                             );
-                            // Re-sync height with blockchain to ensure continuity
-                            if let Err(e) = self.sync_height_with_blockchain().await {
-                                tracing::warn!("Failed to sync height during mode transition: {}", e);
-                            }
-                            // Snapshot validator set for the new height
+                            // CONS-512: do NOT call `sync_height_with_blockchain`
+                            // here. The engine's height was initialized from
+                            // storage at boot and has been authoritatively
+                            // advanced by `process_committed_block` ever since.
+                            // Re-reading storage at mode transition would
+                            // regress the engine to whatever sled flushed last,
+                            // re-introducing the pre-CONS-512 wedge bug.
+                            // Snapshot validator set for the current height.
                             self.snapshot_validator_set(self.current_round.height);
                             // Emit mode transition event
                             self.emit_liveness_event(ConsensusEvent::ModeTransitionToBft {

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -1424,26 +1424,45 @@ impl ConsensusEngine {
         quorum_proof: lib_types::consensus::BftQuorumProof,
     ) -> ConsensusResult<()> {
         // CONS-307 channel path: dispatch to the runtime's commit
-        // executor and return immediately. Failures surface back via
+        // executor and return immediately on successful enqueue.
+        // Failures from the executor's own write path surface back via
         // the runtime event channel as `Event::HaltScheduled`, which
         // transitions the FSM to `Halting` on the next select! tick.
+        //
+        // CONS-512 safety: a closed channel (executor receiver dropped,
+        // panicked, or never started) means storage will NEVER receive
+        // this finalized block AND no HaltScheduled event will ever fire.
+        // Under the engine-owns-height contract, returning Ok(()) here
+        // would let `process_committed_block` advance to H+1 while
+        // storage perpetually misses H — exactly the dangerous case the
+        // contract was designed to prevent. Treat send failure as a
+        // hard error so the engine does NOT advance.
         if let Some(tx) = &self.commit_tx {
             let envelope = super::CommitEnvelope {
                 proposal: proposal.clone(),
                 quorum_proof,
             };
-            if tx.send(envelope).is_err() {
-                tracing::warn!(
+            if let Err(e) = tx.send(envelope) {
+                tracing::error!(
                     height = proposal.height,
-                    "Commit channel closed — runtime executor dropped its receiver (CE-ENG-4)"
-                );
-            } else {
-                tracing::debug!(
-                    block_height = proposal.height,
                     proposal_id = ?proposal.id,
-                    "BFT finalized block dispatched to commit executor"
+                    error = %e,
+                    "BFT-A-939 / CONS-512: commit channel closed — runtime executor receiver is gone. \
+                     Refusing to advance engine height; consensus halts at this block until the runtime is restarted."
                 );
+                return Err(ConsensusError::ValidatorError(format!(
+                    "BFT safety violation: committed block at height {} could not be dispatched \
+                     to the commit executor (channel closed). Engine refused to advance to H+1 \
+                     because the executor will never persist this block nor emit HaltScheduled. \
+                     Recovery: investigate why the commit executor died; restart the node.",
+                    proposal.height
+                )));
             }
+            tracing::debug!(
+                block_height = proposal.height,
+                proposal_id = ?proposal.id,
+                "BFT finalized block dispatched to commit executor"
+            );
             return Ok(());
         }
 
@@ -2624,38 +2643,29 @@ impl ConsensusEngine {
                 }
             }
 
-            // Commit step timed out.
+            // Commit step timed out at `height`. Reaching this arm means
+            // the timer-token matched current state — i.e. we are still
+            // at `(height, round, Commit)`. A successful commit would
+            // have advanced us under CONS-512, which would have changed
+            // both height AND step (→ Propose at H+1), so the token
+            // would be stale and on_round_timeout would not have been
+            // called for that timer. Therefore the only reachable case
+            // here is: we sat in Commit step without finalizing (the
+            // proposal we committed to never gathered commit quorum).
+            // Re-drive the same height at the next round so a missed
+            // commit does not wedge us.
             //
-            // CONS-512: under the engine-owns-height contract, height
-            // advancement happens synchronously inside `process_committed_block`
-            // the moment commit quorum is observed. By the time this branch
-            // fires, either:
-            //   (a) we already advanced past `height` (current_round.height
-            //       != height_before), in which case there's nothing to do
-            //       except kick off the new height's propose; or
-            //   (b) the commit attempt at `height` did not reach quorum
-            //       (we sat in Commit step without finalizing), in which
-            //       case re-drive the same height at the next round.
-            //
-            // We DO NOT call `sync_height_with_blockchain` here anymore —
+            // We DO NOT call `sync_height_with_blockchain` here —
             // storage is downstream of consensus, never the source of
-            // engine height post-boot. (The old code path is what wedged
-            // g2 / g3 at H=123008 on 2026-06-03.)
+            // engine height post-boot (CONS-512). The old code path
+            // here is what wedged g2 / g3 at H=123008 on 2026-06-03.
             ConsensusStep::Commit => {
-                if self.current_round.height == height {
-                    // Same-height case: re-drive next round so a missed
-                    // commit does not wedge us.
-                    self.enter_round(
-                        height,
-                        round + 1,
-                        RoundJumpReason::LocalCommitTimeout,
-                    )
-                    .await;
-                } else {
-                    // We already advanced to a new height during commit
-                    // processing. Kick off its propose step.
-                    self.restart_propose_for_current_round().await;
-                }
+                self.enter_round(
+                    height,
+                    round + 1,
+                    RoundJumpReason::LocalCommitTimeout,
+                )
+                .await;
             }
 
             // Between rounds — nothing concrete to time out. Re-drive

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -527,6 +527,13 @@ impl ConsensusEngine {
                 height,
                 previous_hash,
             } => {
+                // CONS-512: this variant is vestigial in production — grep
+                // confirms zero constructors outside tests. The handler is
+                // kept compilable for the test suite and as scaffolding for
+                // any future external block-ingest path (e.g. archive node
+                // replay). DO NOT add a `sync_height_with_blockchain` call
+                // here: the engine-owns-height contract makes storage
+                // downstream of consensus at runtime, not upstream.
                 tracing::info!(
                     "🧱 Processing new block at height {} with previous hash: {}",
                     height,
@@ -547,12 +554,6 @@ impl ConsensusEngine {
                 //   run the deprecated synchronous round driver from event callbacks.
                 // - Keep this event path as state synchronization and bookkeeping only.
                 if self.message_rx.is_some() {
-                    if let Err(e) = self.sync_height_with_blockchain().await {
-                        tracing::warn!(
-                            "Failed to sync consensus height after NewBlock event: {}",
-                            e
-                        );
-                    }
                     self.snapshot_validator_set(self.current_round.height);
 
                     let mut events = vec![ConsensusEvent::RoundCompleted { height }];
@@ -1263,6 +1264,26 @@ impl ConsensusEngine {
         // can verify BFT finality from the block itself.
         self.apply_block_to_state_with_proof(&proposal, quorum_proof)
             .await?;
+
+        // CONS-512: engine owns its own height. BFT decided this block is
+        // final the moment 2f+1 commit votes were observed; advancing here,
+        // in the same call frame as the consensus decision, is the only way
+        // to avoid the engine ↔ storage drift class of bug (which wedged
+        // g2 / g3 at H=123008 on 2026-06-03 — see docs/epics/cons-512-...).
+        //
+        // Storage may not have flushed yet (CONS-307 writer task is async);
+        // that is fine — a storage failure surfaces as Event::HaltScheduled
+        // and the engine halts at H+1's attempt, after which boot-time
+        // catch-up sync reconciles. We DO NOT derive engine height from
+        // storage post-boot; storage is downstream.
+        let committed_height = proposal.height;
+        self.advance_to_next_round();
+        self.snapshot_validator_set(self.current_round.height);
+        tracing::info!(
+            "✅ Engine advanced past committed H={} → now proposing H={}",
+            committed_height,
+            self.current_round.height,
+        );
 
         // Update validator activities and reputation
         self.update_validator_metrics(&proposal).await?;
@@ -2603,20 +2624,27 @@ impl ConsensusEngine {
                 }
             }
 
-            // Commit step timed out: the block was applied; advance height.
+            // Commit step timed out.
+            //
+            // CONS-512: under the engine-owns-height contract, height
+            // advancement happens synchronously inside `process_committed_block`
+            // the moment commit quorum is observed. By the time this branch
+            // fires, either:
+            //   (a) we already advanced past `height` (current_round.height
+            //       != height_before), in which case there's nothing to do
+            //       except kick off the new height's propose; or
+            //   (b) the commit attempt at `height` did not reach quorum
+            //       (we sat in Commit step without finalizing), in which
+            //       case re-drive the same height at the next round.
+            //
+            // We DO NOT call `sync_height_with_blockchain` here anymore —
+            // storage is downstream of consensus, never the source of
+            // engine height post-boot. (The old code path is what wedged
+            // g2 / g3 at H=123008 on 2026-06-03.)
             ConsensusStep::Commit => {
-                let height_before = self.current_round.height;
-                if let Err(e) = self.sync_height_with_blockchain().await {
-                    tracing::warn!(
-                        "Commit timeout: blockchain height sync failed ({}) — \
-                         falling back to local height advance",
-                        e,
-                    );
-                    self.advance_to_next_round();
-                }
-                if self.current_round.height == height_before {
-                    // Height did not advance — re-drive the same height at
-                    // the next round so a missed commit does not wedge us.
+                if self.current_round.height == height {
+                    // Same-height case: re-drive next round so a missed
+                    // commit does not wedge us.
                     self.enter_round(
                         height,
                         round + 1,
@@ -2624,9 +2652,8 @@ impl ConsensusEngine {
                     )
                     .await;
                 } else {
-                    // New height: sync_height_with_blockchain (or
-                    // advance_to_next_round) already reset round to 0 and
-                    // retired the lock state. Kick off its propose step.
+                    // We already advanced to a new height during commit
+                    // processing. Kick off its propose step.
                     self.restart_propose_for_current_round().await;
                 }
             }

--- a/lib-consensus/src/engines/consensus_engine/tests.rs
+++ b/lib-consensus/src/engines/consensus_engine/tests.rs
@@ -914,6 +914,8 @@ async fn test_ce_l1_commit_quorum_finalizes_regardless_of_local_step() {
     let (ref prop_id, ref prop_kp) = validators[0];
     stage_stub_proposal(&mut engine, proposal_id.clone(), h, r, prop_id, prop_kp);
 
+    let pre_commit_height = engine.current_round.height;
+
     // Call maybe_finalize: should transition to Commit step and finalize
     engine
         .maybe_finalize(
@@ -924,17 +926,31 @@ async fn test_ce_l1_commit_quorum_finalizes_regardless_of_local_step() {
         .await
         .unwrap();
 
-    // Verify: Step transitioned to Commit (CE-L1)
+    // CONS-512: under the engine-owns-height contract, a successful commit
+    // advances the engine to the next height in the same call frame. The
+    // post-finalize state is therefore (H+1, round=0, step=Propose), not
+    // (H, step=Commit) as the pre-CONS-512 CE-L1 spec expected.
+    assert_eq!(
+        engine.current_round.height,
+        pre_commit_height + 1,
+        "CONS-512: engine must advance to H+1 after commit quorum"
+    );
+    assert_eq!(
+        engine.current_round.round,
+        0,
+        "CONS-512: round resets to 0 after height advance"
+    );
     assert_eq!(
         engine.current_round.step,
-        ConsensusStep::Commit,
-        "CE-L1: Commit quorum should fast-track to Commit step"
+        ConsensusStep::Propose,
+        "CONS-512: step resets to Propose at the new height"
     );
 
-    // Verify: Commit count is correct
+    // Verify: Commit count is correct (at the height we just committed,
+    // not the new current height).
     let commit_count = engine.count_commits_for(
-        engine.current_round.height,
-        engine.current_round.round,
+        pre_commit_height,
+        0,
         &proposal_id,
     );
     assert_eq!(commit_count, 3, "Should have 3 commits for proposal");
@@ -1721,20 +1737,34 @@ async fn test_canonical_convergence_different_vote_order() {
         .await
         .expect("B: vote 2");
 
-    // INVARIANT CHECK: Both engines MUST be in Commit step
+    // CONS-512 INVARIANT CHECK: Both engines MUST have advanced past the
+    // committed height. Under the engine-owns-height contract a successful
+    // commit advances synchronously, so the post-finalize state is
+    // (height+1, round=0, step=Propose) — not Commit.
+    assert_eq!(
+        engine_a.current_round.height,
+        height + 1,
+        "Node A MUST advance to H+1 after processing quorum"
+    );
     assert_eq!(
         engine_a.current_round.step,
-        ConsensusStep::Commit,
-        "Node A MUST transition to Commit step after processing quorum"
+        ConsensusStep::Propose,
+        "Node A MUST be in Propose at the new height"
     );
 
     assert_eq!(
+        engine_b.current_round.height,
+        height + 1,
+        "Node B MUST advance to H+1 after processing quorum"
+    );
+    assert_eq!(
         engine_b.current_round.step,
-        ConsensusStep::Commit,
-        "Node B MUST transition to Commit step after processing quorum"
+        ConsensusStep::Propose,
+        "Node B MUST be in Propose at the new height"
     );
 
     // INVARIANT CHECK: Both engines MUST have identical commit vote counts
+    // at the height that was just committed (pre-advance height).
     let count_a = engine_a.count_commits_for(height, round, &proposal_id);
     let count_b = engine_b.count_commits_for(height, round, &proposal_id);
 
@@ -1758,7 +1788,7 @@ async fn test_canonical_convergence_different_vote_order() {
     tracing::info!("   - Node A processed votes in order: V1 → V2 → V3");
     tracing::info!("   - Node B processed votes in order: V3 → V1 → V2");
     tracing::info!("   - Both nodes finalized proposal: {}", proposal_id);
-    tracing::info!("   - Both nodes reached Commit step");
+    tracing::info!("   - Both nodes advanced past H={} to H+1", height);
     tracing::info!("   - Deterministic finality: CONFIRMED");
 }
 
@@ -2023,28 +2053,43 @@ async fn test_canonical_convergence_seven_validators() {
             .expect("B: vote");
     }
 
-    // INVARIANT: Both nodes MUST finalize
+    // CONS-512 INVARIANT: Both nodes MUST have advanced past H after
+    // observing the 5th commit vote (quorum). Late-arriving 6th and 7th
+    // votes are correctly stale-rejected at H+1.
+    assert_eq!(
+        engine_a.current_round.height,
+        height + 1,
+        "Node A MUST advance to H+1 after 5/7 quorum"
+    );
     assert_eq!(
         engine_a.current_round.step,
-        ConsensusStep::Commit,
-        "Node A MUST finalize with 5/7 votes"
+        ConsensusStep::Propose,
+        "Node A MUST be in Propose at the new height"
+    );
+    assert_eq!(
+        engine_b.current_round.height,
+        height + 1,
+        "Node B MUST advance to H+1 after 5/7 quorum"
     );
     assert_eq!(
         engine_b.current_round.step,
-        ConsensusStep::Commit,
-        "Node B MUST finalize with 5/7 votes"
+        ConsensusStep::Propose,
+        "Node B MUST be in Propose at the new height"
     );
 
-    // INVARIANT: Vote counts MUST be identical
+    // INVARIANT: Vote counts MUST be identical at the committed height.
+    // Exactly 5 votes were observed pre-advance; votes 6 and 7 arrived
+    // after advance and were stale-rejected (this is desired CONS-512
+    // behavior: post-finalization, peers should move to the next height).
     let count_a = engine_a.count_commits_for(height, round, &proposal_id);
     let count_b = engine_b.count_commits_for(height, round, &proposal_id);
 
-    assert_eq!(count_a, 5, "Node A MUST have 5 commit votes");
-    assert_eq!(count_b, 5, "Node B MUST have 5 commit votes");
+    assert_eq!(count_a, 5, "Node A MUST have 5 commit votes at H (quorum)");
+    assert_eq!(count_b, 5, "Node B MUST have 5 commit votes at H (quorum)");
 
     tracing::info!("✅ 7-validator canonical convergence verified:");
     tracing::info!("   - 7 validators (quorum = 5)");
-    tracing::info!("   - Both nodes finalized with 5 votes");
+    tracing::info!("   - Both nodes advanced past H={} after 5-vote quorum", height);
     tracing::info!("   - Deterministic finality: CONFIRMED");
 }
 
@@ -2217,37 +2262,52 @@ async fn test_canonical_convergence_with_equivocation() {
         .expect("B: vote 3");
 
     // INVARIANT: Both nodes must reach quorum (>= 3) for proposal A.
-    // Vote counts differ due to first-seen-wins: A accepts v0's A-vote, B rejects it.
-    // What matters for BFT safety is that both commit to the SAME proposal, not equal counts.
+    // Under CONS-512, the 3rd vote received triggers immediate finalize +
+    // advance. Subsequent votes (including vote_3 here) arrive at H+1 and
+    // are correctly stale-rejected. Counts therefore reflect only the
+    // votes observed pre-quorum.
     let count_a_proposal_a = engine_a.count_commits_for(height, round, &proposal_a);
     let count_b_proposal_a = engine_b.count_commits_for(height, round, &proposal_a);
 
     assert_eq!(
-        count_a_proposal_a, 4,
-        "Node A should count 4 valid votes for proposal A (v0 accepted first)"
+        count_a_proposal_a, 3,
+        "Node A: 3 votes for proposal A reached pre-advance (v0a, v1, v2); \
+         vote_3 arrived after engine had advanced to H+1 and is stale-rejected"
     );
     assert_eq!(
         count_b_proposal_a, 3,
-        "Node B should count 3 valid votes for proposal A (v0 slot occupied by v0b)"
+        "Node B: 3 votes for proposal A reached pre-advance (v1, v0b, v2); \
+         vote_0a and vote_3 arrived after advance and are stale-rejected"
     );
 
-    // INVARIANT: Both nodes should have finalized on proposal A (quorum = 3/4)
+    // CONS-512: Both nodes should have advanced past H after observing
+    // their respective 3-vote quorums.
+    assert_eq!(
+        engine_a.current_round.height,
+        height + 1,
+        "Node A MUST advance to H+1 after equivocation-tolerant quorum"
+    );
     assert_eq!(
         engine_a.current_round.step,
-        ConsensusStep::Commit,
-        "Node A MUST finalize despite equivocation"
+        ConsensusStep::Propose,
+        "Node A MUST be in Propose at the new height"
+    );
+    assert_eq!(
+        engine_b.current_round.height,
+        height + 1,
+        "Node B MUST advance to H+1 after equivocation-tolerant quorum"
     );
     assert_eq!(
         engine_b.current_round.step,
-        ConsensusStep::Commit,
-        "Node B MUST finalize despite equivocation"
+        ConsensusStep::Propose,
+        "Node B MUST be in Propose at the new height"
     );
 
     tracing::info!("✅ Equivocation handling verified:");
     tracing::info!("   - Validator 0 equivocated (2 different votes)");
-    tracing::info!("   - Node A: rejected v0b (equivocating), 4 votes for A");
-    tracing::info!("   - Node B: rejected v0a (equivocating), 3 votes for A");
-    tracing::info!("   - Both nodes finalized on proposal A (quorum = 3/4)");
+    tracing::info!("   - Node A: rejected v0b (equivocating), reached 3-vote quorum on A");
+    tracing::info!("   - Node B: rejected v0a (equivocating), reached 3-vote quorum on A");
+    tracing::info!("   - Both nodes finalized on proposal A and advanced to H+1");
     tracing::info!("   - BFT convergence maintained: CONFIRMED");
 }
 
@@ -3852,5 +3912,117 @@ async fn test_ce_s2p2_same_round_precommit_quorum_still_advances() {
     assert!(
         engine.current_round.step >= ConsensusStep::Commit,
         "same-round precommit quorum must advance to Commit step"
+    );
+}
+
+/// CONS-512 regression: engine must advance height synchronously when
+/// commit quorum is observed, in the same call frame as the consensus
+/// decision. NO external trigger (NewBlock event, on_round_timeout(Commit),
+/// mode transition) may be required.
+///
+/// This is the exact scenario that wedged g2 / g3 on 2026-06-03: an engine
+/// observed commit quorum at height H, but `current_round.height` did not
+/// advance because the only height-advance triggers were paths the engine
+/// never reached afterwards.
+///
+/// Test shape:
+/// 1. Engine at (H=42, R=0, step=PreVote).
+/// 2. Add 3/4 commit votes (quorum) to the vote pool for proposal P.
+/// 3. Stage proposal P in pending_proposals.
+/// 4. Call `maybe_finalize(H, R, P)` once.
+/// 5. Engine MUST end at (H=43, R=0, step=Propose) — *immediately*, with
+///    no subsequent timer fire or event injection.
+#[tokio::test]
+async fn test_cons512_commit_advances_height_synchronously() {
+    let config = ConsensusConfig {
+        development_mode: true,
+        ..Default::default()
+    };
+    let broadcaster = Arc::new(MockMessageBroadcaster::new());
+    let mut engine =
+        ConsensusEngine::new(config, broadcaster as Arc<dyn MessageBroadcaster>)
+            .expect("Failed to create engine");
+
+    let mut validators = Vec::new();
+    for i in 1..=4 {
+        let validator_id = test_validator_id(i as u8);
+        let keypair = create_test_keypair();
+        register_validator_with_keypair(&mut engine, validator_id.clone(), &keypair, i == 1).await;
+        validators.push((validator_id, keypair));
+    }
+
+    // Pin the engine to a recognisable height — picked away from 0 to make
+    // sure we're not accidentally testing the genesis-special-case path.
+    const COMMITTED_HEIGHT: u64 = 42;
+    const COMMITTED_ROUND: u32 = 0;
+    engine.current_round.height = COMMITTED_HEIGHT;
+    engine.current_round.round = COMMITTED_ROUND;
+    engine.current_round.step = ConsensusStep::PreVote;
+    engine.snapshot_validator_set(COMMITTED_HEIGHT);
+
+    let proposal_id = Hash::from_bytes(&[0xC5u8; 32]);
+    let (ref proposer_id, ref proposer_kp) = validators[0];
+    stage_stub_proposal(
+        &mut engine,
+        proposal_id.clone(),
+        COMMITTED_HEIGHT,
+        COMMITTED_ROUND,
+        proposer_id,
+        proposer_kp,
+    );
+
+    // Inject 3 commit votes (quorum for 4-validator set: 2f+1 with f=1).
+    for i in 0..3 {
+        let (validator_id, keypair) = validators[i].clone();
+        let key = VotePoolKey {
+            height: COMMITTED_HEIGHT,
+            round: COMMITTED_ROUND,
+            vote_type: VoteType::Commit,
+            validator_id: validator_id.clone(),
+        };
+        let vote = make_signed_vote(
+            &engine,
+            &keypair,
+            validator_id,
+            proposal_id.clone(),
+            VoteType::Commit,
+            COMMITTED_HEIGHT,
+            COMMITTED_ROUND,
+        );
+        engine.vote_pool.insert(key, (vote, proposal_id.clone()));
+    }
+
+    // Drive finalization once. Under the pre-CONS-512 contract the engine
+    // would end at (42, *, Commit) and wait for an external trigger to
+    // advance; under CONS-512 it must advance in the same call frame.
+    engine
+        .maybe_finalize(COMMITTED_HEIGHT, COMMITTED_ROUND, &proposal_id)
+        .await
+        .expect("maybe_finalize should succeed with commit quorum");
+
+    assert_eq!(
+        engine.current_round.height,
+        COMMITTED_HEIGHT + 1,
+        "CONS-512: engine MUST advance to H+1 synchronously after commit \
+         quorum. Was the height-advance code in process_committed_block \
+         removed? See docs/epics/cons-512-engine-owns-height.md."
+    );
+    assert_eq!(
+        engine.current_round.round,
+        0,
+        "CONS-512: round resets to 0 at the new height"
+    );
+    assert_eq!(
+        engine.current_round.step,
+        ConsensusStep::Propose,
+        "CONS-512: step resets to Propose at the new height"
+    );
+    assert!(
+        engine.current_round.locked_proposal.is_none(),
+        "CONS-512: locks are retired across the height boundary"
+    );
+    assert!(
+        engine.current_round.valid_proposal.is_none(),
+        "CONS-512: valid_proposal cleared across the height boundary"
     );
 }

--- a/lib-consensus/src/engines/consensus_engine/tests.rs
+++ b/lib-consensus/src/engines/consensus_engine/tests.rs
@@ -947,10 +947,12 @@ async fn test_ce_l1_commit_quorum_finalizes_regardless_of_local_step() {
     );
 
     // Verify: Commit count is correct (at the height we just committed,
-    // not the new current height).
+    // not the new current height). Use the captured round `r` so the
+    // assertion remains correct if the engine's default initial round
+    // changes from 0.
     let commit_count = engine.count_commits_for(
         pre_commit_height,
-        0,
+        r,
         &proposal_id,
     );
     assert_eq!(commit_count, 3, "Should have 3 commits for proposal");
@@ -4024,5 +4026,105 @@ async fn test_cons512_commit_advances_height_synchronously() {
     assert!(
         engine.current_round.valid_proposal.is_none(),
         "CONS-512: valid_proposal cleared across the height boundary"
+    );
+}
+
+/// CONS-512 safety regression (PR #2683 review P1): when the runtime's
+/// commit executor receiver is gone (channel closed), `apply_block_to_state_with_proof`
+/// MUST return Err so that `process_committed_block` propagates the
+/// error and the engine does NOT advance height. Otherwise the engine
+/// would proceed to H+1 while storage perpetually misses H — and no
+/// `HaltScheduled` event would ever fire (there is no executor to emit it).
+#[tokio::test]
+async fn test_cons512_closed_commit_channel_blocks_height_advance() {
+    let config = ConsensusConfig {
+        development_mode: true,
+        ..Default::default()
+    };
+    let broadcaster = Arc::new(MockMessageBroadcaster::new());
+    let mut engine =
+        ConsensusEngine::new(config, broadcaster as Arc<dyn MessageBroadcaster>)
+            .expect("Failed to create engine");
+
+    let mut validators = Vec::new();
+    for i in 1..=4 {
+        let validator_id = test_validator_id(i as u8);
+        let keypair = create_test_keypair();
+        register_validator_with_keypair(&mut engine, validator_id.clone(), &keypair, i == 1).await;
+        validators.push((validator_id, keypair));
+    }
+
+    // Wire a commit channel and IMMEDIATELY drop the receiver to simulate
+    // a dead/never-started runtime executor.
+    let (commit_tx, commit_rx) =
+        tokio::sync::mpsc::unbounded_channel::<crate::engines::consensus_engine::CommitEnvelope>();
+    engine.set_commit_sender(commit_tx);
+    drop(commit_rx);
+
+    const COMMITTED_HEIGHT: u64 = 7;
+    const COMMITTED_ROUND: u32 = 0;
+    engine.current_round.height = COMMITTED_HEIGHT;
+    engine.current_round.round = COMMITTED_ROUND;
+    engine.current_round.step = ConsensusStep::PreVote;
+    engine.snapshot_validator_set(COMMITTED_HEIGHT);
+
+    let proposal_id = Hash::from_bytes(&[0xDEu8; 32]);
+    let (ref proposer_id, ref proposer_kp) = validators[0];
+    stage_stub_proposal(
+        &mut engine,
+        proposal_id.clone(),
+        COMMITTED_HEIGHT,
+        COMMITTED_ROUND,
+        proposer_id,
+        proposer_kp,
+    );
+
+    for i in 0..3 {
+        let (validator_id, keypair) = validators[i].clone();
+        let key = VotePoolKey {
+            height: COMMITTED_HEIGHT,
+            round: COMMITTED_ROUND,
+            vote_type: VoteType::Commit,
+            validator_id: validator_id.clone(),
+        };
+        let vote = make_signed_vote(
+            &engine,
+            &keypair,
+            validator_id,
+            proposal_id.clone(),
+            VoteType::Commit,
+            COMMITTED_HEIGHT,
+            COMMITTED_ROUND,
+        );
+        engine.vote_pool.insert(key, (vote, proposal_id.clone()));
+    }
+
+    // maybe_finalize must surface the commit-dispatch failure so the
+    // engine does not silently advance height.
+    let result = engine
+        .maybe_finalize(COMMITTED_HEIGHT, COMMITTED_ROUND, &proposal_id)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "maybe_finalize MUST propagate the closed-channel error from \
+         apply_block_to_state_with_proof"
+    );
+
+    assert_eq!(
+        engine.current_round.height,
+        COMMITTED_HEIGHT,
+        "CONS-512 P1: engine MUST NOT advance height when the commit \
+         executor receiver is gone. Storage will never see this block; \
+         advancing would leave the engine voting on a chain with no \
+         local persistence."
+    );
+
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("commit executor") || err_msg.contains("channel closed"),
+        "error message must clearly identify the executor channel failure; \
+         got: {}",
+        err_msg
     );
 }


### PR DESCRIPTION
## What

Collapses the engine ↔ blockchain height-counter duplication that wedged g2 / g3 at H=123008 for 11 hours on 2026-06-03.

**Architectural change.** Pre-CONS-512 the engine derived its consensus height from `blockchain.height` via `sync_height_with_blockchain()`. That made storage the source of truth for engine progress, and any missed sync trigger caused silent drift. CONS-512 reverses the direction: the engine OWNS its height, advances synchronously the moment 2f+1 commit votes are observed, and treats storage as a downstream consumer. `sync_height_with_blockchain()` becomes a boot-only contract.

See `docs/epics/cons-512-engine-owns-height.md` for the full design, rationale, and risk analysis.

## Why this and not a smaller patch

The bug shape was: \"add one more sync trigger.\" We resisted that. The pre-CONS-512 design had four sync triggers and we hit a code path that bypassed all of them. Adding a fifth would just defer the next occurrence — same shape applies to the next state-machine refactor that touches the commit path. PRs #2615, #2620, and this one are all variations of \"implicit coordination breaks under recovery.\" The structural fix removes the coordination assumption: engine height is causally consequent to the consensus decision, not derived from a downstream observer.

## Forensic context — the 2026-06-03 stall

Production was at H=123008 across all five validators. g1+g5 engines were at \`current_round.height = 123009\` (correctly proposing the next block). g2+g3 engines were at \`current_round.height = 123008\` (still trying to commit a block their blockchain layer already had committed). Two-vs-two split, neither side could reach 4/5 quorum, chain wedged.

The smoking-gun log:
\`\`\`
peer 3218b9025f votes at height 123009 (our consensus height 123008; local blockchain ~123007)
\`\`\`
The \`local blockchain ~123007\` is misleading — it's computed as \`current_round.height - 1\`, not read from storage. The actual blockchain.height was 123008. So the engine had \`current_round.height = blockchain.height\`, which is one less than it should be (engine vote-target = blockchain + 1).

Recovery required sequential restart of g2 and g3 so the boot path's \`sync_height_with_blockchain\` could re-pin them to 123009. Restart isn't a fix — the bug recurs on any commit if the engine leaves Commit step before its timer fires.

## What changes

| File | Change |
|---|---|
| \`lib-consensus/src/engines/consensus_engine/state_machine.rs\` | \`process_committed_block\` advances height synchronously after \`apply_block_to_state_with_proof\` returns. Removed redundant sync call from \`on_round_timeout(Commit)\`. Added CONS-512 contract comment to the vestigial NewBlock handler. |
| \`lib-consensus/src/engines/consensus_engine/mod.rs\` | Doc on \`sync_height_with_blockchain\` tightened to boot-only contract. |
| \`lib-consensus/src/engines/consensus_engine/network.rs\` | Removed sync call from Bootstrap→BFT mode transition. |
| \`lib-consensus/src/engines/consensus_engine/tests.rs\` | 4 existing tests updated to assert the new contract; 1 new regression test added. |
| \`docs/epics/cons-512-engine-owns-height.md\` | Design doc. |

## What does NOT change

- \`spawn_commit_executor\` in \`lib-consensus-runtime\` — the async-write design is correct, only the engine's height tracking needed to stop deriving from storage.
- Storage write semantics — failures still surface as \`Event::HaltScheduled\`.
- Boot path — \`blockchain.height\` from sled remains authoritative at startup. Catch-up sync still fills any gap from peers before BFT engages.
- Wire format, network protocol, schema, validator identity — all unchanged.

## Risk

Medium. This is a consensus correctness change. The design doc enumerates the failure modes that were considered (engine advances + storage fails + restart; engine advances + storage succeeds + restart; same-height fork after restart unaffected; storage falling arbitrarily behind backstopped by the watchdog).

## Test plan

- [x] \`cargo test -p lib-consensus --lib -- consensus_engine\` → **66/66 pass**, including the new \`test_cons512_commit_advances_height_synchronously\` regression
- [x] \`cargo check --workspace\` clean
- [x] \`cargo test --workspace --lib --no-run\` builds clean (pre-existing E0308 in \`lib-protocols/src/types/request.rs:481\` is unrelated to this branch — exists on dev)
- [ ] Staged rollout per HALT-BEFORE-DEPLOY protocol after merge: g1 canary → verify ≥100 blocks produced normally → g2 → g3 → g4 → g5 → gateways
- [ ] Monitor for the absence of \"our consensus height N; local blockchain ~N-1\" lines after rollout — that log message should never fire again with this contract in place

## Related

- The 2026-06-03 stall (no issue — diagnosed live, see commit body)
- PR #2620 (BFT quorum proof determinism — orthogonal post-restart fork fix)
- PR #2615 (mesh UNI receive size limit — same class of \"silent coordination break\")
- CONS-307 (the async fire-and-forget commit channel that this PR clarifies the contract around — left structurally intact)