### PR TITLE
Persist durable nullifier index

### DIFF
--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -940,17 +940,24 @@ impl Blockchain {
             blockchain.token_contracts.len()
         );
 
-        let nullifiers: Vec<_> = blockchain.nullifier_set.iter().copied().collect();
-        if !nullifiers.is_empty() {
-            match store.backfill_nullifiers(&nullifiers) {
-                Ok(()) => debug!(
-                    "🔁 Backfilled durable nullifier index from loaded state ({} entries)",
-                    nullifiers.len()
-                ),
-                Err(e) => warn!(
-                    "⚠️ Failed to backfill durable nullifier index during load_from_store: {}",
-                    e
-                ),
+        if let Some(tip_hash) = store.get_block_hash_by_height(blockchain.height)? {
+            if !store.nullifier_index_is_current(blockchain.height, &tip_hash)? {
+                let nullifiers: Vec<_> = blockchain.nullifier_set.iter().copied().collect();
+                if !nullifiers.is_empty() {
+                    match store
+                        .backfill_nullifiers(&nullifiers)
+                        .and_then(|_| store.mark_nullifier_index_current(blockchain.height, &tip_hash))
+                    {
+                        Ok(()) => debug!(
+                            "🔁 Backfilled durable nullifier index from loaded state ({} entries)",
+                            nullifiers.len()
+                        ),
+                        Err(e) => warn!(
+                            "⚠️ Failed to backfill durable nullifier index during load_from_store: {}",
+                            e
+                        ),
+                    }
+                }
             }
         }
 

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -940,6 +940,20 @@ impl Blockchain {
             blockchain.token_contracts.len()
         );
 
+        let nullifiers: Vec<_> = blockchain.nullifier_set.iter().copied().collect();
+        if !nullifiers.is_empty() {
+            match store.backfill_nullifiers(&nullifiers) {
+                Ok(()) => debug!(
+                    "🔁 Backfilled durable nullifier index from loaded state ({} entries)",
+                    nullifiers.len()
+                ),
+                Err(e) => warn!(
+                    "⚠️ Failed to backfill durable nullifier index during load_from_store: {}",
+                    e
+                ),
+            }
+        }
+
         // load_from_store deliberately skips token-tx processing, so the
         // PoUW mint index is not built incrementally on this path. Rebuild it
         // from the loaded blocks so /api/v1/pouw/rewards has the full history.

--- a/lib-blockchain/src/storage/keys.rs
+++ b/lib-blockchain/src/storage/keys.rs
@@ -253,6 +253,9 @@ pub mod meta {
     /// Key for canonical observer admission policy (single global record).
     pub const OBSERVER_POLICY: &[u8] = b"observer_policy";
 
+    /// Key for the durable nullifier index checkpoint: height (u64 BE) || tip hash (32 bytes).
+    pub const NULLIFIER_INDEX_CHECKPOINT: &[u8] = b"nullifier_index_checkpoint";
+
     /// Key for the persisted `identity_metadata` schema version (u32, big-endian).
     /// Drives the version-gated regenerate-from-blocks migration (#58). Absent
     /// key is treated as version 1 (pre-kyber records).

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -55,6 +55,7 @@ pub use table::{Table, TableAccess};
 pub use lib_types::primitives::{
     Address, Amount, BlockHash, BlockHeight, Bps, OutPoint, TokenId, TxHash, Utxo, UtxoMerkleProof,
 };
+use crate::types::Hash;
 
 // =============================================================================
 // EXTENSION TRAITS FOR CANONICAL TYPES
@@ -874,6 +875,51 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(OutPoint, Utxo)>> + '_>> {
         Err(StorageError::Database(
             "UTXO iteration not supported by this store".to_string(),
+        ))
+    }
+
+    // =========================================================================
+    // Nullifier State (Mutable)
+    // =========================================================================
+    // Nullifiers are replay-protection markers for spent inputs. They are
+    // consensus-critical and must be committed atomically with the block that
+    // consumes them.
+    // =========================================================================
+
+    /// Return true if a nullifier has already been committed.
+    fn is_nullifier_used(&self, nullifier: &Hash) -> StorageResult<bool> {
+        let _ = nullifier;
+        Err(StorageError::Database(
+            "Nullifier lookups are not supported by this store".to_string(),
+        ))
+    }
+
+    /// Mark a nullifier as spent.
+    ///
+    /// # Requirements
+    /// - MUST be called within begin_block/commit_block
+    fn put_nullifier(&self, nullifier: &Hash) -> StorageResult<()> {
+        let _ = nullifier;
+        Err(StorageError::Database(
+            "Nullifier writes are not supported by this store".to_string(),
+        ))
+    }
+
+    /// Iterate all committed nullifiers.
+    fn iter_nullifiers(&self) -> StorageResult<Box<dyn Iterator<Item = StorageResult<Hash>> + '_>> {
+        Err(StorageError::Database(
+            "Nullifier iteration is not supported by this store".to_string(),
+        ))
+    }
+
+    /// Idempotently backfill nullifiers outside a block transaction.
+    ///
+    /// Used only during startup migrations from historical blocks. Normal block
+    /// execution must use `put_nullifier` inside begin_block/commit_block.
+    fn backfill_nullifiers(&self, nullifiers: &[Hash]) -> StorageResult<()> {
+        let _ = nullifiers;
+        Err(StorageError::Database(
+            "Nullifier backfill is not supported by this store".to_string(),
         ))
     }
 

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -923,6 +923,28 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
         ))
     }
 
+    /// Return true when the durable nullifier index is complete for this tip.
+    fn nullifier_index_is_current(
+        &self,
+        height: BlockHeight,
+        block_hash: &BlockHash,
+    ) -> StorageResult<bool> {
+        let _ = (height, block_hash);
+        Ok(false)
+    }
+
+    /// Mark the durable nullifier index complete for this tip.
+    fn mark_nullifier_index_current(
+        &self,
+        height: BlockHeight,
+        block_hash: &BlockHash,
+    ) -> StorageResult<()> {
+        let _ = (height, block_hash);
+        Err(StorageError::Database(
+            "Nullifier checkpoint writes are not supported by this store".to_string(),
+        ))
+    }
+
     // =========================================================================
     // UTXO Merkle Tree (Mutable)
     // =========================================================================

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -17,6 +17,7 @@ use super::{
 use crate::block::Block;
 use crate::contracts::TokenContract;
 use crate::transaction::Transaction;
+use crate::types::Hash;
 
 // =============================================================================
 // TREE NAMES (FIXED - DO NOT CHANGE)
@@ -27,6 +28,7 @@ use crate::transaction::Transaction;
 const TREE_BLOCKS_BY_HEIGHT: &str = "blocks_by_height";
 const TREE_BLOCKS_BY_HASH: &str = "blocks_by_hash";
 const TREE_UTXOS: &str = "utxos";
+const TREE_NULLIFIERS: &str = "nullifiers";
 const TREE_UTXO_MERKLE_LEAVES: &str = "utxo_merkle_leaves";
 const TREE_UTXO_MERKLE_INDEX: &str = "utxo_merkle_index";
 const TREE_UTXO_MERKLE_META: &str = "utxo_merkle_meta";
@@ -84,6 +86,7 @@ pub struct SledStore {
     blocks_by_height: Tree,
     blocks_by_hash: Tree,
     utxos: Tree,
+    nullifiers: Tree,
     accounts: Tree,
     wallets: Tree,
     token_balances: Tree,
@@ -312,6 +315,9 @@ impl SledStore {
         let utxos = db
             .open_tree(TREE_UTXOS)
             .map_err(|e| StorageError::Database(e.to_string()))?;
+        let nullifiers = db
+            .open_tree(TREE_NULLIFIERS)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
         let accounts = db
             .open_tree(TREE_ACCOUNTS)
             .map_err(|e| StorageError::Database(e.to_string()))?;
@@ -426,6 +432,7 @@ impl SledStore {
             blocks_by_height,
             blocks_by_hash,
             utxos,
+            nullifiers,
             accounts,
             wallets,
             token_balances,
@@ -812,6 +819,7 @@ impl SledStore {
             TREE_BLOCKS_BY_HEIGHT => &self.blocks_by_height,
             TREE_BLOCKS_BY_HASH => &self.blocks_by_hash,
             TREE_UTXOS => &self.utxos,
+            TREE_NULLIFIERS => &self.nullifiers,
             TREE_ACCOUNTS => &self.accounts,
             TREE_WALLETS => &self.wallets,
             TREE_TOKEN_BALANCES => &self.token_balances,
@@ -1032,6 +1040,13 @@ impl BlockchainStore for SledStore {
                 .tree(TREE_BLOCKS_BY_HEIGHT)
                 .insert(height_key.as_ref(), block_hash.as_bytes().as_ref());
             batch.tree(TREE_BLOCKS_BY_HASH).insert(hash_key.as_ref(), block_bytes);
+            for tx in &block.transactions {
+                for input in &tx.inputs {
+                    batch
+                        .tree(TREE_NULLIFIERS)
+                        .insert(input.nullifier.as_bytes(), &[1u8][..]);
+                }
+            }
             // Record the block hash for the write-ahead commit record.
             batch.block_hash = Some(hash_bytes);
         }
@@ -1141,6 +1156,63 @@ impl BlockchainStore for SledStore {
             Ok((outpoint, utxo))
         });
         Ok(Box::new(iter))
+    }
+
+    fn is_nullifier_used(&self, nullifier: &Hash) -> StorageResult<bool> {
+        let key = nullifier.as_bytes();
+        {
+            let batch_guard = self.tx_batch.lock().unwrap();
+            if let Some(batch) = batch_guard.as_ref() {
+                if let Some(staged) = batch.tree_lookup(TREE_NULLIFIERS, key) {
+                    return Ok(staged.is_some());
+                }
+            }
+        }
+
+        self.nullifiers
+            .contains_key(key)
+            .map_err(|e| StorageError::Database(e.to_string()))
+    }
+
+    fn put_nullifier(&self, nullifier: &Hash) -> StorageResult<()> {
+        self.require_transaction()?;
+
+        let mut batch_guard = self.tx_batch.lock().unwrap();
+        if let Some(ref mut batch) = *batch_guard {
+            batch
+                .tree(TREE_NULLIFIERS)
+                .insert(nullifier.as_bytes(), &[1u8][..]);
+        }
+
+        Ok(())
+    }
+
+    fn iter_nullifiers(&self) -> StorageResult<Box<dyn Iterator<Item = StorageResult<Hash>> + '_>> {
+        let iter = self.nullifiers.iter().map(|result| {
+            let (key, _) = result.map_err(|e| StorageError::Database(e.to_string()))?;
+            if key.len() != 32 {
+                return Err(StorageError::CorruptedData(format!(
+                    "Invalid nullifier key length: {}",
+                    key.len()
+                )));
+            }
+            let mut bytes = [0u8; 32];
+            bytes.copy_from_slice(key.as_ref());
+            Ok(Hash::new(bytes))
+        });
+        Ok(Box::new(iter))
+    }
+
+    fn backfill_nullifiers(&self, nullifiers: &[Hash]) -> StorageResult<()> {
+        for nullifier in nullifiers {
+            self.nullifiers
+                .insert(nullifier.as_bytes(), &[1u8][..])
+                .map_err(|e| StorageError::Database(e.to_string()))?;
+        }
+        self.nullifiers
+            .flush()
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        Ok(())
     }
 
     // =========================================================================
@@ -2816,10 +2888,18 @@ mod tests {
         ValidatorProjectionTable, HOT_STATE_PROJECTION_VERSION,
     };
     use crate::storage::table::TableAccess;
-    use crate::transaction::WalletTransactionData;
-    use crate::types::{Difficulty, Hash};
+    use crate::transaction::{TransactionInput, TransactionPayload, WalletTransactionData};
+    use crate::types::{Hash, TransactionType};
 
     fn create_test_block(height: u64, prev_hash: Hash) -> Block {
+        create_test_block_with_transactions(height, prev_hash, vec![])
+    }
+
+    fn create_test_block_with_transactions(
+        height: u64,
+        prev_hash: Hash,
+        transactions: Vec<Transaction>,
+    ) -> Block {
         // Create a unique block hash based on height
         let mut hash_bytes = [0u8; 32];
         hash_bytes[0..8].copy_from_slice(&height.to_be_bytes());
@@ -2836,7 +2916,31 @@ mod tests {
             bft_quorum_root: [0u8; 32],
             block_hash,
         };
-        Block::new(header, vec![])
+        Block::new(header, transactions)
+    }
+
+    fn transaction_with_nullifier(nullifier: Hash) -> Transaction {
+        Transaction {
+            version: 2,
+            chain_id: 0x03,
+            transaction_type: TransactionType::Transfer,
+            inputs: vec![TransactionInput {
+                previous_output: Hash::new([0x11; 32]),
+                output_index: 0,
+                nullifier,
+                zk_proof: crate::integration::zk_integration::ZkTransactionProof::default(),
+            }],
+            outputs: vec![],
+            fee: 0,
+            signature: Signature {
+                signature: vec![],
+                public_key: PublicKey::new([0u8; 2592]),
+                algorithm: SignatureAlgorithm::DEFAULT,
+                timestamp: 0,
+            },
+            memo: Vec::new(),
+            payload: TransactionPayload::None,
+        }
     }
 
     #[test]
@@ -3984,6 +4088,77 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert_eq!(entries.len(), 5);
+    }
+
+    #[test]
+    fn test_block_append_commits_nullifiers_atomically() {
+        let store = SledStore::open_temporary().unwrap();
+        let nullifier = Hash::new([0x91; 32]);
+        let block = create_test_block_with_transactions(
+            0,
+            Hash::default(),
+            vec![transaction_with_nullifier(nullifier)],
+        );
+
+        store.begin_block(0).unwrap();
+        store.append_block(&block).unwrap();
+        assert!(
+            store.is_nullifier_used(&nullifier).unwrap(),
+            "mid-block reads must see staged nullifiers"
+        );
+        store.commit_block().unwrap();
+
+        assert!(store.is_nullifier_used(&nullifier).unwrap());
+        let entries: Vec<_> = store
+            .iter_nullifiers()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries, vec![nullifier]);
+    }
+
+    #[test]
+    fn test_uncommitted_nullifier_does_not_leak_after_rollback() {
+        let store = SledStore::open_temporary().unwrap();
+        let nullifier = Hash::new([0x92; 32]);
+        let block = create_test_block_with_transactions(
+            0,
+            Hash::default(),
+            vec![transaction_with_nullifier(nullifier)],
+        );
+
+        store.begin_block(0).unwrap();
+        store.append_block(&block).unwrap();
+        store.rollback_block().unwrap();
+
+        assert!(!store.is_nullifier_used(&nullifier).unwrap());
+        let entries: Vec<_> = store
+            .iter_nullifiers()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_nullifier_backfill_is_durable_without_block_transaction() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let nullifier = Hash::new([0x93; 32]);
+
+        {
+            let store = SledStore::open(dir.path()).unwrap();
+            store.backfill_nullifiers(&[nullifier]).unwrap();
+            assert!(store.is_nullifier_used(&nullifier).unwrap());
+        }
+
+        let store = SledStore::open(dir.path()).unwrap();
+        assert!(store.is_nullifier_used(&nullifier).unwrap());
+        let entries: Vec<_> = store
+            .iter_nullifiers()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries, vec![nullifier]);
     }
 
     #[test]

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1204,15 +1204,26 @@ impl BlockchainStore for SledStore {
     }
 
     fn backfill_nullifiers(&self, nullifiers: &[Hash]) -> StorageResult<()> {
-        for nullifier in nullifiers {
-            self.nullifiers
-                .insert(nullifier.as_bytes(), &[1u8][..])
-                .map_err(|e| StorageError::Database(e.to_string()))?;
+        // Must only be called during startup migrations, before block processing begins.
+        if self.tx_active.load(Ordering::SeqCst) {
+            return Err(StorageError::TransactionAlreadyActive);
         }
+        if nullifiers.is_empty() {
+            return Ok(());
+        }
+
+        let mut batch = Batch::default();
+        for nullifier in nullifiers {
+            batch.insert(nullifier.as_bytes(), &[1u8][..]);
+        }
+        self.nullifiers
+            .apply_batch(batch)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
         self.nullifiers
             .flush()
             .map_err(|e| StorageError::Database(e.to_string()))?;
         Ok(())
+    }
     }
 
     // =========================================================================

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -810,6 +810,26 @@ impl SledStore {
         }
     }
 
+    fn nullifier_checkpoint_value(height: BlockHeight, block_hash: &BlockHash) -> [u8; 40] {
+        let mut value = [0u8; 40];
+        value[..8].copy_from_slice(&height.to_be_bytes());
+        value[8..].copy_from_slice(block_hash.as_bytes());
+        value
+    }
+
+    fn nullifier_index_is_current_internal(
+        &self,
+        height: BlockHeight,
+        block_hash: &BlockHash,
+    ) -> StorageResult<bool> {
+        let expected = Self::nullifier_checkpoint_value(height, block_hash);
+        match self.meta.get(keys::meta::NULLIFIER_INDEX_CHECKPOINT) {
+            Ok(Some(bytes)) => Ok(bytes.as_ref() == expected),
+            Ok(None) => Ok(false),
+            Err(e) => Err(StorageError::Database(e.to_string())),
+        }
+    }
+
     /// Map a canonical `TREE_*` name back to its live tree handle.
     ///
     /// Used to replay a WAL post-image onto the correct trees. Only the trees
@@ -1047,6 +1067,18 @@ impl BlockchainStore for SledStore {
                         .insert(input.nullifier.as_bytes(), &[1u8][..]);
                 }
             }
+            let nullifier_index_was_current = if height == 0 {
+                true
+            } else {
+                let previous_hash = BlockHash::new(block.header.previous_hash);
+                self.nullifier_index_is_current_internal(height - 1, &previous_hash)?
+            };
+            if nullifier_index_was_current {
+                let checkpoint = Self::nullifier_checkpoint_value(height, &block_hash);
+                batch
+                    .tree(TREE_META)
+                    .insert(keys::meta::NULLIFIER_INDEX_CHECKPOINT, checkpoint.as_ref());
+            }
             // Record the block hash for the write-ahead commit record.
             batch.block_hash = Some(hash_bytes);
         }
@@ -1224,6 +1256,32 @@ impl BlockchainStore for SledStore {
             .map_err(|e| StorageError::Database(e.to_string()))?;
         Ok(())
     }
+
+    fn nullifier_index_is_current(
+        &self,
+        height: BlockHeight,
+        block_hash: &BlockHash,
+    ) -> StorageResult<bool> {
+        self.nullifier_index_is_current_internal(height, block_hash)
+    }
+
+    fn mark_nullifier_index_current(
+        &self,
+        height: BlockHeight,
+        block_hash: &BlockHash,
+    ) -> StorageResult<()> {
+        if self.tx_active.load(Ordering::SeqCst) {
+            return Err(StorageError::TransactionAlreadyActive);
+        }
+
+        let checkpoint = Self::nullifier_checkpoint_value(height, block_hash);
+        self.meta
+            .insert(keys::meta::NULLIFIER_INDEX_CHECKPOINT, checkpoint.as_ref())
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        self.meta
+            .flush()
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        Ok(())
     }
 
     // =========================================================================
@@ -4170,6 +4228,46 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert_eq!(entries, vec![nullifier]);
+    }
+
+    #[test]
+    fn test_nullifier_backfill_rejects_active_block_transaction() {
+        let store = SledStore::open_temporary().unwrap();
+        store.begin_block(0).unwrap();
+
+        assert!(matches!(
+            store.backfill_nullifiers(&[Hash::new([0x94; 32])]),
+            Err(StorageError::TransactionAlreadyActive)
+        ));
+
+        store.rollback_block().unwrap();
+    }
+
+    #[test]
+    fn test_nullifier_checkpoint_tracks_only_complete_contiguous_index() {
+        let store = SledStore::open_temporary().unwrap();
+        let genesis = create_test_block_with_transactions(
+            0,
+            Hash::default(),
+            vec![transaction_with_nullifier(Hash::new([0x95; 32]))],
+        );
+        let genesis_hash = BlockHash::new(genesis.header.block_hash.as_array());
+
+        store.begin_block(0).unwrap();
+        store.append_block(&genesis).unwrap();
+        store.commit_block().unwrap();
+        assert!(store.nullifier_index_is_current(0, &genesis_hash).unwrap());
+
+        let block1 = create_test_block_with_transactions(
+            1,
+            genesis.header.block_hash,
+            vec![transaction_with_nullifier(Hash::new([0x96; 32]))],
+        );
+        let block1_hash = BlockHash::new(block1.header.block_hash.as_array());
+        store.begin_block(1).unwrap();
+        store.append_block(&block1).unwrap();
+        store.commit_block().unwrap();
+        assert!(store.nullifier_index_is_current(1, &block1_hash).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a durable nullifier tree to BlockchainStore/SledStore with lookup, staged write, lazy iteration, and startup backfill APIs
- stage transaction input nullifiers from append_block so they commit atomically with the block/WAL post-image
- backfill the durable nullifier index during load_from_store from the already-loaded legacy nullifier_set for upgraded stores

## Why
This solves the consensus-critical nullifier persistence gap before the follow-up PR removes the remaining checkpointed startup historical block scan. After this PR, the next architecture step can hydrate nullifiers from durable storage instead of relying on block replay.

## Verification
- cargo test -p lib-blockchain nullifier --lib
- cargo build -p lib-blockchain

## Follow-up
- #2694 can now remove the remaining startup block scan by hydrating the legacy in-memory nullifier_set from iter_nullifiers(), alongside the existing durable projection/UTXO hydration work.