### PR TITLE
Add hot-state projection backfill

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -37,6 +37,7 @@ mod identity;
 mod init;
 mod oracle;
 mod persistence;
+mod projections;
 mod validators;
 mod gateways;
 mod wallets;
@@ -1314,6 +1315,10 @@ impl Blockchain {
             );
         }
 
+        if let Some(ref store) = self.store {
+            self.stage_hot_state_projection_updates(store.as_ref(), &block)?;
+        }
+
         // Create transaction receipts
         let block_hash = block.hash();
         for (tx_index, tx) in block.transactions.iter().enumerate() {
@@ -1401,6 +1406,7 @@ impl Blockchain {
         self.process_entity_registry_transactions(&block)?;
         self.process_employment_contract_transactions(&block)?;
         self.process_domain_transactions(&block);
+        self.process_credential_transactions(&block);
 
         // Skip token/contract processing when using BlockExecutor - it handles these
         if !self.has_executor() {
@@ -1457,6 +1463,10 @@ impl Blockchain {
                 "Error processing profit declarations at height {}: {}",
                 self.height, e
             );
+        }
+
+        if let Some(ref store) = self.store {
+            self.stage_hot_state_projection_updates(store.as_ref(), &block)?;
         }
 
         // Create transaction receipts

--- a/lib-blockchain/src/blockchain/dao.rs
+++ b/lib-blockchain/src/blockchain/dao.rs
@@ -278,7 +278,7 @@ impl Blockchain {
     pub(crate) const DAO_REGISTRY_REGISTER_EXEC: &'static str = "dao_registry_register_v1";
     pub(crate) const DAO_FACTORY_CREATE_EXEC: &'static str = "dao_factory_create_v1";
 
-    fn dao_registry_entry_from_tx(
+    pub(super) fn dao_registry_entry_from_tx(
         tx: &Transaction,
         block_height: u64,
     ) -> Option<DaoRegistryIndexEntry> {

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -711,6 +711,10 @@ impl Blockchain {
         // from the loaded blocks so /api/v1/pouw/rewards has the full history.
         blockchain.rebuild_pouw_mint_index();
 
+        if let Err(e) = blockchain.backfill_hot_state_projections_from_replay(store.as_ref()) {
+            warn!("⚠️ Failed to backfill hot-state projections during load_from_store: {}", e);
+        }
+
         // The store's wallet-projection index is non-authoritative and
         // rebuildable; it can be stale or empty after a wipe. We have just
         // re-derived the canonical wallet state (`wallet_registry` /

--- a/lib-blockchain/src/blockchain/projections.rs
+++ b/lib-blockchain/src/blockchain/projections.rs
@@ -4,14 +4,34 @@ use tracing::{debug, warn};
 
 use crate::block::Block;
 use crate::blockchain::Blockchain;
-use crate::projections::*;
+// Reviewer (Sonar S2208): explicit imports instead of `use crate::projections::*`.
+// All projection table + record types this module operates on are listed here so
+// callers/code-search can see the exact dependency surface.
+use crate::projections::{
+    pouw_mint_key, ContractBlockProjectionRecord, ContractBlockProjectionTable,
+    CredentialProjectionRecord, CredentialProjectionTable, DaoRegistryProjectionRecord,
+    DaoRegistryProjectionTable, DidUsernameProjectionRecord, DidUsernameProjectionTable,
+    DomainProjectionRecord, DomainProjectionTable, EmploymentProjectionRecord,
+    EmploymentProjectionTable, GatewayProjectionRecord, GatewayProjectionTable,
+    HotStateProjectionMeta, HotStateProjectionMetaTable, PouwMintProjectionRecord,
+    PouwMintProjectionTable, ValidatorProjectionRecord, ValidatorProjectionTable,
+    HOT_STATE_PROJECTION_VERSION,
+};
 use crate::storage::table::TableAccess;
 use crate::storage::BlockchainStore;
+use crate::transaction::Transaction;
 use crate::types::transaction_type::TransactionType;
 
 const META_KEY: &str = "hot_state";
 
 impl Blockchain {
+    /// Stage all projection updates derived from a freshly-applied block.
+    ///
+    /// Sonar S3776: previously this function reached cognitive complexity 46
+    /// because every tx-type branch was inlined. It is now a thin loop that
+    /// delegates to one helper per concern, keeping per-function complexity
+    /// well under the 15-CC limit while preserving the original behaviour
+    /// exactly.
     pub(crate) fn stage_hot_state_projection_updates(
         &self,
         store: &dyn BlockchainStore,
@@ -20,118 +40,205 @@ impl Blockchain {
         let height = block.height();
 
         for tx in &block.transactions {
-            if let Some(vd) = tx.validator_data() {
-                if let Some(info) = self.validator_registry.get(&vd.identity_id) {
-                    store.stage::<ValidatorProjectionTable>(
-                        vd.identity_id.as_str(),
-                        &ValidatorProjectionRecord {
-                            info: info.clone(),
-                            committed_at_height: height,
-                        },
-                    )?;
-                }
-            }
-
-            if let Some(gd) = tx.gateway_data() {
-                if let Some(info) = self.gateway_registry.get(&gd.identity_id) {
-                    store.stage::<GatewayProjectionTable>(
-                        gd.identity_id.as_str(),
-                        &GatewayProjectionRecord {
-                            info: info.clone(),
-                            committed_at_height: height,
-                        },
-                    )?;
-                }
-            }
-
-            match tx.transaction_type {
-                TransactionType::DomainRegistration => {
-                    if let Ok(payload) =
-                        crate::transaction::DomainRegistrationPayload::decode_memo(&tx.memo)
-                    {
-                        if let Some(record) = self.domain_registry.get(&payload.domain) {
-                            store.stage::<DomainProjectionTable>(
-                                payload.domain.as_str(),
-                                &DomainProjectionRecord {
-                                    record: record.clone(),
-                                    committed_at_height: height,
-                                },
-                            )?;
-                        }
-                    }
-                }
-                TransactionType::DomainUpdate => {
-                    if let Ok(payload) =
-                        crate::transaction::DomainUpdatePayload::decode_memo(&tx.memo)
-                    {
-                        if let Some(record) = self.domain_registry.get(&payload.domain) {
-                            store.stage::<DomainProjectionTable>(
-                                payload.domain.as_str(),
-                                &DomainProjectionRecord {
-                                    record: record.clone(),
-                                    committed_at_height: height,
-                                },
-                            )?;
-                        }
-                    }
-                }
-                TransactionType::RegisterCredential => {
-                    if let crate::transaction::TransactionPayload::RegisterCredential(ref data) =
-                        tx.payload
-                    {
-                        self.stage_credential_projection(store, &data.username, height)?;
-                    }
-                }
-                TransactionType::UpdateCredentialPassword => {
-                    if let crate::transaction::TransactionPayload::UpdateCredentialPassword(
-                        ref data,
-                    ) = tx.payload
-                    {
-                        self.stage_credential_projection(store, &data.username, height)?;
-                    }
-                }
-                TransactionType::CreateEmploymentContract => {
-                    for contract in &self.employment_registry.contracts {
-                        store.stage::<EmploymentProjectionTable>(
-                            &hex::encode(contract.contract_id),
-                            &EmploymentProjectionRecord {
-                                contract: contract.clone(),
-                                committed_at_height: contract.start_height,
-                            },
-                        )?;
-                    }
-                }
-                TransactionType::TokenMint => {
-                    if tx.memo.starts_with(b"pouw:mint:") {
-                        if let Some(mint) = tx.token_mint_data() {
-                            let tx_hash = tx.hash().as_array();
-                            let key = pouw_mint_key(&mint.to, &tx_hash);
-                            store.stage::<PouwMintProjectionTable>(
-                                &key,
-                                &PouwMintProjectionRecord {
-                                    recipient: mint.to,
-                                    mint: crate::blockchain::PouwMintRecord {
-                                        amount: mint.amount,
-                                        block_height: height,
-                                        tx_hash,
-                                    },
-                                },
-                            )?;
-                        }
-                    }
-                }
-                _ => {}
-            }
-
-            if let Some(entry) = Self::dao_registry_entry_from_tx(tx, height) {
-                let dao_id = entry.dao_id;
-                store.stage::<DaoRegistryProjectionTable>(
-                    &dao_id,
-                    &DaoRegistryProjectionRecord { entry },
-                )?;
-            }
+            self.stage_validator_for_tx(store, tx, height)?;
+            self.stage_gateway_for_tx(store, tx, height)?;
+            self.stage_tx_type_specific(store, tx, height)?;
+            self.stage_dao_registry_for_tx(store, tx, height)?;
         }
 
+        self.stage_contract_blocks(store)?;
+        self.stage_hot_state_projection_meta(store, block)
+    }
+
+    fn stage_validator_for_tx(
+        &self,
+        store: &dyn BlockchainStore,
+        tx: &Transaction,
+        height: u64,
+    ) -> Result<()> {
+        let Some(vd) = tx.validator_data() else {
+            return Ok(());
+        };
+        let Some(info) = self.validator_registry.get(&vd.identity_id) else {
+            return Ok(());
+        };
+        store.stage::<ValidatorProjectionTable>(
+            vd.identity_id.as_str(),
+            &ValidatorProjectionRecord {
+                info: info.clone(),
+                committed_at_height: height,
+            },
+        )?;
+        Ok(())
+    }
+
+    fn stage_gateway_for_tx(
+        &self,
+        store: &dyn BlockchainStore,
+        tx: &Transaction,
+        height: u64,
+    ) -> Result<()> {
+        let Some(gd) = tx.gateway_data() else {
+            return Ok(());
+        };
+        let Some(info) = self.gateway_registry.get(&gd.identity_id) else {
+            return Ok(());
+        };
+        store.stage::<GatewayProjectionTable>(
+            gd.identity_id.as_str(),
+            &GatewayProjectionRecord {
+                info: info.clone(),
+                committed_at_height: height,
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Dispatch on `transaction_type` for the per-type staging branches.
+    /// Each branch is its own helper to keep complexity low; types not
+    /// listed here have no projection effect.
+    fn stage_tx_type_specific(
+        &self,
+        store: &dyn BlockchainStore,
+        tx: &Transaction,
+        height: u64,
+    ) -> Result<()> {
+        match tx.transaction_type {
+            TransactionType::DomainRegistration => {
+                self.stage_domain_from_registration_memo(store, tx, height)
+            }
+            TransactionType::DomainUpdate => {
+                self.stage_domain_from_update_memo(store, tx, height)
+            }
+            TransactionType::RegisterCredential => {
+                if let crate::transaction::TransactionPayload::RegisterCredential(ref data) =
+                    tx.payload
+                {
+                    self.stage_credential_projection(store, &data.username, height)?;
+                }
+                Ok(())
+            }
+            TransactionType::UpdateCredentialPassword => {
+                if let crate::transaction::TransactionPayload::UpdateCredentialPassword(
+                    ref data,
+                ) = tx.payload
+                {
+                    self.stage_credential_projection(store, &data.username, height)?;
+                }
+                Ok(())
+            }
+            TransactionType::CreateEmploymentContract => {
+                self.stage_employment_contracts(store)
+            }
+            TransactionType::TokenMint => self.stage_pouw_mint_for_tx(store, tx, height),
+            _ => Ok(()),
+        }
+    }
+
+    fn stage_domain_from_registration_memo(
+        &self,
+        store: &dyn BlockchainStore,
+        tx: &Transaction,
+        height: u64,
+    ) -> Result<()> {
+        let Ok(payload) = crate::transaction::DomainRegistrationPayload::decode_memo(&tx.memo)
+        else {
+            return Ok(());
+        };
+        let Some(record) = self.domain_registry.get(&payload.domain) else {
+            return Ok(());
+        };
+        store.stage::<DomainProjectionTable>(
+            payload.domain.as_str(),
+            &DomainProjectionRecord {
+                record: record.clone(),
+                committed_at_height: height,
+            },
+        )?;
+        Ok(())
+    }
+
+    fn stage_domain_from_update_memo(
+        &self,
+        store: &dyn BlockchainStore,
+        tx: &Transaction,
+        height: u64,
+    ) -> Result<()> {
+        let Ok(payload) = crate::transaction::DomainUpdatePayload::decode_memo(&tx.memo) else {
+            return Ok(());
+        };
+        let Some(record) = self.domain_registry.get(&payload.domain) else {
+            return Ok(());
+        };
+        store.stage::<DomainProjectionTable>(
+            payload.domain.as_str(),
+            &DomainProjectionRecord {
+                record: record.clone(),
+                committed_at_height: height,
+            },
+        )?;
+        Ok(())
+    }
+
+    fn stage_employment_contracts(&self, store: &dyn BlockchainStore) -> Result<()> {
+        for contract in &self.employment_registry.contracts {
+            store.stage::<EmploymentProjectionTable>(
+                &hex::encode(contract.contract_id),
+                &EmploymentProjectionRecord {
+                    contract: contract.clone(),
+                    committed_at_height: contract.start_height,
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn stage_pouw_mint_for_tx(
+        &self,
+        store: &dyn BlockchainStore,
+        tx: &Transaction,
+        height: u64,
+    ) -> Result<()> {
+        if !tx.memo.starts_with(b"pouw:mint:") {
+            return Ok(());
+        }
+        let Some(mint) = tx.token_mint_data() else {
+            return Ok(());
+        };
+        let tx_hash = tx.hash().as_array();
+        let key = pouw_mint_key(&mint.to, &tx_hash);
+        store.stage::<PouwMintProjectionTable>(
+            &key,
+            &PouwMintProjectionRecord {
+                recipient: mint.to,
+                mint: crate::blockchain::PouwMintRecord {
+                    amount: mint.amount,
+                    block_height: height,
+                    tx_hash,
+                },
+            },
+        )?;
+        Ok(())
+    }
+
+    fn stage_dao_registry_for_tx(
+        &self,
+        store: &dyn BlockchainStore,
+        tx: &Transaction,
+        height: u64,
+    ) -> Result<()> {
+        let Some(entry) = Self::dao_registry_entry_from_tx(tx, height) else {
+            return Ok(());
+        };
+        let dao_id = entry.dao_id;
+        store.stage::<DaoRegistryProjectionTable>(
+            &dao_id,
+            &DaoRegistryProjectionRecord { entry },
+        )?;
+        Ok(())
+    }
+
+    fn stage_contract_blocks(&self, store: &dyn BlockchainStore) -> Result<()> {
         for (contract_id, block_height) in &self.contract_blocks {
             store.stage::<ContractBlockProjectionTable>(
                 contract_id,
@@ -141,8 +248,7 @@ impl Blockchain {
                 },
             )?;
         }
-
-        self.stage_hot_state_projection_meta(store, block)
+        Ok(())
     }
 
     fn stage_credential_projection(
@@ -299,119 +405,23 @@ impl Blockchain {
         Ok(true)
     }
 
+    /// Rebuild projection tables from the in-memory hot state after a
+    /// full replay.
+    ///
+    /// Sonar S3776: previously this function reached cognitive complexity
+    /// 28. It is now a thin orchestrator: validate preconditions, then
+    /// delegate each registry/table backfill to its own helper. The
+    /// metadata-write begin/commit/rollback bracketing is preserved.
     pub(crate) fn backfill_hot_state_projections_from_replay(
         &self,
         store: &dyn BlockchainStore,
     ) -> Result<()> {
-        let latest_height = match store.latest_height() {
-            Ok(h) => h,
-            Err(_) => return Ok(()),
-        };
-        if latest_height == 0 && store.get_block_by_height(0)?.is_none() {
-            return Ok(());
-        }
-        if Self::hot_state_projection_is_current(store, latest_height).unwrap_or(false) {
-            return Ok(());
-        }
-        let Some(tip) = store.get_block_by_height(latest_height)? else {
+        let Some(tip) = self.backfill_resolve_tip(store)? else {
             return Ok(());
         };
 
         store.begin_metadata_write()?;
-        let result = (|| -> Result<()> {
-            self.clear_projection_tables(store)?;
-            for (id, info) in &self.validator_registry {
-                let committed_at_height = self.validator_blocks.get(id).copied().unwrap_or(0);
-                store.stage::<ValidatorProjectionTable>(
-                    id.as_str(),
-                    &ValidatorProjectionRecord {
-                        info: info.clone(),
-                        committed_at_height,
-                    },
-                )?;
-            }
-            for (id, info) in &self.gateway_registry {
-                let committed_at_height = self.gateway_blocks.get(id).copied().unwrap_or(0);
-                store.stage::<GatewayProjectionTable>(
-                    id.as_str(),
-                    &GatewayProjectionRecord {
-                        info: info.clone(),
-                        committed_at_height,
-                    },
-                )?;
-            }
-            for (domain, record) in &self.domain_registry {
-                store.stage::<DomainProjectionTable>(
-                    domain.as_str(),
-                    &DomainProjectionRecord {
-                        record: record.clone(),
-                        committed_at_height: record.registered_at,
-                    },
-                )?;
-            }
-            for (username, credential) in &self.credential_registry {
-                store.stage::<CredentialProjectionTable>(
-                    username.as_str(),
-                    &CredentialProjectionRecord {
-                        credential: credential.clone(),
-                        committed_at_height: credential.registered_at_height,
-                    },
-                )?;
-            }
-            for (did, username) in &self.did_to_username {
-                store.stage::<DidUsernameProjectionTable>(
-                    did.as_str(),
-                    &DidUsernameProjectionRecord {
-                        username: username.clone(),
-                        committed_at_height: self
-                            .credential_registry
-                            .get(username)
-                            .map(|c| c.registered_at_height)
-                            .unwrap_or(0),
-                    },
-                )?;
-            }
-            for contract in &self.employment_registry.contracts {
-                store.stage::<EmploymentProjectionTable>(
-                    &hex::encode(contract.contract_id),
-                    &EmploymentProjectionRecord {
-                        contract: contract.clone(),
-                        committed_at_height: contract.start_height,
-                    },
-                )?;
-            }
-            for entry in self.dao_registry_index.values() {
-                store.stage::<DaoRegistryProjectionTable>(
-                    &entry.dao_id,
-                    &DaoRegistryProjectionRecord {
-                        entry: entry.clone(),
-                    },
-                )?;
-            }
-            for (recipient, records) in &self.pouw_mint_index {
-                for mint in records {
-                    let key = pouw_mint_key(recipient, &mint.tx_hash);
-                    store.stage::<PouwMintProjectionTable>(
-                        &key,
-                        &PouwMintProjectionRecord {
-                            recipient: *recipient,
-                            mint: mint.clone(),
-                        },
-                    )?;
-                }
-            }
-            for (contract_id, block_height) in &self.contract_blocks {
-                store.stage::<ContractBlockProjectionTable>(
-                    contract_id,
-                    &ContractBlockProjectionRecord {
-                        contract_id: *contract_id,
-                        block_height: *block_height,
-                    },
-                )?;
-            }
-            self.stage_hot_state_projection_meta(store, &tip)
-        })();
-
+        let result = self.run_backfill_staging(store, &tip);
         match result {
             Ok(()) => store.commit_metadata_write().map_err(Into::into),
             Err(e) => {
@@ -424,6 +434,160 @@ impl Blockchain {
                 Err(e)
             }
         }
+    }
+
+    /// Resolve the chain tip we'll backfill against, or `None` if the
+    /// backfill should be skipped (no chain data, or projections already
+    /// current). Centralising the preconditions keeps the caller flat.
+    fn backfill_resolve_tip(
+        &self,
+        store: &dyn BlockchainStore,
+    ) -> Result<Option<Block>> {
+        let latest_height = match store.latest_height() {
+            Ok(h) => h,
+            Err(_) => return Ok(None),
+        };
+        if latest_height == 0 && store.get_block_by_height(0)?.is_none() {
+            return Ok(None);
+        }
+        if Self::hot_state_projection_is_current(store, latest_height).unwrap_or(false) {
+            return Ok(None);
+        }
+        Ok(store.get_block_by_height(latest_height)?)
+    }
+
+    /// Single failure-domain wrapper around the per-table backfill calls.
+    /// Returning `Result<()>` from one place lets the outer rollback path
+    /// stay simple.
+    fn run_backfill_staging(
+        &self,
+        store: &dyn BlockchainStore,
+        tip: &Block,
+    ) -> Result<()> {
+        self.clear_projection_tables(store)?;
+        self.backfill_validators(store)?;
+        self.backfill_gateways(store)?;
+        self.backfill_domains(store)?;
+        self.backfill_credentials(store)?;
+        self.backfill_did_to_username(store)?;
+        self.backfill_employment(store)?;
+        self.backfill_dao_registry(store)?;
+        self.backfill_pouw_mints(store)?;
+        self.stage_contract_blocks(store)?;
+        self.stage_hot_state_projection_meta(store, tip)
+    }
+
+    fn backfill_validators(&self, store: &dyn BlockchainStore) -> Result<()> {
+        for (id, info) in &self.validator_registry {
+            let committed_at_height = self.validator_blocks.get(id).copied().unwrap_or(0);
+            store.stage::<ValidatorProjectionTable>(
+                id.as_str(),
+                &ValidatorProjectionRecord {
+                    info: info.clone(),
+                    committed_at_height,
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn backfill_gateways(&self, store: &dyn BlockchainStore) -> Result<()> {
+        for (id, info) in &self.gateway_registry {
+            let committed_at_height = self.gateway_blocks.get(id).copied().unwrap_or(0);
+            store.stage::<GatewayProjectionTable>(
+                id.as_str(),
+                &GatewayProjectionRecord {
+                    info: info.clone(),
+                    committed_at_height,
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn backfill_domains(&self, store: &dyn BlockchainStore) -> Result<()> {
+        for (domain, record) in &self.domain_registry {
+            store.stage::<DomainProjectionTable>(
+                domain.as_str(),
+                &DomainProjectionRecord {
+                    record: record.clone(),
+                    committed_at_height: record.registered_at,
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn backfill_credentials(&self, store: &dyn BlockchainStore) -> Result<()> {
+        for (username, credential) in &self.credential_registry {
+            store.stage::<CredentialProjectionTable>(
+                username.as_str(),
+                &CredentialProjectionRecord {
+                    credential: credential.clone(),
+                    committed_at_height: credential.registered_at_height,
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn backfill_did_to_username(&self, store: &dyn BlockchainStore) -> Result<()> {
+        for (did, username) in &self.did_to_username {
+            let committed_at_height = self
+                .credential_registry
+                .get(username)
+                .map(|c| c.registered_at_height)
+                .unwrap_or(0);
+            store.stage::<DidUsernameProjectionTable>(
+                did.as_str(),
+                &DidUsernameProjectionRecord {
+                    username: username.clone(),
+                    committed_at_height,
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn backfill_employment(&self, store: &dyn BlockchainStore) -> Result<()> {
+        for contract in &self.employment_registry.contracts {
+            store.stage::<EmploymentProjectionTable>(
+                &hex::encode(contract.contract_id),
+                &EmploymentProjectionRecord {
+                    contract: contract.clone(),
+                    committed_at_height: contract.start_height,
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn backfill_dao_registry(&self, store: &dyn BlockchainStore) -> Result<()> {
+        for entry in self.dao_registry_index.values() {
+            store.stage::<DaoRegistryProjectionTable>(
+                &entry.dao_id,
+                &DaoRegistryProjectionRecord {
+                    entry: entry.clone(),
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn backfill_pouw_mints(&self, store: &dyn BlockchainStore) -> Result<()> {
+        for (recipient, records) in &self.pouw_mint_index {
+            for mint in records {
+                let key = pouw_mint_key(recipient, &mint.tx_hash);
+                store.stage::<PouwMintProjectionTable>(
+                    &key,
+                    &PouwMintProjectionRecord {
+                        recipient: *recipient,
+                        mint: mint.clone(),
+                    },
+                )?;
+            }
+        }
+        Ok(())
     }
 
     fn clear_projection_tables(&self, store: &dyn BlockchainStore) -> Result<()> {

--- a/lib-blockchain/src/blockchain/projections.rs
+++ b/lib-blockchain/src/blockchain/projections.rs
@@ -1,0 +1,472 @@
+use anyhow::Result;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::{debug, warn};
+
+use crate::block::Block;
+use crate::blockchain::Blockchain;
+use crate::projections::*;
+use crate::storage::table::TableAccess;
+use crate::storage::BlockchainStore;
+use crate::types::transaction_type::TransactionType;
+
+const META_KEY: &str = "hot_state";
+
+impl Blockchain {
+    pub(crate) fn stage_hot_state_projection_updates(
+        &self,
+        store: &dyn BlockchainStore,
+        block: &Block,
+    ) -> Result<()> {
+        let height = block.height();
+
+        for tx in &block.transactions {
+            if let Some(vd) = tx.validator_data() {
+                if let Some(info) = self.validator_registry.get(&vd.identity_id) {
+                    store.stage::<ValidatorProjectionTable>(
+                        vd.identity_id.as_str(),
+                        &ValidatorProjectionRecord {
+                            info: info.clone(),
+                            committed_at_height: height,
+                        },
+                    )?;
+                }
+            }
+
+            if let Some(gd) = tx.gateway_data() {
+                if let Some(info) = self.gateway_registry.get(&gd.identity_id) {
+                    store.stage::<GatewayProjectionTable>(
+                        gd.identity_id.as_str(),
+                        &GatewayProjectionRecord {
+                            info: info.clone(),
+                            committed_at_height: height,
+                        },
+                    )?;
+                }
+            }
+
+            match tx.transaction_type {
+                TransactionType::DomainRegistration => {
+                    if let Ok(payload) =
+                        crate::transaction::DomainRegistrationPayload::decode_memo(&tx.memo)
+                    {
+                        if let Some(record) = self.domain_registry.get(&payload.domain) {
+                            store.stage::<DomainProjectionTable>(
+                                payload.domain.as_str(),
+                                &DomainProjectionRecord {
+                                    record: record.clone(),
+                                    committed_at_height: height,
+                                },
+                            )?;
+                        }
+                    }
+                }
+                TransactionType::DomainUpdate => {
+                    if let Ok(payload) =
+                        crate::transaction::DomainUpdatePayload::decode_memo(&tx.memo)
+                    {
+                        if let Some(record) = self.domain_registry.get(&payload.domain) {
+                            store.stage::<DomainProjectionTable>(
+                                payload.domain.as_str(),
+                                &DomainProjectionRecord {
+                                    record: record.clone(),
+                                    committed_at_height: height,
+                                },
+                            )?;
+                        }
+                    }
+                }
+                TransactionType::RegisterCredential => {
+                    if let crate::transaction::TransactionPayload::RegisterCredential(ref data) =
+                        tx.payload
+                    {
+                        self.stage_credential_projection(store, &data.username, height)?;
+                    }
+                }
+                TransactionType::UpdateCredentialPassword => {
+                    if let crate::transaction::TransactionPayload::UpdateCredentialPassword(
+                        ref data,
+                    ) = tx.payload
+                    {
+                        self.stage_credential_projection(store, &data.username, height)?;
+                    }
+                }
+                TransactionType::CreateEmploymentContract => {
+                    for contract in &self.employment_registry.contracts {
+                        store.stage::<EmploymentProjectionTable>(
+                            &hex::encode(contract.contract_id),
+                            &EmploymentProjectionRecord {
+                                contract: contract.clone(),
+                                committed_at_height: contract.start_height,
+                            },
+                        )?;
+                    }
+                }
+                TransactionType::TokenMint => {
+                    if tx.memo.starts_with(b"pouw:mint:") {
+                        if let Some(mint) = tx.token_mint_data() {
+                            let tx_hash = tx.hash().as_array();
+                            let key = pouw_mint_key(&mint.to, &tx_hash);
+                            store.stage::<PouwMintProjectionTable>(
+                                &key,
+                                &PouwMintProjectionRecord {
+                                    recipient: mint.to,
+                                    mint: crate::blockchain::PouwMintRecord {
+                                        amount: mint.amount,
+                                        block_height: height,
+                                        tx_hash,
+                                    },
+                                },
+                            )?;
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            if let Some(entry) = Self::dao_registry_entry_from_tx(tx, height) {
+                let dao_id = entry.dao_id;
+                store.stage::<DaoRegistryProjectionTable>(
+                    &dao_id,
+                    &DaoRegistryProjectionRecord { entry },
+                )?;
+            }
+        }
+
+        for (contract_id, block_height) in &self.contract_blocks {
+            store.stage::<ContractBlockProjectionTable>(
+                contract_id,
+                &ContractBlockProjectionRecord {
+                    contract_id: *contract_id,
+                    block_height: *block_height,
+                },
+            )?;
+        }
+
+        self.stage_hot_state_projection_meta(store, block)
+    }
+
+    fn stage_credential_projection(
+        &self,
+        store: &dyn BlockchainStore,
+        username: &str,
+        height: u64,
+    ) -> Result<()> {
+        let Some(credential) = self.credential_registry.get(username) else {
+            return Ok(());
+        };
+        store.stage::<CredentialProjectionTable>(
+            username,
+            &CredentialProjectionRecord {
+                credential: credential.clone(),
+                committed_at_height: height,
+            },
+        )?;
+        store.stage::<DidUsernameProjectionTable>(
+            credential.owner_did.as_str(),
+            &DidUsernameProjectionRecord {
+                username: username.to_owned(),
+                committed_at_height: height,
+            },
+        )?;
+        Ok(())
+    }
+
+    fn stage_hot_state_projection_meta(
+        &self,
+        store: &dyn BlockchainStore,
+        block: &Block,
+    ) -> Result<()> {
+        let meta = HotStateProjectionMeta {
+            version: HOT_STATE_PROJECTION_VERSION,
+            height: block.height(),
+            block_hash: block.hash().as_array(),
+            completed_at_unix: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            validators: self.validator_registry.len(),
+            gateways: self.gateway_registry.len(),
+            domains: self.domain_registry.len(),
+            credentials: self.credential_registry.len(),
+            employment_contracts: self.employment_registry.contracts.len(),
+            dao_entries: self.dao_registry_index.len(),
+            pouw_mints: self.pouw_mint_index.values().map(Vec::len).sum(),
+            contract_blocks: self.contract_blocks.len(),
+        };
+        store.stage::<HotStateProjectionMetaTable>(META_KEY, &meta)?;
+        Ok(())
+    }
+
+    pub(crate) fn hot_state_projection_is_current(
+        store: &dyn BlockchainStore,
+        latest_height: u64,
+    ) -> Result<bool> {
+        let Some(block_hash) = store.get_block_hash_by_height(latest_height)? else {
+            return Ok(false);
+        };
+        let Some(meta) = store.get::<HotStateProjectionMetaTable>(META_KEY)? else {
+            return Ok(false);
+        };
+        Ok(meta.is_current_for(latest_height, block_hash.0))
+    }
+
+    pub(crate) fn hydrate_hot_state_from_projections(
+        &mut self,
+        store: &dyn BlockchainStore,
+        latest_height: u64,
+    ) -> Result<bool> {
+        if !Self::hot_state_projection_is_current(store, latest_height)? {
+            return Ok(false);
+        }
+
+        self.validator_registry.clear();
+        self.validator_blocks.clear();
+        for (_, record) in store.iter::<ValidatorProjectionTable>()? {
+            self.validator_blocks
+                .insert(record.info.identity_id.clone(), record.committed_at_height);
+            self.validator_registry
+                .insert(record.info.identity_id.clone(), record.info);
+        }
+
+        self.gateway_registry.clear();
+        self.gateway_blocks.clear();
+        for (_, record) in store.iter::<GatewayProjectionTable>()? {
+            self.gateway_blocks
+                .insert(record.info.identity_id.clone(), record.committed_at_height);
+            self.gateway_registry
+                .insert(record.info.identity_id.clone(), record.info);
+        }
+
+        self.domain_registry.clear();
+        for (_, record) in store.iter::<DomainProjectionTable>()? {
+            self.domain_registry
+                .insert(record.record.domain.clone(), record.record);
+        }
+
+        self.credential_registry.clear();
+        for (_, record) in store.iter::<CredentialProjectionTable>()? {
+            self.credential_registry
+                .insert(record.credential.username.clone(), record.credential);
+        }
+
+        self.did_to_username.clear();
+        for (raw_did, record) in store.iter::<DidUsernameProjectionTable>()? {
+            if let Ok(did) = String::from_utf8(raw_did) {
+                self.did_to_username.insert(did, record.username);
+            }
+        }
+
+        self.employment_registry = crate::contracts::employment::EmploymentRegistry::new();
+        for (_, record) in store.iter::<EmploymentProjectionTable>()? {
+            let c = record.contract;
+            self.employment_registry
+                .contract_by_sid
+                .entry(c.employee_sid.key_id)
+                .or_default()
+                .push(c.contract_id);
+            self.employment_registry
+                .contract_by_dao
+                .entry(c.dao_id)
+                .or_default()
+                .push(c.contract_id);
+            self.employment_registry.contracts.push(c);
+        }
+
+        self.dao_registry_index.clear();
+        for (_, record) in store.iter::<DaoRegistryProjectionTable>()? {
+            self.dao_registry_index
+                .insert(record.entry.dao_id, record.entry);
+        }
+
+        self.pouw_mint_index.clear();
+        for (_, record) in store.iter::<PouwMintProjectionTable>()? {
+            self.pouw_mint_index
+                .entry(record.recipient)
+                .or_default()
+                .push(record.mint);
+        }
+
+        self.contract_blocks.clear();
+        for (_, record) in store.iter::<ContractBlockProjectionTable>()? {
+            self.contract_blocks
+                .insert(record.contract_id, record.block_height);
+        }
+
+        debug!(
+            "hydrated hot blockchain state from projections at height {}",
+            latest_height
+        );
+        Ok(true)
+    }
+
+    pub(crate) fn backfill_hot_state_projections_from_replay(
+        &self,
+        store: &dyn BlockchainStore,
+    ) -> Result<()> {
+        let latest_height = match store.latest_height() {
+            Ok(h) => h,
+            Err(_) => return Ok(()),
+        };
+        if latest_height == 0 && store.get_block_by_height(0)?.is_none() {
+            return Ok(());
+        }
+        if Self::hot_state_projection_is_current(store, latest_height).unwrap_or(false) {
+            return Ok(());
+        }
+        let Some(tip) = store.get_block_by_height(latest_height)? else {
+            return Ok(());
+        };
+
+        store.begin_metadata_write()?;
+        let result = (|| -> Result<()> {
+            self.clear_projection_tables(store)?;
+            for (id, info) in &self.validator_registry {
+                let committed_at_height = self.validator_blocks.get(id).copied().unwrap_or(0);
+                store.stage::<ValidatorProjectionTable>(
+                    id.as_str(),
+                    &ValidatorProjectionRecord {
+                        info: info.clone(),
+                        committed_at_height,
+                    },
+                )?;
+            }
+            for (id, info) in &self.gateway_registry {
+                let committed_at_height = self.gateway_blocks.get(id).copied().unwrap_or(0);
+                store.stage::<GatewayProjectionTable>(
+                    id.as_str(),
+                    &GatewayProjectionRecord {
+                        info: info.clone(),
+                        committed_at_height,
+                    },
+                )?;
+            }
+            for (domain, record) in &self.domain_registry {
+                store.stage::<DomainProjectionTable>(
+                    domain.as_str(),
+                    &DomainProjectionRecord {
+                        record: record.clone(),
+                        committed_at_height: record.registered_at,
+                    },
+                )?;
+            }
+            for (username, credential) in &self.credential_registry {
+                store.stage::<CredentialProjectionTable>(
+                    username.as_str(),
+                    &CredentialProjectionRecord {
+                        credential: credential.clone(),
+                        committed_at_height: credential.registered_at_height,
+                    },
+                )?;
+            }
+            for (did, username) in &self.did_to_username {
+                store.stage::<DidUsernameProjectionTable>(
+                    did.as_str(),
+                    &DidUsernameProjectionRecord {
+                        username: username.clone(),
+                        committed_at_height: self
+                            .credential_registry
+                            .get(username)
+                            .map(|c| c.registered_at_height)
+                            .unwrap_or(0),
+                    },
+                )?;
+            }
+            for contract in &self.employment_registry.contracts {
+                store.stage::<EmploymentProjectionTable>(
+                    &hex::encode(contract.contract_id),
+                    &EmploymentProjectionRecord {
+                        contract: contract.clone(),
+                        committed_at_height: contract.start_height,
+                    },
+                )?;
+            }
+            for entry in self.dao_registry_index.values() {
+                store.stage::<DaoRegistryProjectionTable>(
+                    &entry.dao_id,
+                    &DaoRegistryProjectionRecord {
+                        entry: entry.clone(),
+                    },
+                )?;
+            }
+            for (recipient, records) in &self.pouw_mint_index {
+                for mint in records {
+                    let key = pouw_mint_key(recipient, &mint.tx_hash);
+                    store.stage::<PouwMintProjectionTable>(
+                        &key,
+                        &PouwMintProjectionRecord {
+                            recipient: *recipient,
+                            mint: mint.clone(),
+                        },
+                    )?;
+                }
+            }
+            for (contract_id, block_height) in &self.contract_blocks {
+                store.stage::<ContractBlockProjectionTable>(
+                    contract_id,
+                    &ContractBlockProjectionRecord {
+                        contract_id: *contract_id,
+                        block_height: *block_height,
+                    },
+                )?;
+            }
+            self.stage_hot_state_projection_meta(store, &tip)
+        })();
+
+        match result {
+            Ok(()) => store.commit_metadata_write().map_err(Into::into),
+            Err(e) => {
+                if let Err(rollback) = store.rollback_block() {
+                    warn!(
+                        "failed to roll back projection backfill metadata batch: {}",
+                        rollback
+                    );
+                }
+                Err(e)
+            }
+        }
+    }
+
+    fn clear_projection_tables(&self, store: &dyn BlockchainStore) -> Result<()> {
+        for (key, _) in store.iter::<ValidatorProjectionTable>()? {
+            store.stage_delete::<ValidatorProjectionTable>(std::str::from_utf8(&key)?)?;
+        }
+        for (key, _) in store.iter::<GatewayProjectionTable>()? {
+            store.stage_delete::<GatewayProjectionTable>(std::str::from_utf8(&key)?)?;
+        }
+        for (key, _) in store.iter::<DomainProjectionTable>()? {
+            store.stage_delete::<DomainProjectionTable>(std::str::from_utf8(&key)?)?;
+        }
+        for (key, _) in store.iter::<CredentialProjectionTable>()? {
+            store.stage_delete::<CredentialProjectionTable>(std::str::from_utf8(&key)?)?;
+        }
+        for (key, _) in store.iter::<DidUsernameProjectionTable>()? {
+            store.stage_delete::<DidUsernameProjectionTable>(std::str::from_utf8(&key)?)?;
+        }
+        for (key, _) in store.iter::<EmploymentProjectionTable>()? {
+            store.stage_delete::<EmploymentProjectionTable>(std::str::from_utf8(&key)?)?;
+        }
+        for (key, _) in store.iter::<DaoRegistryProjectionTable>()? {
+            if key.len() == 32 {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&key);
+                store.stage_delete::<DaoRegistryProjectionTable>(&arr)?;
+            }
+        }
+        for (key, _) in store.iter::<PouwMintProjectionTable>()? {
+            if key.len() == 64 {
+                let mut arr = [0u8; 64];
+                arr.copy_from_slice(&key);
+                store.stage_delete::<PouwMintProjectionTable>(&arr)?;
+            }
+        }
+        for (key, _) in store.iter::<ContractBlockProjectionTable>()? {
+            if key.len() == 32 {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&key);
+                store.stage_delete::<ContractBlockProjectionTable>(&arr)?;
+            }
+        }
+        store.stage_delete::<HotStateProjectionMetaTable>(META_KEY)?;
+        Ok(())
+    }
+}

--- a/lib-blockchain/src/lib.rs
+++ b/lib-blockchain/src/lib.rs
@@ -33,6 +33,7 @@ pub mod onramp;
 pub mod opaque;
 pub mod oracle;
 pub mod pricing;
+pub mod projections;
 pub mod protocol;
 pub mod receipts;
 pub mod resources;

--- a/lib-blockchain/src/projections.rs
+++ b/lib-blockchain/src/projections.rs
@@ -1,0 +1,207 @@
+//! Rebuildable hot-state projections for restart hydration.
+//!
+//! These tables mirror state that is fully derivable from committed block
+//! history but too expensive to rebuild on every restart. Projection metadata
+//! pins the table set to a concrete chain tip; startup may hydrate from the
+//! projections only when that tip matches the block store tip.
+
+use serde::{Deserialize, Serialize};
+
+use crate::blockchain::{DaoRegistryIndexEntry, GatewayInfo, PouwMintRecord, ValidatorInfo};
+use crate::storage::table::Table;
+
+pub const HOT_STATE_PROJECTION_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HotStateProjectionMeta {
+    pub version: u32,
+    pub height: u64,
+    pub block_hash: [u8; 32],
+    pub completed_at_unix: u64,
+    pub validators: usize,
+    pub gateways: usize,
+    pub domains: usize,
+    pub credentials: usize,
+    pub employment_contracts: usize,
+    pub dao_entries: usize,
+    pub pouw_mints: usize,
+    pub contract_blocks: usize,
+}
+
+impl HotStateProjectionMeta {
+    pub fn is_current_for(&self, height: u64, block_hash: [u8; 32]) -> bool {
+        self.version == HOT_STATE_PROJECTION_VERSION
+            && self.height == height
+            && self.block_hash == block_hash
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidatorProjectionRecord {
+    pub info: ValidatorInfo,
+    pub committed_at_height: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayProjectionRecord {
+    pub info: GatewayInfo,
+    pub committed_at_height: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DomainProjectionRecord {
+    pub record: crate::transaction::OnChainDomainRecord,
+    pub committed_at_height: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CredentialProjectionRecord {
+    pub credential: crate::transaction::UserCredential,
+    pub committed_at_height: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DidUsernameProjectionRecord {
+    pub username: String,
+    pub committed_at_height: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmploymentProjectionRecord {
+    pub contract: crate::contracts::employment::EmploymentContract,
+    pub committed_at_height: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaoRegistryProjectionRecord {
+    pub entry: DaoRegistryIndexEntry,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PouwMintProjectionRecord {
+    pub recipient: [u8; 32],
+    pub mint: PouwMintRecord,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractBlockProjectionRecord {
+    pub contract_id: [u8; 32],
+    pub block_height: u64,
+}
+
+pub struct HotStateProjectionMetaTable;
+impl Table for HotStateProjectionMetaTable {
+    const NAME: &'static str = "projection_hot_state_meta";
+    const VERSION: u32 = HOT_STATE_PROJECTION_VERSION;
+    type Key = str;
+    type Value = HotStateProjectionMeta;
+    fn encode_key(key: &Self::Key) -> Vec<u8> {
+        key.as_bytes().to_vec()
+    }
+}
+
+pub struct ValidatorProjectionTable;
+impl Table for ValidatorProjectionTable {
+    const NAME: &'static str = "projection_validators";
+    const VERSION: u32 = HOT_STATE_PROJECTION_VERSION;
+    type Key = str;
+    type Value = ValidatorProjectionRecord;
+    fn encode_key(key: &Self::Key) -> Vec<u8> {
+        key.as_bytes().to_vec()
+    }
+}
+
+pub struct GatewayProjectionTable;
+impl Table for GatewayProjectionTable {
+    const NAME: &'static str = "projection_gateways";
+    const VERSION: u32 = HOT_STATE_PROJECTION_VERSION;
+    type Key = str;
+    type Value = GatewayProjectionRecord;
+    fn encode_key(key: &Self::Key) -> Vec<u8> {
+        key.as_bytes().to_vec()
+    }
+}
+
+pub struct DomainProjectionTable;
+impl Table for DomainProjectionTable {
+    const NAME: &'static str = "projection_domains";
+    const VERSION: u32 = HOT_STATE_PROJECTION_VERSION;
+    type Key = str;
+    type Value = DomainProjectionRecord;
+    fn encode_key(key: &Self::Key) -> Vec<u8> {
+        key.as_bytes().to_vec()
+    }
+}
+
+pub struct CredentialProjectionTable;
+impl Table for CredentialProjectionTable {
+    const NAME: &'static str = "projection_credentials";
+    const VERSION: u32 = HOT_STATE_PROJECTION_VERSION;
+    type Key = str;
+    type Value = CredentialProjectionRecord;
+    fn encode_key(key: &Self::Key) -> Vec<u8> {
+        key.as_bytes().to_vec()
+    }
+}
+
+pub struct DidUsernameProjectionTable;
+impl Table for DidUsernameProjectionTable {
+    const NAME: &'static str = "projection_did_usernames";
+    const VERSION: u32 = HOT_STATE_PROJECTION_VERSION;
+    type Key = str;
+    type Value = DidUsernameProjectionRecord;
+    fn encode_key(key: &Self::Key) -> Vec<u8> {
+        key.as_bytes().to_vec()
+    }
+}
+
+pub struct EmploymentProjectionTable;
+impl Table for EmploymentProjectionTable {
+    const NAME: &'static str = "projection_employment";
+    const VERSION: u32 = HOT_STATE_PROJECTION_VERSION;
+    type Key = str;
+    type Value = EmploymentProjectionRecord;
+    fn encode_key(key: &Self::Key) -> Vec<u8> {
+        key.as_bytes().to_vec()
+    }
+}
+
+pub struct DaoRegistryProjectionTable;
+impl Table for DaoRegistryProjectionTable {
+    const NAME: &'static str = "projection_dao_registry";
+    const VERSION: u32 = HOT_STATE_PROJECTION_VERSION;
+    type Key = [u8; 32];
+    type Value = DaoRegistryProjectionRecord;
+    fn encode_key(key: &Self::Key) -> Vec<u8> {
+        key.to_vec()
+    }
+}
+
+pub struct PouwMintProjectionTable;
+impl Table for PouwMintProjectionTable {
+    const NAME: &'static str = "projection_pouw_mints";
+    const VERSION: u32 = HOT_STATE_PROJECTION_VERSION;
+    type Key = [u8; 64];
+    type Value = PouwMintProjectionRecord;
+    fn encode_key(key: &Self::Key) -> Vec<u8> {
+        key.to_vec()
+    }
+}
+
+pub struct ContractBlockProjectionTable;
+impl Table for ContractBlockProjectionTable {
+    const NAME: &'static str = "projection_contract_blocks";
+    const VERSION: u32 = HOT_STATE_PROJECTION_VERSION;
+    type Key = [u8; 32];
+    type Value = ContractBlockProjectionRecord;
+    fn encode_key(key: &Self::Key) -> Vec<u8> {
+        key.to_vec()
+    }
+}
+
+pub fn pouw_mint_key(recipient: &[u8; 32], tx_hash: &[u8; 32]) -> [u8; 64] {
+    let mut key = [0u8; 64];
+    key[..32].copy_from_slice(recipient);
+    key[32..].copy_from_slice(tx_hash);
+    key
+}

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -53,6 +53,16 @@ const TREE_META: &str = "meta";
 const TREE_WAL: &str = "wal_block_commit"; // Write-ahead log for crash-safe block commits
 const TREE_FORK_POINTS: &str = "fork_points"; // Fork audit log — direct durable writes
 const TREE_RECEIPTS: &str = "receipts"; // Transaction receipts — direct writes, tx_hash → receipt
+const TREE_PROJECTION_HOT_STATE_META: &str = "projection_hot_state_meta";
+const TREE_PROJECTION_VALIDATORS: &str = "projection_validators";
+const TREE_PROJECTION_GATEWAYS: &str = "projection_gateways";
+const TREE_PROJECTION_DOMAINS: &str = "projection_domains";
+const TREE_PROJECTION_CREDENTIALS: &str = "projection_credentials";
+const TREE_PROJECTION_DID_USERNAMES: &str = "projection_did_usernames";
+const TREE_PROJECTION_EMPLOYMENT: &str = "projection_employment";
+const TREE_PROJECTION_DAO_REGISTRY: &str = "projection_dao_registry";
+const TREE_PROJECTION_POUW_MINTS: &str = "projection_pouw_mints";
+const TREE_PROJECTION_CONTRACT_BLOCKS: &str = "projection_contract_blocks";
 
 /// The single key under which an in-progress block commit's post-image is
 /// staged in the `wal` tree. Only one block commits at a time, so one key
@@ -100,6 +110,16 @@ pub struct SledStore {
     wal: Tree,                   // Write-ahead log: durable block-commit post-image
     fork_points: Tree,           // Fork audit log: direct durable writes (non-batched)
     receipts: Tree,              // Transaction receipts: tx_hash → TransactionReceipt
+    projection_hot_state_meta: Tree,
+    projection_validators: Tree,
+    projection_gateways: Tree,
+    projection_domains: Tree,
+    projection_credentials: Tree,
+    projection_did_usernames: Tree,
+    projection_employment: Tree,
+    projection_dao_registry: Tree,
+    projection_pouw_mints: Tree,
+    projection_contract_blocks: Tree,
 
     // Transaction state
     tx_active: AtomicBool,
@@ -370,6 +390,36 @@ impl SledStore {
         let receipts = db
             .open_tree(TREE_RECEIPTS)
             .map_err(|e| StorageError::Database(e.to_string()))?;
+        let projection_hot_state_meta = db
+            .open_tree(TREE_PROJECTION_HOT_STATE_META)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let projection_validators = db
+            .open_tree(TREE_PROJECTION_VALIDATORS)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let projection_gateways = db
+            .open_tree(TREE_PROJECTION_GATEWAYS)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let projection_domains = db
+            .open_tree(TREE_PROJECTION_DOMAINS)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let projection_credentials = db
+            .open_tree(TREE_PROJECTION_CREDENTIALS)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let projection_did_usernames = db
+            .open_tree(TREE_PROJECTION_DID_USERNAMES)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let projection_employment = db
+            .open_tree(TREE_PROJECTION_EMPLOYMENT)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let projection_dao_registry = db
+            .open_tree(TREE_PROJECTION_DAO_REGISTRY)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let projection_pouw_mints = db
+            .open_tree(TREE_PROJECTION_POUW_MINTS)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let projection_contract_blocks = db
+            .open_tree(TREE_PROJECTION_CONTRACT_BLOCKS)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
 
         let store = Self {
             db,
@@ -402,6 +452,16 @@ impl SledStore {
             wal,
             fork_points,
             receipts,
+            projection_hot_state_meta,
+            projection_validators,
+            projection_gateways,
+            projection_domains,
+            projection_credentials,
+            projection_did_usernames,
+            projection_employment,
+            projection_dao_registry,
+            projection_pouw_mints,
+            projection_contract_blocks,
             tx_active: AtomicBool::new(false),
             tx_height: AtomicU64::new(0),
             tx_utxo_merkle_next_index: AtomicU64::new(0),
@@ -750,6 +810,16 @@ impl SledStore {
             TREE_UTXO_MERKLE_META => &self.utxo_merkle_meta,
             TREE_UTXO_MERKLE_NODES => &self.utxo_merkle_nodes,
             TREE_META => &self.meta,
+            TREE_PROJECTION_HOT_STATE_META => &self.projection_hot_state_meta,
+            TREE_PROJECTION_VALIDATORS => &self.projection_validators,
+            TREE_PROJECTION_GATEWAYS => &self.projection_gateways,
+            TREE_PROJECTION_DOMAINS => &self.projection_domains,
+            TREE_PROJECTION_CREDENTIALS => &self.projection_credentials,
+            TREE_PROJECTION_DID_USERNAMES => &self.projection_did_usernames,
+            TREE_PROJECTION_EMPLOYMENT => &self.projection_employment,
+            TREE_PROJECTION_DAO_REGISTRY => &self.projection_dao_registry,
+            TREE_PROJECTION_POUW_MINTS => &self.projection_pouw_mints,
+            TREE_PROJECTION_CONTRACT_BLOCKS => &self.projection_contract_blocks,
             _ => return None,
         })
     }
@@ -2507,6 +2577,11 @@ mod tests {
     use super::*;
     use crate::block::{Block, BlockHeader};
     use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+    use crate::projections::{
+        HotStateProjectionMeta, HotStateProjectionMetaTable, ValidatorProjectionRecord,
+        ValidatorProjectionTable, HOT_STATE_PROJECTION_VERSION,
+    };
+    use crate::storage::table::TableAccess;
     use crate::transaction::WalletTransactionData;
     use crate::types::{Difficulty, Hash};
 
@@ -2647,6 +2722,73 @@ mod tests {
         // Non-existent balance should be 0
         let other_addr = Address([0x33; 32]);
         assert_eq!(store.get_token_balance(&token, &other_addr).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_hot_state_projection_tables_commit_atomically() {
+        let store = SledStore::open_temporary().unwrap();
+        let block0 = create_test_block(0, Hash::default());
+        let validator = crate::blockchain::ValidatorInfo {
+            identity_id: "did:sovn:test-validator".to_string(),
+            stake: 100,
+            storage_provided: 64,
+            consensus_key: [7u8; 2592],
+            networking_key: vec![1, 2, 3],
+            rewards_key: vec![4, 5, 6],
+            network_address: "127.0.0.1:7000".to_string(),
+            commission_rate: 50,
+            status: "active".to_string(),
+            registered_at: 0,
+            last_activity: 0,
+            blocks_validated: 0,
+            slash_count: 0,
+            admission_source: crate::blockchain::ADMISSION_SOURCE_ONCHAIN_GOVERNANCE.to_string(),
+            governance_proposal_id: None,
+            oracle_key_id: None,
+        };
+        let meta = HotStateProjectionMeta {
+            version: HOT_STATE_PROJECTION_VERSION,
+            height: 0,
+            block_hash: block0.hash().as_array(),
+            completed_at_unix: 1,
+            validators: 1,
+            gateways: 0,
+            domains: 0,
+            credentials: 0,
+            employment_contracts: 0,
+            dao_entries: 0,
+            pouw_mints: 0,
+            contract_blocks: 0,
+        };
+
+        store.begin_block(0).unwrap();
+        store.append_block(&block0).unwrap();
+        store
+            .stage::<ValidatorProjectionTable>(
+                validator.identity_id.as_str(),
+                &ValidatorProjectionRecord {
+                    info: validator.clone(),
+                    committed_at_height: 0,
+                },
+            )
+            .unwrap();
+        store
+            .stage::<HotStateProjectionMetaTable>("hot_state", &meta)
+            .unwrap();
+        store.commit_block().unwrap();
+
+        let loaded = store
+            .get::<ValidatorProjectionTable>(validator.identity_id.as_str())
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.info.identity_id, validator.identity_id);
+        assert_eq!(loaded.committed_at_height, 0);
+
+        let loaded_meta = store
+            .get::<HotStateProjectionMetaTable>("hot_state")
+            .unwrap()
+            .unwrap();
+        assert!(loaded_meta.is_current_for(0, block0.hash().as_array()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add versioned hot-state projection tables for validators, gateways, domains, credentials, employment, DAO registry entries, PoUW mints, and contract block indexes
- Register projection keyspaces in SledStore so generic table writes participate in WAL-backed block/metadata commits
- Stage projection updates during block finalization and backfill projection tables after historical replay
- Process credential transactions on the executor finalization path so credential projections have a live source

## Validation
- cargo build -p lib-blockchain
- cargo test -p lib-blockchain storage::sled_store::tests::test_hot_state_projection_tables_commit_atomically

## Notes
This PR establishes the durable projection/backfill layer. Startup can only switch away from historical replay once the remaining startup hydrate path is wired to consume these projections plus existing durable state.