### PR TITLE
fix(api/rewards): stop gating read endpoints behind treasury keystore

### DIFF
--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -867,9 +867,14 @@ impl RewardsHandler {
     }
 
     async fn handle_balance(&self, did: &str) -> ZhtpResponse {
-        if self.treasury.is_none() {
-            return Self::unavailable();
-        }
+        // READS don't need the treasury keystore — only mints/claims do.
+        // The 503 here was wrong: it told every non-treasury node "rewards
+        // endpoint not configured", even though local sled has whatever
+        // counters this node has accumulated. Returning the local state
+        // (zeros for nodes that haven't processed claims) is at least
+        // an honest answer; the proper architectural fix is to read the
+        // canonical BUBL balance from the on-chain token contract and
+        // move reward-event state on-chain too.
         if let Err(msg) = Self::validate_did(did) {
             return Self::bad(msg);
         }
@@ -890,9 +895,7 @@ impl RewardsHandler {
     }
 
     async fn handle_status(&self, did: &str) -> ZhtpResponse {
-        if self.treasury.is_none() {
-            return Self::unavailable();
-        }
+        // READS don't need the treasury keystore — see `handle_balance`.
         if let Err(msg) = Self::validate_did(did) {
             return Self::bad(msg);
         }
@@ -976,9 +979,7 @@ impl RewardsHandler {
         limit: usize,
         cursor: Option<(u64, u64)>,
     ) -> ZhtpResponse {
-        if self.treasury.is_none() {
-            return Self::unavailable();
-        }
+        // READS don't need the treasury keystore — see `handle_balance`.
         if let Err(msg) = Self::validate_did(did) {
             return Self::bad(msg);
         }


### PR DESCRIPTION
## Summary

\`RewardsHandler\` returned **503 \"rewards endpoint not configured on this node\"** from \`/api/v1/rewards/balance\`, \`/status\`, and \`/history\` whenever the node didn't have \`ZHTP_REWARDS_TREASURY_KEYSTORE\` set — which today is every node except g1. Every mobile client hitting a gateway got that 503 even though no write was attempted.

## What changed

The treasury keystore is only needed to **sign mint transactions**:

| Endpoint | Method | Needs treasury? | Fix |
|---|---|---|---|
| \`/api/v1/rewards/claim\` | POST | YES (mints BUBL) | unchanged |
| \`/api/v1/rewards/conversation\` | POST | YES (mints BUBL) | unchanged |
| \`/api/v1/rewards/balance\` | GET | NO (sled read) | drop the gate |
| \`/api/v1/rewards/status\` | GET | NO (sled read) | drop the gate |
| \`/api/v1/rewards/history\` | GET | NO (sled read) | drop the gate |

## Honest caveat — this is fix 1 of 2

The reward state backing the reads is the **per-node sled** (\`lifetime\`, \`welcomed\`, \`checkins\`, \`sessions\`, \`streak\`, \`partners\`) — not the chain. A non-treasury node will answer \"zero\" for any DID it has never processed locally. That's at least a truthful \"no record here\" instead of a misleading \"endpoint not configured\", but the real architectural fix is:

1. **\`handle_balance\` should query the on-chain BUBL token balance** via \`Blockchain::token_balance(BUBL_TOKEN_ID, key_id_for(did))\`. That state IS replicated and authoritative.
2. **Reward-event ledger entries should be written to chain** so every node serves the same \`/status\` and \`/history\`.

Both are outside the scope of this commit and worth a separate design discussion.

## Test plan
- [x] \`cargo build --profile dev-release -p zhtp\` clean
- [ ] After deploy, mobile \`/api/v1/rewards/balance/<did>\` returns 200 with body (zeros from any non-g1 gateway, truthful counters from g1)