### PR TITLE
fix(CONS-513): get_token_nonce reads sled-first in executor mode

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2661,12 +2661,34 @@ impl Blockchain {
     /// is only consulted when the key is absent from the HashMap (e.g. for
     /// nonces written by the BlockExecutor path but not yet reflected in memory).
     pub fn get_token_nonce(&self, token_id: &[u8; 32], address: &[u8; 32]) -> u64 {
-        // In-memory HashMap is the primary source (populated from snapshot on
-        // restart and incremented during process_token_transactions).
+        // CONS-513: when the BlockExecutor is wired (sled-canonical mode, PR
+        // #2675), sled is the source of truth — the in-memory HashMap is no
+        // longer kept in sync (the executor-mode write at contracts.rs is
+        // guarded by `!self.has_executor()`, so it stops incrementing). The
+        // mempool/consensus pre-check (`is_nonce_current`) must therefore
+        // read from sled FIRST in executor mode; otherwise it accepts a tx
+        // with a nonce the BlockExecutor will reject at commit time, halting
+        // consensus via the CONS-512 HaltScheduled path. Exact production
+        // failure: "Invalid nonce: expected 2280, got 2279" at H=123044,
+        // 2026-06-04 — pre-check saw HashMap=2279 (stale) while sled=2280.
+        if self.has_executor() {
+            if let Some(store) = self.get_store() {
+                let token = crate::storage::TokenId::new(*token_id);
+                let addr = crate::storage::Address::new(*address);
+                if let Ok(nonce) = store.get_token_nonce(&token, &addr) {
+                    return nonce;
+                }
+            }
+            // Sled unreachable under executor mode — fall through to the
+            // in-memory HashMap as best-effort (still better than 0).
+        }
+        // Legacy / store-less mode: in-memory HashMap is the authoritative
+        // source (populated from snapshot on restart and incremented during
+        // process_token_transactions).
         if let Some(&nonce) = self.token_nonces.get(&(*token_id, *address)) {
             return nonce;
         }
-        // Fallback to store for nonces not yet reflected in the HashMap.
+        // Store fallback when nothing in-memory yet (e.g., snapshot pre-load).
         if let Some(store) = self.get_store() {
             let token = crate::storage::TokenId::new(*token_id);
             let addr = crate::storage::Address::new(*address);

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2656,10 +2656,16 @@ impl Blockchain {
     /// For SOV transfers, the address is the wallet_id bytes.
     /// For custom token transfers, the address is the key_id bytes.
     ///
-    /// The in-memory HashMap is checked first; it is populated both during live
-    /// block processing and from the TokenStateSnapshot on restart.  The store
-    /// is only consulted when the key is absent from the HashMap (e.g. for
-    /// nonces written by the BlockExecutor path but not yet reflected in memory).
+    /// Source-of-truth depends on mode (CONS-513):
+    /// - **Executor mode** (`has_executor()` true, sled-canonical): sled is
+    ///   queried first because the in-memory HashMap is no longer kept in
+    ///   sync — the contracts.rs increment is gated by `!has_executor()`,
+    ///   so it stops updating once the executor is wired. HashMap is used
+    ///   only as a best-effort fallback when sled is unreachable.
+    /// - **Legacy / store-less mode**: in-memory HashMap is authoritative
+    ///   (populated from the TokenStateSnapshot on restart and incremented
+    ///   during `process_token_transactions`). The store is consulted only
+    ///   when the HashMap has no entry yet (e.g. pre-snapshot-load).
     pub fn get_token_nonce(&self, token_id: &[u8; 32], address: &[u8; 32]) -> u64 {
         // CONS-513: when the BlockExecutor is wired (sled-canonical mode, PR
         // #2675), sled is the source of truth — the in-memory HashMap is no

--- a/lib-blockchain/src/blockchain/tests/store_backed_blockchain_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/store_backed_blockchain_tests.rs
@@ -58,3 +58,72 @@ async fn test_store_backed_apply_genesis_and_block1() {
 
 // cbe_token field removed from Blockchain (EPIC-001 Phase 1).
 // Tests that verified cbe_token state on the Blockchain struct are no longer applicable.
+
+/// CONS-513 regression (PR following #2683): `Blockchain::get_token_nonce`
+/// must read sled FIRST when the BlockExecutor is wired. The pre-fix code
+/// read the in-memory HashMap first, but PR #2675 stopped writing to the
+/// HashMap in executor mode (sled is canonical), so the HashMap value
+/// goes stale as soon as the BlockExecutor increments sled. That stale
+/// value made the mempool/consensus pre-check accept a transaction whose
+/// nonce the BlockExecutor would reject at commit — halting the live
+/// chain at H=123044 on 2026-06-04 ("Invalid nonce: expected 2280, got
+/// 2279").
+#[tokio::test]
+async fn test_get_token_nonce_reads_sled_first_under_executor() {
+    use crate::storage::{Address, BlockchainStore, TokenId};
+
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("test_store");
+    let store = std::sync::Arc::new(SledStore::open(&store_path).unwrap());
+
+    let mut bc = Blockchain::new_with_store(store.clone()).unwrap();
+    assert!(bc.has_executor(), "test setup expects executor wired");
+
+    let token_id = [0xAAu8; 32];
+    let sender = [0xBBu8; 32];
+    let token = TokenId::new(token_id);
+    let addr = Address::new(sender);
+
+    // Sled holds the canonical nonce — write it via a block bracket as
+    // production code does (SledStore requires `begin_block` / `commit_block`).
+    store.begin_block(0).unwrap();
+    store.set_token_nonce(&token, &addr, 2280).unwrap();
+    store.commit_block().unwrap();
+    assert_eq!(
+        store.get_token_nonce(&token, &addr).unwrap(),
+        2280,
+        "precondition: sled holds 2280"
+    );
+
+    // Deliberately seed the in-memory HashMap with the STALE value the bug
+    // produced in production. Pre-fix `get_token_nonce` returned this 2279
+    // (HashMap-first), causing the mempool to accept a tx with nonce 2279.
+    bc.token_nonces.insert((token_id, sender), 2279);
+
+    // CONS-513: under executor mode, sled wins.
+    assert_eq!(
+        bc.get_token_nonce(&token_id, &sender),
+        2280,
+        "CONS-513: get_token_nonce MUST return the sled value (2280) under \
+         executor mode, NOT the stale HashMap value (2279). Pre-fix this \
+         returned 2279 and halted the chain at H=123044."
+    );
+}
+
+/// Counter-test: in legacy (store-less) mode the HashMap is still
+/// authoritative — sled isn't part of the picture.
+#[tokio::test]
+async fn test_get_token_nonce_uses_hashmap_in_storeless_mode() {
+    let mut bc = Blockchain::new().unwrap();
+    assert!(!bc.has_executor(), "storeless Blockchain has no executor");
+
+    let token_id = [0xAAu8; 32];
+    let sender = [0xBBu8; 32];
+
+    // Empty HashMap → 0 (no nonce yet).
+    assert_eq!(bc.get_token_nonce(&token_id, &sender), 0);
+
+    // Populate HashMap → that value is the answer.
+    bc.token_nonces.insert((token_id, sender), 7);
+    assert_eq!(bc.get_token_nonce(&token_id, &sender), 7);
+}


### PR DESCRIPTION
## What

`Blockchain::get_token_nonce` read the in-memory `token_nonces` HashMap first and fell back to sled. PR #2675 stopped writing the HashMap in executor mode (sled is canonical), so once the BlockExecutor incremented sled, the HashMap was perpetually stale. `is_nonce_current` (mempool/consensus pre-check) called `get_token_nonce`, accepted txs with stale nonces, and CONS-512's strict halt-on-commit-failure caught the divergence at commit time and halted the chain.

Fix: under `has_executor()`, read sled FIRST. HashMap is best-effort fallback only when sled is unreachable. Legacy storeless-mode behavior unchanged.

## Production trigger

```
Commit executor: commit failed — scheduling consensus halt to prevent fork
error=BlockExecutor failed to apply block: Transaction failed at index 0:
      Invalid nonce: expected 2280, got 2279
height=123044
```

All four active validators (g1, g2, g3, g5) voted YES on the proposal at H=123044, BlockExecutor rejected the embedded tx, CONS-512 correctly fired `Event::HaltScheduled`. The chain is sitting halted at H=123045 awaiting this fix.

## Not a CONS-512 regression

CONS-512 is doing exactly what it's designed to do — surface the divergence, halt, prevent silent fork. The pre-CONS-512 binary masked this bug by ignoring commit-callback errors. This PR removes the underlying divergence so the halt path stops triggering.

## Test plan

- [x] `test_get_token_nonce_reads_sled_first_under_executor` — exact repro of production state (sled=2280, HashMap=2279) under executor mode, asserts sled wins.
- [x] `test_get_token_nonce_uses_hashmap_in_storeless_mode` — guards the legacy path so we don't regress storeless / test callers.
- [x] `cargo test -p lib-blockchain --lib test_get_token_nonce` → 2/2 pass.
- [x] `cargo check -p lib-blockchain` clean.
- [x] Binary built (`cargo build --profile dev-release -p zhtp`) for staged rollout.

## Follow-up (separate)

The balance-equivalent of this drift is suspected behind g4's "Insufficient token balance" failure at H=74010 during fresh genesis-replay (chain-history-level state-validation divergence). Different surface, different fix. Tracked separately.