### PR TITLE
fix(CONS-515): drop replay TokenTransfer at executor, don't halt chain

### DIFF
--- a/lib-blockchain/src/execution/errors.rs
+++ b/lib-blockchain/src/execution/errors.rs
@@ -135,6 +135,15 @@ pub enum TxApplyError {
     #[error("Invalid nonce: expected {expected}, got {actual}")]
     InvalidNonce { expected: u64, actual: u64 },
 
+    /// CONS-515: replay protection at execution. The tx's nonce is strictly
+    /// below the account's expected nonce, which means it was already applied
+    /// in an earlier block. The apply loop treats this as a soft drop — the
+    /// tx is skipped and execution continues with the next tx in the block.
+    /// Hard-failing on replays would halt consensus whenever the proposer
+    /// re-included a since-applied tx (mempool eviction race).
+    #[error("Replay nonce dropped: expected {expected}, got {actual} (replay protection)")]
+    ReplayDropped { expected: u64, actual: u64 },
+
     #[error("Account not found: {0}")]
     AccountNotFound(Address),
 

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -786,8 +786,24 @@ impl BlockExecutor {
                 .map_err(|e| BlockApplyError::TxFailed { index, reason: e })?;
 
             // validate_tx_stateful (reads only)
-            self.validate_tx_stateful(tx)
-                .map_err(|e| BlockApplyError::TxFailed { index, reason: e })?;
+            // CONS-515: ReplayDropped is a soft drop, not a block-killing error.
+            // The proposer may include a tx whose nonce was advanced in an
+            // earlier block (mempool eviction race). Skip it and continue
+            // with the next tx so consensus stays live; the block hash stays
+            // valid because we don't mutate `block.transactions`.
+            if let Err(e) = self.validate_tx_stateful(tx) {
+                if let TxApplyError::ReplayDropped { expected, actual } = e {
+                    tracing::warn!(
+                        index = index,
+                        height = block_height,
+                        expected_nonce = expected,
+                        actual_nonce = actual,
+                        "CONS-515: dropping replay tx during block apply"
+                    );
+                    continue;
+                }
+                return Err(BlockApplyError::TxFailed { index, reason: e });
+            }
 
             // apply_tx (writes)
             let tx_result = self
@@ -1377,6 +1393,16 @@ impl BlockExecutor {
                 let from = Address::new(transfer.from);
 
                 let expected_nonce = view.get_token_nonce(&token, &from)?;
+                // CONS-515: distinguish replay (nonce < expected) from gap
+                // (nonce > expected). Replay means an earlier block already
+                // applied this tx — the apply loop drops it and continues so
+                // a mempool-eviction race cannot halt consensus.
+                if transfer.nonce < expected_nonce {
+                    return Err(TxApplyError::ReplayDropped {
+                        expected: expected_nonce,
+                        actual: transfer.nonce,
+                    });
+                }
                 if transfer.nonce != expected_nonce {
                     return Err(TxApplyError::InvalidNonce {
                         expected: expected_nonce,


### PR DESCRIPTION
## Problem

A proposer can include a `TokenTransfer` whose nonce was already applied in an earlier block (mempool eviction race). Previously the executor returned `InvalidNonce` → `BlockApplyError::TxFailed` → runtime scheduled a fork-prevention halt.

Production hit this exact path: chain halted at H=125678 with `Invalid nonce: expected 2377, got 2376` on block 125677. All 5 validators stuck.

Replay-too-low is not a fork condition — the tx is by definition non-canonical and safe to skip. Hard-failing the whole block over a stale tx is incorrect.

## Fix

- Add `TxApplyError::ReplayDropped { expected, actual }` (soft outcome, distinct from `InvalidNonce` which still hard-fails on nonce-too-high / gap).
- `validate_tx_stateful` returns `ReplayDropped` for `transfer.nonce < expected_nonce`; keeps `InvalidNonce` for `transfer.nonce > expected`.
- Block-apply loop matches on `ReplayDropped`: logs a warn (`index`, `height`, `expected_nonce`, `actual_nonce`) and `continue`s to the next tx. Block hash stays valid — we don't mutate `block.transactions`, only skip the apply side-effects.

## Determinism

All validators on this binary make the same drop decision for the same tx (sled-first read + identical compare). No state divergence.

## Production verification

Deployed binary `0ab11a2f` to all 5 validators while halted at 125678:
- First re-application of block 125677 → bad tx dropped (`CONS-515: dropping replay tx during block apply` warn)
- Block applied, consensus resumed
- H=125678, 125679, 125680 committed within minutes

## Follow-ups (separate work)

- Mempool eviction race that allowed the replay tx in the first place (still a bug, just no longer chain-halting)
- Executor checkpoint so restart doesn't full-replay (#2687)

## Test plan

- [x] Existing executor unit tests pass
- [ ] **TODO**: add unit test for ReplayDropped path
- [x] Live verified on testnet (g1-g5, H=125677 unwedged → 125680 within minutes)
