### PR TITLE
fix: chain stability — replay registries, sled balance reads, FSM/mesh fork-recovery

### DIFF
--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -744,6 +744,28 @@ impl Blockchain {
                             );
                         }
 
+                        // Replay credential registration/update so credential_registry
+                        // and did_to_username are populated. Without these the OPAQUE
+                        // login handler returns 401 for every user, and the profile
+                        // handler reports no username for every DID, because both
+                        // in-memory maps are empty after this fallback-replay path
+                        // runs (the fast hydrate in `hydrate_hot_state_from_projections`
+                        // would have populated them, but every node in the cluster has
+                        // been falling through to here — credentials=0 on all 7 nodes).
+                        // Same call already made by `replay_block_state` in replay.rs.
+                        blockchain.process_credential_transactions(&block);
+
+                        // Replay NFT registration so nft_registry is populated.
+                        blockchain.process_nft_transactions(&block);
+
+                        // Replay entity-registry transactions so the registry index is populated.
+                        if let Err(e) = blockchain.process_entity_registry_transactions(&block) {
+                            warn!(
+                                "⚠️ Failed to replay entity registry tx at height {}: {}",
+                                height, e
+                            );
+                        }
+
                         // During sled-store replay we skip SOV token transaction processing
                         // entirely.  The correct final SOV balances are loaded from the
                         // token_balances sled tree after this loop.

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -769,6 +769,15 @@ impl BlockExecutor {
         for (rel_index, tx) in block.transactions[non_coinbase_start..].iter().enumerate() {
             let index = rel_index + non_coinbase_start;
 
+            let _tx_hash_hex = hex::encode(tx.hash().as_bytes());
+            tracing::info!(
+                tx_hash = %&_tx_hash_hex[..16],
+                tx_type = ?tx.transaction_type,
+                index = index,
+                height = block_height,
+                "[fee-debug] executor entering per-tx loop"
+            );
+
             // Resource accounting: accumulate tx resources BEFORE application
             // Block is rejected if any limit exceeded
             let (payload_bytes, witness_bytes, verify_units, state_write_bytes) =
@@ -3118,6 +3127,16 @@ impl BlockExecutor {
                 } else {
                     crate::contracts::tokens::constants::SOV_FEE_RATE_BPS
                 };
+                tracing::info!(
+                    tx_hash = %hex::encode(&tx.hash().as_bytes()[..8]),
+                    token = %hex::encode(&token.0[..8]),
+                    from = %hex::encode(&from.0[..8]),
+                    to = %hex::encode(&to.0[..8]),
+                    amount = amount,
+                    nonce = transfer_data.nonce,
+                    fee_bps = fee_bps,
+                    "[fee-debug] BEFORE apply_token_transfer"
+                );
                 let _fee_collected = tx_apply::apply_token_transfer(
                     mutator,
                     &token,
@@ -3127,6 +3146,14 @@ impl BlockExecutor {
                     fee_bps,
                     &fee_destination,
                 )?;
+                tracing::info!(
+                    tx_hash = %hex::encode(&tx.hash().as_bytes()[..8]),
+                    from = %hex::encode(&from.0[..8]),
+                    to = %hex::encode(&to.0[..8]),
+                    amount = amount,
+                    fee_collected = _fee_collected,
+                    "[fee-debug] AFTER apply_token_transfer (debit succeeded)"
+                );
 
                 // Increment nonce for replay protection
                 mutator.increment_token_nonce(&token, &from)?;

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -2580,6 +2580,46 @@ impl ConsensusEngine {
     pub(super) async fn on_round_timeout(&mut self) -> ConsensusResult<()> {
         use lib_consensus_core::fsm::{transition, Event};
 
+        // BFT-FF-2026-06-18: Fast-forward the FSM when the local blockchain has
+        // advanced past our consensus height via observer-sync (or any external
+        // commit path that bypassed `process_committed_block`). Without this,
+        // a validator that restarts and catches up via observer-sync ends up
+        // with `engine.current_height < blockchain.height`, spinning rounds
+        // proposing at already-committed heights — every proposal it makes is
+        // rejected by peers as a fork. This was the Jun-17/18 g1 wedge.
+        //
+        // CONS-512 safety: that bug was advancing the engine via
+        // `sync_height_with_blockchain` when `blockchain.height == engine.height`
+        // AND engine was mid-vote in Commit step (engine was finishing N when
+        // storage already reflected N, and the sync incorrectly bumped it to N+1).
+        //
+        // Our guard: only fast-forward when blockchain has STRICTLY moved past
+        // (or AT) our height AND we are not currently in Commit step. The
+        // step != Commit check preserves CONS-512's invariant that storage is
+        // never the source of truth during a live commit at our own height.
+        if !matches!(self.current_round.step, ConsensusStep::Commit) {
+            if let Some(ref provider) = self.blockchain_provider {
+                if let Ok(blockchain_height) = provider.get_blockchain_height().await {
+                    if blockchain_height >= self.current_round.height {
+                        tracing::warn!(
+                            "🔧 FSM fast-forward: blockchain h={} >= engine h={} step={:?} round={} — chain advanced via external commit, resyncing",
+                            blockchain_height,
+                            self.current_round.height,
+                            self.current_round.step,
+                            self.current_round.round,
+                        );
+                        // Delegate to the existing height-sync helper. It
+                        // already runs the BFT-J-1015 monotonic-height
+                        // invariant check and clears lock/proposal state on a
+                        // height crossing. New caller per CONS-512 docs is
+                        // justified above.
+                        self.sync_height_with_blockchain().await?;
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
         let height = self.current_round.height;
         let round = self.current_round.round;
         let step = self.current_round.step.clone();

--- a/lib-network/src/protocols/quic_mesh.rs
+++ b/lib-network/src/protocols/quic_mesh.rs
@@ -959,11 +959,36 @@ impl QuicMeshProtocol {
     }
 
     /// List all connected peer node IDs.
+    ///
+    /// Self-prunes stale entries whose underlying quinn::Connection is closed.
+    /// A receive-loop teardown race (see `Receive loop ended (removed only if
+    /// still owner)` log line) can leave dead entries in the DashMap — and
+    /// `send_to_peer` would then attempt to write to a closed connection,
+    /// silently dropping votes/heartbeats. The Jun-19 2026 cluster wedge
+    /// (5/5 validators in-quorum but no commits after several hours) was
+    /// caused by accumulating stale entries here.
     pub fn connected_peer_ids(&self) -> Vec<Vec<u8>> {
-        self.connections
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect()
+        let mut alive: Vec<Vec<u8>> = Vec::new();
+        let mut to_prune: Vec<Vec<u8>> = Vec::new();
+        for entry in self.connections.iter() {
+            if entry.value().quic_conn.close_reason().is_none() {
+                alive.push(entry.key().clone());
+            } else {
+                to_prune.push(entry.key().clone());
+            }
+        }
+        for k in to_prune {
+            // Only remove if the stale connection is still the one we saw —
+            // a newer connection may have raced in under the same node_id
+            // between our scan and this remove.
+            self.connections
+                .remove_if(&k, |_, entry| entry.quic_conn.close_reason().is_some());
+            tracing::warn!(
+                node_id = %hex::encode(&k),
+                "Pruned stale (closed) connection entry from canonical mesh store"
+            );
+        }
+        alive
     }
 
     /// Return the socket address of every currently-connected peer.
@@ -1199,9 +1224,13 @@ impl QuicMeshProtocol {
                         }
                     }
                     Err(e) => {
-                        debug!(peer = %node_id_hex,
-                               error = %e,
-                               "UNI stream accept ended - peer disconnected");
+                        // Logged at INFO so we can correlate teardown with cause
+                        // (idle timeout / app close / transport error) without
+                        // raising RUST_LOG. Receive-loop teardowns are the
+                        // event we're chasing.
+                        info!(peer = %node_id_hex,
+                              error = %e,
+                              "UNI stream accept ended - peer disconnected");
                         break;
                     }
                 }
@@ -1225,6 +1254,20 @@ impl QuicMeshProtocol {
                 .connections
                 .get(peer_pubkey)
                 .ok_or_else(|| anyhow!("No connection to peer"))?;
+            // Reject sends through a closed connection. Pair with the prune
+            // in `connected_peer_ids`. Without this, the consensus broadcaster
+            // would write to a dead stream, the send "succeeds" at the API
+            // layer, but votes never reach the peer — silently breaking
+            // quorum after a connection teardown race.
+            if entry.quic_conn.close_reason().is_some() {
+                let key = peer_pubkey.to_vec();
+                drop(entry);
+                self.connections
+                    .remove_if(&key, |_, e| e.quic_conn.close_reason().is_some());
+                return Err(anyhow!(
+                    "send_to_peer: underlying QUIC connection is closed (stale entry purged)"
+                ));
+            }
             (entry.quic_conn.clone(), entry.session_key)
         };
 

--- a/scripts/deploy-gateways.sh
+++ b/scripts/deploy-gateways.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# Gateway deploy wrapper. Modeled on deploy-validators.sh.
+#
+# Gateways are observer-mode (no BFT) so no halt-consensus needed, BUT the
+# Jun-17 2026 incident proved the binary backup + verify steps are mandatory:
+# I overwrote a working gw1 binary with one that has a historical-sync bug
+# and almost bricked the node because there was no backup.
+#
+# Usage:
+#   scripts/deploy-gateways.sh <binary-path>
+#   scripts/deploy-gateways.sh --dry-run <binary-path>
+#   scripts/deploy-gateways.sh --only gw1 <binary-path>     # one gateway only
+#
+# What it does, in order:
+#   1. md5sum the local binary.
+#   2. For each gateway, in series (NOT parallel — bulk gateway rollout is
+#      what took mobile offline in the Jun-17 incident):
+#        a. cp /opt/zhtp/zhtp /opt/zhtp/zhtp.bak.<timestamp>
+#        b. verify backup exists with same md5 as the currently-running binary
+#        c. rsync new binary to /tmp/zhtp.new
+#        d. md5 verify the rsync
+#        e. mv into place, chmod, systemctl restart
+#        f. wait up to 60s for zhtp.service to enter active state
+#        g. attempt a QUIC CLI test against the node (blockchain status)
+#        h. if test fails → STOP, do not proceed to next gateway
+#   3. Print final cluster state.
+#
+# The script refuses to proceed past a gateway that fails its post-deploy
+# health check. This is what the user wants: never two gateways down at once.
+
+set -euo pipefail
+
+# ---- node table -------------------------------------------------------------
+#
+# Format: ssh-alias|ip|sudo
+GATEWAYS=(
+    "zhtp-gateway|91.98.113.188|sudo"
+    "zhtp-gateway-2|57.128.30.74|sudo"
+)
+
+REMOTE_BIN=/opt/zhtp/zhtp
+SERVICE=zhtp
+RESTART_WAIT_SECS=60
+HEALTH_TIMEOUT=30
+
+# ---- arg parse --------------------------------------------------------------
+
+DRY_RUN=0
+ONLY=""
+BINARY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --only)    ONLY="$2"; shift 2 ;;
+        -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+        -*)        echo "unknown flag: $1" >&2; exit 2 ;;
+        *)         BINARY="$1"; shift ;;
+    esac
+done
+
+[[ -z "$BINARY" ]] && { echo "usage: $0 [--dry-run] [--only <alias>] <binary-path>" >&2; exit 2; }
+[[ -f "$BINARY" ]] || { echo "binary not found: $BINARY" >&2; exit 2; }
+
+# locate zhtp-cli for post-deploy health checks
+CLI=./target/release/zhtp-cli
+[[ -x "$CLI" ]] || CLI=./target/dev-release/zhtp-cli
+[[ -x "$CLI" ]] || { echo "no zhtp-cli binary found in target/release or target/dev-release" >&2; exit 2; }
+
+# ---- helpers ----------------------------------------------------------------
+
+log()  { printf '\033[36m[%s]\033[0m %s\n' "$(date +%H:%M:%S)" "$*"; }
+ok()   { printf '\033[32m[ ok ]\033[0m %s\n' "$*"; }
+warn() { printf '\033[33m[warn]\033[0m %s\n' "$*"; }
+fail() { printf '\033[31m[fail]\033[0m %s\n' "$*"; exit 1; }
+
+# ---- step 1: local md5 ------------------------------------------------------
+
+LOCAL_MD5=$(md5sum "$BINARY" | awk '{print $1}')
+log "local binary md5: $LOCAL_MD5  ($BINARY)"
+[[ $DRY_RUN -eq 1 ]] && log "DRY RUN — printing planned actions, no changes."
+
+# ---- step 2: per-gateway serial deploy -------------------------------------
+
+for entry in "${GATEWAYS[@]}"; do
+    IFS='|' read -r alias ip sudo <<< "$entry"
+
+    if [[ -n "$ONLY" && "$alias" != "$ONLY" && "$alias" != "zhtp-$ONLY" ]]; then
+        log "skipping $alias (--only $ONLY)"
+        continue
+    fi
+
+    log "==== $alias ($ip) ===="
+
+    if [[ $DRY_RUN -eq 1 ]]; then
+        echo "  ssh $alias \"$sudo cp $REMOTE_BIN ${REMOTE_BIN}.bak.\$(date +%Y%m%d-%H%M%S)-deploy\""
+        echo "  scp $BINARY $alias:/tmp/zhtp.new"
+        echo "  ssh $alias \"$sudo md5sum /tmp/zhtp.new\"   # must equal $LOCAL_MD5"
+        echo "  ssh $alias \"$sudo mv /tmp/zhtp.new $REMOTE_BIN && $sudo chmod +x $REMOTE_BIN && $sudo systemctl restart $SERVICE\""
+        echo "  health check via $CLI -s $ip:9334 blockchain status"
+        continue
+    fi
+
+    # 2a. backup
+    BAK_NAME="${REMOTE_BIN}.bak.$(date +%Y%m%d-%H%M%S)-deploy"
+    log "backing up running binary → $BAK_NAME"
+    ssh "$alias" "${sudo} cp $REMOTE_BIN $BAK_NAME"
+
+    # 2b. verify backup
+    BAK_MD5=$(ssh "$alias" "${sudo} md5sum $BAK_NAME" | awk '{print $1}')
+    RUNNING_MD5=$(ssh "$alias" "${sudo} md5sum $REMOTE_BIN" | awk '{print $1}')
+    if [[ "$BAK_MD5" != "$RUNNING_MD5" ]]; then
+        fail "backup md5 mismatch on $alias — refusing to overwrite"
+    fi
+    ok "backup verified ($BAK_MD5)"
+
+    # 2c. rsync to /tmp
+    log "rsync new binary to $alias:/tmp/zhtp.new"
+    scp -q "$BINARY" "$alias:/tmp/zhtp.new"
+
+    # 2d. md5 verify the rsync
+    PUSHED_MD5=$(ssh "$alias" "${sudo} md5sum /tmp/zhtp.new" | awk '{print $1}')
+    if [[ "$PUSHED_MD5" != "$LOCAL_MD5" ]]; then
+        ssh "$alias" "${sudo} rm /tmp/zhtp.new"
+        fail "pushed binary md5 mismatch on $alias (got $PUSHED_MD5, expected $LOCAL_MD5)"
+    fi
+    ok "pushed binary md5 verified"
+
+    # 2e. move into place + restart
+    log "swapping binary and restarting $SERVICE"
+    ssh "$alias" "${sudo} mv /tmp/zhtp.new $REMOTE_BIN && ${sudo} chmod +x $REMOTE_BIN && ${sudo} systemctl restart $SERVICE"
+
+    # 2f. wait for active state
+    log "waiting up to ${RESTART_WAIT_SECS}s for $SERVICE to become active"
+    DEADLINE=$(( $(date +%s) + RESTART_WAIT_SECS ))
+    while (( $(date +%s) < DEADLINE )); do
+        if ssh "$alias" "${sudo} systemctl is-active $SERVICE" 2>/dev/null | grep -q '^active$'; then
+            break
+        fi
+        sleep 2
+    done
+    if ! ssh "$alias" "${sudo} systemctl is-active $SERVICE" 2>/dev/null | grep -q '^active$'; then
+        fail "$SERVICE did not reach active state on $alias — ABORTING (other gateways NOT touched)"
+    fi
+    ok "service active on $alias"
+
+    # 2g. QUIC health check
+    log "QUIC health check against $ip:9334 (timeout ${HEALTH_TIMEOUT}s)"
+    if timeout "$HEALTH_TIMEOUT" "$CLI" -s "$ip:9334" blockchain status >/dev/null 2>&1; then
+        ok "$alias responds to inbound QUIC"
+    else
+        warn "$alias does NOT respond to inbound QUIC after restart"
+        warn "ROLLBACK: restoring $BAK_NAME"
+        ssh "$alias" "${sudo} cp $BAK_NAME $REMOTE_BIN && ${sudo} systemctl restart $SERVICE"
+        sleep 10
+        if timeout "$HEALTH_TIMEOUT" "$CLI" -s "$ip:9334" blockchain status >/dev/null 2>&1; then
+            ok "$alias recovered after rollback"
+        else
+            fail "$alias still broken after rollback — manual intervention required"
+        fi
+        fail "deploy aborted on $alias — fix binary, then retry (other gateways NOT touched)"
+    fi
+
+    log "$alias deploy complete"
+    echo
+done
+
+ok "all selected gateways deployed and verified"

--- a/scripts/zhtp-watchdog.service
+++ b/scripts/zhtp-watchdog.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=ZHTP QUIC reachability watchdog
+After=zhtp.service
+Wants=zhtp.service
+
+[Service]
+Type=simple
+ExecStart=/opt/zhtp/watchdog.sh
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+# Watchdog must run as root to issue systemctl restart on g1-g3 (root) and
+# work via sudoers NOPASSWD on g4/g5/gateways (where zhtp.service is owned
+# by root but the unit file may be owned by a non-root user).
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/zhtp-watchdog.sh
+++ b/scripts/zhtp-watchdog.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# External QUIC reachability watchdog for ZHTP nodes.
+#
+# Runs on the same host as zhtp.service. Every WATCHDOG_INTERVAL seconds,
+# attempts a QUIC `blockchain status` call against 127.0.0.1:9334 using
+# zhtp-cli. After WATCHDOG_FAIL_THRESHOLD consecutive failures, restarts
+# zhtp.service.
+#
+# Why this exists:
+#   The Jun-17 2026 gateway outage was caused by a `?` operator in the QUIC
+#   accept loop that terminated the loop permanently on the first transient
+#   quinn error. The fix is in quic_handler.rs. This watchdog is the
+#   belt-and-braces second line of defense for any future failure mode
+#   where the process stays alive but stops accepting inbound.
+#
+# Install:
+#   cp scripts/zhtp-watchdog.sh /opt/zhtp/watchdog.sh
+#   cp scripts/zhtp-watchdog.service /etc/systemd/system/
+#   systemctl enable --now zhtp-watchdog.service
+
+set -u
+
+WATCHDOG_INTERVAL=${WATCHDOG_INTERVAL:-60}
+WATCHDOG_FAIL_THRESHOLD=${WATCHDOG_FAIL_THRESHOLD:-3}
+WATCHDOG_CLI=${WATCHDOG_CLI:-/opt/zhtp/zhtp-cli}
+WATCHDOG_TARGET=${WATCHDOG_TARGET:-127.0.0.1:9334}
+WATCHDOG_PROBE_TIMEOUT=${WATCHDOG_PROBE_TIMEOUT:-20}
+WATCHDOG_RESTART_CMD=${WATCHDOG_RESTART_CMD:-"systemctl restart zhtp"}
+WATCHDOG_BACKOFF_AFTER_RESTART=${WATCHDOG_BACKOFF_AFTER_RESTART:-120}
+
+log() { printf '[%s] watchdog: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+
+if [[ ! -x "$WATCHDOG_CLI" ]]; then
+    log "FATAL: zhtp-cli not found or not executable at $WATCHDOG_CLI"
+    exit 2
+fi
+
+log "starting (interval=${WATCHDOG_INTERVAL}s, threshold=${WATCHDOG_FAIL_THRESHOLD}, target=${WATCHDOG_TARGET})"
+
+fails=0
+last_restart=0
+
+while true; do
+    sleep "$WATCHDOG_INTERVAL"
+
+    if timeout "$WATCHDOG_PROBE_TIMEOUT" "$WATCHDOG_CLI" -s "$WATCHDOG_TARGET" blockchain status >/dev/null 2>&1; then
+        if [[ $fails -gt 0 ]]; then
+            log "probe OK (recovered after $fails failures)"
+        fi
+        fails=0
+        continue
+    fi
+
+    fails=$((fails + 1))
+    log "probe FAILED ($fails/$WATCHDOG_FAIL_THRESHOLD)"
+
+    if [[ $fails -ge $WATCHDOG_FAIL_THRESHOLD ]]; then
+        now=$(date +%s)
+        since_last=$(( now - last_restart ))
+        if [[ $last_restart -gt 0 && $since_last -lt $WATCHDOG_BACKOFF_AFTER_RESTART ]]; then
+            log "skipping restart — last restart was ${since_last}s ago (<$WATCHDOG_BACKOFF_AFTER_RESTART)"
+            continue
+        fi
+        log "RESTARTING zhtp.service: $WATCHDOG_RESTART_CMD"
+        # shellcheck disable=SC2086
+        $WATCHDOG_RESTART_CMD
+        last_restart=$now
+        fails=0
+        log "restart issued — backing off ${WATCHDOG_BACKOFF_AFTER_RESTART}s before next probe"
+        sleep "$WATCHDOG_BACKOFF_AFTER_RESTART"
+    fi
+done

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1132,13 +1132,23 @@ impl IdentityHandler {
         // Extract DID from path: /api/v1/identity/get/{did}
         // DID format: did:zhtp:xxx or just the hash part
         let path_parts: Vec<&str> = request.uri.split('/').collect();
-        let did_str = path_parts
+        let did_str_raw = path_parts
             .get(5)
             .ok_or_else(|| anyhow::anyhow!("DID required"))?;
+        // Mobile sends the DID percent-encoded (the colons in `did:zhtp:`
+        // come through as `%3A`). Without decoding here, the
+        // `starts_with("did:zhtp:")` check below misses, the handler
+        // prepends `did:zhtp:` to the already-encoded form, and the chain
+        // lookup against `did_to_username` / `identity_registry` never
+        // hits — the profile renders without a username even though the
+        // binding exists on chain.
+        let did_str = urlencoding::decode(did_str_raw)
+            .map(|s| s.into_owned())
+            .unwrap_or_else(|_| did_str_raw.to_string());
 
         // Handle both full DID and short form
         let did = if did_str.starts_with("did:zhtp:") {
-            did_str.to_string()
+            did_str.clone()
         } else {
             format!("did:zhtp:{}", did_str)
         };
@@ -1203,9 +1213,15 @@ impl IdentityHandler {
 
         // Extract DID from path: /api/v1/identity/verify/{did}
         let path_parts: Vec<&str> = request.uri.split('/').collect();
-        let did_str = path_parts
+        let did_str_raw = path_parts
             .get(5)
             .ok_or_else(|| anyhow::anyhow!("DID required"))?;
+        // Same percent-decode as `handle_get_identity_by_did`: mobile
+        // sends `did%3Azhtp%3A<hex>` and the lookup-key comparison below
+        // needs the literal `did:zhtp:` form.
+        let did_str = urlencoding::decode(did_str_raw)
+            .map(|s| s.into_owned())
+            .unwrap_or_else(|_| did_str_raw.to_string());
 
         // Parse optional verification requirements from body
         #[derive(Deserialize, Default)]

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -725,13 +725,29 @@ impl TokenHandler {
         // Collect balances from all token contracts
         for (token_id, token) in blockchain.query_all_token_contracts() {
             let balance = if *token_id == native_token_id {
+                // Mirror handle_get_balance (singular): when BlockExecutor is
+                // active it writes SOV debits/credits to the sled
+                // `token_balances` tree, and the post-apply sync to the
+                // in-memory `token_contracts` HashMap can lag (or miss
+                // entries when the original was inserted under a non-synthetic
+                // PublicKey). Reading sled first guarantees the mobile wallet
+                // sees the post-debit balance immediately after a domain
+                // registration fee_payment_tx commits.
                 if let Some(wallet_id) = sov_wallet_id {
-                    let wallet_key = PublicKey {
-                        dilithium_pk: [0u8; 2592],
-                        kyber_pk: [0u8; 1568],
-                        key_id: wallet_id,
-                    };
-                    token.balance_of(&wallet_key)
+                    if let Some(store) = blockchain.get_store() {
+                        let storage_token_id = lib_blockchain::storage::TokenId(*token_id);
+                        let addr = lib_blockchain::storage::Address::new(wallet_id);
+                        store
+                            .get_token_balance(&storage_token_id, &addr)
+                            .unwrap_or(0)
+                    } else {
+                        let wallet_key = PublicKey {
+                            dilithium_pk: [0u8; 2592],
+                            kyber_pk: [0u8; 1568],
+                            key_id: wallet_id,
+                        };
+                        token.balance_of(&wallet_key)
+                    }
                 } else {
                     0
                 }

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -304,21 +304,23 @@ impl WalletHandler {
                 if !owned {
                     continue;
                 }
+                // Mirror the main path at line 393: read SOV balance sled-first
+                // via blockchain.token_balance() rather than the in-memory
+                // TokenContract.balances HashMap. The executor writes SOV
+                // debits/credits to the sled `token_balances` tree, and the
+                // post-apply sync to in-memory can miss entries when the
+                // identity_manager has no live entry for this DID (the path
+                // this fallback exists for in the first place). Reading sled
+                // here guarantees the mobile wallet displays the post-debit
+                // balance immediately after a domain registration fee_payment_tx
+                // commits.
                 let effective_balance = hex::decode(wallet_id_hex)
                     .ok()
                     .filter(|b| b.len() == 32)
-                    .and_then(|bytes| {
-                        blockchain.query_token_contract(&sov_token_id).and_then(|token| {
-                            let mut key_id = [0u8; 32];
-                            key_id.copy_from_slice(&bytes);
-                            let wallet_key =
-                                lib_blockchain::integration::crypto_integration::PublicKey {
-                                    dilithium_pk: [0u8; 2592],
-                                    kyber_pk: [0u8; 1568],
-                                    key_id,
-                                };
-                            Some(token.balance_of(&wallet_key))
-                        })
+                    .map(|bytes| {
+                        let mut key_id = [0u8; 32];
+                        key_id.copy_from_slice(&bytes);
+                        blockchain.token_balance(&sov_token_id, &key_id).unwrap_or(0)
                     })
                     .unwrap_or(0);
                 let wallet_info = WalletInfo {

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -370,13 +370,84 @@ async fn try_initial_sync_from_peer(
                 &blocks_resp.body,
             ) {
                 Ok(b) => b,
-                Err(e) => {
+                Err(batch_err) => {
+                    // Batch decode failed. Fall back to fetching this range one
+                    // block at a time. The Jun-17 2026 incident showed that batch
+                    // decode can fail on a specific block while the same block
+                    // decodes fine via the per-block path (e.g. when the bincode
+                    // Vec wrapper interacts badly with a `TransactionPayload`
+                    // variant boundary). Per-block requests still hit the same
+                    // endpoint with start==end, but each response is a Vec of
+                    // length 1 — far less surface area for the decoder.
                     warn!(
-                        "⚠️  Failed to deserialize blocks {}-{} from {}: {}",
-                        start, end, peer_addr, e
+                        "⚠️  Batch decode failed for blocks {}-{} from {}: {} — falling back to per-block fetch",
+                        start, end, peer_addr, batch_err
                     );
-                    page_error = true;
-                    break;
+                    let mut singles: Vec<lib_blockchain::Block> = Vec::new();
+                    let mut single_error = false;
+                    for h in start..=end {
+                        let single_url = format!("/api/v1/blockchain/blocks/{}/{}", h, h);
+                        let single_resp = match tokio::time::timeout(
+                            std::time::Duration::from_secs(30),
+                            client.get(&single_url),
+                        )
+                        .await
+                        {
+                            Ok(Ok(r)) => r,
+                            Ok(Err(e)) => {
+                                warn!(
+                                    "⚠️  Per-block fallback: block {} request failed from {}: {}",
+                                    h, peer_addr, e
+                                );
+                                single_error = true;
+                                break;
+                            }
+                            Err(_) => {
+                                warn!(
+                                    "⚠️  Per-block fallback: block {} request timed out from {}",
+                                    h, peer_addr
+                                );
+                                single_error = true;
+                                break;
+                            }
+                        };
+                        if !single_resp.is_success() {
+                            warn!(
+                                "⚠️  Per-block fallback: block {} from {} returned error: {}",
+                                h, peer_addr, single_resp.status_message
+                            );
+                            single_error = true;
+                            break;
+                        }
+                        match deserialize_blocks_compatible(&single_resp.body) {
+                            Ok(mut bs) if !bs.is_empty() => singles.append(&mut bs),
+                            Ok(_) => {
+                                warn!(
+                                    "⚠️  Per-block fallback: block {} from {} returned empty body",
+                                    h, peer_addr
+                                );
+                                single_error = true;
+                                break;
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "⚠️  Per-block fallback: block {} from {} failed to decode individually: {} — peer abandoned",
+                                    h, peer_addr, e
+                                );
+                                single_error = true;
+                                break;
+                            }
+                        }
+                    }
+                    if single_error {
+                        page_error = true;
+                        break;
+                    }
+                    info!(
+                        "✅ Per-block fallback succeeded for blocks {}-{} from {} ({} blocks)",
+                        start, end, peer_addr, singles.len()
+                    );
+                    singles
                 }
             };
 

--- a/zhtp/src/server/quic_handler.rs
+++ b/zhtp/src/server/quic_handler.rs
@@ -355,10 +355,17 @@ impl QuicHandler {
         loop {
             match endpoint.accept().await {
                 Some(incoming) => {
-                    self.handle_connection_incoming(incoming).await?;
+                    // Errors from handle_connection_incoming must NOT terminate the
+                    // accept loop. The Jun-17 2026 gateway outage was caused by a
+                    // `?` here that killed the loop on the first transient quinn
+                    // error — gateways went 60+ hours with zero inbound while the
+                    // process otherwise looked healthy.
+                    if let Err(e) = self.handle_connection_incoming(incoming).await {
+                        warn!("⚠️ QUIC accept: handle_connection_incoming failed: {} (loop continues)", e);
+                    }
                 }
                 None => {
-                    warn!("QUIC endpoint closed");
+                    error!("QUIC endpoint closed — accept loop exiting");
                     break;
                 }
             }
@@ -472,6 +479,24 @@ impl QuicHandler {
         // Auto-register the authenticated peer identity
         self.auto_register_peer_identity(&handshake_result.verified_peer.identity)
             .await;
+
+        // DO NOT register this control-plane connection in the mesh store.
+        // Control-plane connections (ALPN zhtp-uhp/1, zhtp-uhp/2) are created
+        // by ZhtpClient for short-lived RPC: catch-up sync, observer sync,
+        // CLI calls. ZhtpClient::Drop closes the underlying QUIC connection
+        // (lib-network/src/client/zhtp_client.rs:865) — so any entry added
+        // here is killed within hundreds of milliseconds when the RPC finishes
+        // and the client is dropped. Persistent mesh peers come in via
+        // handle_mesh_connection (ALPN zhtp-mesh/1), which is the correct
+        // path and is unaffected by ZhtpClient::Drop.
+        //
+        // History: a previous attempt registered control-plane peers here as
+        // a workaround for "No validator targets resolved" warnings. It
+        // appeared to populate the mesh store but actually polluted it with
+        // churning short-lived entries (observed: 15:1 control-plane:true-
+        // mesh registration ratio over 2 minutes). The real solution is to
+        // ensure validators establish true ALPN zhtp-mesh/1 connections via
+        // the periodic try_reconnect_to_bootstrap task.
 
         // Record session in POUW session log for proof-of-presence verification
         if let Some(session_log) = &self.pouw_session_log {


### PR DESCRIPTION
## Summary

Closes the chain-stability bugs that combined to (1) make OPAQUE login impossible for every registered user, (2) hide new SOV balances and welcome state from mobile, and (3) cause recurring forks and observer-sync wedges across the cluster.

Verified in production: chain has been committing in lockstep at ~10s/block for the last ~13h with all 5/5 validators voting on the binary built from this branch (md5 `458327a4...`).

---

## Commit-by-commit

### 1. Replay rebuilds missing registries — `bc3cc108`
`Blockchain::load_from_store` fallback replay loop in `init.rs:613-773` was missing three tx-type processors (`process_credential_transactions`, `process_nft_transactions`, `process_entity_registry_transactions`). Every node in the cluster was falling through this path with `credentials=0`, breaking OPAQUE login for every user.

### 2. API DID percent-decode — `47798735`
`/api/identity/get/{did}` and `/verify/{did}` rejected percent-encoded DIDs from mobile (`did%3Azhtp%3A...`) because the prefix check ran before URL decoding. Decode before validation.

### 3. Sled-first SOV balance reads — `5fcd4bf0`, `9645003a`
`handle_get_balances_for_address` and `handle_list_wallets` (fallback path) read SOV from the in-mem `TokenContract.balances` map, which is empty for any wallet that registered before the running process started. Read from `token_balances` sled tree instead.

### 4. Fee debug instrumentation — `8a1e332e`
`[fee-debug]` log instrumentation around `apply_token_transfer`. No behavior change.

### 5. Consensus FSM fast-forward — `d2668fe6` (new)
When a validator restarts and catches up via observer-sync, `engine.current_height` lags `blockchain.height`. The FSM spins rounds at already-committed heights; every proposal rejected as fork. Was the Jun-17/18 g1 wedge.

Adds fast-forward at start of `on_round_timeout`: when `blockchain.height >= engine.current_round.height` AND `step != Commit`, calls `sync_height_with_blockchain` and returns. The `step != Commit` guard preserves CONS-512.

### 6. Mesh stale-connection prune + send rejection — `55bd2f54` (new)
Receive-loop teardown race left dead entries in `QuicMeshProtocol.connections`. `send_to_peer` then wrote to a closed quinn connection — bytes never reached the peer. Jun-19 cluster wedge (5/5 in-quorum, no commits for hours).

- `connected_peer_ids()` self-prunes entries with `close_reason().is_some()` via `remove_if` (preserves a newer connection raced in under the same node_id).
- `send_to_peer` rejects sends through closed connections, purging the stale entry.
- UNI-stream accept-end log raised `debug -> info` for teardown correlation.

### 7. QUIC accept-loop kept alive + Option-A revert — `48e99715` (new)
- `accept_loop`: `?` replaced with log-and-continue around `handle_connection_incoming`. A `?` here killed the loop on the first transient quinn error — gateways went 60+ hours with zero inbound while the process otherwise looked healthy (Jun-17).
- Reverts prior registration of control-plane (ALPN `zhtp-uhp/1`, `zhtp-uhp/2`) connections in mesh store. Those are created by `ZhtpClient` for short-lived RPC; `ZhtpClient::Drop` closes the connection, killing the mesh entry within ms. Pollution ratio was 15:1 control-plane:true-mesh over 2 min. Persistent mesh comes via `handle_mesh_connection` (ALPN `zhtp-mesh/1`).

### 8. Initial-sync per-block fallback — `8a8597b1` (new)
Batch decode failed at h=1000 with `"fixed-int invalid value: ... you may have a version disagreement?"` while same range decoded fine per-block. Bincode Vec wrapper interacts badly with a `TransactionPayload` variant boundary. On batch decode error, fall back to per-block fetches in the range.

### 9. Ops scripts — `97ab4693` (new)
- `deploy-gateways.sh`: per-gateway serial deploy with backup, md5 verify, restart, health check, rollback.
- `zhtp-watchdog.sh` + `.service`: external QUIC reachability probe; restart on 3 consecutive failures.