### PR TITLE
ci: dev-profile builds + cache target/debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,15 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/debug
             target/release
+          # Key cache on Cargo.lock so refactors that don't touch deps
+          # hit the cache; dual-cache both target/debug (PR builds) and
+          # target/release (deploy artifact path on dev/main pushes).
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Build
+      - name: Build (dev profile)
         run: cargo build --workspace --locked
 
       - name: Build Release Binary (zhtp node)
@@ -136,18 +140,21 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target/release
+            target/debug
+          # macOS only needs dev mode — the released CLI is built
+          # separately in release-cli.yml. No release artifact comes
+          # out of this job, so don't cache target/release here.
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Build workspace
+      - name: Build workspace (dev profile)
         run: cargo build --workspace --locked
 
       - name: Test lib-network (BLE/GATT coverage)
         run: cargo test -p lib-network --locked --features ble-mock -- --nocapture
 
-      - name: Build zhtp-cli
-        run: cargo build --release -p zhtp-cli --locked
+      - name: Build zhtp-cli (dev profile, for tests below)
+        run: cargo build -p zhtp-cli --locked
 
       - name: Run zhtp-cli Integration Tests (macOS)
         run: cargo test -p zhtp-cli --test integration_tests --locked -- --nocapture


### PR DESCRIPTION
Cut PR CI wall time by ~half on cached builds.

## Changes

1. **Cache `target/debug`** alongside `target/release` in the linux job. PR build runs `cargo build --workspace --locked` (dev profile) but the cache only saved `target/release`, so every PR cold-rebuilt the workspace. Adding `target/debug` means unchanged deps skip recompilation between PR pushes.

2. **macOS: drop the unused `--release` zhtp-cli build.** That job tests zhtp-cli but built it `--release` before tests (which compile + run in dev mode anyway). The release CLI binary is produced separately by `release-cli.yml` — no consumer here. Switching to dev removes a full release-profile compile of a 65 MB binary that's never used.

## What's NOT changed

- Linux deploy artifact (`cargo build --release -p zhtp`) is still release-profile — gated to dev/main pushes only, not PRs.
- All release tag workflows untouched.

## Test plan

- [x] Local: `cargo build --workspace` builds cleanly (current dev default)
- [ ] First CI run after merge will be cold (cache miss); subsequent PRs should see significant cache hits