### PR TITLE
fix(lib-network/client): dual-stack bind + long-lived endpoint runtime

### DIFF
--- a/lib-network/src/client/zhtp_client.rs
+++ b/lib-network/src/client/zhtp_client.rs
@@ -19,7 +19,8 @@ use quinn::{ClientConfig, Connection, Endpoint};
 
 /// Singleton QUIC client `Endpoint` plus a dedicated long-lived runtime that
 /// owns its I/O driver task. Sharing the endpoint across all `ZhtpClient`
-/// instances is necessary for two distinct reasons; both bit us on iOS.
+/// instances is necessary for three distinct reasons, all of which bit us
+/// on iOS in the lib-client FFI path.
 ///
 /// 1. **Socket budget (Bug 1, also bites macOS/Linux at scale).** Without
 ///    sharing, every call to `new_with_config` binds a brand-new UDP socket

--- a/lib-network/src/client/zhtp_client.rs
+++ b/lib-network/src/client/zhtp_client.rs
@@ -17,17 +17,35 @@ static BOOTSTRAP_NONCE_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 use quinn::{ClientConfig, Connection, Endpoint};
 
-/// Singleton QUIC client `Endpoint`. Quinn's Endpoint is Arc-backed and Clone,
-/// so cloning shares the same UDP socket and I/O driver task across all
-/// `ZhtpClient` instances. Without this, every call to `new_with_config`
-/// binds a fresh UDP socket. On iOS the per-process socket limit is small
-/// (~256) and the lib-client FFI spawns a session per authenticated request,
-/// so a busy app exhausts the budget and `Endpoint::client` starts returning
-/// EPERM ("Operation not permitted") — which then bubbles up as
-/// `QuicSession.open failed: openFailed`. Sharing one endpoint fixes that
-/// and is the standard quinn pattern; the per-connection config is
-/// supplied at `connect_with()` time.
+/// Singleton QUIC client `Endpoint` plus a dedicated long-lived runtime that
+/// owns its I/O driver task. Sharing the endpoint across all `ZhtpClient`
+/// instances is necessary for two distinct reasons; both bit us on iOS.
+///
+/// 1. **Socket budget (Bug 1, also bites macOS/Linux at scale).** Without
+///    sharing, every call to `new_with_config` binds a brand-new UDP socket
+///    via `Endpoint::client`. The lib-client FFI spawns a session per
+///    authenticated request, so a busy app racks up file descriptors at
+///    one per request. iOS clamps at ~256 fds per process and starts
+///    returning EPERM ("Operation not permitted") from the bind.
+///
+/// 2. **Driver lifetime (Bug 2, iOS-specific in the FFI path).**
+///    `Endpoint::client` spawns its async I/O driver task on the **current**
+///    tokio runtime. The lib-client FFI builds a fresh single-threaded
+///    runtime per session in `spawn_session_worker`; whichever session
+///    happened to be the first caller would parent the driver onto its
+///    transient runtime, and the moment that worker exited the driver got
+///    dropped and every later clone of the singleton started failing with
+///    "endpoint stopping". Park the singleton on a process-lived runtime
+///    we build here under `runtime.enter()` so the driver outlives every
+///    individual session worker.
+///
+/// 3. **iOS bind permission.** `0.0.0.0:0` (IPv4-only wildcard) is rejected
+///    by iOS in many app sandboxes with EPERM even before any socket-budget
+///    pressure. `[::]:0` produces a dual-stack socket that accepts and
+///    sends IPv4 traffic too — matches the pattern the working `quinn-ffi`
+///    code path on the mobile side has used since day one.
 static CLIENT_ENDPOINT: OnceLock<Endpoint> = OnceLock::new();
+static CLIENT_ENDPOINT_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 static CLIENT_ENDPOINT_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn shared_client_endpoint() -> Result<Endpoint> {
@@ -40,8 +58,35 @@ fn shared_client_endpoint() -> Result<Endpoint> {
     if let Some(ep) = CLIENT_ENDPOINT.get() {
         return Ok(ep.clone());
     }
+
+    // Build (or get) the dedicated runtime that will own the endpoint's
+    // I/O driver task. Single worker thread is plenty — the driver is the
+    // only work that runs here; per-session client/handshake/RPC tasks
+    // still run on their own per-session runtimes.
+    let runtime = match CLIENT_ENDPOINT_RUNTIME.get() {
+        Some(rt) => rt,
+        None => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .thread_name("zhtp-client-endpoint")
+                .build()
+                .context("Failed to build shared client endpoint runtime")?;
+            let _ = CLIENT_ENDPOINT_RUNTIME.set(rt);
+            CLIENT_ENDPOINT_RUNTIME
+                .get()
+                .expect("CLIENT_ENDPOINT_RUNTIME just initialized")
+        }
+    };
+    let _enter = runtime.enter();
+
+    // Dual-stack bind. `[::]:0` accepts/sends IPv4 too; `0.0.0.0:0` is
+    // rejected by iOS with EPERM in many contexts.
+    let bind_addr: SocketAddr = "[::]:0"
+        .parse()
+        .context("Failed to parse default bind address")?;
     let ep =
-        Endpoint::client("0.0.0.0:0".parse()?).context("Failed to create shared QUIC endpoint")?;
+        Endpoint::client(bind_addr).context("Failed to create shared QUIC endpoint")?;
     let _ = CLIENT_ENDPOINT.set(ep.clone());
     Ok(ep)
 }


### PR DESCRIPTION
## Summary

Two iOS-specific follow-ups on top of PR #2702 (endpoint singleton). Both surfaced once the mobile team added diagnostic logging that prints the actual FFI error chain instead of just \`openFailed\`:

\`\`\`
[lib-client/quic_session] session open to 91.98.113.188:9334:
    ZhtpClient::connect: Operation not permitted (os error 1)
[lib-client/quic_session] session open to 91.98.113.188:9334:
    ZhtpClient::connect: endpoint stopping
[lib-client/quic_session] session open to 91.98.113.188:9334:
    ZhtpClient::connect: endpoint stopping
...
\`\`\`

### Bug 1 — EPERM on first bind

\`Endpoint::client("0.0.0.0:0".parse()?)\` is rejected by iOS in many sandbox contexts with EPERM. The mobile app's working \`quinn-ffi\` path has bound the IPv6 wildcard since day one for exactly this reason.

**Fix**: bind to \`[::]:0\`. Dual-stack socket accepts and sends IPv4 traffic too, so the same line works for CLI on Linux, mobile on iOS, and server-side outbound connections.

### Bug 2 — \"endpoint stopping\" cascade on every subsequent bind

\`Endpoint::client\` spawns the endpoint's async I/O driver task on **whatever tokio runtime is current at the moment of the call**. The lib-client FFI builds a fresh single-threaded runtime per session inside \`spawn_session_worker\` and drops it when that session worker exits. Whichever session happened to be the first caller into our singleton ended up owning the driver — and the moment that session's worker thread returned and its runtime dropped, the driver died and every cloned Endpoint from then on returned \`endpoint stopping\`.

**Fix**: lazy-init a process-lived \`tokio::runtime::Runtime\` alongside the singleton Endpoint (same OnceLock-+-Mutex pattern), \`enter()\` it before calling \`Endpoint::client\`, so the driver task is parented to the long-lived runtime instead of the transient per-session one. Single worker thread is plenty — only the driver task runs there; per-session client / handshake / RPC tasks continue to run on their own per-session runtimes via \`Endpoint::clone()\` and \`connect_with\`.

Both fixes are independent — Bug 1 prevented the first connect from landing; Bug 2 would still have killed all subsequent connects after the bind succeeded. Need both to clear the cascade.

## Test plan
- [x] \`cargo build --profile dev-release -p zhtp -p lib-client\` clean
- [ ] Mobile rebuild of \`libzhtp_client.a\` (iOS) and Android \`libquic_jni.so\` against this commit
- [ ] On-device: \`[lib-client/quic_session]\` should no longer print \`Operation not permitted\` or \`endpoint stopping\`; authenticated \`/api/v1/wallet/*\`, \`/api/v1/token/*\`, \`/api/v1/rewards/claim\`, \`/api/v1/msg/receive\` should return 200

## Server impact
None. The QUIC listener is already accepting these handshakes — the mobile app's working \`quinn-ffi\` path connects to the same hostname/IP/port and authenticates fine in the same logs. This patch is entirely client-side.