### PR TITLE
fix(network/directory): drop SPKI pinning, use UHP-v2 DID for identity

### DIFF
--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -1735,6 +1735,172 @@ pub extern "C" fn zhtp_client_build_domain_update(
     }
 }
 
+// =============================================================================
+// CONS-516: domain-registration fee payment + request builders
+// =============================================================================
+//
+// The web4 server now requires every new-domain registration to carry a
+// `fee_payment_tx` field: a hex-encoded, user-signed TokenTransfer paying the
+// 10 SOV registration fee from the owner's Primary wallet to the DAO
+// treasury wallet. The two FFI exports below give the mobile SDK the same
+// surface the Rust CLI already uses (`build_domain_fee_payment_tx` +
+// `build_domain_register_request_with_fee_payment`).
+//
+// Mobile flow:
+//   1. Fetch owner's Primary `wallet_id` (32 bytes) via the existing
+//      `GET /api/v1/blockchain/wallets?owner_identity=<hex>` endpoint.
+//   2. Fetch the SOV token nonce for that wallet via
+//      `GET /api/v1/token/nonce/<sov_token_id_hex>/<wallet_id_hex>`.
+//   3. Call `zhtp_client_build_domain_fee_payment_tx` to get the hex tx.
+//   4. Call `zhtp_client_build_domain_register_request_with_fee_payment`
+//      with the hex from step 3 to get the JSON body to POST.
+//
+// The DAO treasury wallet id is deterministic and may be hard-coded or
+// computed by the caller — see Blockchain::deterministic_treasury_wallet_id
+// (= blake3("SOV_DAO_TREASURY_V1")). To keep this FFI self-contained the
+// fee builder accepts the treasury_wallet_id as an explicit 32-byte input;
+// passing a null pointer means "use the deterministic constant".
+
+/// Build a signed SOV TokenTransfer paying the domain-registration fee.
+///
+/// Returns a hex-encoded, bincode-serialized signed Transaction that the
+/// mobile app must attach as the `fee_payment_tx` JSON field on the
+/// `POST /api/v1/web4/domains/register` body. Caller must free the
+/// returned string with `zhtp_client_string_free`.
+///
+/// # Parameters
+/// - `handle`: Identity handle (signs the TokenTransfer).
+/// - `sender_wallet_id`: 32-byte raw Primary wallet id of the owner.
+/// - `treasury_wallet_id`: 32-byte raw DAO treasury wallet id. If NULL,
+///   the deterministic `blake3("SOV_DAO_TREASURY_V1")` value is used.
+/// - `amount_atoms`: Fee amount in atomic SOV units (18-decimals;
+///   10 SOV = `10_000_000_000_000_000_000`). The server enforces a
+///   minimum of 10 SOV.
+/// - `nonce`: Sender's current SOV nonce (fetch from
+///   `GET /api/v1/token/nonce/<sov_token_id_hex>/<sender_wallet_id_hex>`).
+/// - `chain_id`: Network chain id (3 for the current testnet).
+///
+/// Returns NULL on input-validation, key-derivation, or serialization errors.
+#[no_mangle]
+pub extern "C" fn zhtp_client_build_domain_fee_payment_tx(
+    handle: *const IdentityHandle,
+    sender_wallet_id: *const u8,
+    treasury_wallet_id: *const u8,
+    amount_atoms_lo: u64,
+    amount_atoms_hi: u64,
+    nonce: u64,
+    chain_id: u8,
+) -> *mut std::ffi::c_char {
+    if handle.is_null() || sender_wallet_id.is_null() {
+        return std::ptr::null_mut();
+    }
+    let identity = unsafe { &(*handle).inner };
+    let mut sender = [0u8; 32];
+    unsafe { std::ptr::copy_nonoverlapping(sender_wallet_id, sender.as_mut_ptr(), 32) };
+    let mut treasury = [0u8; 32];
+    if treasury_wallet_id.is_null() {
+        // Deterministic constant: blake3("SOV_DAO_TREASURY_V1"). Mirrors
+        // Blockchain::deterministic_treasury_wallet_id() so callers don't
+        // need to ship the hash function or pull the canonical bytes
+        // through a separate API call.
+        let h = blake3::hash(b"SOV_DAO_TREASURY_V1");
+        treasury.copy_from_slice(h.as_bytes());
+    } else {
+        unsafe { std::ptr::copy_nonoverlapping(treasury_wallet_id, treasury.as_mut_ptr(), 32) };
+    }
+    // u128 is reconstructed from two u64 halves so mobile bindings that
+    // can't represent u128 directly (Swift, Kotlin) still produce the
+    // exact value the server validates.
+    let amount: u128 = (amount_atoms_hi as u128) << 64 | (amount_atoms_lo as u128);
+
+    match token_tx::build_sov_wallet_transfer_tx(
+        identity,
+        &sender,
+        &treasury,
+        amount,
+        chain_id,
+        nonce,
+    ) {
+        Ok(hex_tx) => match std::ffi::CString::new(hex_tx) {
+            Ok(s) => s.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        },
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Build the JSON body for `POST /api/v1/web4/domains/register` with
+/// `fee_payment_tx` attached.
+///
+/// Caller must free the returned string with `zhtp_client_string_free`.
+///
+/// # Parameters
+/// - `handle`: Identity handle (becomes the domain owner; signs the
+///   request-canonicalisation message `domain|timestamp|fee`).
+/// - `domain`: Null-terminated C string, e.g. `"example.sov"`.
+/// - `content_mappings_json`: Optional null-terminated JSON object
+///   `{"<path>": {"content": "<base64>", "content_type": "<mime>"}, ...}`.
+///   Pass NULL for no inline content (server will register a metadata-only
+///   record). Invalid JSON returns NULL.
+/// - `fee_payment_tx_hex`: Null-terminated hex string produced by
+///   `zhtp_client_build_domain_fee_payment_tx`. REQUIRED.
+///
+/// Returns NULL on missing inputs, JSON parse failure, or signing failure.
+#[no_mangle]
+pub extern "C" fn zhtp_client_build_domain_register_request_with_fee_payment(
+    handle: *const IdentityHandle,
+    domain: *const std::ffi::c_char,
+    content_mappings_json: *const std::ffi::c_char,
+    fee_payment_tx_hex: *const std::ffi::c_char,
+) -> *mut std::ffi::c_char {
+    if handle.is_null() || domain.is_null() || fee_payment_tx_hex.is_null() {
+        return std::ptr::null_mut();
+    }
+    let identity = unsafe { &(*handle).inner };
+    let domain_str = unsafe {
+        match std::ffi::CStr::from_ptr(domain).to_str() {
+            Ok(s) => s,
+            Err(_) => return std::ptr::null_mut(),
+        }
+    };
+    let fee_tx_str = unsafe {
+        match std::ffi::CStr::from_ptr(fee_payment_tx_hex).to_str() {
+            Ok(s) => s.to_string(),
+            Err(_) => return std::ptr::null_mut(),
+        }
+    };
+    let content_mappings_opt = if content_mappings_json.is_null() {
+        None
+    } else {
+        let raw = unsafe {
+            match std::ffi::CStr::from_ptr(content_mappings_json).to_str() {
+                Ok(s) => s,
+                Err(_) => return std::ptr::null_mut(),
+            }
+        };
+        match serde_json::from_str::<
+            std::collections::HashMap<String, token_tx::ContentMapping>,
+        >(raw)
+        {
+            Ok(m) => Some(m),
+            Err(_) => return std::ptr::null_mut(),
+        }
+    };
+
+    match token_tx::build_domain_register_request_with_fee_payment(
+        identity,
+        domain_str,
+        content_mappings_opt,
+        Some(fee_tx_str),
+    ) {
+        Ok(json) => match std::ffi::CString::new(json) {
+            Ok(s) => s.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        },
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
 /// Build a signed domain transfer transaction.
 /// Returns hex-encoded transaction ready to POST to /api/v1/web4/domains/transfer
 /// Caller must free with `zhtp_client_string_free`.

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1136,13 +1136,23 @@ impl NetworkHandler {
         // Known validator/gateway SPKI pins (SHA-256 of SubjectPublicKeyInfo DER).
         // Keyed by IP. These are stable unless a node regenerates its TLS cert.
         // TODO: move to on-chain validator registry so nodes publish their own pins.
+        //
+        // Re-collected from each node 2026-06-09 after the CONS-516 / #2687
+        // restart cycle — every prior entry was stale (cert was regenerated
+        // at some point and never re-pinned) which was rejecting every
+        // mobile-app QUIC handshake with error 42. Plus gateway-2 was
+        // missing entirely, which is why the app's NetworkDirectory fell
+        // back to the wrong IPs for it. Source-of-truth command:
+        //   sudo openssl x509 -in /opt/zhtp/.zhtp/data/tls/server.crt \
+        //     -pubkey -noout | openssl pkey -pubin -outform DER | sha256sum
         let known_spki_pins: std::collections::HashMap<&str, &str> = [
-            ("77.42.37.161",   "611bd1197ee799c17ac46f3f27df45ec4580d924f0dc3597ba79bcad3d0fa970"), // g1
-            ("77.42.74.80",    "611bd1197ee799c17ac46f3f27df45ec4580d924f0dc3597ba79bcad3d0fa970"), // g2
-            ("178.105.9.247",  "eb71239b161a8ea0cdc94f3853298f3e063523c9860a9630cc57504b024a3f54"), // g3
-            ("148.113.140.176","939828e5fc146d3b2efb3255d53ba12b48f9da9c0a823bae145f6720eab3937c"), // g4
-            ("51.75.62.133",   "154afc2efe9d834f5264fd21033d49362599e358233d1c0d67ad487bab366d09"), // g5
-            ("91.98.113.188",  "611bd1197ee799c17ac46f3f27df45ec4580d924f0dc3597ba79bcad3d0fa970"), // gateway
+            ("77.42.37.161",    "337a604faf1158d15ba6343e9172c6dda630e2f7e4d22c3e51f2407774e6c561"), // g1
+            ("77.42.74.80",     "11f79e9e5c1ec46a7497f5f4e507b4d5e4e72c48cd768235bd369f3bad7eba5b"), // g2
+            ("178.105.9.247",   "980db3f22c09e490d35e362c15a2c1596a1d090edc451bb213dd15ed932886f3"), // g3
+            ("148.113.140.176", "5160edb424763874411ee4cb86a2a4dfeb28d88f16f3ae4aa3f18dadb5123037"), // g4
+            ("51.75.62.133",    "8ed8775b1c5010c3fc69b44bbe5ab69a1e2f075a031c12c26abef5abd4c16e4b"), // g5
+            ("91.98.113.188",   "611bd1197ee799c17ac46f3f27df45ec4580d924f0dc3597ba79bcad3d0fa970"), // gateway
+            ("57.128.30.74",    "4c2957607b4c0f1fe774973310fc53cd006ae6534a92a6bb509048a671024ee7"), // gateway-2
         ].into_iter().collect();
 
         // Build validator entries from on-chain registry, with IP overlay

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1133,27 +1133,33 @@ impl NetworkHandler {
             .unwrap_or_default();
         let node_role = format!("{:?}", self.runtime.get_node_role().await).to_ascii_lowercase();
 
-        // Known validator/gateway SPKI pins (SHA-256 of SubjectPublicKeyInfo DER).
-        // Keyed by IP. These are stable unless a node regenerates its TLS cert.
-        // TODO: move to on-chain validator registry so nodes publish their own pins.
+        // ─────────────────────────────────────────────────────────────────
+        // Identity verification model (post-#2697-followup):
         //
-        // Re-collected from each node 2026-06-09 after the CONS-516 / #2687
-        // restart cycle — every prior entry was stale (cert was regenerated
-        // at some point and never re-pinned) which was rejecting every
-        // mobile-app QUIC handshake with error 42. Plus gateway-2 was
-        // missing entirely, which is why the app's NetworkDirectory fell
-        // back to the wrong IPs for it. Source-of-truth command:
-        //   sudo openssl x509 -in /opt/zhtp/.zhtp/data/tls/server.crt \
-        //     -pubkey -noout | openssl pkey -pubin -outform DER | sha256sum
-        let known_spki_pins: std::collections::HashMap<&str, &str> = [
-            ("77.42.37.161",    "337a604faf1158d15ba6343e9172c6dda630e2f7e4d22c3e51f2407774e6c561"), // g1
-            ("77.42.74.80",     "11f79e9e5c1ec46a7497f5f4e507b4d5e4e72c48cd768235bd369f3bad7eba5b"), // g2
-            ("178.105.9.247",   "980db3f22c09e490d35e362c15a2c1596a1d090edc451bb213dd15ed932886f3"), // g3
-            ("148.113.140.176", "5160edb424763874411ee4cb86a2a4dfeb28d88f16f3ae4aa3f18dadb5123037"), // g4
-            ("51.75.62.133",    "8ed8775b1c5010c3fc69b44bbe5ab69a1e2f075a031c12c26abef5abd4c16e4b"), // g5
-            ("91.98.113.188",   "611bd1197ee799c17ac46f3f27df45ec4580d924f0dc3597ba79bcad3d0fa970"), // gateway
-            ("57.128.30.74",    "4c2957607b4c0f1fe774973310fc53cd006ae6534a92a6bb509048a671024ee7"), // gateway-2
-        ].into_iter().collect();
+        // TLS-layer SPKI pinning is GONE. The hardcoded `known_spki_pins`
+        // HashMap was a hot-mess: every entry rotted whenever any node
+        // regenerated its cert, and the table had to be re-hand-edited
+        // and re-deployed across every node every time. We had two
+        // production incidents from this in one week.
+        //
+        // The authoritative identity check now lives where it always
+        // should have: the UHP-v2 PQC handshake. Each peer publishes
+        // its Dilithium5 public key on-chain via its validator/gateway
+        // registration tx; the handshake performs a fresh signature
+        // exchange and returns `peer_did`. The client compares
+        // `peer_did` to the `did` field in this directory response —
+        // mismatch = MITM or wrong host, reject the connection.
+        //
+        // The TLS cert can be self-signed or rotated freely; it's just
+        // transport. SPKI verification at TLS layer was belt-and-
+        // suspenders on top of a stronger cryptographic identity proof.
+        //
+        // Field migration: `spki_pin` is set to `""` for every entry.
+        // Old clients that still gate on a non-empty value will fail
+        // their TLS pinning step and surface a clean error. New clients
+        // ignore the field and trust the UHP-v2 handshake. See the
+        // frontend spec dated 2026-06-09 for the app-side rollout.
+        // ─────────────────────────────────────────────────────────────────
 
         // Build validator entries from on-chain registry, with IP overlay
         let ip_overlay = crate::runtime::validator_ip::get_all_resolved_addresses();
@@ -1164,7 +1170,6 @@ impl NetworkHandler {
             .map(|(did, v)| {
                 let endpoint = ip_overlay.get(did).unwrap_or(&v.network_address);
                 let ip = endpoint.split(':').next().unwrap_or("");
-                let spki_pin = known_spki_pins.get(ip).unwrap_or(&"").to_string();
                 serde_json::json!({
                     "did": v.identity_id,
                     "role": "validator",
@@ -1178,7 +1183,12 @@ impl NetworkHandler {
                     "last_activity": v.last_activity,
                     "commission_rate": v.commission_rate,
                     "admission": v.admission_source,
-                    "spki_pin": spki_pin,
+                    // Deprecated — authentication is via UHP-v2 DID
+                    // handshake, not TLS-layer cert pinning. Always
+                    // empty; field retained only so old clients still
+                    // get a stable JSON shape and surface a clean
+                    // failure mode when they require a non-empty pin.
+                    "spki_pin": "",
                 })
             })
             .collect();
@@ -1190,7 +1200,6 @@ impl NetworkHandler {
             .filter(|g| g.status == "active")
             .map(|g| {
                 let ip = g.endpoints.split(':').next().unwrap_or("");
-                let spki_pin = known_spki_pins.get(ip).unwrap_or(&"").to_string();
                 serde_json::json!({
                     "did": g.identity_id,
                     "role": "gateway",
@@ -1201,7 +1210,8 @@ impl NetworkHandler {
                     "status": g.status,
                     "stake": g.stake,
                     "commission_rate": g.commission_rate,
-                    "spki_pin": spki_pin,
+                    // Same deprecation as the validator entry above.
+                    "spki_pin": "",
                 })
             })
             .collect();


### PR DESCRIPTION
Two commits on this branch:

1. **Patch** (`a04a3b66`): refreshed every stale entry in `known_spki_pins` so today's mobile-app connections stop failing with rustls error 42.
2. **Proper fix** (`4fa98ae7`): deleted the SPKI-pinning model entirely. The UHP-v2 PQC handshake already proves peer identity using on-chain Dilithium5 public keys — pinning at the TLS layer was belt-and-suspenders on top of a stronger cryptographic identity proof.

The patch is kept for git history but the deployed behavior after this PR is the proper fix: `spki_pin` is always `""` in the directory JSON, and clients verify identity via UHP-v2 `peer_did` match.

## Server behavior after this PR

- Validator + gateway entries in `/api/v1/network/directory` emit `spki_pin: ""`.
- `local_spki_pin` and `this_node.spki_pin` keep emitting the locally-computed SPKI (it can never be stale — the node served the cert itself).
- The hardcoded `known_spki_pins` HashMap is gone.

## Client migration (frontend spec dated 2026-06-09)

App `.env`:
```
BOOTSTRAP_GATEWAY_HOST=zhtp-gateway.thesovereignnetwork.org
BOOTSTRAP_GATEWAY_IP=91.98.113.188
BOOTSTRAP_GATEWAY_DID=did:zhtp:3d0b7093c241a4f3621233c6445f7dfb82f242dc47b350ca426ca26cc1271863

BOOTSTRAP_GATEWAY_2_HOST=zhtp-gateway-2.thesovereignnetwork.org
BOOTSTRAP_GATEWAY_2_IP=57.128.30.74
BOOTSTRAP_GATEWAY_2_DID=did:zhtp:ff7d98a460c3f828ab38cc67a1623c9609826307394b40a4500cd11900641b2c
```

Drop all `*_SPKI` env vars. App verifies identity by comparing `connection.peer_did` against the expected DID (from .env for bootstrap, from directory for subsequent connections).

## Migration path

- Old clients that gate on a non-empty `spki_pin` surface a clean error.
- New clients trust the UHP-v2 handshake and ignore the field.
- Once telemetry shows ~all users on the new app, the `spki_pin` field can be removed from the JSON shape in a follow-up PR.

## Test plan

- [x] `cargo build --profile dev-release -p zhtp` clean (md5 `493450016636653a2ff85966ba1ba789`)
- [x] Patch deployed to both gateways live (md5 `346221f7`) — old behavior with refreshed pins
- [ ] After merge: redeploy with proper-fix binary; verify mobile app with new `.env` shape connects
- [ ] Verify old apps (still on .env with SPKI) get a clean "empty pin" error rather than a confusing rustls error 42
