### PR TITLE
fix(CONS-514): apply_dao_vote tolerant of legacy-only proposals

### DIFF
--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -1566,29 +1566,46 @@ impl BlockExecutor {
         let contract_id = Self::dao_state_contract_id();
         let mut proposal_key = b"proposal:".to_vec();
         proposal_key.extend_from_slice(data.proposal_id.as_bytes());
-        let proposal_raw = self
-            .store
-            .get_contract_storage(&contract_id, &proposal_key)?
-            .ok_or_else(|| {
-                TxApplyError::InvalidType("DaoVote references unknown proposal".to_string())
-            })?;
+        let proposal_raw_opt = self.store.get_contract_storage(&contract_id, &proposal_key)?;
 
-        // Validate that the voting period has not expired.
-        let proposal: crate::transaction::DaoProposalData = bincode::deserialize(&proposal_raw)
-            .map_err(|e| {
-                TxApplyError::Internal(format!(
-                    "Failed to deserialize proposal for vote check: {e}"
-                ))
-            })?;
-        let voting_deadline = proposal
-            .created_at_height
-            .saturating_add(proposal.voting_period_blocks);
-        if block_height > voting_deadline {
-            return Err(TxApplyError::InvalidType(format!(
-                "DaoVote rejected: voting period for proposal '{}' expired at height {voting_deadline} (current height: {block_height})",
-                data.proposal_id,
-            )));
+        // CONS-514 (legacy-DAO tolerance): proposals submitted via the raw
+        // broadcast path land in `blockchain.dao_proposals` (legacy tally
+        // source) AND are visible to `process_approved_governance_proposals`
+        // via `get_dao_proposals` (iterates sled blocks), but historically
+        // were NOT mirrored into the executor's contract_storage. Rejecting
+        // the vote here halted the cluster on 2026-06-05 (Halt at H=125647)
+        // even though the proposal was demonstrably committed at H=125621.
+        //
+        // The legacy tally path (`Blockchain::tally_dao_votes` →
+        // `get_dao_votes_for_proposal`) reads votes directly from sled
+        // blocks too, so accepting the vote and skipping the executor-side
+        // deadline check is safe — the eventual
+        // `process_approved_governance_proposals` apply path re-reads the
+        // proposal from the canonical block-iter and enforces the deadline
+        // there. Worst case the executor stores a vote whose tally never
+        // counts (unknown proposal), which is identical in effect to no
+        // contract_storage entry at all.
+        if let Some(proposal_raw) = proposal_raw_opt {
+            // Fast path: proposal IS in contract_storage. Enforce the
+            // deadline at apply time as before.
+            let proposal: crate::transaction::DaoProposalData =
+                bincode::deserialize(&proposal_raw).map_err(|e| {
+                    TxApplyError::Internal(format!(
+                        "Failed to deserialize proposal for vote check: {e}"
+                    ))
+                })?;
+            let voting_deadline = proposal
+                .created_at_height
+                .saturating_add(proposal.voting_period_blocks);
+            if block_height > voting_deadline {
+                return Err(TxApplyError::InvalidType(format!(
+                    "DaoVote rejected: voting period for proposal '{}' expired at height {voting_deadline} (current height: {block_height})",
+                    data.proposal_id,
+                )));
+            }
         }
+        // else: legacy proposal — accept the vote, defer the deadline check
+        // to the legacy `apply_difficulty_parameter_update` execution path.
 
         // Key on voter identity so each voter casts exactly one vote per proposal
         // (any subsequent vote by the same voter overwrites the previous one).
@@ -4870,6 +4887,33 @@ mod tests {
         );
         let result = executor.apply_block(&block3);
         assert!(result.is_err(), "Double DaoExecution must be rejected");
+    }
+
+    /// CONS-514 regression: a DaoVote whose proposal is not in the
+    /// executor's contract_storage must NOT halt block application — the
+    /// legacy DAO path (`Blockchain::dao_proposals` / `get_dao_proposals`)
+    /// still owns the canonical tally and the proposal exists there.
+    ///
+    /// Pre-fix this rejected with `"DaoVote references unknown proposal"`
+    /// and halted the live cluster at H=125647 on 2026-06-05.
+    #[test]
+    fn test_dao_vote_accepted_when_proposal_not_in_contract_storage() {
+        let store = create_test_store();
+        let executor = create_test_executor(store.clone());
+
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        // Vote on a proposal_id that was NEVER written to contract_storage
+        // (i.e. legacy-only path). Pre-fix this halts the chain; post-fix
+        // it stores the vote and continues.
+        let unknown_proposal_id = proposal_id_for("legacy-only-proposal");
+        let vote_tx = create_dao_vote_tx(unknown_proposal_id, "alice", "Yes");
+        let block1 = create_block_with_txs(1, genesis.header.block_hash, vec![vote_tx]);
+
+        executor
+            .apply_block(&block1)
+            .expect("vote on legacy-only proposal must apply, not halt the block");
     }
 
     /// DaoVote must be rejected when the proposal voting period has expired.

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -1576,18 +1576,28 @@ impl BlockExecutor {
         // the vote here halted the cluster on 2026-06-05 (Halt at H=125647)
         // even though the proposal was demonstrably committed at H=125621.
         //
-        // The legacy tally path (`Blockchain::tally_dao_votes` →
-        // `get_dao_votes_for_proposal`) reads votes directly from sled
-        // blocks too, so accepting the vote and skipping the executor-side
-        // deadline check is safe — the eventual
-        // `process_approved_governance_proposals` apply path re-reads the
-        // proposal from the canonical block-iter and enforces the deadline
-        // there. Worst case the executor stores a vote whose tally never
-        // counts (unknown proposal), which is identical in effect to no
-        // contract_storage entry at all.
-        if let Some(proposal_raw) = proposal_raw_opt {
-            // Fast path: proposal IS in contract_storage. Enforce the
-            // deadline at apply time as before.
+        // Behaviour now splits cleanly:
+        //
+        //   - Proposal IS in contract_storage (modern path)
+        //       → enforce the voting deadline at apply time.
+        //       → persist the vote into contract_storage so the executor-side
+        //         tally can find it.
+        //
+        //   - Proposal is NOT in contract_storage (legacy-only)
+        //       → accept the tx so consensus continues.
+        //       → skip the contract_storage write entirely. The legacy tally
+        //         path (`Blockchain::tally_dao_votes` →
+        //         `get_dao_votes_for_proposal`) reads votes directly from
+        //         sled blocks, not from contract_storage, so the vote still
+        //         counts. Skipping the write avoids:
+        //           a) state bloat from votes referencing
+        //              arbitrary/nonexistent proposal IDs (#2686 review L1614)
+        //           b) "ghost" vote records that have no enforceable deadline
+        //              if the proposal is later mirrored.
+        //         The eventual `apply_difficulty_parameter_update` execution
+        //         re-reads the proposal from canonical block iteration and
+        //         enforces the deadline there.
+        let proposal_in_storage = if let Some(proposal_raw) = proposal_raw_opt {
             let proposal: crate::transaction::DaoProposalData =
                 bincode::deserialize(&proposal_raw).map_err(|e| {
                     TxApplyError::Internal(format!(
@@ -1603,19 +1613,29 @@ impl BlockExecutor {
                     data.proposal_id,
                 )));
             }
-        }
-        // else: legacy proposal — accept the vote, defer the deadline check
-        // to the legacy `apply_difficulty_parameter_update` execution path.
+            true
+        } else {
+            false
+        };
 
-        // Key on voter identity so each voter casts exactly one vote per proposal
-        // (any subsequent vote by the same voter overwrites the previous one).
-        let mut vote_key = b"vote:".to_vec();
-        vote_key.extend_from_slice(data.proposal_id.as_bytes());
-        vote_key.extend_from_slice(b":");
-        vote_key.extend_from_slice(data.voter.as_bytes());
-        let encoded = bincode::serialize(data)
-            .map_err(|e| TxApplyError::Internal(format!("Failed to serialize DaoVoteData: {e}")))?;
-        mutator.put_contract_storage(&contract_id, &vote_key, &encoded)?;
+        if proposal_in_storage {
+            // Key on voter identity so each voter casts exactly one vote per proposal
+            // (any subsequent vote by the same voter overwrites the previous one).
+            let mut vote_key = b"vote:".to_vec();
+            vote_key.extend_from_slice(data.proposal_id.as_bytes());
+            vote_key.extend_from_slice(b":");
+            vote_key.extend_from_slice(data.voter.as_bytes());
+            let encoded = bincode::serialize(data).map_err(|e| {
+                TxApplyError::Internal(format!("Failed to serialize DaoVoteData: {e}"))
+            })?;
+            mutator.put_contract_storage(&contract_id, &vote_key, &encoded)?;
+        } else {
+            tracing::debug!(
+                proposal_id = %data.proposal_id,
+                voter = %data.voter,
+                "CONS-514: DaoVote accepted for legacy-only proposal — skipping contract_storage write (legacy tally reads from blocks)"
+            );
+        }
 
         Ok(DaoVoteOutcome {
             proposal_id: data.proposal_id,
@@ -4889,31 +4909,87 @@ mod tests {
         assert!(result.is_err(), "Double DaoExecution must be rejected");
     }
 
-    /// CONS-514 regression: a DaoVote whose proposal is not in the
-    /// executor's contract_storage must NOT halt block application — the
-    /// legacy DAO path (`Blockchain::dao_proposals` / `get_dao_proposals`)
-    /// still owns the canonical tally and the proposal exists there.
+    /// CONS-514 regression — reviewer #2686/L4917 refinement: model the
+    /// real production scenario where the proposal IS persisted in the
+    /// block history (so `Blockchain::get_dao_proposals` / legacy tally
+    /// can see it) but NOT mirrored into the executor's
+    /// `contract_storage`. Pre-fix the vote was rejected with
+    /// `"DaoVote references unknown proposal"` and halted the live
+    /// cluster at H=125647 on 2026-06-05.
     ///
-    /// Pre-fix this rejected with `"DaoVote references unknown proposal"`
-    /// and halted the live cluster at H=125647 on 2026-06-05.
+    /// Test setup:
+    ///   1. Append a block containing a DaoProposal tx to the store
+    ///      directly via `append_block`, bypassing the executor — this
+    ///      reproduces a chain where the proposal lives in block history
+    ///      only (the production scenario; e31ca185 at H=125621).
+    ///   2. Apply a vote block via the executor.
+    ///   3. Assert the vote block applies cleanly AND no vote was
+    ///      persisted to contract_storage (reviewer #2686/L1614 — votes
+    ///      for missing-from-storage proposals must not bloat
+    ///      contract_storage; the legacy tally reads from blocks).
     #[test]
-    fn test_dao_vote_accepted_when_proposal_not_in_contract_storage() {
+    fn test_dao_vote_accepted_when_proposal_only_in_block_history() {
         let store = create_test_store();
         let executor = create_test_executor(store.clone());
 
         let genesis = create_genesis_block();
         executor.apply_block(&genesis).unwrap();
 
-        // Vote on a proposal_id that was NEVER written to contract_storage
-        // (i.e. legacy-only path). Pre-fix this halts the chain; post-fix
-        // it stores the vote and continues.
-        let unknown_proposal_id = proposal_id_for("legacy-only-proposal");
-        let vote_tx = create_dao_vote_tx(unknown_proposal_id, "alice", "Yes");
-        let block1 = create_block_with_txs(1, genesis.header.block_hash, vec![vote_tx]);
+        // Build a block at height 1 containing a DaoProposal and APPEND
+        // it directly to sled — skipping the executor entirely so the
+        // proposal lives in block history but not in contract_storage.
+        let proposal_id = proposal_id_for("legacy-only-proposal");
+        let proposal_tx = create_dao_proposal_tx(proposal_id);
+        let proposal_block = create_block_with_txs(
+            1,
+            genesis.header.block_hash,
+            vec![proposal_tx],
+        );
+        store.begin_block(1).unwrap();
+        store.append_block(&proposal_block).unwrap();
+        store.commit_block().unwrap();
 
+        // Sanity: proposal must NOT be in contract_storage (the whole
+        // point — this is the legacy-only state).
+        let contract_id = BlockExecutor::dao_state_contract_id();
+        let mut proposal_key = b"proposal:".to_vec();
+        proposal_key.extend_from_slice(proposal_id.as_bytes());
+        assert!(
+            store
+                .get_contract_storage(&contract_id, &proposal_key)
+                .unwrap()
+                .is_none(),
+            "proposal must be absent from contract_storage (legacy-only setup)"
+        );
+
+        // Apply a vote at height 2 via the executor (the real path).
+        // Pre-fix this would error with "DaoVote references unknown
+        // proposal" and halt the block; post-fix it applies cleanly.
+        let vote_tx = create_dao_vote_tx(proposal_id, "alice", "Yes");
+        let vote_block = create_block_with_txs(
+            2,
+            proposal_block.header.block_hash,
+            vec![vote_tx.clone()],
+        );
         executor
-            .apply_block(&block1)
+            .apply_block(&vote_block)
             .expect("vote on legacy-only proposal must apply, not halt the block");
+
+        // Reviewer #2686/L1614: no vote should be persisted to
+        // contract_storage for a proposal absent from contract_storage,
+        // to avoid state bloat from votes targeting arbitrary IDs.
+        let mut vote_key = b"vote:".to_vec();
+        vote_key.extend_from_slice(proposal_id.as_bytes());
+        vote_key.extend_from_slice(b":");
+        let voter = &vote_tx.dao_vote_data().expect("vote payload").voter;
+        vote_key.extend_from_slice(voter.as_bytes());
+        assert!(
+            store
+                .get_contract_storage(&contract_id, &vote_key)
+                .unwrap()
+                .is_none(),
+            "legacy-only vote must NOT be written to contract_storage"
+        );
     }
 
     /// DaoVote must be rejected when the proposal voting period has expired.


### PR DESCRIPTION
## What

Executor's \`apply_dao_vote\` halted the live cluster on 2026-06-05 because it required the referenced proposal to exist in contract_storage. Proposals that live only in the legacy path (\`Blockchain.dao_proposals\` / sled-block iteration) triggered \`\"DaoVote references unknown proposal\"\` → CONS-512 HaltScheduled → 5/5 validators halted at H=125647.

Fix: when the proposal is absent from contract_storage, accept the vote and skip the executor-side voting-period deadline check. The legacy tally/execution path (\`Blockchain::has_proposal_passed\` → \`apply_difficulty_parameter_update\`) still reads votes from sled blocks and enforces the deadline there.

## Why

Same divergence class as CONS-512 / CONS-513: two parallel state stores (\`Blockchain.dao_*\` vs \`executor.store.contract_storage\`) that should mirror each other but don't always. Aligning them at the proposal-write site is the next step; this PR keeps the chain producing in the meantime.

## Production trigger

\`\`\`
Commit executor: commit failed — scheduling consensus halt to prevent fork
error=BlockExecutor failed to apply block: Transaction failed at index 0:
      Invalid transaction type: DaoVote references unknown proposal
height=125646
\`\`\`
Proposal \`e31ca185...\` was committed at H=125621 and visible via \`get_dao_proposals\`, but never made it into contract_storage. The vote rightly halted to prevent fork; the rejection logic was wrong.

## Test plan

- [x] **New regression test** \`test_dao_vote_accepted_when_proposal_not_in_contract_storage\` — exact production scenario; pre-fix halts the block, post-fix applies.
- [x] **Existing** \`test_dao_vote_rejected_after_voting_period\` still passes — deadline check still fires when the proposal IS in contract_storage (fast path).
- [x] \`cargo check -p lib-blockchain\` clean.
- [ ] Staged rollout per HALT-BEFORE-DEPLOY: deploy to one halted validator, observe it accept the queued vote tx without halting, then roll the others.