### PR TITLE
fix(runtime): use load_from_store so PR #2687 fast-hydrate actually fires

### DIFF
--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1166,12 +1166,21 @@ impl RuntimeOrchestrator {
                     bc.store.clone()
                 };
                 if let Some(store) = store {
-                    if let Some(replayed) = lib_blockchain::Blockchain::replay_from_store(store)? {
+                    // `load_from_store` calls `hydrate_checkpointed_state_from_store`
+                    // first (lib-blockchain/src/blockchain/init.rs:585) and only
+                    // falls back to full historical replay when the projection
+                    // meta isn't current for the sled tip. Previously this site
+                    // called `replay_from_store` directly, which unconditionally
+                    // walks `for height in 0..=latest_height { apply_block }`
+                    // and ignores PR #2687's fast-hydrate path entirely — so
+                    // every restart was a full ~141k-block replay even though
+                    // the projection tables were durable and current.
+                    if let Some(reloaded) = lib_blockchain::Blockchain::load_from_store(store)? {
                         let mut bc = blockchain_arc.write().await;
-                        // Preserve the store and executor from replayed blockchain
-                        let store = replayed.store.clone();
-                        let executor = replayed.executor.clone();
-                        *bc = replayed;
+                        // Preserve the store and executor from the reloaded blockchain
+                        let store = reloaded.store.clone();
+                        let executor = reloaded.executor.clone();
+                        *bc = reloaded;
                         bc.store = store;
                         bc.executor = executor;
                         // Seed validators from bootstrap config (not stored in blocks)
@@ -1180,7 +1189,7 @@ impl RuntimeOrchestrator {
                             &self.config.network_config.bootstrap_validators,
                         );
                         info!(
-                            "Block replay complete: height={}, identities={}, validators={}, domains={}, credentials={}",
+                            "Blockchain load complete: height={}, identities={}, validators={}, domains={}, credentials={}",
                             bc.height,
                             bc.identity_count(), // #2639: sled-authoritative
                             bc.validator_registry.len(),


### PR DESCRIPTION
## Summary

PR #2687 added \`Blockchain::load_from_store\` which calls \`hydrate_checkpointed_state_from_store\` and only falls back to a full block-by-block replay if the projection-meta marker isn't current for the sled tip. The fast path takes well under a second on a 141k-block node; the slow path takes 30-60 minutes.

\`zhtp/src/runtime/mod.rs:1169\` was still calling the *old* \`Blockchain::replay_from_store\`. That function unconditionally walks \`for height in 0..=latest_height { apply_block(…) }\` with no projection check.

**So every startup ran the slow path, even though the projection tables were durable and current. The fast-hydrate code shipped but was unreachable from production.**

## Evidence

On g1, journal grep across the full retained history (Jun 08 → Jun 11) shows:
- \`\"Sled has existing chain data — replaying blocks to rebuild state\"\` fires on **every** restart (5 restarts logged)
- **zero** \`\"Hydrated blockchain hot state from current projection checkpoint\"\` lines, ever
- **zero** \`\"Failed to commit projection meta\"\` warn lines either — meta-write isn't erroring; the read path just isn't being called

The decision was being made at the wrong layer.

## Fix

One-line API swap: \`replay_from_store\` → \`load_from_store\`. Same \`Result<Option<Self>>\` shape, same returned populated Blockchain, just with the fast path in front of the slow path.

Renamed the local binding from \`replayed\` to \`reloaded\` and adjusted the success log line from \"Block replay complete\" to \"Blockchain load complete\" so it reflects that load may have come from either path.

## What deploys look like

| Restart | Before | After |
|---|---|---|
| First on this binary | 30-60 min replay | 30-60 min replay (no meta yet from this binary), then backfill writes meta |
| Every subsequent restart | 30-60 min replay | **< 1 s hydrate from projections** |

## Empty sled

No behaviour change. \`load_from_store\` returns \`Ok(None)\` for an empty store, same as \`replay_from_store\` did.

## Test plan
- [x] \`cargo build --profile dev-release -p zhtp\` clean
- [ ] After deploy: on the *second* restart per node, log shows \`\"Hydrated blockchain hot state from current projection checkpoint at height N\"\` and replay is skipped
- [ ] Mobile observes that gateway downtime per redeploy collapses from ~30 min to seconds