### PR TITLE
Hydrate startup state from projections

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -1321,6 +1321,12 @@ impl Blockchain {
 
         if let Some(ref store) = self.store {
             self.stage_hot_state_projection_updates(store.as_ref(), &block)?;
+            // Pure-legacy path: data + meta commit together inside the
+            // same WAL-protected `commit_block` batch via
+            // `persist_to_sled_store` below, so bundling meta here is
+            // safe (atomicity #2692/L1470 only matters on the executor
+            // path's non-WAL `commit_metadata_write`).
+            self.stage_hot_state_projection_meta(store.as_ref(), &block)?;
         }
 
         // Create transaction receipts
@@ -1471,6 +1477,15 @@ impl Blockchain {
 
         if let Some(ref store) = self.store {
             self.stage_hot_state_projection_updates(store.as_ref(), &block)?;
+            // Mixed executor/legacy fn:
+            // - Executor path: meta is committed AFTER commit_metadata_write
+            //   in a separate WAL-bracketed batch (see #2692/L1470 fix below
+            //   at the `if using_executor` block); do NOT stage meta here.
+            // - Legacy path: data + meta commit together inside the same
+            //   WAL-protected `commit_block` batch, so bundling meta is safe.
+            if !using_executor {
+                self.stage_hot_state_projection_meta(store.as_ref(), &block)?;
+            }
         }
 
         // Create transaction receipts
@@ -1500,6 +1515,22 @@ impl Blockchain {
                         block.height(),
                         e
                     );
+                } else {
+                    // Reviewer #2692/L1470: commit_metadata_write is not
+                    // WAL-protected across trees. Stage + commit the
+                    // projection-meta marker ONLY AFTER the data tables
+                    // are durable. If we crash between the two commits,
+                    // the meta marker is absent → next startup falls
+                    // back to historical replay (which re-runs backfill).
+                    if let Err(e) = self
+                        .commit_hot_state_projection_meta_only(store.as_ref(), &block)
+                    {
+                        warn!(
+                            "Failed to commit projection meta for block {}: {}",
+                            block.height(),
+                            e
+                        );
+                    }
                 }
             }
             debug!(

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -333,6 +333,152 @@ impl Blockchain {
         Ok(blockchain)
     }
 
+    fn load_blocks_and_legacy_indexes_from_store(
+        &mut self,
+        store: &dyn BlockchainStore,
+        latest_height: u64,
+    ) -> Result<()> {
+        self.blocks.clear();
+        self.utxo_set.clear();
+        self.nullifier_set.clear();
+
+        for height in 0..=latest_height {
+            let Some(block) = store.get_block_by_height(height)? else {
+                return Err(anyhow::anyhow!(
+                    "Missing block at height {} - store is corrupted",
+                    height
+                ));
+            };
+
+            for tx in &block.transactions {
+                for input in &tx.inputs {
+                    self.nullifier_set.insert(input.nullifier);
+                    self.utxo_set.remove(&input.previous_output);
+                }
+
+                for output in &tx.outputs {
+                    self.utxo_set.insert(tx.hash(), output.clone());
+                }
+            }
+
+            self.blocks.push(block);
+            self.height = height;
+        }
+
+        Ok(())
+    }
+
+    fn hydrate_checkpointed_state_from_store(
+        &mut self,
+        store: &dyn BlockchainStore,
+        latest_height: u64,
+    ) -> Result<bool> {
+        if !Self::hot_state_projection_is_current(store, latest_height)? {
+            return Ok(false);
+        }
+
+        self.load_blocks_and_legacy_indexes_from_store(store, latest_height)?;
+        let expected_identity_count = self
+            .blocks
+            .iter()
+            .flat_map(|block| block.transactions.iter())
+            .filter(|tx| tx.identity_data().is_some())
+            .count();
+        let expected_wallet_count = self
+            .blocks
+            .iter()
+            .flat_map(|block| block.transactions.iter())
+            .filter(|tx| tx.wallet_data().is_some())
+            .count();
+
+        self.identity_registry.clear();
+        self.identity_blocks.clear();
+        for (_did_hash, consensus, metadata) in store.iter_identities()? {
+            let Some(metadata) = metadata else {
+                return Ok(false);
+            };
+            if metadata.did.is_empty() {
+                return Ok(false);
+            }
+            self.identity_blocks
+                .insert(metadata.did.clone(), consensus.registered_at_height);
+            self.identity_registry.insert(
+                metadata.did.clone(),
+                crate::transaction::IdentityTransactionData {
+                    did: metadata.did,
+                    display_name: metadata.display_name,
+                    public_key: metadata.public_key,
+                    ownership_proof: metadata.ownership_proof,
+                    identity_type: consensus.identity_type.as_str().to_string(),
+                    did_document_hash: Hash::new(consensus.did_document_hash),
+                    created_at: consensus.created_at,
+                    registration_fee: consensus.registration_fee,
+                    dao_fee: consensus.dao_fee,
+                    controlled_nodes: metadata.controlled_nodes,
+                    owned_wallets: metadata.owned_wallets,
+                    kyber_public_key: Vec::new(),
+                },
+            );
+        }
+
+        if self.identity_registry.len() != expected_identity_count {
+            return Ok(false);
+        }
+
+        self.wallet_registry.clear();
+        self.wallet_blocks.clear();
+        for (wallet_id, record) in store.iter_wallet_projections()? {
+            let wallet_id_hex = hex::encode(wallet_id);
+            self.wallet_blocks
+                .insert(wallet_id_hex.clone(), record.committed_at_height);
+            self.wallet_registry
+                .insert(wallet_id_hex, record.wallet_data);
+        }
+        if self.wallet_registry.len() != expected_wallet_count {
+            return Ok(false);
+        }
+
+        self.token_contracts.clear();
+        self.token_nonces.clear();
+        match store.get_token_state_snapshot()? {
+            Some(snapshot) => {
+                self.token_contracts = snapshot.token_contracts;
+                self.token_nonces = snapshot.token_nonces;
+            }
+            None => {
+                for (token_id, contract) in store.iter_token_contracts()? {
+                    self.token_contracts.insert(token_id.0, contract);
+                }
+            }
+        }
+
+        self.bonding_curve_registry = crate::contracts::bonding_curve::BondingCurveRegistry::new();
+        for (_token_id, token) in store.iter_bonding_curve_tokens()? {
+            if let Err(e) = self.bonding_curve_registry.register(token) {
+                warn!(
+                    "⚠️ Failed to hydrate bonding curve token from SledStore: {}",
+                    e
+                );
+            }
+        }
+
+        match store.get_oracle_state() {
+            Ok(Some(oracle_state)) => self.oracle_state = oracle_state,
+            Ok(None) => {}
+            Err(e) => warn!("⚠️ Failed to hydrate oracle_state from SledStore: {}", e),
+        }
+
+        if !self.hydrate_hot_state_from_projections(store, latest_height)? {
+            return Ok(false);
+        }
+
+        info!(
+            "📂 Hydrated blockchain hot state from current projection checkpoint at height {}",
+            latest_height
+        );
+        Ok(true)
+    }
+
     pub fn load_from_store(store: std::sync::Arc<dyn BlockchainStore>) -> Result<Option<Self>> {
         info!("📂 Loading blockchain from SledStore...");
 
@@ -384,156 +530,192 @@ impl Blockchain {
             ),
         }
 
-        for height in 0..=latest_height {
-            match store.get_block_by_height(height)? {
-                Some(block) => {
-                    for tx in &block.transactions {
-                        for input in &tx.inputs {
-                            blockchain.nullifier_set.insert(input.nullifier);
-                            blockchain.utxo_set.remove(&input.previous_output);
-                        }
+        let used_projection_hydrate = match blockchain
+            .hydrate_checkpointed_state_from_store(store.as_ref(), latest_height)
+        {
+            Ok(true) => true,
+            Ok(false) => false,
+            Err(e) => {
+                warn!(
+                    "⚠️ Failed to hydrate checkpointed state from SledStore, falling back to replay: {}",
+                    e
+                );
+                false
+            }
+        };
 
-                        for output in &tx.outputs {
-                            let tx_hash = tx.hash();
-                            blockchain.utxo_set.insert(tx_hash, output.clone());
-                        }
+        if !used_projection_hydrate {
+            blockchain.blocks.clear();
+            blockchain.height = 0;
+            blockchain.utxo_set.clear();
+            blockchain.nullifier_set.clear();
+            blockchain.identity_registry.clear();
+            blockchain.identity_blocks.clear();
+            blockchain.wallet_registry.clear();
+            blockchain.wallet_blocks.clear();
+            blockchain.token_contracts.clear();
+            blockchain.token_nonces.clear();
+            blockchain.bonding_curve_registry =
+                crate::contracts::bonding_curve::BondingCurveRegistry::new();
 
-                        if let Some(identity_data) = tx.identity_data() {
-                            blockchain
-                                .identity_registry
-                                .insert(identity_data.did.clone(), identity_data.clone());
-                            blockchain
-                                .identity_blocks
-                                .insert(identity_data.did.clone(), height);
-                        }
+            for height in 0..=latest_height {
+                match store.get_block_by_height(height)? {
+                    Some(block) => {
+                        for tx in &block.transactions {
+                            for input in &tx.inputs {
+                                blockchain.nullifier_set.insert(input.nullifier);
+                                blockchain.utxo_set.remove(&input.previous_output);
+                            }
 
-                        if let Some(wallet_data) = tx.wallet_data() {
-                            let wallet_id = hex::encode(wallet_data.wallet_id.as_bytes());
-                            blockchain
-                                .wallet_registry
-                                .insert(wallet_id.clone(), wallet_data.clone());
-                            blockchain.wallet_blocks.insert(wallet_id, height);
+                            for output in &tx.outputs {
+                                let tx_hash = tx.hash();
+                                blockchain.utxo_set.insert(tx_hash, output.clone());
+                            }
 
-                            // Replay SOV minting for WalletRegistration transactions.
-                            // process_token_transactions (called below with the sled store
-                            // temporarily removed) reads balances from the in-memory
-                            // token_contracts HashMap.  Without replaying the minting here,
-                            // any subsequent TokenTransfer from this wallet will fail with
-                            // "insufficient balance: have 0" even though the balance was
-                            // correctly committed to sled during the original block execution.
-                            if tx.transaction_type == TransactionType::WalletRegistration
-                                && wallet_data.initial_balance > 0
-                            {
-                                blockchain.ensure_sov_token_contract();
-                                let sov_token_id =
-                                    crate::contracts::utils::generate_lib_token_id();
-                                let mut wallet_id_bytes = [0u8; 32];
-                                wallet_id_bytes
-                                    .copy_from_slice(wallet_data.wallet_id.as_bytes());
-                                let recipient_pk =
-                                    Self::wallet_key_for_sov(&wallet_id_bytes);
-                                let current = blockchain
-                                    .token_contracts
-                                    .get(&sov_token_id)
-                                    .map(|t| t.balance_of(&recipient_pk))
-                                    .unwrap_or(0);
-                                let target = wallet_data.initial_balance as u128;
-                                let deficit = target.saturating_sub(current);
-                                if deficit > 0 {
-                                    if let Some(token) =
-                                        blockchain.token_contracts.get_mut(&sov_token_id)
-                                    {
-                                        let _ = token.mint(&recipient_pk, deficit);
+                            if let Some(identity_data) = tx.identity_data() {
+                                blockchain
+                                    .identity_registry
+                                    .insert(identity_data.did.clone(), identity_data.clone());
+                                blockchain
+                                    .identity_blocks
+                                    .insert(identity_data.did.clone(), height);
+                            }
+
+                            if let Some(wallet_data) = tx.wallet_data() {
+                                let wallet_id = hex::encode(wallet_data.wallet_id.as_bytes());
+                                blockchain
+                                    .wallet_registry
+                                    .insert(wallet_id.clone(), wallet_data.clone());
+                                blockchain.wallet_blocks.insert(wallet_id, height);
+
+                                // Replay SOV minting for WalletRegistration transactions.
+                                // process_token_transactions (called below with the sled store
+                                // temporarily removed) reads balances from the in-memory
+                                // token_contracts HashMap.  Without replaying the minting here,
+                                // any subsequent TokenTransfer from this wallet will fail with
+                                // "insufficient balance: have 0" even though the balance was
+                                // correctly committed to sled during the original block execution.
+                                if tx.transaction_type == TransactionType::WalletRegistration
+                                    && wallet_data.initial_balance > 0
+                                {
+                                    blockchain.ensure_sov_token_contract();
+                                    let sov_token_id =
+                                        crate::contracts::utils::generate_lib_token_id();
+                                    let mut wallet_id_bytes = [0u8; 32];
+                                    wallet_id_bytes
+                                        .copy_from_slice(wallet_data.wallet_id.as_bytes());
+                                    let recipient_pk = Self::wallet_key_for_sov(&wallet_id_bytes);
+                                    let current = blockchain
+                                        .token_contracts
+                                        .get(&sov_token_id)
+                                        .map(|t| t.balance_of(&recipient_pk))
+                                        .unwrap_or(0);
+                                    let target = wallet_data.initial_balance as u128;
+                                    let deficit = target.saturating_sub(current);
+                                    if deficit > 0 {
+                                        if let Some(token) =
+                                            blockchain.token_contracts.get_mut(&sov_token_id)
+                                        {
+                                            let _ = token.mint(&recipient_pk, deficit);
+                                        }
                                     }
                                 }
                             }
-                        }
 
-                        if tx.transaction_type == TransactionType::ContractExecution {
-                            debug!(
-                                "📦 Replaying ContractExecution tx at height {}, memo_len={}",
-                                height,
-                                tx.memo.len()
-                            );
-                            if let Err(e) = blockchain.process_contract_execution(tx, height) {
-                                warn!(
-                                    "⚠️ Failed to replay ContractExecution at height {}: {}",
-                                    height, e
+                            if tx.transaction_type == TransactionType::ContractExecution {
+                                debug!(
+                                    "📦 Replaying ContractExecution tx at height {}, memo_len={}",
+                                    height,
+                                    tx.memo.len()
                                 );
+                                if let Err(e) = blockchain.process_contract_execution(tx, height) {
+                                    warn!(
+                                        "⚠️ Failed to replay ContractExecution at height {}: {}",
+                                        height, e
+                                    );
+                                }
+                            }
+
+                            if let Some(validator_data) = tx.validator_data() {
+                                let status = match validator_data.operation {
+                                    crate::transaction::ValidatorOperation::Register => "active",
+                                    crate::transaction::ValidatorOperation::Update => "active",
+                                    crate::transaction::ValidatorOperation::Unregister => {
+                                        "inactive"
+                                    }
+                                };
+                                let validator_info = ValidatorInfo {
+                                    identity_id: validator_data.identity_id.clone(),
+                                    stake: validator_data.stake,
+                                    storage_provided: validator_data.storage_provided,
+                                    consensus_key: validator_data
+                                        .consensus_key
+                                        .as_slice()
+                                        .try_into()
+                                        .unwrap_or([0u8; 2592]),
+                                    networking_key: validator_data.networking_key.clone(),
+                                    rewards_key: validator_data.rewards_key.clone(),
+                                    network_address: validator_data.network_address.clone(),
+                                    commission_rate: validator_data.commission_rate,
+                                    status: status.to_string(),
+                                    registered_at: height,
+                                    last_activity: height,
+                                    blocks_validated: 0,
+                                    slash_count: 0,
+                                    admission_source: ADMISSION_SOURCE_ONCHAIN_GOVERNANCE
+                                        .to_string(),
+                                    governance_proposal_id: None,
+                                    oracle_key_id: None,
+                                };
+                                blockchain
+                                    .validator_registry
+                                    .insert(validator_data.identity_id.clone(), validator_info);
+                                blockchain
+                                    .validator_blocks
+                                    .insert(validator_data.identity_id.clone(), height);
                             }
                         }
 
-                        if let Some(validator_data) = tx.validator_data() {
-                            let status = match validator_data.operation {
-                                crate::transaction::ValidatorOperation::Register => "active",
-                                crate::transaction::ValidatorOperation::Update => "active",
-                                crate::transaction::ValidatorOperation::Unregister => "inactive",
-                            };
-                            let validator_info = ValidatorInfo {
-                                identity_id: validator_data.identity_id.clone(),
-                                stake: validator_data.stake,
-                                storage_provided: validator_data.storage_provided,
-                                consensus_key: validator_data.consensus_key.as_slice().try_into().unwrap_or([0u8; 2592]),
-                                networking_key: validator_data.networking_key.clone(),
-                                rewards_key: validator_data.rewards_key.clone(),
-                                network_address: validator_data.network_address.clone(),
-                                commission_rate: validator_data.commission_rate,
-                                status: status.to_string(),
-                                registered_at: height,
-                                last_activity: height,
-                                blocks_validated: 0,
-                                slash_count: 0,
-                                admission_source: ADMISSION_SOURCE_ONCHAIN_GOVERNANCE.to_string(),
-                                governance_proposal_id: None,
-                                oracle_key_id: None,
-                            };
-                            blockchain
-                                .validator_registry
-                                .insert(validator_data.identity_id.clone(), validator_info);
-                            blockchain
-                                .validator_blocks
-                                .insert(validator_data.identity_id.clone(), height);
+                        // Replay CBE pool initialization from on-chain InitCbeToken transactions.
+                        // Replay domain registration/update transactions.
+                        blockchain.process_domain_transactions(&block);
+
+                        // Replay gateway registration/update transactions.
+                        blockchain.process_gateway_transactions(&block);
+
+                        // Replay employment contract creation so employment_registry is populated.
+                        if let Err(e) = blockchain.process_employment_contract_transactions(&block)
+                        {
+                            warn!(
+                                "⚠️ Failed to replay CreateEmploymentContract at height {}: {}",
+                                height, e
+                            );
                         }
+
+                        // During sled-store replay we skip SOV token transaction processing
+                        // entirely.  The correct final SOV balances are loaded from the
+                        // token_balances sled tree after this loop.
+                        //
+                        // We intentionally leave blockchain.token_nonces EMPTY here.
+                        // In BlockExecutor mode (the only production mode), nonces are
+                        // tracked exclusively in sled via increment_token_nonce() and
+                        // get_token_nonce() falls through to sled when the in-memory map
+                        // has no entry.  Populating the in-memory map from the block
+                        // history would make it a stale cache: after restart the executor
+                        // continues to update only sled, so the in-memory entry never
+                        // advances past the replay count and the nonce API returns stale
+                        // values — causing clients to submit wrong nonces that the executor
+                        // then rejects with "expected N+1, got N".
+
+                        blockchain.blocks.push(block);
+                        blockchain.height = height;
                     }
-
-                    // Replay CBE pool initialization from on-chain InitCbeToken transactions.
-                    // Replay domain registration/update transactions.
-                    blockchain.process_domain_transactions(&block);
-
-                    // Replay gateway registration/update transactions.
-                    blockchain.process_gateway_transactions(&block);
-
-                    // Replay employment contract creation so employment_registry is populated.
-                    if let Err(e) = blockchain.process_employment_contract_transactions(&block) {
-                        warn!(
-                            "⚠️ Failed to replay CreateEmploymentContract at height {}: {}",
-                            height, e
-                        );
+                    None => {
+                        return Err(anyhow::anyhow!(
+                            "Missing block at height {} - store is corrupted",
+                            height
+                        ));
                     }
-
-                    // During sled-store replay we skip SOV token transaction processing
-                    // entirely.  The correct final SOV balances are loaded from the
-                    // token_balances sled tree after this loop.
-                    //
-                    // We intentionally leave blockchain.token_nonces EMPTY here.
-                    // In BlockExecutor mode (the only production mode), nonces are
-                    // tracked exclusively in sled via increment_token_nonce() and
-                    // get_token_nonce() falls through to sled when the in-memory map
-                    // has no entry.  Populating the in-memory map from the block
-                    // history would make it a stale cache: after restart the executor
-                    // continues to update only sled, so the in-memory entry never
-                    // advances past the replay count and the nonce API returns stale
-                    // values — causing clients to submit wrong nonces that the executor
-                    // then rejects with "expected N+1, got N".
-
-                    blockchain.blocks.push(block);
-                    blockchain.height = height;
-                }
-                None => {
-                    return Err(anyhow::anyhow!(
-                        "Missing block at height {} - store is corrupted",
-                        height
-                    ));
                 }
             }
         }
@@ -625,7 +807,7 @@ impl Blockchain {
                     synced
                 );
             }
-            
+
             // Also sync total supply from sled
             if let Ok(Some(supply)) = store.get_token_supply(&storage_sov_id) {
                 if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
@@ -709,10 +891,15 @@ impl Blockchain {
         // load_from_store deliberately skips token-tx processing, so the
         // PoUW mint index is not built incrementally on this path. Rebuild it
         // from the loaded blocks so /api/v1/pouw/rewards has the full history.
-        blockchain.rebuild_pouw_mint_index();
+        if !used_projection_hydrate {
+            blockchain.rebuild_pouw_mint_index();
 
-        if let Err(e) = blockchain.backfill_hot_state_projections_from_replay(store.as_ref()) {
-            warn!("⚠️ Failed to backfill hot-state projections during load_from_store: {}", e);
+            if let Err(e) = blockchain.backfill_hot_state_projections_from_replay(store.as_ref()) {
+                warn!(
+                    "⚠️ Failed to backfill hot-state projections during load_from_store: {}",
+                    e
+                );
+            }
         }
 
         // The store's wallet-projection index is non-authoritative and
@@ -723,7 +910,7 @@ impl Blockchain {
         // purpose-built for exactly this startup recovery. Without this, a
         // wiped projection index is never repaired and `get_wallet_projection`
         // diverges from the replayed truth.
-        {
+        if !used_projection_hydrate {
             let projections: Vec<([u8; 32], crate::storage::WalletProjectionRecord)> = blockchain
                 .wallet_registry
                 .iter()
@@ -789,8 +976,7 @@ impl Blockchain {
         for tx in recovered {
             // Drop entries that no longer satisfy nonce or phase-2 rules; this
             // matches the eviction sweeps that run during normal block commit.
-            let phase2_invalid =
-                tx.transaction_type == TransactionType::TokenMint && tx.fee != 0;
+            let phase2_invalid = tx.transaction_type == TransactionType::TokenMint && tx.fee != 0;
             if phase2_invalid || !self.is_nonce_current(&tx) {
                 let h = tx.hash().as_array();
                 if let Err(e) = store.delete_pending_transaction(&h) {
@@ -810,10 +996,7 @@ impl Blockchain {
             kept += 1;
         }
         if kept + dropped > 0 {
-            info!(
-                "Pending tx recovery: kept={}, dropped={}",
-                kept, dropped
-            );
+            info!("Pending tx recovery: kept={}, dropped={}", kept, dropped);
         }
     }
 
@@ -958,7 +1141,10 @@ impl Blockchain {
 
         for validator_data in validator_registrations {
             match self.register_validator(validator_data.clone()) {
-                Ok(_) => info!("Registered genesis validator: {}", validator_data.identity_id),
+                Ok(_) => info!(
+                    "Registered genesis validator: {}",
+                    validator_data.identity_id
+                ),
                 Err(e) => warn!(
                     "Failed to register genesis validator {}: {}",
                     validator_data.identity_id, e

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -378,50 +378,102 @@ impl Blockchain {
         }
 
         self.load_blocks_and_legacy_indexes_from_store(store, latest_height)?;
-        let expected_identity_count = self
+
+        // Count unique IDs (not raw tx hits). identity_data() returns Some
+        // for Registration, Update, AND Revocation, so the original check
+        // counted updated identities multiple times — any identity with
+        // an Update produced 2+ hits but 1 registry entry, falsely
+        // triggering fallback for every long-lived identity. Same for
+        // wallets. Counting unique wallet_id/did_hash gives the actual
+        // expected entity count regardless of how many tx versions exist.
+        use std::collections::HashSet;
+        let expected_identity_count: HashSet<Vec<u8>> = self
             .blocks
             .iter()
             .flat_map(|block| block.transactions.iter())
-            .filter(|tx| tx.identity_data().is_some())
-            .count();
-        let expected_wallet_count = self
+            .filter_map(|tx| tx.identity_data().map(|d| d.did.as_bytes().to_vec()))
+            .collect();
+        let expected_wallet_count: HashSet<[u8; 32]> = self
             .blocks
             .iter()
             .flat_map(|block| block.transactions.iter())
-            .filter(|tx| tx.wallet_data().is_some())
-            .count();
+            .filter_map(|tx| tx.wallet_data().map(|w| {
+                let mut id = [0u8; 32];
+                id.copy_from_slice(w.wallet_id.as_bytes());
+                id
+            }))
+            .collect();
 
         self.identity_registry.clear();
         self.identity_blocks.clear();
-        for (_did_hash, consensus, metadata) in store.iter_identities()? {
-            let Some(metadata) = metadata else {
-                return Ok(false);
+        // #2692 rename: `iter_identities` (consensus-only) already
+        // existed on development from the #2639 migration; the metadata-
+        // bearing variant is now `iter_identities_with_metadata` and
+        // yields `Result<...>` items lazily.
+        for entry in store.iter_identities_with_metadata()? {
+            let (_did_hash, consensus, metadata) = entry?;
+            // identity_consensus rows without metadata are a recoverable
+            // partial-write state; we still surface the consensus view
+            // so callers don't see missing identities. The did string
+            // falls back to the hex of did_hash and metadata-derived
+            // fields default to empty.
+            let (
+                did,
+                display_name,
+                public_key,
+                ownership_proof,
+                controlled_nodes,
+                owned_wallets,
+            ) = match metadata {
+                Some(m) => {
+                    let did = if m.did.is_empty() {
+                        hex::encode(consensus.did_hash)
+                    } else {
+                        m.did
+                    };
+                    (
+                        did,
+                        m.display_name,
+                        m.public_key,
+                        m.ownership_proof,
+                        m.controlled_nodes,
+                        m.owned_wallets,
+                    )
+                }
+                None => (
+                    hex::encode(consensus.did_hash),
+                    String::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                ),
             };
-            if metadata.did.is_empty() {
-                return Ok(false);
-            }
             self.identity_blocks
-                .insert(metadata.did.clone(), consensus.registered_at_height);
+                .insert(did.clone(), consensus.registered_at_height);
             self.identity_registry.insert(
-                metadata.did.clone(),
+                did.clone(),
                 crate::transaction::IdentityTransactionData {
-                    did: metadata.did,
-                    display_name: metadata.display_name,
-                    public_key: metadata.public_key,
-                    ownership_proof: metadata.ownership_proof,
+                    did,
+                    display_name,
+                    public_key,
+                    ownership_proof,
                     identity_type: consensus.identity_type.as_str().to_string(),
                     did_document_hash: Hash::new(consensus.did_document_hash),
                     created_at: consensus.created_at,
                     registration_fee: consensus.registration_fee,
                     dao_fee: consensus.dao_fee,
-                    controlled_nodes: metadata.controlled_nodes,
-                    owned_wallets: metadata.owned_wallets,
+                    controlled_nodes,
+                    owned_wallets,
                     kyber_public_key: Vec::new(),
                 },
             );
         }
 
-        if self.identity_registry.len() != expected_identity_count {
+        if self.identity_registry.len() != expected_identity_count.len() {
+            // Projection store disagrees with block history — projections
+            // were wiped or never staged for this tip. Bail to replay so
+            // the next backfill re-syncs them.
             return Ok(false);
         }
 
@@ -434,7 +486,7 @@ impl Blockchain {
             self.wallet_registry
                 .insert(wallet_id_hex, record.wallet_data);
         }
-        if self.wallet_registry.len() != expected_wallet_count {
+        if self.wallet_registry.len() != expected_wallet_count.len() {
             return Ok(false);
         }
 
@@ -1161,5 +1213,192 @@ impl Blockchain {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::{Block, BlockHeader};
+    use crate::storage::{
+        IdentityConsensus, IdentityMetadata, IdentityStatus, IdentityType, SledStore,
+    };
+    use std::sync::Arc;
+
+    fn block_with(height: u64, txs: Vec<crate::transaction::Transaction>) -> Block {
+        let mut hash = [0u8; 32];
+        hash[..8].copy_from_slice(&height.to_be_bytes());
+        let header = BlockHeader {
+            version: 1,
+            previous_hash: Hash::zero().into(),
+            data_helix_root: Hash::zero().into(),
+            timestamp: 1_700_000_000 + height,
+            height,
+            verification_helix_root: [0u8; 32],
+            state_root: Hash::default().into(),
+            bft_quorum_root: [0u8; 32],
+            block_hash: Hash::new(hash),
+        };
+        Block::new(header, txs)
+    }
+
+    fn identity_tx_register(did: &str) -> crate::transaction::Transaction {
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+        let data = crate::transaction::IdentityTransactionData {
+            did: did.to_string(),
+            display_name: "alice".to_string(),
+            public_key: vec![],
+            ownership_proof: vec![],
+            identity_type: "Human".to_string(),
+            did_document_hash: Hash::zero(),
+            created_at: 0,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_nodes: vec![],
+            owned_wallets: vec![],
+            kyber_public_key: vec![],
+        };
+        let sig = Signature {
+            signature: vec![0u8; 64],
+            public_key: PublicKey {
+                dilithium_pk: [0u8; 2592],
+                kyber_pk: [0u8; 1568],
+                key_id: [0u8; 32],
+            },
+            algorithm: SignatureAlgorithm::Dilithium5,
+            timestamp: 0,
+        };
+        crate::transaction::Transaction::new_identity_registration(data, vec![], sig, vec![])
+    }
+
+    fn identity_tx_update(did: &str) -> crate::transaction::Transaction {
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+        let data = crate::transaction::IdentityTransactionData {
+            did: did.to_string(),
+            display_name: "alice-renamed".to_string(),
+            public_key: vec![],
+            ownership_proof: vec![],
+            identity_type: "Human".to_string(),
+            did_document_hash: Hash::zero(),
+            created_at: 0,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_nodes: vec![],
+            owned_wallets: vec![],
+            kyber_public_key: vec![],
+        };
+        let sig = Signature {
+            signature: vec![0u8; 64],
+            public_key: PublicKey {
+                dilithium_pk: [0u8; 2592],
+                kyber_pk: [0u8; 1568],
+                key_id: [0u8; 32],
+            },
+            algorithm: SignatureAlgorithm::Dilithium5,
+            timestamp: 0,
+        };
+        crate::transaction::Transaction::new_identity_update(data, vec![], vec![], 0, sig, vec![])
+    }
+
+    fn consensus(did_hash: [u8; 32], registered_at_height: u64) -> IdentityConsensus {
+        IdentityConsensus {
+            did_hash,
+            owner: crate::storage::Address([0xAB; 32]),
+            public_key_hash: [0xCD; 32],
+            did_document_hash: [0xEF; 32],
+            seed_commitment: None,
+            identity_type: IdentityType::Human,
+            status: IdentityStatus::Active,
+            version: 1,
+            created_at: 0,
+            registered_at_height,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_node_count: 0,
+            owned_wallet_count: 0,
+            attribute_count: 0,
+        }
+    }
+
+    fn metadata(did: &str, display: &str) -> IdentityMetadata {
+        IdentityMetadata {
+            did: did.to_string(),
+            display_name: display.to_string(),
+            public_key: vec![],
+            kyber_public_key: vec![],
+            ownership_proof: vec![],
+            controlled_nodes: vec![],
+            owned_wallets: vec![],
+            attributes: vec![],
+        }
+    }
+
+    /// Reviewer fix: prove the fast path is taken even when an identity
+    /// has both a registration and an update on-chain. Pre-fix the count
+    /// check
+    ///     identity_registry.len() != tx.identity_data().count()
+    /// triggered the fallback to historical replay for any updated
+    /// identity, because identity_data() returns Some for Register +
+    /// Update + Revoke. Post-fix the projection meta block-hash gate is
+    /// the sole correctness check, so the fast path takes the load.
+    #[test]
+    fn hydrate_checkpointed_state_takes_fast_path_with_updated_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store: Arc<dyn BlockchainStore> = Arc::new(SledStore::open(tmp.path()).unwrap());
+
+        let did_hash = [0x11u8; 32];
+
+        // Block 0: real IdentityRegistration tx; block 1: real
+        // IdentityUpdate tx. Both blocks committed inside their own
+        // begin/commit. The identity sled trees mirror the final state
+        // so iter_identities sees one row (post-fix) while blocks have
+        // two identity_data() tx hits (the broken-count scenario).
+        store.begin_block(0).unwrap();
+        store
+            .append_block(&block_with(0, vec![identity_tx_register("did:zhtp:alice")]))
+            .unwrap();
+        store.put_identity(&did_hash, &consensus(did_hash, 0)).unwrap();
+        store
+            .put_identity_metadata(&did_hash, &metadata("did:zhtp:alice", "alice"))
+            .unwrap();
+        store.commit_block().unwrap();
+
+        store.begin_block(1).unwrap();
+        store
+            .append_block(&block_with(1, vec![identity_tx_update("did:zhtp:alice")]))
+            .unwrap();
+        // Update keeps the same did_hash; bumps version on consensus and
+        // changes the display_name in metadata.
+        let mut c = consensus(did_hash, 0);
+        c.version = 2;
+        store.put_identity(&did_hash, &c).unwrap();
+        store
+            .put_identity_metadata(&did_hash, &metadata("did:zhtp:alice", "alice-renamed"))
+            .unwrap();
+        store.commit_block().unwrap();
+
+        // Backfill projections so the meta records the current tip.
+        let bc = Blockchain::default();
+        bc.backfill_hot_state_projections_from_replay(store.as_ref())
+            .unwrap();
+
+        // Drive the fast path directly to assert its return value rather
+        // than just observing the end state.
+        let mut fresh = Blockchain::default();
+        let used_fast = fresh
+            .hydrate_checkpointed_state_from_store(store.as_ref(), 1)
+            .expect("hydrate must not error");
+        assert!(
+            used_fast,
+            "fast path must be taken — projection meta is current and updated-identity \
+             count mismatch must no longer fall through to replay"
+        );
+
+        // Sanity-check: the loaded state reflects the updated identity.
+        let entry = fresh
+            .identity_registry
+            .get("did:zhtp:alice")
+            .expect("identity must be present after fast-path load");
+        assert_eq!(entry.display_name, "alice-renamed");
     }
 }

--- a/lib-blockchain/src/blockchain/projections.rs
+++ b/lib-blockchain/src/blockchain/projections.rs
@@ -46,8 +46,13 @@ impl Blockchain {
             self.stage_dao_registry_for_tx(store, tx, height)?;
         }
 
-        self.stage_contract_blocks(store)?;
-        self.stage_hot_state_projection_meta(store, block)
+        self.stage_contract_blocks_for_block(store, height)?;
+        // Reviewer #2692/L1470 + L327: meta is committed in a separate
+        // batch (`commit_hot_state_projection_meta_only`) AFTER the data
+        // batch flushes. Staging it here would tie data-write durability
+        // to meta-write durability inside the same non-WAL batch and
+        // re-open the atomicity gap.
+        Ok(())
     }
 
     fn stage_validator_for_tx(
@@ -128,7 +133,7 @@ impl Blockchain {
                 Ok(())
             }
             TransactionType::CreateEmploymentContract => {
-                self.stage_employment_contracts(store)
+                self.stage_employment_contracts_for_block(store, height)
             }
             TransactionType::TokenMint => self.stage_pouw_mint_for_tx(store, tx, height),
             _ => Ok(()),
@@ -180,8 +185,24 @@ impl Blockchain {
         Ok(())
     }
 
-    fn stage_employment_contracts(&self, store: &dyn BlockchainStore) -> Result<()> {
+    /// Reviewer #2692/L103: stage only employment contracts that were
+    /// created in THIS block (`start_height == height`). The old
+    /// `stage_employment_contracts` looped the entire registry on every
+    /// CreateEmploymentContract tx, making batch size proportional to
+    /// the historical contract count. Older contracts are already in
+    /// the projection from when they originally committed.
+    ///
+    /// `backfill_employment` (replay-time rebuild) still iterates the
+    /// whole registry — that's a one-time operation.
+    fn stage_employment_contracts_for_block(
+        &self,
+        store: &dyn BlockchainStore,
+        height: u64,
+    ) -> Result<()> {
         for contract in &self.employment_registry.contracts {
+            if contract.start_height != height {
+                continue;
+            }
             store.stage::<EmploymentProjectionTable>(
                 &hex::encode(contract.contract_id),
                 &EmploymentProjectionRecord {
@@ -238,6 +259,37 @@ impl Blockchain {
         Ok(())
     }
 
+    /// Reviewer #2692/L143: stage only contract_blocks entries that
+    /// landed in THIS block (`block_height == height`). The old
+    /// `stage_contract_blocks` re-staged every entry on every block —
+    /// O(total_contracts) per block, unbounded batch growth. Older
+    /// entries are already in the projection table from when they
+    /// originally committed.
+    ///
+    /// `backfill_contract_blocks` (replay-time rebuild) keeps the
+    /// whole-map iteration — it's a one-time operation.
+    fn stage_contract_blocks_for_block(
+        &self,
+        store: &dyn BlockchainStore,
+        height: u64,
+    ) -> Result<()> {
+        for (contract_id, block_height) in &self.contract_blocks {
+            if *block_height != height {
+                continue;
+            }
+            store.stage::<ContractBlockProjectionTable>(
+                contract_id,
+                &ContractBlockProjectionRecord {
+                    contract_id: *contract_id,
+                    block_height: *block_height,
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Used by the replay-time backfill — iterates the entire
+    /// contract_blocks map (one-time cost).
     fn stage_contract_blocks(&self, store: &dyn BlockchainStore) -> Result<()> {
         for (contract_id, block_height) in &self.contract_blocks {
             store.stage::<ContractBlockProjectionTable>(
@@ -277,11 +329,21 @@ impl Blockchain {
         Ok(())
     }
 
-    fn stage_hot_state_projection_meta(
+    /// Stage the projection meta record. Used by:
+    /// - `commit_hot_state_projection_meta_only` (executor path; meta is
+    ///   committed in a separate batch after data tables are durable —
+    ///   atomicity gap #2692/L1470 / L327).
+    /// - The legacy non-executor block-apply path, where data and meta
+    ///   are committed together inside one WAL-protected `commit_block`
+    ///   batch (atomic — safe to bundle).
+    /// - The replay-time backfill data commit (caller commits the data
+    ///   batch first, then this meta in a second batch).
+    pub(crate) fn stage_hot_state_projection_meta(
         &self,
         store: &dyn BlockchainStore,
         block: &Block,
     ) -> Result<()> {
+        let pouw_total: usize = self.pouw_mint_index.values().map(Vec::len).sum();
         let meta = HotStateProjectionMeta {
             version: HOT_STATE_PROJECTION_VERSION,
             height: block.height(),
@@ -290,17 +352,52 @@ impl Blockchain {
                 .duration_since(UNIX_EPOCH)
                 .map(|d| d.as_secs())
                 .unwrap_or(0),
-            validators: self.validator_registry.len(),
-            gateways: self.gateway_registry.len(),
-            domains: self.domain_registry.len(),
-            credentials: self.credential_registry.len(),
-            employment_contracts: self.employment_registry.contracts.len(),
-            dao_entries: self.dao_registry_index.len(),
-            pouw_mints: self.pouw_mint_index.values().map(Vec::len).sum(),
-            contract_blocks: self.contract_blocks.len(),
+            validators: self.validator_registry.len() as u64,
+            gateways: self.gateway_registry.len() as u64,
+            domains: self.domain_registry.len() as u64,
+            credentials: self.credential_registry.len() as u64,
+            employment_contracts: self.employment_registry.contracts.len() as u64,
+            dao_entries: self.dao_registry_index.len() as u64,
+            pouw_mints: pouw_total as u64,
+            contract_blocks: self.contract_blocks.len() as u64,
         };
         store.stage::<HotStateProjectionMetaTable>(META_KEY, &meta)?;
         Ok(())
+    }
+
+    /// Reviewer #2692/L1470 + L327: write the projection meta in its own
+    /// metadata-write batch *after* the data tables have been committed
+    /// and flushed.
+    ///
+    /// `commit_metadata_write` applies per-tree batches without
+    /// cross-tree WAL atomicity (its doc-comment is explicit:
+    /// `"This path is not WAL-protected"`). A crash mid-commit could
+    /// leave `projection_hot_state_meta` durable while sibling
+    /// projection tables are stale, making
+    /// `hot_state_projection_is_current` return true at next startup
+    /// and hydrate inconsistent hot state.
+    ///
+    /// By committing meta in a second batch, the worst case becomes:
+    /// crash before meta commit → meta absent → fast path skipped at
+    /// next startup → fallback to historical replay → backfill
+    /// re-stages atomically. The hydrate path never observes meta-
+    /// current + data-stale.
+    pub(crate) fn commit_hot_state_projection_meta_only(
+        &self,
+        store: &dyn BlockchainStore,
+        block: &Block,
+    ) -> Result<()> {
+        store.begin_metadata_write()?;
+        let result = self.stage_hot_state_projection_meta(store, block);
+        match result {
+            Ok(()) => store.commit_metadata_write().map_err(Into::into),
+            Err(e) => {
+                if let Err(rb) = store.rollback_block() {
+                    warn!("failed to roll back projection-meta batch: {}", rb);
+                }
+                Err(e)
+            }
+        }
     }
 
     pub(crate) fn hot_state_projection_is_current(
@@ -423,7 +520,16 @@ impl Blockchain {
         store.begin_metadata_write()?;
         let result = self.run_backfill_staging(store, &tip);
         match result {
-            Ok(()) => store.commit_metadata_write().map_err(Into::into),
+            Ok(()) => {
+                // Commit data first and flush.
+                store.commit_metadata_write()?;
+                // Only AFTER data is durable, write the meta marker in a
+                // separate batch (reviewer #2692/L327). If we crash
+                // between these two commits, meta is absent → next
+                // startup falls back to historical replay → backfill
+                // rebuilds atomically.
+                self.commit_hot_state_projection_meta_only(store, &tip)
+            }
             Err(e) => {
                 if let Err(rollback) = store.rollback_block() {
                     warn!(
@@ -462,7 +568,7 @@ impl Blockchain {
     fn run_backfill_staging(
         &self,
         store: &dyn BlockchainStore,
-        tip: &Block,
+        _tip: &Block,
     ) -> Result<()> {
         self.clear_projection_tables(store)?;
         self.backfill_validators(store)?;
@@ -474,7 +580,10 @@ impl Blockchain {
         self.backfill_dao_registry(store)?;
         self.backfill_pouw_mints(store)?;
         self.stage_contract_blocks(store)?;
-        self.stage_hot_state_projection_meta(store, tip)
+        // Reviewer #2692/L327: meta is committed in a second batch by
+        // the caller after the data batch flushes. Do NOT stage meta
+        // here — see `commit_hot_state_projection_meta_only`.
+        Ok(())
     }
 
     fn backfill_validators(&self, store: &dyn BlockchainStore) -> Result<()> {

--- a/lib-blockchain/src/projections.rs
+++ b/lib-blockchain/src/projections.rs
@@ -18,14 +18,18 @@ pub struct HotStateProjectionMeta {
     pub height: u64,
     pub block_hash: [u8; 32],
     pub completed_at_unix: u64,
-    pub validators: usize,
-    pub gateways: usize,
-    pub domains: usize,
-    pub credentials: usize,
-    pub employment_contracts: usize,
-    pub dao_entries: usize,
-    pub pouw_mints: usize,
-    pub contract_blocks: usize,
+    // Reviewer #2692/L29: fixed-width counts so the bincode payload is
+    // architecture-independent. `usize` round-trips differently between
+    // 32-bit and 64-bit targets and can fail deserialization if a count
+    // ever exceeds the local `usize` width.
+    pub validators: u64,
+    pub gateways: u64,
+    pub domains: u64,
+    pub credentials: u64,
+    pub employment_contracts: u64,
+    pub dao_entries: u64,
+    pub pouw_mints: u64,
+    pub contract_blocks: u64,
 }
 
 impl HotStateProjectionMeta {

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -863,6 +863,20 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     /// - Deleting non-existent UTXO is a no-op (idempotent)
     fn delete_utxo(&self, op: &OutPoint) -> StorageResult<()>;
 
+    /// Iterate all currently unspent UTXOs.
+    ///
+    /// Yields lazily so callers don't materialise the entire UTXO set in
+    /// RAM — at mainnet scale this set is unbounded. Each `Item` is a
+    /// `StorageResult` so per-row decode failures surface to the caller
+    /// without aborting the rest of the scan.
+    fn iter_utxos(
+        &self,
+    ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(OutPoint, Utxo)>> + '_>> {
+        Err(StorageError::Database(
+            "UTXO iteration not supported by this store".to_string(),
+        ))
+    }
+
     // =========================================================================
     // UTXO Merkle Tree (Mutable)
     // =========================================================================
@@ -1181,6 +1195,36 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     /// No default for the same reason as [`iter_identities`]: an empty/zero
     /// default would silently misreport the validator/citizen population.
     fn count_identities(&self) -> StorageResult<usize>;
+
+    /// Iterate identity consensus records joined with their optional
+    /// `IdentityMetadata`.
+    ///
+    /// Distinct from [`iter_identities`] which returns the bare consensus
+    /// row. This variant pairs each consensus record with its metadata
+    /// (display name, did string, controlled nodes, etc.) and is the
+    /// surface the startup hydrate path uses to rebuild
+    /// `identity_registry` from sled.
+    ///
+    /// Yields lazily so the entire identity set never lives in RAM at
+    /// once. Each `Item` is a `StorageResult` so per-row decode failures
+    /// surface to the caller without aborting the rest of the scan.
+    fn iter_identities_with_metadata(
+        &self,
+    ) -> StorageResult<
+        Box<
+            dyn Iterator<
+                    Item = StorageResult<(
+                        [u8; 32],
+                        IdentityConsensus,
+                        Option<IdentityMetadata>,
+                    )>,
+                > + '_,
+        >,
+    > {
+        Err(StorageError::Database(
+            "identity-with-metadata iteration not supported by this store".to_string(),
+        ))
+    }
 
     /// Store identity consensus state.
     ///

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1122,6 +1122,27 @@ impl BlockchainStore for SledStore {
         Ok(())
     }
 
+    fn iter_utxos(
+        &self,
+    ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(OutPoint, Utxo)>> + '_>> {
+        // Wrap the sled iterator directly so rows yield one at a time —
+        // hydrate paths can stream into projection tables without ever
+        // holding the whole UTXO set in memory. Per-row decode errors
+        // bubble up as `StorageResult` items.
+        let iter = self.utxos.iter().map(|result| {
+            let (key, value) = result.map_err(|e| StorageError::Database(e.to_string()))?;
+            let outpoint = keys::parse_utxo_key(key.as_ref()).ok_or_else(|| {
+                StorageError::CorruptedData(format!(
+                    "Invalid UTXO key length: {}",
+                    key.len()
+                ))
+            })?;
+            let utxo: Utxo = Self::deserialize(&value)?;
+            Ok((outpoint, utxo))
+        });
+        Ok(Box::new(iter))
+    }
+
     // =========================================================================
     // UTXO Merkle Tree Operations
     // =========================================================================
@@ -1863,6 +1884,49 @@ impl BlockchainStore for SledStore {
         // sled::Tree::len is an O(n) walk but avoids deserializing every record,
         // so it is the cheapest authoritative count available.
         Ok(self.identities.len())
+    }
+
+    fn iter_identities_with_metadata(
+        &self,
+    ) -> StorageResult<
+        Box<
+            dyn Iterator<
+                    Item = StorageResult<(
+                        [u8; 32],
+                        IdentityConsensus,
+                        Option<IdentityMetadata>,
+                    )>,
+                > + '_,
+        >,
+    > {
+        // Streams rows lazily so the hydrate path can process the
+        // identity set (~thousands+ at mainnet scale) without
+        // materialising it. The metadata lookup is intentionally
+        // per-row: identity_metadata is a separate sled tree and there
+        // is no efficient co-iteration primitive — the cost is one
+        // point-lookup per identity. If this ever shows up in profiling
+        // we can switch to scanning both trees in lock-step using
+        // sled's sorted-key ordering.
+        let metadata_tree = self.identity_metadata.clone();
+        let iter = self.identities.iter().map(move |result| {
+            let (key, value) = result.map_err(|e| StorageError::Database(e.to_string()))?;
+            if key.len() != 32 {
+                return Err(StorageError::CorruptedData(format!(
+                    "Invalid identity key length: {}",
+                    key.len()
+                )));
+            }
+            let mut did_hash = [0u8; 32];
+            did_hash.copy_from_slice(&key);
+            let consensus: IdentityConsensus = Self::deserialize(&value)?;
+            let metadata = match metadata_tree.get(did_hash) {
+                Ok(Some(bytes)) => Some(Self::deserialize(&bytes)?),
+                Ok(None) => None,
+                Err(e) => return Err(StorageError::Database(e.to_string())),
+            };
+            Ok((did_hash, consensus, metadata))
+        });
+        Ok(Box::new(iter))
     }
 
     fn put_identity(&self, did_hash: &[u8; 32], identity: &IdentityConsensus) -> StorageResult<()> {
@@ -3860,5 +3924,176 @@ mod tests {
         // Durable across reopen.
         let store = SledStore::open(dir.path()).unwrap();
         assert!(store.get_receipt(&tx_hash.as_array()).unwrap().is_some());
+    }
+
+    // =========================================================================
+    // Hot-state iterator tests (added in PR #2692 — lazy + Result)
+    // =========================================================================
+
+    #[test]
+    fn test_iter_utxos_returns_committed_unspent_outputs() {
+        let store = SledStore::open_temporary().unwrap();
+        let block = create_test_block(0, Hash::default());
+        let outpoint = OutPoint::new(TxHash([0x44; 32]), 7);
+        let utxo = Utxo::native(42u128, Address([0x55; 32]), 0);
+
+        store.begin_block(0).unwrap();
+        store.append_block(&block).unwrap();
+        store.put_utxo(&outpoint, &utxo).unwrap();
+        store.commit_block().unwrap();
+
+        let entries: Vec<_> = store
+            .iter_utxos()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, outpoint);
+        assert_eq!(entries[0].1.amount, 42);
+    }
+
+    #[test]
+    fn test_iter_utxos_empty_store_yields_nothing() {
+        let store = SledStore::open_temporary().unwrap();
+        let entries: Vec<_> = store
+            .iter_utxos()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_iter_utxos_returns_all_entries() {
+        let store = SledStore::open_temporary().unwrap();
+        let block = create_test_block(0, Hash::default());
+        store.begin_block(0).unwrap();
+        store.append_block(&block).unwrap();
+        for i in 0..5u8 {
+            let mut hash = [0u8; 32];
+            hash[0] = i;
+            let outpoint = OutPoint::new(TxHash(hash), i as u32);
+            let utxo = Utxo::native(100u128 + i as u128, Address([i; 32]), 0);
+            store.put_utxo(&outpoint, &utxo).unwrap();
+        }
+        store.commit_block().unwrap();
+
+        let entries: Vec<_> = store
+            .iter_utxos()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 5);
+    }
+
+    #[test]
+    fn test_iter_identities_with_metadata_returns_consensus_and_metadata() {
+        use super::super::{IdentityConsensus, IdentityMetadata, IdentityStatus, IdentityType};
+
+        let store = SledStore::open_temporary().unwrap();
+        let block = create_test_block(0, Hash::default());
+        let did_hash = [0x88; 32];
+        let consensus = IdentityConsensus {
+            did_hash,
+            owner: Address([0x99; 32]),
+            public_key_hash: [0xaa; 32],
+            did_document_hash: [0xbb; 32],
+            seed_commitment: None,
+            identity_type: IdentityType::Human,
+            status: IdentityStatus::Active,
+            version: 2,
+            created_at: 1,
+            registered_at_height: 0,
+            registration_fee: 1000,
+            dao_fee: 100,
+            controlled_node_count: 0,
+            owned_wallet_count: 1,
+            attribute_count: 0,
+        };
+        let metadata = IdentityMetadata {
+            did: "did:sovn:test-identity".to_string(),
+            display_name: "Test Identity".to_string(),
+            public_key: vec![1, 2, 3],
+            kyber_public_key: vec![],
+            ownership_proof: vec![4, 5, 6],
+            controlled_nodes: vec![],
+            owned_wallets: vec!["wallet-1".to_string()],
+            attributes: vec![],
+        };
+
+        store.begin_block(0).unwrap();
+        store.append_block(&block).unwrap();
+        store.put_identity(&did_hash, &consensus).unwrap();
+        store.put_identity_metadata(&did_hash, &metadata).unwrap();
+        store.commit_block().unwrap();
+
+        let entries: Vec<_> = store
+            .iter_identities_with_metadata()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, did_hash);
+        assert_eq!(entries[0].1.owner, consensus.owner);
+        assert_eq!(entries[0].2.as_ref().unwrap().did, metadata.did);
+    }
+
+    /// Edge case: an identity may exist in the consensus tree without
+    /// a corresponding metadata row (legacy / partial-write recovery
+    /// scenarios). Must yield `Option<_> = None` for metadata in that
+    /// case rather than erroring.
+    #[test]
+    fn test_iter_identities_with_metadata_handles_missing_metadata() {
+        use super::super::{IdentityConsensus, IdentityStatus, IdentityType};
+
+        let store = SledStore::open_temporary().unwrap();
+        let block = create_test_block(0, Hash::default());
+        let did_hash = [0x77; 32];
+        let consensus = IdentityConsensus {
+            did_hash,
+            owner: Address([0x66; 32]),
+            public_key_hash: [0x55; 32],
+            did_document_hash: [0x44; 32],
+            seed_commitment: None,
+            identity_type: IdentityType::Human,
+            status: IdentityStatus::Active,
+            version: 1,
+            created_at: 0,
+            registered_at_height: 0,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_node_count: 0,
+            owned_wallet_count: 0,
+            attribute_count: 0,
+        };
+
+        store.begin_block(0).unwrap();
+        store.append_block(&block).unwrap();
+        store.put_identity(&did_hash, &consensus).unwrap();
+        // Intentionally NO put_identity_metadata.
+        store.commit_block().unwrap();
+
+        let entries: Vec<_> = store
+            .iter_identities_with_metadata()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, did_hash);
+        assert!(
+            entries[0].2.is_none(),
+            "identity without metadata must yield Option::None, not error"
+        );
+    }
+
+    #[test]
+    fn test_iter_identities_with_metadata_empty_store_yields_nothing() {
+        let store = SledStore::open_temporary().unwrap();
+        let entries: Vec<_> = store
+            .iter_identities_with_metadata()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(entries.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Add a checkpointed `load_from_store` hydrate path that uses the hot-state projection meta as the safety gate.
- Restore durable state from typed store surfaces: blocks/nullifiers legacy indexes, identity records, wallet projections, token snapshots/contracts, bonding curves, oracle state, and hot projection tables.
- Fall back to the existing historical replay when projections are stale or required projection surfaces are incomplete, preserving wallet projection rebuild behavior.

## Validation
- `cargo build -p lib-blockchain`
- `cargo test -p lib-blockchain --test wallet_projection_restart_tests`
- `cargo test -p lib-blockchain --test token_snapshot_restart_tests`

Stacked on #2692 for issue #2687.
