### PR TITLE
fix(lib-network/client): async DNS + shared QUIC endpoint singleton

### DIFF
--- a/lib-network/src/client/zhtp_client.rs
+++ b/lib-network/src/client/zhtp_client.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use std::collections::HashMap;
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use tracing::{debug, info, warn};
@@ -304,11 +304,27 @@ impl ZhtpClient {
         // handles literal IPs, so a hostname like
         // "zhtp-gateway.thesovereignnetwork.org:9334" used to fail here and
         // the FFI surfaced it as "QuicSession.open failed: openFailed".
-        // `to_socket_addrs` performs DNS lookup and returns the first result.
-        let socket_addr: SocketAddr = addr
-            .to_socket_addrs()
+        //
+        // Use tokio's async DNS (`tokio::net::lookup_host`) — std's
+        // `to_socket_addrs` is a blocking syscall and stalling it inside
+        // an async fn parked on a single-thread runtime (which is exactly
+        // how `spawn_session_worker` runs us) blocks the whole session.
+        //
+        // On dual-stack hosts a hostname can resolve to both AAAA and A
+        // records; pick A first because IPv6 routing isn't universal
+        // (mobile carriers, captive nets, container egress) and a v6
+        // attempt that times out adds a full RTT of latency to the
+        // first request. Fall back to whatever resolves if no A record
+        // is returned.
+        let candidates: Vec<SocketAddr> = tokio::net::lookup_host(addr)
+            .await
             .with_context(|| format!("Failed to resolve address: {}", addr))?
-            .next()
+            .collect();
+        let socket_addr: SocketAddr = candidates
+            .iter()
+            .find(|s| s.is_ipv4())
+            .or_else(|| candidates.first())
+            .copied()
             .ok_or_else(|| anyhow!("Address '{}' resolved to no socket addresses", addr))?;
 
         if self.trust_config.bootstrap_mode && !self.config.allow_bootstrap {

--- a/lib-network/src/client/zhtp_client.rs
+++ b/lib-network/src/client/zhtp_client.rs
@@ -17,6 +17,35 @@ static BOOTSTRAP_NONCE_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 use quinn::{ClientConfig, Connection, Endpoint};
 
+/// Singleton QUIC client `Endpoint`. Quinn's Endpoint is Arc-backed and Clone,
+/// so cloning shares the same UDP socket and I/O driver task across all
+/// `ZhtpClient` instances. Without this, every call to `new_with_config`
+/// binds a fresh UDP socket. On iOS the per-process socket limit is small
+/// (~256) and the lib-client FFI spawns a session per authenticated request,
+/// so a busy app exhausts the budget and `Endpoint::client` starts returning
+/// EPERM ("Operation not permitted") — which then bubbles up as
+/// `QuicSession.open failed: openFailed`. Sharing one endpoint fixes that
+/// and is the standard quinn pattern; the per-connection config is
+/// supplied at `connect_with()` time.
+static CLIENT_ENDPOINT: OnceLock<Endpoint> = OnceLock::new();
+static CLIENT_ENDPOINT_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn shared_client_endpoint() -> Result<Endpoint> {
+    if let Some(ep) = CLIENT_ENDPOINT.get() {
+        return Ok(ep.clone());
+    }
+    let _guard = CLIENT_ENDPOINT_MUTEX
+        .lock()
+        .map_err(|_| anyhow!("client endpoint init mutex poisoned"))?;
+    if let Some(ep) = CLIENT_ENDPOINT.get() {
+        return Ok(ep.clone());
+    }
+    let ep =
+        Endpoint::client("0.0.0.0:0".parse()?).context("Failed to create shared QUIC endpoint")?;
+    let _ = CLIENT_ENDPOINT.set(ep.clone());
+    Ok(ep)
+}
+
 use lib_identity::ZhtpIdentity;
 use lib_protocols::types::{ZhtpRequest, ZhtpResponse};
 use lib_protocols::wire::{read_response, write_request, ZhtpRequestWire};
@@ -115,9 +144,9 @@ impl ZhtpClient {
         // Install rustls crypto provider
         let _ = rustls::crypto::ring::default_provider().install_default();
 
-        // Create QUIC endpoint
-        let endpoint =
-            Endpoint::client("0.0.0.0:0".parse()?).context("Failed to create QUIC endpoint")?;
+        // Reuse the process-wide singleton endpoint (UDP socket + Quinn driver).
+        // See `CLIENT_ENDPOINT` docs above for why this is load-bearing on iOS.
+        let endpoint = shared_client_endpoint()?;
 
         // Create nonce cache.
         // Bootstrap clients share a single NonceCache instance (opened once via OnceLock).
@@ -346,14 +375,14 @@ impl ZhtpClient {
             }
         };
 
-        // Configure QUIC client
+        // Per-connection client config: the endpoint is shared across all
+        // ZhtpClients, so we mustn't mutate its default config (that would
+        // race against concurrent connects from other ZhtpClient instances).
+        // `connect_with` applies the config to just this connection.
         let client_config = Self::configure_client(verifier)?;
-        self.endpoint.set_default_client_config(client_config);
-
-        // Establish QUIC connection
         let connection = self
             .endpoint
-            .connect(socket_addr, "zhtp-node")?
+            .connect_with(client_config, socket_addr, "zhtp-node")?
             .await
             .context("QUIC connection failed")?;
 


### PR DESCRIPTION
## Summary

Two follow-up fixes on top of PR #2701. Both surfaced on the mobile device once #2701 made hostname-form addresses actually reach `connect_internal`.

### 1. Async DNS + prefer IPv4 (commit `5752facf`)

`connect_internal` now uses `tokio::net::lookup_host` instead of `std::net::ToSocketAddrs::to_socket_addrs`:

- `to_socket_addrs` is a **synchronous syscall** (`getaddrinfo`). `connect_internal` is async, and the FFI's `spawn_session_worker` parks it on a single-thread tokio runtime — blocking that thread on DNS blocks the whole session worker.
- On dual-stack hosts a hostname can return AAAA before A. Picking `.next()` may give us an IPv6 result, and an unreachable v6 route (mobile carriers, captive nets) adds a full RTT of timeout latency before we'd ever try v4. Filter for `is_ipv4()` first, fall back to whatever resolves.

### 2. Share a single `quinn::Endpoint` across all `ZhtpClient`s (commit `b483415b`)

Every call to `ZhtpClient::new_with_config` was allocating a fresh `quinn::Endpoint` via `Endpoint::client("0.0.0.0:0")`, which binds a brand-new UDP socket. The lib-client FFI spawns a `ZhtpClient` per authenticated session, so a busy mobile app racks up UDP sockets at one per request.

On iOS the per-process socket budget is small (~256 fds). Once exceeded, the OS denies `bind` with EPERM and `Endpoint::client` returns:

```
ZhtpClient::connect: Operation not permitted (os error 1)
```

…surfaced to the JS as `QuicSession.open failed: openFailed` on every authenticated request. Public-ALPN calls succeed because they use a different code path that reuses sockets. The mobile log (`[lib-client/quic_session] session open to 91.98.113.188:9334: ZhtpClient::connect: Operation not permitted (os error 1)`) was the smoking gun.

Fix: process-wide `CLIENT_ENDPOINT: OnceLock<Endpoint>` initialized under a mutex (same pattern as the existing `BOOTSTRAP_NONCE_CACHE` right above). Quinn's `Endpoint` is `Clone` and Arc-backed, so cloning gives every `ZhtpClient` a handle to the same UDP socket and I/O driver task — the pattern quinn's own docs recommend.

Side change in `connect_internal`: from `set_default_client_config(...); endpoint.connect(addr, name)` to `endpoint.connect_with(config, addr, name)`. Now that the endpoint is shared, two concurrent `connect_internal` calls from different `ZhtpClient`s would race on the default config; `connect_with` applies the config to just the one connection.

## Test plan
- [x] `cargo build --profile dev-release -p zhtp -p lib-client` clean
- [x] Server binary deployed to both gateways (md5 `37011b9d33171782a7080fba4aad5b8f`)
- [ ] Mobile re-link `lib-client` from this branch — `[lib-client/quic_session] ... Operation not permitted (os error 1)` should disappear; authenticated `/api/v1/wallet/*` calls should return 200