### PR TITLE
fix(pouw): recover rewards stuck in Processing state on payout-task startup

### DIFF
--- a/zhtp/src/pouw/mod.rs
+++ b/zhtp/src/pouw/mod.rs
@@ -53,6 +53,23 @@ pub fn spawn_pouw_payout_task(
         interval.tick().await;
         tracing::info!(interval_secs = interval_secs, "POUW payout task started");
 
+        // Recover rewards left in `Processing` by an earlier run that
+        // crashed / restarted between `mark_processing` and
+        // `mark_paid` / `mark_failed`. Without this, every such reward
+        // is permanently skipped by the `mark_processing` guard below
+        // and the SOV the user is owed is never minted. Safe to do
+        // unconditionally at task startup: this task is the only
+        // producer of `Processing` state, and at this point no payout
+        // is in flight.
+        let stale_processing = calculator.reset_processing_rewards().await;
+        if stale_processing > 0 {
+            tracing::warn!(
+                count = stale_processing,
+                "Reset stale POUW rewards from Processing to Pending on startup \
+                 (likely from a prior crash mid-mint)"
+            );
+        }
+
         loop {
             interval.tick().await;
 

--- a/zhtp/src/pouw/rewards.rs
+++ b/zhtp/src/pouw/rewards.rs
@@ -750,6 +750,35 @@ impl RewardCalculator {
         count
     }
 
+    /// Reset rewards stuck in `Processing` back to `Pending`.
+    ///
+    /// `Processing` is the locked-for-mint state. A reward enters it when
+    /// `mark_processing` succeeds and leaves it when either `mark_paid` or
+    /// `mark_failed` is called. If the node crashes / restarts between
+    /// those two ends — or if the mint future is dropped for any other
+    /// reason — the reward is left in `Processing` permanently. The
+    /// payout loop then skips it forever (the `if !mark_processing { … }`
+    /// guard in `zhtp/src/pouw/mod.rs`), and the SOV the user is owed is
+    /// never minted.
+    ///
+    /// Call this at task startup. The payout task is the only producer of
+    /// `Processing` state and we know no payout is in-flight at that
+    /// moment, so blanket-resetting every `Processing` row is safe and
+    /// recovers stuck rewards. Within a single running cycle, there's
+    /// no need to call this (concurrent payouts in the same epoch are
+    /// already prevented by `mark_processing`'s CAS-like semantics).
+    pub async fn reset_processing_rewards(&self) -> usize {
+        let mut rewards = self.rewards.write().await;
+        let mut count = 0;
+        for reward in rewards.iter_mut() {
+            if reward.payout_status == PayoutStatus::Processing {
+                reward.payout_status = PayoutStatus::Pending;
+                count += 1;
+            }
+        }
+        count
+    }
+
     /// Get rewards for a specific client
     pub async fn get_client_rewards(&self, client_did: &str) -> Vec<Reward> {
         self.rewards


### PR DESCRIPTION
## Summary

`RewardCalculator::mark_processing` is a CAS-style guard that flips a reward from `Pending → Processing` exactly once per epoch payout, preventing concurrent mints. It's supposed to flip again to `Paid` (success) or `Failed` (error) once the mint resolves. **If the node crashes / restarts / drops the mint future between those two ends, the reward is left in `Processing` permanently** — and the payout loop's `mark_processing` guard at `zhtp/src/pouw/mod.rs:80` then skips it forever. \`reset_failed_rewards\` recovers the `Failed` half every cycle; nothing recovers `Processing`.

## Evidence (g1, today)

- 102 rewards persisted in \`rewards.dat\`
- \`total_paid=630_000_000_000_000\` atoms (0.00063 SOV) **stuck at the same value across every retained journal entry**
- **24 hours** without a single \`\"POUW reward paid\"\` log line, even though the payout task is running and ticking hourly
- Validator g1 is the one with the treasury keystore — the system that *should* be minting these isn't, because every reward is sitting in `Processing` from earlier crash/restart cycles

## Fix

- Add \`RewardCalculator::reset_processing_rewards()\` mirroring \`reset_failed_rewards\`.
- Call it **once at the top of \`spawn_pouw_payout_task\`** (after the startup tick, before the loop). Safe to do unconditionally there: the payout task is the only producer of \`Processing\`, and at that moment no payout is in-flight, so blanket-resetting every \`Processing\` row recovers stuck rewards without racing anything.
- Log a \`warn!\` with the recovered count so operators see the recovery happening rather than the silent skip.

After deploy, the next restart of each node makes any previously-stuck rewards \`Pending\` again. They get picked up on the next hourly cycle and mint as \`TokenMint\` txs.

## Why startup-only (not also per-cycle)

Within a single running cycle, \`mark_processing\` already provides CAS-style mutual exclusion within the same process, and the cycle owns the only producer. So we only need recovery at process boundaries — i.e. at task startup.

## Test plan
- [x] \`cargo build --profile dev-release -p zhtp\` clean
- [ ] After deploy: on first restart, gateway log shows \`\"Reset stale POUW rewards from Processing to Pending on startup (likely from a prior crash mid-mint)\"\` with count > 0
- [ ] Within the next epoch tick (≤ 3600 s), \`\"Processing POUW reward payouts\"\` log line appears and \`total_paid\` increments past \`630_000_000_000_000\`