### PR TITLE
feat(#2638): sled-first token_nonce facade

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2680,42 +2680,7 @@ impl Blockchain {
     ///   during `process_token_transactions`). The store is consulted only
     ///   when the HashMap has no entry yet (e.g. pre-snapshot-load).
     pub fn get_token_nonce(&self, token_id: &[u8; 32], address: &[u8; 32]) -> u64 {
-        // CONS-513: when the BlockExecutor is wired (sled-canonical mode, PR
-        // #2675), sled is the source of truth — the in-memory HashMap is no
-        // longer kept in sync (the executor-mode write at contracts.rs is
-        // guarded by `!self.has_executor()`, so it stops incrementing). The
-        // mempool/consensus pre-check (`is_nonce_current`) must therefore
-        // read from sled FIRST in executor mode; otherwise it accepts a tx
-        // with a nonce the BlockExecutor will reject at commit time, halting
-        // consensus via the CONS-512 HaltScheduled path. Exact production
-        // failure: "Invalid nonce: expected 2280, got 2279" at H=123044,
-        // 2026-06-04 — pre-check saw HashMap=2279 (stale) while sled=2280.
-        if self.has_executor() {
-            if let Some(store) = self.get_store() {
-                let token = crate::storage::TokenId::new(*token_id);
-                let addr = crate::storage::Address::new(*address);
-                if let Ok(nonce) = store.get_token_nonce(&token, &addr) {
-                    return nonce;
-                }
-            }
-            // Sled unreachable under executor mode — fall through to the
-            // in-memory HashMap as best-effort (still better than 0).
-        }
-        // Legacy / store-less mode: in-memory HashMap is the authoritative
-        // source (populated from snapshot on restart and incremented during
-        // process_token_transactions).
-        if let Some(&nonce) = self.token_nonces.get(&(*token_id, *address)) {
-            return nonce;
-        }
-        // Store fallback when nothing in-memory yet (e.g., snapshot pre-load).
-        if let Some(store) = self.get_store() {
-            let token = crate::storage::TokenId::new(*token_id);
-            let addr = crate::storage::Address::new(*address);
-            if let Ok(nonce) = store.get_token_nonce(&token, &addr) {
-                return nonce;
-            }
-        }
-        0
+        self.token_nonce(token_id, address).unwrap_or(0)
     }
 
     // ========================================================================

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1144,6 +1144,28 @@ impl Blockchain {
     /// mid-`apply_block` caller uses this facade (Phase 3), a `tx_batch`-aware
     /// read must be added to `SledStore::get_token_balance`** or that caller
     /// will see the pre-block value and could authorize a double-spend.
+    /// Sled-first nonce facade (state-unification #2638).
+    ///
+    /// When a `BlockchainStore` is attached it is the authoritative source and a
+    /// sled failure is **propagated as an error** — we do NOT silently fall back
+    /// to a possibly-stale in-memory nonce (the class that caused CONS-513).
+    pub fn token_nonce(
+        &self,
+        token_id: &[u8; 32],
+        address: &[u8; 32],
+    ) -> crate::storage::StorageResult<u64> {
+        if let Some(store) = self.get_store() {
+            let token = crate::storage::TokenId::new(*token_id);
+            let addr = crate::storage::Address::new(*address);
+            return store.get_token_nonce(&token, &addr);
+        }
+        Ok(self
+            .token_nonces
+            .get(&(*token_id, *address))
+            .copied()
+            .unwrap_or(0))
+    }
+
     pub fn token_balance(
         &self,
         token_id: &[u8; 32],

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -100,6 +100,27 @@ fn token_balance_mid_block_reads_staged_write() {
 }
 
 #[test]
+fn token_nonce_reads_sled_when_store_attached() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("facade_nonce_store")).unwrap());
+    let token = TokenId::new([5u8; 32]);
+    let addr = Address::new([0xCC; 32]);
+    store.begin_block(0).unwrap();
+    store.set_token_nonce(&token, &addr, 42).unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    bc.token_nonces.insert(([5u8; 32], [0xCC; 32]), 7);
+
+    assert_eq!(
+        bc.token_nonce(&[5u8; 32], &[0xCC; 32]).unwrap(),
+        42,
+        "facade must return sled nonce, not stale in-memory value"
+    );
+}
+
+#[test]
 fn token_balance_reads_sled_when_store_attached() {
     let temp = tempfile::tempdir().unwrap();
     let store = Arc::new(SledStore::open(&temp.path().join("facade_bal_store")).unwrap());

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -2945,10 +2945,10 @@ impl<'a> StatefulTransactionValidator<'a> {
             None => return Ok(()), // no store — defer lock check to executor
         };
 
-        // Validate nonce against current SOV nonce for the staker to prevent replays.
-        let sov_token = crate::storage::TokenId(crate::contracts::utils::generate_lib_token_id());
-        let staker_addr = crate::storage::Address(data.staker);
-        let current_nonce = store.get_token_nonce(&sov_token, &staker_addr)
+        // Validate nonce against current SOV nonce for the staker to prevent replays (#2638).
+        let sov_token_id = crate::contracts::utils::generate_lib_token_id();
+        let current_nonce = blockchain
+            .token_nonce(&sov_token_id, &data.staker)
             .map_err(|_| ValidationError::InvalidTransaction)?;
         if data.nonce != current_nonce {
             tracing::warn!(

--- a/zhtp/src/api/handlers/observer_admission.rs
+++ b/zhtp/src/api/handlers/observer_admission.rs
@@ -678,7 +678,6 @@ pub async fn handle_admission_prepare(
         Some(s) => s.clone(),
         None => return Ok(server_error("blockchain has no persistent store")),
     };
-    drop(blockchain);
 
     let sponsor_did_hash = did_to_hash(&req.sponsor_user_did);
     let identity = match store.get_identity(&sponsor_did_hash) {
@@ -692,14 +691,13 @@ pub async fn handle_admission_prepare(
         Err(e) => return Ok(server_error(format!("identity store error: {e}"))),
     };
 
-    let sov_token = lib_blockchain::storage::TokenId::new(
-        lib_blockchain::contracts::utils::generate_lib_token_id(),
-    );
-    let sponsor_addr = identity.owner;
-    let current_nonce = match store.get_token_nonce(&sov_token, &sponsor_addr) {
+    let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
+    let sponsor_addr = identity.owner.0;
+    let current_nonce = match blockchain.token_nonce(&sov_token_id, &sponsor_addr) {
         Ok(n) => n,
         Err(e) => return Ok(server_error(format!("nonce lookup failed: {e}"))),
     };
+    drop(blockchain);
 
     let data = RegisterObserverData {
         observer_node_did: req.observer_node_did,

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -464,7 +464,8 @@ impl RewardsHandler {
         // concurrent claims so this read-then-use is safe.
         let nonce = {
             let bc = self.blockchain.read().await;
-            bc.get_token_nonce(&treasury.bubl_token_id, &treasury.signer_key_id)
+            bc.token_nonce(&treasury.bubl_token_id, &treasury.signer_key_id)
+                .unwrap_or(0)
         };
 
         let data = TokenTransferData {

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -618,7 +618,7 @@ impl TokenHandler {
         address.copy_from_slice(&address_bytes);
 
         let blockchain = self.blockchain.read().await;
-        let nonce = blockchain.get_token_nonce(&token_id, &address);
+        let nonce = blockchain.token_nonce(&token_id, &address).unwrap_or(0);
 
         create_json_response(json!({
             "token_id": token_id_hex,


### PR DESCRIPTION
## Summary

Phase 2c of state unification (#2638): all public nonce reads now go through a sled-first facade.

- Add `Blockchain::token_nonce()` — sled-authoritative when store attached; propagates errors instead of falling back to stale in-memory nonces (CONS-513 class)
- Simplify `get_token_nonce()` to delegate to the facade
- Migrate bypass sites:
  - `observer_admission.rs` — was calling `store.get_token_nonce` directly
  - `validation.rs` (DAO unstake) — same
  - `rewards/mod.rs`, `token/mod.rs` — explicit facade use

## Testing

- `token_nonce_reads_sled_when_store_attached`
- `test_get_token_nonce_reads_sled_first_under_executor` (CONS-513 regression)
- `cargo build -p zhtp`

Next: #2639 registry read migration.