### PR TITLE
feat(#2639): persist runtime validator bootstrap and dat restore to sled

### DIFF
--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -702,6 +702,40 @@ fn validator_exists_union_inmem_or_sled() {
     assert_eq!(got.stake, 200_000);
 }
 
+/// Bootstrap install writes overlay + sled in one batch (#2639).
+#[test]
+fn install_bootstrap_validator_records_persists_to_sled() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = std::sync::Arc::new(SledStore::open(&temp.path().join("val-bootstrap")).unwrap());
+    let mut bc = Blockchain::new_runtime_state();
+    bc.store = Some(store.clone());
+
+    let written = bc
+        .install_bootstrap_validator_records(vec![ValidatorInfo {
+            identity_id: "did:zhtp:bootstrap-1".to_string(),
+            stake: 100_000,
+            storage_provided: 1 << 40,
+            consensus_key: [9u8; 2592],
+            networking_key: vec![1],
+            rewards_key: vec![2],
+            network_address: "10.0.0.1:9334".to_string(),
+            commission_rate: 5,
+            status: "active".to_string(),
+            registered_at: 0,
+            last_activity: 0,
+            blocks_validated: 0,
+            slash_count: 0,
+            admission_source: "bootstrap_genesis".to_string(),
+            governance_proposal_id: None,
+            oracle_key_id: None,
+        }])
+        .expect("install");
+    assert_eq!(written, 1);
+    assert_eq!(store.count_validator_records().unwrap(), 1);
+    assert_eq!(bc.active_validators_for_consensus().len(), 1);
+    assert_eq!(store.validator_record_schema_version().unwrap(), 1);
+}
+
 /// Repeated reads hit the generation/fingerprint cache; sled-only writes invalidate gen (#56).
 #[test]
 fn active_validator_infos_cache_invalidates_on_sled_write() {

--- a/lib-blockchain/src/blockchain/validators.rs
+++ b/lib-blockchain/src/blockchain/validators.rs
@@ -402,16 +402,25 @@ impl Blockchain {
         if infos.is_empty() {
             return Ok(0);
         }
-        for info in &infos {
-            self.validator_registry
-                .insert(info.identity_id.clone(), info.clone());
-            self.validator_blocks
-                .entry(info.identity_id.clone())
-                .or_insert(info.registered_at);
-        }
         let Some(ref store) = self.store else {
+            for info in &infos {
+                self.validator_registry
+                    .insert(info.identity_id.clone(), info.clone());
+                self.validator_blocks
+                    .entry(info.identity_id.clone())
+                    .or_insert(info.registered_at);
+            }
             return Ok(infos.len());
         };
+        // Bump schema version before the sled write. Bootstrap records are not
+        // replay-derivable; if we wrote sled at v0 and crashed before this bump,
+        // migrate_validator_records_schema would clear the tree on next boot.
+        let current = crate::storage::VALIDATOR_RECORD_SCHEMA_VERSION;
+        if store.validator_record_schema_version()? < current {
+            store
+                .set_validator_record_schema_version(current)
+                .map_err(|e| anyhow::anyhow!("Failed to set validator schema version: {e}"))?;
+        }
         let records: Vec<([u8; 32], StoredValidatorRecord)> = infos
             .iter()
             .map(|info| (did_to_hash(&info.identity_id), StoredValidatorRecord::from(info)))
@@ -425,11 +434,12 @@ impl Blockchain {
                 "bootstrap validator persist: only {written}/{expected} records written"
             ));
         }
-        let current = crate::storage::VALIDATOR_RECORD_SCHEMA_VERSION;
-        if store.validator_record_schema_version()? < current {
-            store
-                .set_validator_record_schema_version(current)
-                .map_err(|e| anyhow::anyhow!("Failed to set validator schema version: {e}"))?;
+        for info in &infos {
+            self.validator_registry
+                .insert(info.identity_id.clone(), info.clone());
+            self.validator_blocks
+                .entry(info.identity_id.clone())
+                .or_insert(info.registered_at);
         }
         self.invalidate_active_validator_cache();
         Ok(written)

--- a/lib-blockchain/src/blockchain/validators.rs
+++ b/lib-blockchain/src/blockchain/validators.rs
@@ -390,6 +390,51 @@ impl Blockchain {
         Ok(())
     }
 
+    /// Install bootstrap/emergency validators into overlay + durable sled (#2639).
+    ///
+    /// Used when validators are seeded from bootstrap config or restored from
+    /// `blockchain.dat` — outside the block-apply metadata batch path.
+    pub fn install_bootstrap_validator_records(
+        &mut self,
+        validators: impl IntoIterator<Item = ValidatorInfo>,
+    ) -> Result<usize> {
+        let infos: Vec<ValidatorInfo> = validators.into_iter().collect();
+        if infos.is_empty() {
+            return Ok(0);
+        }
+        for info in &infos {
+            self.validator_registry
+                .insert(info.identity_id.clone(), info.clone());
+            self.validator_blocks
+                .entry(info.identity_id.clone())
+                .or_insert(info.registered_at);
+        }
+        let Some(ref store) = self.store else {
+            return Ok(infos.len());
+        };
+        let records: Vec<([u8; 32], StoredValidatorRecord)> = infos
+            .iter()
+            .map(|info| (did_to_hash(&info.identity_id), StoredValidatorRecord::from(info)))
+            .collect();
+        let expected = records.len();
+        let written = store
+            .put_validator_record_batch(&records)
+            .map_err(|e| anyhow::anyhow!("Failed to batch-persist bootstrap validators: {e}"))?;
+        if written != expected {
+            return Err(anyhow::anyhow!(
+                "bootstrap validator persist: only {written}/{expected} records written"
+            ));
+        }
+        let current = crate::storage::VALIDATOR_RECORD_SCHEMA_VERSION;
+        if store.validator_record_schema_version()? < current {
+            store
+                .set_validator_record_schema_version(current)
+                .map_err(|e| anyhow::anyhow!("Failed to set validator schema version: {e}"))?;
+        }
+        self.invalidate_active_validator_cache();
+        Ok(written)
+    }
+
     pub fn register_validator(&mut self, validator_info: ValidatorInfo) -> Result<Hash> {
         if self.validator_exists(&validator_info.identity_id) {
             return Err(anyhow::anyhow!(

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1255,15 +1255,19 @@ impl RuntimeOrchestrator {
                         bc.store = store;
                         bc.executor = executor;
                         // Seed validators from bootstrap config (not stored in blocks)
-                        seed_validators_from_bootstrap_config(
+                        if let Err(e) = seed_validators_from_bootstrap_config(
                             &mut bc,
                             &self.config.network_config.bootstrap_validators,
-                        );
+                        ) {
+                            warn!(
+                                "Failed to seed bootstrap validators after load_from_store: {e}"
+                            );
+                        }
                         info!(
                             "Blockchain load complete: height={}, identities={}, validators={}, domains={}, credentials={}",
                             bc.height,
                             bc.identity_count(), // #2639: sled-authoritative
-                            bc.validator_registry.len(),
+                            bc.active_validators_for_consensus().len(),
                             bc.domain_registry.len(),
                             bc.credential_registry.len(),
                         );
@@ -2286,7 +2290,7 @@ impl RuntimeOrchestrator {
                     );
                 }
 
-                if bc.get_active_validators().is_empty() {
+                if bc.active_validators_for_consensus().is_empty() {
                     let restored = if emergency_restore_enabled {
                         try_restore_validators_from_dat(
                             &mut bc,
@@ -2300,7 +2304,7 @@ impl RuntimeOrchestrator {
                         seed_validators_from_bootstrap_config(
                             &mut bc,
                             &self.config.network_config.bootstrap_validators,
-                        );
+                        )?;
                     }
                 }
 
@@ -2568,13 +2572,13 @@ impl RuntimeOrchestrator {
                         info!("💾 Genesis block (height 0) persisted to SledStore");
                     }
 
-                    // Seed bootstrap validators into the validator registry so
-                    // consensus can find them. Genesis allocations carry identities
-                    // and wallets but NOT validator registrations.
+                    // Seed bootstrap validators into overlay + sled so consensus can
+                    // find them. Genesis allocations carry identities and wallets
+                    // but NOT validator registrations.
                     seed_validators_from_bootstrap_config(
                         &mut bc,
                         &self.config.network_config.bootstrap_validators,
-                    );
+                    )?;
 
                     (bc, false)
                 } else {
@@ -5598,8 +5602,11 @@ pub(super) fn try_restore_oracle_from_dat(
     }
 }
 
-/// Seed validator_registry from bootstrap config when neither sled nor blockchain.dat
-/// contains any validators (i.e. validators were never committed as on-chain transactions).
+/// Seed validators from bootstrap config when the authoritative active set is empty.
+///
+/// Bootstrap validators are not committed as on-chain transactions on testnet; this path
+/// installs them into the in-memory overlay **and** durable sled so consensus reads agree
+/// with the fleet (#2639).
 ///
 /// Uses blake3 domain separation to derive distinct placeholder keys for the networking and
 /// rewards roles from the identity ID — these only need to be non-empty and mutually distinct
@@ -5607,11 +5614,14 @@ pub(super) fn try_restore_oracle_from_dat(
 pub(super) fn seed_validators_from_bootstrap_config(
     bc: &mut lib_blockchain::Blockchain,
     bootstrap_validators: &[crate::config::aggregation::BootstrapValidator],
-) {
+) -> Result<()> {
     if bootstrap_validators.is_empty() {
-        return;
+        return Ok(());
     }
-    let mut count = 0usize;
+    if !bc.active_validators_for_consensus().is_empty() {
+        return Ok(());
+    }
+    let mut seeded = Vec::new();
     for bv in bootstrap_validators {
         // Decode bootstrap consensus key (must be 2592 bytes for Dilithium5)
         // If not provided, generate a deterministic key from identity hash
@@ -5655,13 +5665,14 @@ pub(super) fn seed_validators_from_bootstrap_config(
             governance_proposal_id: None,
             oracle_key_id: None,
         };
-        bc.validator_registry.insert(bv.identity_id.clone(), vi);
-        count += 1;
+        seeded.push(vi);
     }
+    let count = bc.install_bootstrap_validator_records(seeded)?;
     info!(
-        "validator_registry empty — seeded {} validator(s) from bootstrap config (in-memory only)",
+        "validator set empty — seeded {} validator(s) from bootstrap config (overlay + sled)",
         count
     );
+    Ok(())
 }
 
 fn bootstrap_commission_percent(commission_rate_bps: u16) -> u8 {
@@ -5674,10 +5685,16 @@ pub(super) fn try_restore_validators_from_dat(
 ) -> Result<bool> {
     match load_validated_blockchain_dat(dat_path, allow_genesis_mismatch)? {
         Some(dat_bc) if !dat_bc.get_active_validators().is_empty() => {
-            let count = dat_bc.get_active_validators().len();
-            bc.validator_registry = dat_bc.validator_registry;
+            let restored: Vec<_> = dat_bc
+                .validator_registry
+                .values()
+                .cloned()
+                .collect();
+            let count = restored.len();
+            bc.validator_blocks = dat_bc.validator_blocks;
+            bc.install_bootstrap_validator_records(restored)?;
             warn!(
-                "⚠️  Emergency restore loaded validator_registry from blockchain.dat ({} validators)",
+                "⚠️  Emergency restore loaded validator_registry from blockchain.dat ({} validators, persisted to sled)",
                 count
             );
             Ok(true)
@@ -6558,8 +6575,14 @@ mod oracle_startup_tests {
 
 #[cfg(test)]
 mod validator_startup_tests {
-    use super::{bootstrap_commission_percent, try_restore_validators_from_dat};
+    use super::{
+        bootstrap_commission_percent, seed_validators_from_bootstrap_config,
+        try_restore_validators_from_dat,
+    };
+    use crate::config::aggregation::BootstrapValidator;
+    use lib_blockchain::storage::{BlockchainStore, SledStore};
     use lib_blockchain::{Blockchain, ValidatorInfo};
+    use std::sync::Arc;
     use tempfile::tempdir;
 
     fn make_validator(id: &str) -> ValidatorInfo {
@@ -6587,6 +6610,7 @@ mod validator_startup_tests {
     fn restore_succeeds_when_dat_has_validators() {
         let dir = tempdir().unwrap();
         let dat_path = dir.path().join("blockchain.dat");
+        let sled_path = dir.path().join("sled");
 
         let mut src = Blockchain::new().expect("Blockchain::new");
         src.validator_registry
@@ -6596,18 +6620,49 @@ mod validator_startup_tests {
         #[allow(deprecated)]
         src.save_to_file(&dat_path).expect("save_to_file");
 
+        let store = Arc::new(SledStore::open(&sled_path).expect("open sled"));
         let mut target = Blockchain::new().expect("Blockchain::new");
-        assert!(target.get_active_validators().is_empty());
+        target.store = Some(store.clone());
+        assert!(target.active_validators_for_consensus().is_empty());
 
         let restored = try_restore_validators_from_dat(&mut target, &dat_path, false)
             .expect("try_restore_validators_from_dat");
 
         assert!(restored, "expected restoration to succeed");
         assert_eq!(
-            target.get_active_validators().len(),
+            target.active_validators_for_consensus().len(),
             2,
             "validator_registry should have been restored from dat"
         );
+        assert_eq!(
+            store.as_ref().count_validator_records().expect("count"),
+            2,
+            "emergency restore must persist validators to sled"
+        );
+    }
+
+    #[test]
+    fn bootstrap_seed_persists_to_sled_when_active_set_empty() {
+        let dir = tempdir().unwrap();
+        let store = Arc::new(SledStore::open(dir.path().join("sled")).expect("open sled"));
+        let mut bc = Blockchain::new().expect("Blockchain::new");
+        bc.store = Some(store.clone());
+
+        seed_validators_from_bootstrap_config(
+            &mut bc,
+            &[BootstrapValidator {
+                identity_id: "did:zhtp:seed-test".to_string(),
+                consensus_key: String::new(),
+                stake: 50_000,
+                storage_provided: 1 << 30,
+                commission_rate: 500,
+                endpoints: vec!["10.0.0.9:9334".to_string()],
+            }],
+        )
+        .expect("seed");
+
+        assert_eq!(bc.active_validators_for_consensus().len(), 1);
+        assert_eq!(store.as_ref().count_validator_records().expect("count"), 1);
     }
 
     #[test]
@@ -6627,7 +6682,7 @@ mod validator_startup_tests {
             !restored,
             "should not restore when dat also has empty registry"
         );
-        assert!(target.get_active_validators().is_empty());
+        assert!(target.active_validators_for_consensus().is_empty());
     }
 
     #[test]
@@ -6649,7 +6704,7 @@ mod validator_startup_tests {
             .expect("try_restore_validators_from_dat");
 
         assert!(!restored, "should not restore when dat file does not exist");
-        assert!(target.get_active_validators().is_empty());
+        assert!(target.active_validators_for_consensus().is_empty());
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the runtime validator divergence gap left after PR #2710: bootstrap seeding and emergency `blockchain.dat` restore wrote only to the in-memory `validator_registry`, so nodes could disagree on the active set despite sled-first consensus reads.

Partially addresses **#2639** / epic **#2645**.

---

## Changes

| Path | Before | After |
|------|--------|-------|
| Bootstrap config seed (`seed_validators_from_bootstrap_config`) | In-mem insert only | `install_bootstrap_validator_records` → overlay + sled batch |
| Emergency dat restore (`try_restore_validators_from_dat`) | Copy in-mem registry | Restore + persist to sled; copy `validator_blocks` |
| Startup empty-set checks | `get_active_validators()` | `active_validators_for_consensus()` (sled-first) |
| Post-`load_from_store` seed | Always ran | Skips when authoritative active set non-empty |

**New API:** `Blockchain::install_bootstrap_validator_records` — out-of-band overlay+sled install (bootstrap / emergency restore), sets validator schema v1 when needed.

---

## Tests

- `install_bootstrap_validator_records_persists_to_sled` (lib-blockchain facade)
- `bootstrap_seed_persists_to_sled_when_active_set_empty` (zhtp)
- `restore_succeeds_when_dat_has_validators` — asserts sled record count (zhtp)

---

## Risks

| Risk | Mitigation |
|------|------------|
| Duplicate seed on nodes with on-chain validators | Gated on `active_validators_for_consensus().is_empty()` |
| Schema version unset after bootstrap write | `install_*` bumps to v1 when persisted < current |
| Persist failure on seed | Startup paths log warn or return `Err` (dat restore propagates) |

---

## Out of scope

- Remaining `validator_registry` read sites in zhtp runtime/oracle consumer
- `quic_handler` identity gateway-auth (#2639 blocking site)
- On-chain validator `state_root` (#2369)