### PR TITLE
Add core store iterators for projection hydration

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -1321,6 +1321,12 @@ impl Blockchain {
 
         if let Some(ref store) = self.store {
             self.stage_hot_state_projection_updates(store.as_ref(), &block)?;
+            // Pure-legacy path: data + meta commit together inside the
+            // same WAL-protected `commit_block` batch via
+            // `persist_to_sled_store` below, so bundling meta here is
+            // safe (atomicity #2692/L1470 only matters on the executor
+            // path's non-WAL `commit_metadata_write`).
+            self.stage_hot_state_projection_meta(store.as_ref(), &block)?;
         }
 
         // Create transaction receipts
@@ -1471,6 +1477,15 @@ impl Blockchain {
 
         if let Some(ref store) = self.store {
             self.stage_hot_state_projection_updates(store.as_ref(), &block)?;
+            // Mixed executor/legacy fn:
+            // - Executor path: meta is committed AFTER commit_metadata_write
+            //   in a separate WAL-bracketed batch (see #2692/L1470 fix below
+            //   at the `if using_executor` block); do NOT stage meta here.
+            // - Legacy path: data + meta commit together inside the same
+            //   WAL-protected `commit_block` batch, so bundling meta is safe.
+            if !using_executor {
+                self.stage_hot_state_projection_meta(store.as_ref(), &block)?;
+            }
         }
 
         // Create transaction receipts
@@ -1500,6 +1515,22 @@ impl Blockchain {
                         block.height(),
                         e
                     );
+                } else {
+                    // Reviewer #2692/L1470: commit_metadata_write is not
+                    // WAL-protected across trees. Stage + commit the
+                    // projection-meta marker ONLY AFTER the data tables
+                    // are durable. If we crash between the two commits,
+                    // the meta marker is absent → next startup falls
+                    // back to historical replay (which re-runs backfill).
+                    if let Err(e) = self
+                        .commit_hot_state_projection_meta_only(store.as_ref(), &block)
+                    {
+                        warn!(
+                            "Failed to commit projection meta for block {}: {}",
+                            block.height(),
+                            e
+                        );
+                    }
                 }
             }
             debug!(

--- a/lib-blockchain/src/blockchain/projections.rs
+++ b/lib-blockchain/src/blockchain/projections.rs
@@ -46,8 +46,13 @@ impl Blockchain {
             self.stage_dao_registry_for_tx(store, tx, height)?;
         }
 
-        self.stage_contract_blocks(store)?;
-        self.stage_hot_state_projection_meta(store, block)
+        self.stage_contract_blocks_for_block(store, height)?;
+        // Reviewer #2692/L1470 + L327: meta is committed in a separate
+        // batch (`commit_hot_state_projection_meta_only`) AFTER the data
+        // batch flushes. Staging it here would tie data-write durability
+        // to meta-write durability inside the same non-WAL batch and
+        // re-open the atomicity gap.
+        Ok(())
     }
 
     fn stage_validator_for_tx(
@@ -128,7 +133,7 @@ impl Blockchain {
                 Ok(())
             }
             TransactionType::CreateEmploymentContract => {
-                self.stage_employment_contracts(store)
+                self.stage_employment_contracts_for_block(store, height)
             }
             TransactionType::TokenMint => self.stage_pouw_mint_for_tx(store, tx, height),
             _ => Ok(()),
@@ -180,8 +185,24 @@ impl Blockchain {
         Ok(())
     }
 
-    fn stage_employment_contracts(&self, store: &dyn BlockchainStore) -> Result<()> {
+    /// Reviewer #2692/L103: stage only employment contracts that were
+    /// created in THIS block (`start_height == height`). The old
+    /// `stage_employment_contracts` looped the entire registry on every
+    /// CreateEmploymentContract tx, making batch size proportional to
+    /// the historical contract count. Older contracts are already in
+    /// the projection from when they originally committed.
+    ///
+    /// `backfill_employment` (replay-time rebuild) still iterates the
+    /// whole registry — that's a one-time operation.
+    fn stage_employment_contracts_for_block(
+        &self,
+        store: &dyn BlockchainStore,
+        height: u64,
+    ) -> Result<()> {
         for contract in &self.employment_registry.contracts {
+            if contract.start_height != height {
+                continue;
+            }
             store.stage::<EmploymentProjectionTable>(
                 &hex::encode(contract.contract_id),
                 &EmploymentProjectionRecord {
@@ -238,6 +259,37 @@ impl Blockchain {
         Ok(())
     }
 
+    /// Reviewer #2692/L143: stage only contract_blocks entries that
+    /// landed in THIS block (`block_height == height`). The old
+    /// `stage_contract_blocks` re-staged every entry on every block —
+    /// O(total_contracts) per block, unbounded batch growth. Older
+    /// entries are already in the projection table from when they
+    /// originally committed.
+    ///
+    /// `backfill_contract_blocks` (replay-time rebuild) keeps the
+    /// whole-map iteration — it's a one-time operation.
+    fn stage_contract_blocks_for_block(
+        &self,
+        store: &dyn BlockchainStore,
+        height: u64,
+    ) -> Result<()> {
+        for (contract_id, block_height) in &self.contract_blocks {
+            if *block_height != height {
+                continue;
+            }
+            store.stage::<ContractBlockProjectionTable>(
+                contract_id,
+                &ContractBlockProjectionRecord {
+                    contract_id: *contract_id,
+                    block_height: *block_height,
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Used by the replay-time backfill — iterates the entire
+    /// contract_blocks map (one-time cost).
     fn stage_contract_blocks(&self, store: &dyn BlockchainStore) -> Result<()> {
         for (contract_id, block_height) in &self.contract_blocks {
             store.stage::<ContractBlockProjectionTable>(
@@ -277,11 +329,21 @@ impl Blockchain {
         Ok(())
     }
 
-    fn stage_hot_state_projection_meta(
+    /// Stage the projection meta record. Used by:
+    /// - `commit_hot_state_projection_meta_only` (executor path; meta is
+    ///   committed in a separate batch after data tables are durable —
+    ///   atomicity gap #2692/L1470 / L327).
+    /// - The legacy non-executor block-apply path, where data and meta
+    ///   are committed together inside one WAL-protected `commit_block`
+    ///   batch (atomic — safe to bundle).
+    /// - The replay-time backfill data commit (caller commits the data
+    ///   batch first, then this meta in a second batch).
+    pub(crate) fn stage_hot_state_projection_meta(
         &self,
         store: &dyn BlockchainStore,
         block: &Block,
     ) -> Result<()> {
+        let pouw_total: usize = self.pouw_mint_index.values().map(Vec::len).sum();
         let meta = HotStateProjectionMeta {
             version: HOT_STATE_PROJECTION_VERSION,
             height: block.height(),
@@ -290,17 +352,52 @@ impl Blockchain {
                 .duration_since(UNIX_EPOCH)
                 .map(|d| d.as_secs())
                 .unwrap_or(0),
-            validators: self.validator_registry.len(),
-            gateways: self.gateway_registry.len(),
-            domains: self.domain_registry.len(),
-            credentials: self.credential_registry.len(),
-            employment_contracts: self.employment_registry.contracts.len(),
-            dao_entries: self.dao_registry_index.len(),
-            pouw_mints: self.pouw_mint_index.values().map(Vec::len).sum(),
-            contract_blocks: self.contract_blocks.len(),
+            validators: self.validator_registry.len() as u64,
+            gateways: self.gateway_registry.len() as u64,
+            domains: self.domain_registry.len() as u64,
+            credentials: self.credential_registry.len() as u64,
+            employment_contracts: self.employment_registry.contracts.len() as u64,
+            dao_entries: self.dao_registry_index.len() as u64,
+            pouw_mints: pouw_total as u64,
+            contract_blocks: self.contract_blocks.len() as u64,
         };
         store.stage::<HotStateProjectionMetaTable>(META_KEY, &meta)?;
         Ok(())
+    }
+
+    /// Reviewer #2692/L1470 + L327: write the projection meta in its own
+    /// metadata-write batch *after* the data tables have been committed
+    /// and flushed.
+    ///
+    /// `commit_metadata_write` applies per-tree batches without
+    /// cross-tree WAL atomicity (its doc-comment is explicit:
+    /// `"This path is not WAL-protected"`). A crash mid-commit could
+    /// leave `projection_hot_state_meta` durable while sibling
+    /// projection tables are stale, making
+    /// `hot_state_projection_is_current` return true at next startup
+    /// and hydrate inconsistent hot state.
+    ///
+    /// By committing meta in a second batch, the worst case becomes:
+    /// crash before meta commit → meta absent → fast path skipped at
+    /// next startup → fallback to historical replay → backfill
+    /// re-stages atomically. The hydrate path never observes meta-
+    /// current + data-stale.
+    pub(crate) fn commit_hot_state_projection_meta_only(
+        &self,
+        store: &dyn BlockchainStore,
+        block: &Block,
+    ) -> Result<()> {
+        store.begin_metadata_write()?;
+        let result = self.stage_hot_state_projection_meta(store, block);
+        match result {
+            Ok(()) => store.commit_metadata_write().map_err(Into::into),
+            Err(e) => {
+                if let Err(rb) = store.rollback_block() {
+                    warn!("failed to roll back projection-meta batch: {}", rb);
+                }
+                Err(e)
+            }
+        }
     }
 
     pub(crate) fn hot_state_projection_is_current(
@@ -423,7 +520,16 @@ impl Blockchain {
         store.begin_metadata_write()?;
         let result = self.run_backfill_staging(store, &tip);
         match result {
-            Ok(()) => store.commit_metadata_write().map_err(Into::into),
+            Ok(()) => {
+                // Commit data first and flush.
+                store.commit_metadata_write()?;
+                // Only AFTER data is durable, write the meta marker in a
+                // separate batch (reviewer #2692/L327). If we crash
+                // between these two commits, meta is absent → next
+                // startup falls back to historical replay → backfill
+                // rebuilds atomically.
+                self.commit_hot_state_projection_meta_only(store, &tip)
+            }
             Err(e) => {
                 if let Err(rollback) = store.rollback_block() {
                     warn!(
@@ -462,7 +568,7 @@ impl Blockchain {
     fn run_backfill_staging(
         &self,
         store: &dyn BlockchainStore,
-        tip: &Block,
+        _tip: &Block,
     ) -> Result<()> {
         self.clear_projection_tables(store)?;
         self.backfill_validators(store)?;
@@ -474,7 +580,10 @@ impl Blockchain {
         self.backfill_dao_registry(store)?;
         self.backfill_pouw_mints(store)?;
         self.stage_contract_blocks(store)?;
-        self.stage_hot_state_projection_meta(store, tip)
+        // Reviewer #2692/L327: meta is committed in a second batch by
+        // the caller after the data batch flushes. Do NOT stage meta
+        // here — see `commit_hot_state_projection_meta_only`.
+        Ok(())
     }
 
     fn backfill_validators(&self, store: &dyn BlockchainStore) -> Result<()> {

--- a/lib-blockchain/src/projections.rs
+++ b/lib-blockchain/src/projections.rs
@@ -18,14 +18,18 @@ pub struct HotStateProjectionMeta {
     pub height: u64,
     pub block_hash: [u8; 32],
     pub completed_at_unix: u64,
-    pub validators: usize,
-    pub gateways: usize,
-    pub domains: usize,
-    pub credentials: usize,
-    pub employment_contracts: usize,
-    pub dao_entries: usize,
-    pub pouw_mints: usize,
-    pub contract_blocks: usize,
+    // Reviewer #2692/L29: fixed-width counts so the bincode payload is
+    // architecture-independent. `usize` round-trips differently between
+    // 32-bit and 64-bit targets and can fail deserialization if a count
+    // ever exceeds the local `usize` width.
+    pub validators: u64,
+    pub gateways: u64,
+    pub domains: u64,
+    pub credentials: u64,
+    pub employment_contracts: u64,
+    pub dao_entries: u64,
+    pub pouw_mints: u64,
+    pub contract_blocks: u64,
 }
 
 impl HotStateProjectionMeta {

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -863,6 +863,20 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     /// - Deleting non-existent UTXO is a no-op (idempotent)
     fn delete_utxo(&self, op: &OutPoint) -> StorageResult<()>;
 
+    /// Iterate all currently unspent UTXOs.
+    ///
+    /// Yields lazily so callers don't materialise the entire UTXO set in
+    /// RAM — at mainnet scale this set is unbounded. Each `Item` is a
+    /// `StorageResult` so per-row decode failures surface to the caller
+    /// without aborting the rest of the scan.
+    fn iter_utxos(
+        &self,
+    ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(OutPoint, Utxo)>> + '_>> {
+        Err(StorageError::Database(
+            "UTXO iteration not supported by this store".to_string(),
+        ))
+    }
+
     // =========================================================================
     // UTXO Merkle Tree (Mutable)
     // =========================================================================
@@ -1181,6 +1195,36 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     /// No default for the same reason as [`iter_identities`]: an empty/zero
     /// default would silently misreport the validator/citizen population.
     fn count_identities(&self) -> StorageResult<usize>;
+
+    /// Iterate identity consensus records joined with their optional
+    /// `IdentityMetadata`.
+    ///
+    /// Distinct from [`iter_identities`] which returns the bare consensus
+    /// row. This variant pairs each consensus record with its metadata
+    /// (display name, did string, controlled nodes, etc.) and is the
+    /// surface the startup hydrate path uses to rebuild
+    /// `identity_registry` from sled.
+    ///
+    /// Yields lazily so the entire identity set never lives in RAM at
+    /// once. Each `Item` is a `StorageResult` so per-row decode failures
+    /// surface to the caller without aborting the rest of the scan.
+    fn iter_identities_with_metadata(
+        &self,
+    ) -> StorageResult<
+        Box<
+            dyn Iterator<
+                    Item = StorageResult<(
+                        [u8; 32],
+                        IdentityConsensus,
+                        Option<IdentityMetadata>,
+                    )>,
+                > + '_,
+        >,
+    > {
+        Err(StorageError::Database(
+            "identity-with-metadata iteration not supported by this store".to_string(),
+        ))
+    }
 
     /// Store identity consensus state.
     ///

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1122,6 +1122,27 @@ impl BlockchainStore for SledStore {
         Ok(())
     }
 
+    fn iter_utxos(
+        &self,
+    ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(OutPoint, Utxo)>> + '_>> {
+        // Wrap the sled iterator directly so rows yield one at a time —
+        // hydrate paths can stream into projection tables without ever
+        // holding the whole UTXO set in memory. Per-row decode errors
+        // bubble up as `StorageResult` items.
+        let iter = self.utxos.iter().map(|result| {
+            let (key, value) = result.map_err(|e| StorageError::Database(e.to_string()))?;
+            let outpoint = keys::parse_utxo_key(key.as_ref()).ok_or_else(|| {
+                StorageError::CorruptedData(format!(
+                    "Invalid UTXO key length: {}",
+                    key.len()
+                ))
+            })?;
+            let utxo: Utxo = Self::deserialize(&value)?;
+            Ok((outpoint, utxo))
+        });
+        Ok(Box::new(iter))
+    }
+
     // =========================================================================
     // UTXO Merkle Tree Operations
     // =========================================================================
@@ -1863,6 +1884,49 @@ impl BlockchainStore for SledStore {
         // sled::Tree::len is an O(n) walk but avoids deserializing every record,
         // so it is the cheapest authoritative count available.
         Ok(self.identities.len())
+    }
+
+    fn iter_identities_with_metadata(
+        &self,
+    ) -> StorageResult<
+        Box<
+            dyn Iterator<
+                    Item = StorageResult<(
+                        [u8; 32],
+                        IdentityConsensus,
+                        Option<IdentityMetadata>,
+                    )>,
+                > + '_,
+        >,
+    > {
+        // Streams rows lazily so the hydrate path can process the
+        // identity set (~thousands+ at mainnet scale) without
+        // materialising it. The metadata lookup is intentionally
+        // per-row: identity_metadata is a separate sled tree and there
+        // is no efficient co-iteration primitive — the cost is one
+        // point-lookup per identity. If this ever shows up in profiling
+        // we can switch to scanning both trees in lock-step using
+        // sled's sorted-key ordering.
+        let metadata_tree = self.identity_metadata.clone();
+        let iter = self.identities.iter().map(move |result| {
+            let (key, value) = result.map_err(|e| StorageError::Database(e.to_string()))?;
+            if key.len() != 32 {
+                return Err(StorageError::CorruptedData(format!(
+                    "Invalid identity key length: {}",
+                    key.len()
+                )));
+            }
+            let mut did_hash = [0u8; 32];
+            did_hash.copy_from_slice(&key);
+            let consensus: IdentityConsensus = Self::deserialize(&value)?;
+            let metadata = match metadata_tree.get(did_hash) {
+                Ok(Some(bytes)) => Some(Self::deserialize(&bytes)?),
+                Ok(None) => None,
+                Err(e) => return Err(StorageError::Database(e.to_string())),
+            };
+            Ok((did_hash, consensus, metadata))
+        });
+        Ok(Box::new(iter))
     }
 
     fn put_identity(&self, did_hash: &[u8; 32], identity: &IdentityConsensus) -> StorageResult<()> {
@@ -3860,5 +3924,176 @@ mod tests {
         // Durable across reopen.
         let store = SledStore::open(dir.path()).unwrap();
         assert!(store.get_receipt(&tx_hash.as_array()).unwrap().is_some());
+    }
+
+    // =========================================================================
+    // Hot-state iterator tests (added in PR #2692 — lazy + Result)
+    // =========================================================================
+
+    #[test]
+    fn test_iter_utxos_returns_committed_unspent_outputs() {
+        let store = SledStore::open_temporary().unwrap();
+        let block = create_test_block(0, Hash::default());
+        let outpoint = OutPoint::new(TxHash([0x44; 32]), 7);
+        let utxo = Utxo::native(42u128, Address([0x55; 32]), 0);
+
+        store.begin_block(0).unwrap();
+        store.append_block(&block).unwrap();
+        store.put_utxo(&outpoint, &utxo).unwrap();
+        store.commit_block().unwrap();
+
+        let entries: Vec<_> = store
+            .iter_utxos()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, outpoint);
+        assert_eq!(entries[0].1.amount, 42);
+    }
+
+    #[test]
+    fn test_iter_utxos_empty_store_yields_nothing() {
+        let store = SledStore::open_temporary().unwrap();
+        let entries: Vec<_> = store
+            .iter_utxos()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_iter_utxos_returns_all_entries() {
+        let store = SledStore::open_temporary().unwrap();
+        let block = create_test_block(0, Hash::default());
+        store.begin_block(0).unwrap();
+        store.append_block(&block).unwrap();
+        for i in 0..5u8 {
+            let mut hash = [0u8; 32];
+            hash[0] = i;
+            let outpoint = OutPoint::new(TxHash(hash), i as u32);
+            let utxo = Utxo::native(100u128 + i as u128, Address([i; 32]), 0);
+            store.put_utxo(&outpoint, &utxo).unwrap();
+        }
+        store.commit_block().unwrap();
+
+        let entries: Vec<_> = store
+            .iter_utxos()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 5);
+    }
+
+    #[test]
+    fn test_iter_identities_with_metadata_returns_consensus_and_metadata() {
+        use super::super::{IdentityConsensus, IdentityMetadata, IdentityStatus, IdentityType};
+
+        let store = SledStore::open_temporary().unwrap();
+        let block = create_test_block(0, Hash::default());
+        let did_hash = [0x88; 32];
+        let consensus = IdentityConsensus {
+            did_hash,
+            owner: Address([0x99; 32]),
+            public_key_hash: [0xaa; 32],
+            did_document_hash: [0xbb; 32],
+            seed_commitment: None,
+            identity_type: IdentityType::Human,
+            status: IdentityStatus::Active,
+            version: 2,
+            created_at: 1,
+            registered_at_height: 0,
+            registration_fee: 1000,
+            dao_fee: 100,
+            controlled_node_count: 0,
+            owned_wallet_count: 1,
+            attribute_count: 0,
+        };
+        let metadata = IdentityMetadata {
+            did: "did:sovn:test-identity".to_string(),
+            display_name: "Test Identity".to_string(),
+            public_key: vec![1, 2, 3],
+            kyber_public_key: vec![],
+            ownership_proof: vec![4, 5, 6],
+            controlled_nodes: vec![],
+            owned_wallets: vec!["wallet-1".to_string()],
+            attributes: vec![],
+        };
+
+        store.begin_block(0).unwrap();
+        store.append_block(&block).unwrap();
+        store.put_identity(&did_hash, &consensus).unwrap();
+        store.put_identity_metadata(&did_hash, &metadata).unwrap();
+        store.commit_block().unwrap();
+
+        let entries: Vec<_> = store
+            .iter_identities_with_metadata()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, did_hash);
+        assert_eq!(entries[0].1.owner, consensus.owner);
+        assert_eq!(entries[0].2.as_ref().unwrap().did, metadata.did);
+    }
+
+    /// Edge case: an identity may exist in the consensus tree without
+    /// a corresponding metadata row (legacy / partial-write recovery
+    /// scenarios). Must yield `Option<_> = None` for metadata in that
+    /// case rather than erroring.
+    #[test]
+    fn test_iter_identities_with_metadata_handles_missing_metadata() {
+        use super::super::{IdentityConsensus, IdentityStatus, IdentityType};
+
+        let store = SledStore::open_temporary().unwrap();
+        let block = create_test_block(0, Hash::default());
+        let did_hash = [0x77; 32];
+        let consensus = IdentityConsensus {
+            did_hash,
+            owner: Address([0x66; 32]),
+            public_key_hash: [0x55; 32],
+            did_document_hash: [0x44; 32],
+            seed_commitment: None,
+            identity_type: IdentityType::Human,
+            status: IdentityStatus::Active,
+            version: 1,
+            created_at: 0,
+            registered_at_height: 0,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_node_count: 0,
+            owned_wallet_count: 0,
+            attribute_count: 0,
+        };
+
+        store.begin_block(0).unwrap();
+        store.append_block(&block).unwrap();
+        store.put_identity(&did_hash, &consensus).unwrap();
+        // Intentionally NO put_identity_metadata.
+        store.commit_block().unwrap();
+
+        let entries: Vec<_> = store
+            .iter_identities_with_metadata()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, did_hash);
+        assert!(
+            entries[0].2.is_none(),
+            "identity without metadata must yield Option::None, not error"
+        );
+    }
+
+    #[test]
+    fn test_iter_identities_with_metadata_empty_store_yields_nothing() {
+        let store = SledStore::open_temporary().unwrap();
+        let entries: Vec<_> = store
+            .iter_identities_with_metadata()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(entries.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Add `BlockchainStore::iter_utxos` and `BlockchainStore::iter_identities` as typed durable iteration surfaces for restart hydration.
- Implement both iterators in `SledStore` with key validation and deserialization errors mapped through `StorageError`.
- Cover committed UTXO and identity+metadata iteration with focused storage tests.

## Validation
- `cargo build -p lib-blockchain`
- `cargo test -p lib-blockchain test_iter_`

Stacked on #2690 for issue #2687.
