### PR TITLE
feat(#2639): registry sled-first read migration (identity, wallet, validator)

### DIFF
--- a/lib-blockchain/src/blockchain/dao.rs
+++ b/lib-blockchain/src/blockchain/dao.rs
@@ -1221,7 +1221,7 @@ impl Blockchain {
         validator_dids: Vec<String>,
         _reason: String,
     ) -> Result<()> {
-        let validator_count = self.validator_registry.len();
+        let validator_count = self.validator_count();
         if validator_count == 0 {
             return Err(anyhow::anyhow!(
                 "Insufficient validator signatures: got 0, need at least 1 validator"
@@ -1241,7 +1241,7 @@ impl Blockchain {
         }
 
         for did in &unique_validator_dids {
-            match self.validator_registry.get(did) {
+            match self.validator_info_by_did(did) {
                 Some(v) if v.status == "active" => continue,
                 _ => return Err(anyhow::anyhow!("Invalid or inactive validator: {}", did)),
             }

--- a/lib-blockchain/src/blockchain/identity.rs
+++ b/lib-blockchain/src/blockchain/identity.rs
@@ -444,6 +444,89 @@ impl Blockchain {
             .map(|id| id.controlled_nodes.clone())
     }
 
+    /// Reconstruct `IdentityTransactionData` from durable sled metadata + consensus (#2639).
+    fn identity_transaction_data_from_sled(
+        meta: &crate::storage::IdentityMetadata,
+        consensus: Option<&crate::storage::IdentityConsensus>,
+    ) -> IdentityTransactionData {
+        IdentityTransactionData {
+            did: meta.did.clone(),
+            display_name: meta.display_name.clone(),
+            public_key: meta.public_key.clone(),
+            ownership_proof: meta.ownership_proof.clone(),
+            identity_type: consensus
+                .map(|c| c.identity_type.as_str().to_string())
+                .unwrap_or_else(|| "human".to_string()),
+            did_document_hash: crate::types::hash::Hash::new(
+                consensus.map(|c| c.did_document_hash).unwrap_or([0u8; 32]),
+            ),
+            created_at: consensus.map(|c| c.created_at).unwrap_or(0),
+            registration_fee: consensus.map(|c| c.registration_fee).unwrap_or(0),
+            dao_fee: consensus.map(|c| c.dao_fee).unwrap_or(0),
+            controlled_nodes: meta.controlled_nodes.clone(),
+            owned_wallets: meta.owned_wallets.clone(),
+            kyber_public_key: meta.kyber_public_key.clone(),
+        }
+    }
+
+    /// Sled-first identity record for handlers needing full `IdentityTransactionData` (#2639).
+    ///
+    /// Returns an owned record from durable metadata + consensus when the store
+    /// is attached, with the in-memory shadow as the pre-commit / store-less fallback.
+    pub fn identity_transaction_data(&self, did: &str) -> Option<IdentityTransactionData> {
+        if let Some(store) = self.get_store() {
+            let did_hash = crate::storage::did_to_hash(did);
+            if let Ok(Some(meta)) = store.get_identity_metadata(&did_hash) {
+                let consensus = store.get_identity(&did_hash).ok().flatten();
+                return Some(Self::identity_transaction_data_from_sled(
+                    &meta,
+                    consensus.as_ref(),
+                ));
+            }
+        }
+        self.identity_registry.get(did).cloned()
+    }
+
+    /// Sled-first snapshot for backfill / iteration (#2639).
+    ///
+    /// Builds a map from durable sled metadata, then overlays the in-memory shadow
+    /// (pending / same-block registrations win).
+    pub fn identity_registry_snapshot(&self) -> HashMap<String, IdentityTransactionData> {
+        let mut out = HashMap::new();
+        if let Some(store) = self.get_store() {
+            if let Ok(iter) = store.iter_identity_metadata() {
+                for meta in iter {
+                    let did_hash = crate::storage::did_to_hash(&meta.did);
+                    let consensus = store.get_identity(&did_hash).ok().flatten();
+                    out.insert(
+                        meta.did.clone(),
+                        Self::identity_transaction_data_from_sled(&meta, consensus.as_ref()),
+                    );
+                }
+            }
+        }
+        for (did, data) in &self.identity_registry {
+            out.insert(did.clone(), data.clone());
+        }
+        out
+    }
+
+    /// Case-insensitive display-name collision check, sled-first (#2639).
+    pub fn identity_display_name_taken(&self, display_name_lower: &str) -> bool {
+        if let Some(store) = self.get_store() {
+            if let Ok(iter) = store.iter_identity_metadata() {
+                if iter.into_iter().any(|m| {
+                    m.display_name.to_lowercase() == display_name_lower
+                }) {
+                    return true;
+                }
+            }
+        }
+        self.identity_registry.values().any(|id| {
+            id.display_name.to_lowercase() == display_name_lower
+        })
+    }
+
     pub fn update_identity(
         &mut self,
         did: &str,

--- a/lib-blockchain/src/blockchain/identity.rs
+++ b/lib-blockchain/src/blockchain/identity.rs
@@ -445,28 +445,38 @@ impl Blockchain {
     }
 
     /// Reconstruct `IdentityTransactionData` from durable sled metadata + consensus (#2639).
+    ///
+    /// Returns `None` when consensus is missing — metadata without a consensus
+    /// row is a half-broken store state and must not surface as plausible zeros
+    /// (`created_at: 0`, `registration_fee: 0`, etc.).
     fn identity_transaction_data_from_sled(
         meta: &crate::storage::IdentityMetadata,
         consensus: Option<&crate::storage::IdentityConsensus>,
-    ) -> IdentityTransactionData {
-        IdentityTransactionData {
+    ) -> Option<IdentityTransactionData> {
+        let consensus = match consensus {
+            Some(c) => c,
+            None => {
+                tracing::warn!(
+                    did = %meta.did,
+                    "identity_transaction_data_from_sled: metadata without consensus; skipping"
+                );
+                return None;
+            }
+        };
+        Some(IdentityTransactionData {
             did: meta.did.clone(),
             display_name: meta.display_name.clone(),
             public_key: meta.public_key.clone(),
             ownership_proof: meta.ownership_proof.clone(),
-            identity_type: consensus
-                .map(|c| c.identity_type.as_str().to_string())
-                .unwrap_or_else(|| "human".to_string()),
-            did_document_hash: crate::types::hash::Hash::new(
-                consensus.map(|c| c.did_document_hash).unwrap_or([0u8; 32]),
-            ),
-            created_at: consensus.map(|c| c.created_at).unwrap_or(0),
-            registration_fee: consensus.map(|c| c.registration_fee).unwrap_or(0),
-            dao_fee: consensus.map(|c| c.dao_fee).unwrap_or(0),
+            identity_type: consensus.identity_type.as_str().to_string(),
+            did_document_hash: crate::types::hash::Hash::new(consensus.did_document_hash),
+            created_at: consensus.created_at,
+            registration_fee: consensus.registration_fee,
+            dao_fee: consensus.dao_fee,
             controlled_nodes: meta.controlled_nodes.clone(),
             owned_wallets: meta.owned_wallets.clone(),
             kyber_public_key: meta.kyber_public_key.clone(),
-        }
+        })
     }
 
     /// Sled-first identity record for handlers needing full `IdentityTransactionData` (#2639).
@@ -478,10 +488,11 @@ impl Blockchain {
             let did_hash = crate::storage::did_to_hash(did);
             if let Ok(Some(meta)) = store.get_identity_metadata(&did_hash) {
                 let consensus = store.get_identity(&did_hash).ok().flatten();
-                return Some(Self::identity_transaction_data_from_sled(
-                    &meta,
-                    consensus.as_ref(),
-                ));
+                if let Some(data) =
+                    Self::identity_transaction_data_from_sled(&meta, consensus.as_ref())
+                {
+                    return Some(data);
+                }
             }
         }
         self.identity_registry.get(did).cloned()
@@ -494,13 +505,22 @@ impl Blockchain {
     pub fn identity_registry_snapshot(&self) -> HashMap<String, IdentityTransactionData> {
         let mut out = HashMap::new();
         if let Some(store) = self.get_store() {
-            if let Ok(iter) = store.iter_identity_metadata() {
-                for meta in iter {
-                    let did_hash = crate::storage::did_to_hash(&meta.did);
-                    let consensus = store.get_identity(&did_hash).ok().flatten();
-                    out.insert(
-                        meta.did.clone(),
-                        Self::identity_transaction_data_from_sled(&meta, consensus.as_ref()),
+            match store.iter_identity_metadata() {
+                Ok(iter) => {
+                    for meta in iter {
+                        let did_hash = crate::storage::did_to_hash(&meta.did);
+                        let consensus = store.get_identity(&did_hash).ok().flatten();
+                        if let Some(data) =
+                            Self::identity_transaction_data_from_sled(&meta, consensus.as_ref())
+                        {
+                            out.insert(meta.did.clone(), data);
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "identity_registry_snapshot: sled iter failed; using in-memory shadow only"
                     );
                 }
             }
@@ -512,13 +532,26 @@ impl Blockchain {
     }
 
     /// Case-insensitive display-name collision check, sled-first (#2639).
+    ///
+    /// TODO(#2639): O(N) sled scan per check — add a `display_name_lower → did_hash`
+    /// secondary index before scale.
+    /// TODO(#2639): Unicode normalization — `.to_lowercase()` only; fullwidth
+    /// homoglyphs (e.g. `ＵｓｅｒＡ` vs `userA`) do not collide today.
     pub fn identity_display_name_taken(&self, display_name_lower: &str) -> bool {
         if let Some(store) = self.get_store() {
-            if let Ok(iter) = store.iter_identity_metadata() {
-                if iter.into_iter().any(|m| {
-                    m.display_name.to_lowercase() == display_name_lower
-                }) {
-                    return true;
+            match store.iter_identity_metadata() {
+                Ok(iter) => {
+                    if iter.into_iter().any(|m| {
+                        m.display_name.to_lowercase() == display_name_lower
+                    }) {
+                        return true;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "identity_display_name_taken: sled iter failed; using in-memory shadow only"
+                    );
                 }
             }
         }

--- a/lib-blockchain/src/blockchain/identity.rs
+++ b/lib-blockchain/src/blockchain/identity.rs
@@ -463,6 +463,14 @@ impl Blockchain {
                 return None;
             }
         };
+        if crate::types::hash::blake3_hash(&meta.public_key).as_array() != consensus.public_key_hash
+        {
+            tracing::warn!(
+                did = %meta.did,
+                "identity_transaction_data_from_sled: metadata key hash != consensus public_key_hash; refusing drifted key"
+            );
+            return None;
+        }
         Some(IdentityTransactionData {
             did: meta.did.clone(),
             display_name: meta.display_name.clone(),
@@ -486,12 +494,32 @@ impl Blockchain {
     pub fn identity_transaction_data(&self, did: &str) -> Option<IdentityTransactionData> {
         if let Some(store) = self.get_store() {
             let did_hash = crate::storage::did_to_hash(did);
-            if let Ok(Some(meta)) = store.get_identity_metadata(&did_hash) {
-                let consensus = store.get_identity(&did_hash).ok().flatten();
-                if let Some(data) =
-                    Self::identity_transaction_data_from_sled(&meta, consensus.as_ref())
-                {
-                    return Some(data);
+            match store.get_identity_metadata(&did_hash) {
+                Ok(Some(meta)) => {
+                    let consensus = match store.get_identity(&did_hash) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                did = %did,
+                                "identity_transaction_data: consensus read failed"
+                            );
+                            return self.identity_registry.get(did).cloned();
+                        }
+                    };
+                    if let Some(data) =
+                        Self::identity_transaction_data_from_sled(&meta, consensus.as_ref())
+                    {
+                        return Some(data);
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        did = %did,
+                        "identity_transaction_data: metadata read failed"
+                    );
                 }
             }
         }
@@ -509,7 +537,17 @@ impl Blockchain {
                 Ok(iter) => {
                     for meta in iter {
                         let did_hash = crate::storage::did_to_hash(&meta.did);
-                        let consensus = store.get_identity(&did_hash).ok().flatten();
+                        let consensus = match store.get_identity(&did_hash) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    did = %meta.did,
+                                    "identity_registry_snapshot: consensus read failed; skipping entry"
+                                );
+                                continue;
+                            }
+                        };
                         if let Some(data) =
                             Self::identity_transaction_data_from_sled(&meta, consensus.as_ref())
                         {
@@ -550,8 +588,9 @@ impl Blockchain {
                 Err(e) => {
                     tracing::warn!(
                         error = %e,
-                        "identity_display_name_taken: sled iter failed; using in-memory shadow only"
+                        "identity_display_name_taken: sled iter failed; failing closed (treat as taken)"
                     );
+                    return true;
                 }
             }
         }

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -542,12 +542,15 @@ fn identity_transaction_data_reads_sled_metadata() {
     let store = Arc::new(SledStore::open(&temp.path().join("id_tx_data")).unwrap());
     let did = "did:zhtp:tx-data";
     let did_hash = crate::storage::did_to_hash(did);
+    let pk = vec![0xAB; 2592];
+    let pk_hash = crate::types::hash::blake3_hash(&pk).as_array();
     store.begin_block(0).unwrap();
     store
         .put_identity(
             &did_hash,
             &IdentityConsensus {
                 did_hash,
+                public_key_hash: pk_hash,
                 created_at: 42,
                 registration_fee: 7,
                 ..Default::default()
@@ -560,7 +563,7 @@ fn identity_transaction_data_reads_sled_metadata() {
             &crate::storage::IdentityMetadata {
                 did: did.to_string(),
                 display_name: "Sled User".to_string(),
-                public_key: vec![0xAB; 2592],
+                public_key: pk,
                 ..Default::default()
             },
         )
@@ -583,9 +586,18 @@ fn identity_registry_snapshot_includes_sled_without_in_memory() {
     let store = Arc::new(SledStore::open(&temp.path().join("id_snapshot")).unwrap());
     let did = "did:zhtp:snapshot-only";
     let did_hash = crate::storage::did_to_hash(did);
+    let pk = vec![0xCD; 2592];
+    let pk_hash = crate::types::hash::blake3_hash(&pk).as_array();
     store.begin_block(0).unwrap();
     store
-        .put_identity(&did_hash, &IdentityConsensus { did_hash, ..Default::default() })
+        .put_identity(
+            &did_hash,
+            &IdentityConsensus {
+                did_hash,
+                public_key_hash: pk_hash,
+                ..Default::default()
+            },
+        )
         .unwrap();
     store
         .put_identity_metadata(
@@ -593,7 +605,7 @@ fn identity_registry_snapshot_includes_sled_without_in_memory() {
             &crate::storage::IdentityMetadata {
                 did: did.to_string(),
                 display_name: "Only Sled".to_string(),
-                public_key: vec![0xCD; 2592],
+                public_key: pk,
                 ..Default::default()
             },
         )
@@ -697,12 +709,15 @@ fn identity_registry_snapshot_overlay_in_memory_wins() {
     let store = Arc::new(SledStore::open(&temp.path().join("id_overlay")).unwrap());
     let did = "did:zhtp:overlay";
     let did_hash = crate::storage::did_to_hash(did);
+    let pk = vec![0xCD; 2592];
+    let pk_hash = crate::types::hash::blake3_hash(&pk).as_array();
     store.begin_block(0).unwrap();
     store
         .put_identity(
             &did_hash,
             &IdentityConsensus {
                 did_hash,
+                public_key_hash: pk_hash,
                 created_at: 1,
                 ..Default::default()
             },
@@ -714,7 +729,7 @@ fn identity_registry_snapshot_overlay_in_memory_wins() {
             &crate::storage::IdentityMetadata {
                 did: did.to_string(),
                 display_name: "From Sled".to_string(),
-                public_key: vec![0xCD; 2592],
+                public_key: pk,
                 ..Default::default()
             },
         )

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -635,6 +635,128 @@ fn identity_display_name_taken_reads_sled() {
     assert!(!bc.identity_display_name_taken("available"));
 }
 
+fn test_wallet_data(wallet_id: [u8; 32], name: &str) -> crate::transaction::WalletTransactionData {
+    crate::transaction::WalletTransactionData {
+        wallet_id: crate::types::hash::Hash::new(wallet_id),
+        wallet_type: "Primary".to_string(),
+        wallet_name: name.to_string(),
+        alias: None,
+        public_key: vec![],
+        owner_identity_id: None,
+        seed_commitment: crate::types::hash::Hash::zero(),
+        created_at: 0,
+        registration_fee: 0,
+        capabilities: 0,
+        initial_balance: 0,
+    }
+}
+
+#[test]
+fn wallet_exists_union_inmem_or_sled() {
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    let wallet_id = [0x77u8; 32];
+    let wallet_id_hex = hex::encode(wallet_id);
+    bc.wallet_registry.insert(
+        wallet_id_hex.clone(),
+        test_wallet_data(wallet_id, "In-Mem"),
+    );
+    assert!(bc.wallet_exists(&wallet_id_hex), "in-mem present -> true");
+    assert!(!bc.wallet_exists("00000000000000000000000000000000000000000000000000000000000000ab"));
+
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("wallet_exists")).unwrap());
+    store.begin_block(0).unwrap();
+    store
+        .put_wallet_projection(
+            &wallet_id,
+            &crate::storage::WalletProjectionRecord {
+                wallet_data: test_wallet_data(wallet_id, "Sled Only"),
+                committed_at_height: 0,
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc2 = Blockchain::new().expect("blockchain construct");
+    bc2.set_store(store);
+    assert!(bc2.wallet_exists(&wallet_id_hex), "sled-only wallet found via union");
+}
+
+#[test]
+fn wallet_transaction_data_reads_sled_projection() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("wallet_tx_data")).unwrap());
+    let wallet_id = [0x88u8; 32];
+    let wallet_id_hex = hex::encode(wallet_id);
+    store.begin_block(0).unwrap();
+    store
+        .put_wallet_projection(
+            &wallet_id,
+            &crate::storage::WalletProjectionRecord {
+                wallet_data: test_wallet_data(wallet_id, "Projection Wallet"),
+                committed_at_height: 3,
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    let got = bc
+        .wallet_transaction_data(&wallet_id_hex)
+        .expect("sled-backed wallet");
+    assert_eq!(got.wallet_name, "Projection Wallet");
+    assert_eq!(got.wallet_type, "Primary");
+}
+
+#[test]
+fn wallet_registry_snapshot_includes_sled_without_in_memory() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("wallet_snapshot")).unwrap());
+    let wallet_id = [0x99u8; 32];
+    let did_hex = hex::encode(wallet_id);
+    store.begin_block(0).unwrap();
+    store
+        .put_wallet_projection(
+            &wallet_id,
+            &crate::storage::WalletProjectionRecord {
+                wallet_data: test_wallet_data(wallet_id, "Only Sled"),
+                committed_at_height: 0,
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    let snap = bc.wallet_registry_snapshot();
+    assert_eq!(snap.get(&did_hex).map(|w| w.wallet_name.as_str()), Some("Only Sled"));
+}
+
+#[test]
+fn wallet_count_reads_sled() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("wallet_count")).unwrap());
+    store.begin_block(0).unwrap();
+    for i in 0..3u8 {
+        let wallet_id = [i; 32];
+        store
+            .put_wallet_projection(
+                &wallet_id,
+                &crate::storage::WalletProjectionRecord {
+                    wallet_data: test_wallet_data(wallet_id, &format!("Wallet{}", i)),
+                    committed_at_height: 0,
+                },
+            )
+            .unwrap();
+    }
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().unwrap();
+    bc.set_store(store);
+    assert_eq!(bc.wallet_count(), 3, "count comes from sled, not the in-mem shadow");
+}
+
 /// did_by_public_key() resolves a DID from a public key by scanning sled
 /// metadata even when the in-memory shadow is empty (restart case) — the read
 /// that lets council-membership / dedup checks work on a store-backed node

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -635,6 +635,119 @@ fn identity_display_name_taken_reads_sled() {
     assert!(!bc.identity_display_name_taken("available"));
 }
 
+#[test]
+fn identity_display_name_taken_sees_in_memory_pending_registration() {
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    let did = "did:zhtp:pending-name";
+    bc.identity_registry.insert(
+        did.to_string(),
+        crate::transaction::IdentityTransactionData {
+            did: did.to_string(),
+            display_name: "PendingUser".to_string(),
+            public_key: vec![0x11; 2592],
+            ownership_proof: vec![],
+            identity_type: "human".to_string(),
+            did_document_hash: crate::types::hash::Hash::zero(),
+            created_at: 1,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_nodes: vec![],
+            owned_wallets: vec![],
+            kyber_public_key: vec![],
+        },
+    );
+    assert!(bc.identity_display_name_taken("pendinguser"));
+}
+
+#[test]
+fn identity_transaction_data_skips_metadata_without_consensus() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("id_meta_only")).unwrap());
+    let did = "did:zhtp:meta-only";
+    let did_hash = crate::storage::did_to_hash(did);
+    store.begin_block(0).unwrap();
+    store
+        .put_identity_metadata(
+            &did_hash,
+            &crate::storage::IdentityMetadata {
+                did: did.to_string(),
+                display_name: "Broken".to_string(),
+                public_key: vec![0xAB; 2592],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    assert!(
+        bc.identity_transaction_data(did).is_none(),
+        "metadata without consensus must not surface as zero-filled record"
+    );
+    assert!(
+        bc.identity_registry_snapshot().get(did).is_none(),
+        "snapshot must skip half-broken sled rows"
+    );
+}
+
+#[test]
+fn identity_registry_snapshot_overlay_in_memory_wins() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("id_overlay")).unwrap());
+    let did = "did:zhtp:overlay";
+    let did_hash = crate::storage::did_to_hash(did);
+    store.begin_block(0).unwrap();
+    store
+        .put_identity(
+            &did_hash,
+            &IdentityConsensus {
+                did_hash,
+                created_at: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    store
+        .put_identity_metadata(
+            &did_hash,
+            &crate::storage::IdentityMetadata {
+                did: did.to_string(),
+                display_name: "From Sled".to_string(),
+                public_key: vec![0xCD; 2592],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    bc.identity_registry.insert(
+        did.to_string(),
+        crate::transaction::IdentityTransactionData {
+            did: did.to_string(),
+            display_name: "From InMem".to_string(),
+            public_key: vec![0xCD; 2592],
+            ownership_proof: vec![],
+            identity_type: "human".to_string(),
+            did_document_hash: crate::types::hash::Hash::zero(),
+            created_at: 99,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_nodes: vec![],
+            owned_wallets: vec![],
+            kyber_public_key: vec![],
+        },
+    );
+    let snap = bc.identity_registry_snapshot();
+    assert_eq!(
+        snap.get(did).map(|d| d.display_name.as_str()),
+        Some("From InMem"),
+        "in-memory overlay must win over sled"
+    );
+}
+
 fn test_wallet_data(wallet_id: [u8; 32], name: &str) -> crate::transaction::WalletTransactionData {
     crate::transaction::WalletTransactionData {
         wallet_id: crate::types::hash::Hash::new(wallet_id),
@@ -755,6 +868,73 @@ fn wallet_count_reads_sled() {
     let mut bc = Blockchain::new().unwrap();
     bc.set_store(store);
     assert_eq!(bc.wallet_count(), 3, "count comes from sled, not the in-mem shadow");
+}
+
+#[test]
+fn wallet_count_ignores_in_memory_only_entries() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("wallet_count_union")).unwrap());
+    store.begin_block(0).unwrap();
+    store
+        .put_wallet_projection(
+            &[1u8; 32],
+            &crate::storage::WalletProjectionRecord {
+                wallet_data: test_wallet_data([1u8; 32], "Sled"),
+                committed_at_height: 0,
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new_runtime_state();
+    bc.set_store(store);
+    let sled_hex = hex::encode([1u8; 32]);
+    let inmem_hex = hex::encode([2u8; 32]);
+    bc.wallet_registry
+        .insert(inmem_hex.clone(), test_wallet_data([2u8; 32], "InMemOnly"));
+    assert_eq!(bc.wallet_count(), 1, "count is sled cardinality, not union");
+    let snap = bc.wallet_registry_snapshot();
+    assert_eq!(
+        snap.get(&sled_hex).map(|w| w.wallet_name.as_str()),
+        Some("Sled")
+    );
+    assert_eq!(
+        snap.get(&inmem_hex).map(|w| w.wallet_name.as_str()),
+        Some("InMemOnly"),
+        "snapshot is sled ∪ in-memory overlay"
+    );
+}
+
+#[test]
+fn wallet_registry_snapshot_overlay_in_memory_wins() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("wallet_overlay")).unwrap());
+    let wallet_id = [0xAAu8; 32];
+    let wallet_id_hex = hex::encode(wallet_id);
+    store.begin_block(0).unwrap();
+    store
+        .put_wallet_projection(
+            &wallet_id,
+            &crate::storage::WalletProjectionRecord {
+                wallet_data: test_wallet_data(wallet_id, "From Sled"),
+                committed_at_height: 0,
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    bc.wallet_registry.insert(
+        wallet_id_hex.clone(),
+        test_wallet_data(wallet_id, "From InMem"),
+    );
+    let snap = bc.wallet_registry_snapshot();
+    assert_eq!(
+        snap.get(&wallet_id_hex).map(|w| w.wallet_name.as_str()),
+        Some("From InMem"),
+        "in-memory overlay must win over sled"
+    );
 }
 
 /// did_by_public_key() resolves a DID from a public key by scanning sled
@@ -1325,6 +1505,59 @@ fn validator_registry_snapshot_includes_sled_without_in_memory() {
     bc.store = Some(store);
     let snap = bc.validator_registry_snapshot();
     assert_eq!(snap.get(did).map(|v| v.stake), Some(300_000));
+}
+
+#[test]
+fn validator_registry_snapshot_overlay_in_memory_wins() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = std::sync::Arc::new(SledStore::open(&temp.path().join("val_overlay")).unwrap());
+    let did = "did:zhtp:val-overlay";
+    let did_hash = crate::storage::did_to_hash(did);
+    store
+        .put_validator_record_direct(
+            &did_hash,
+            &crate::storage::StoredValidatorRecord {
+                consensus: crate::storage::ValidatorConsensusRecord {
+                    identity_id: did.to_string(),
+                    consensus_key: [5u8; 2592],
+                    stake: 100_000,
+                    storage_provided: 1 << 40,
+                    status: "active".to_string(),
+                    oracle_key_id: None,
+                },
+                metadata: crate::storage::ValidatorMetadata::default(),
+            },
+        )
+        .unwrap();
+    let mut bc = Blockchain::new_runtime_state();
+    bc.store = Some(store);
+    bc.validator_registry.insert(
+        did.to_string(),
+        ValidatorInfo {
+            identity_id: did.to_string(),
+            stake: 999_000,
+            storage_provided: 1 << 40,
+            consensus_key: [5u8; 2592],
+            networking_key: vec![],
+            rewards_key: vec![],
+            network_address: "overlay:1".to_string(),
+            commission_rate: 0,
+            status: "active".to_string(),
+            registered_at: 0,
+            last_activity: 0,
+            blocks_validated: 0,
+            slash_count: 0,
+            admission_source: "test".to_string(),
+            governance_proposal_id: None,
+            oracle_key_id: None,
+        },
+    );
+    let snap = bc.validator_registry_snapshot();
+    assert_eq!(
+        snap.get(did).map(|v| v.stake),
+        Some(999_000),
+        "in-memory overlay must win over sled"
+    );
 }
 
 #[test]

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -1288,6 +1288,74 @@ fn legacy_fee_deduction_syncs_sled_balance() {
     );
 }
 
+#[test]
+fn validator_registry_snapshot_includes_sled_without_in_memory() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = std::sync::Arc::new(SledStore::open(&temp.path().join("val_snapshot")).unwrap());
+    let did = "did:zhtp:val-snapshot";
+    let did_hash = crate::storage::did_to_hash(did);
+    store
+        .put_validator_record_direct(
+            &did_hash,
+            &crate::storage::StoredValidatorRecord {
+                consensus: crate::storage::ValidatorConsensusRecord {
+                    identity_id: did.to_string(),
+                    consensus_key: [5u8; 2592],
+                    stake: 300_000,
+                    storage_provided: 1 << 40,
+                    status: "active".to_string(),
+                    oracle_key_id: None,
+                },
+                metadata: crate::storage::ValidatorMetadata {
+                    networking_key: vec![],
+                    rewards_key: vec![],
+                    network_address: "snap:1".to_string(),
+                    commission_rate: 0,
+                    registered_at: 0,
+                    last_activity: 0,
+                    blocks_validated: 0,
+                    slash_count: 0,
+                    admission_source: "test".to_string(),
+                    governance_proposal_id: None,
+                },
+            },
+        )
+        .unwrap();
+    let mut bc = Blockchain::new_runtime_state();
+    bc.store = Some(store);
+    let snap = bc.validator_registry_snapshot();
+    assert_eq!(snap.get(did).map(|v| v.stake), Some(300_000));
+}
+
+#[test]
+fn validator_count_reads_sled() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = std::sync::Arc::new(SledStore::open(&temp.path().join("val_count")).unwrap());
+    for i in 0..3u8 {
+        let did = format!("did:zhtp:val-count{}", i);
+        let did_hash = crate::storage::did_to_hash(&did);
+        store
+            .put_validator_record_direct(
+                &did_hash,
+                &crate::storage::StoredValidatorRecord {
+                    consensus: crate::storage::ValidatorConsensusRecord {
+                        identity_id: did,
+                        consensus_key: [i; 2592],
+                        stake: 100_000,
+                        storage_provided: 1 << 40,
+                        status: "active".to_string(),
+                        oracle_key_id: None,
+                    },
+                    metadata: crate::storage::ValidatorMetadata::default(),
+                },
+            )
+            .unwrap();
+    }
+    let mut bc = Blockchain::new_runtime_state();
+    bc.store = Some(store);
+    assert_eq!(bc.validator_count(), 3, "count comes from sled, not the in-mem shadow");
+}
+
 /// iter_token_contract_entries returns sled ids + metadata (#2637).
 #[test]
 fn iter_token_contract_entries_lists_sled_ids() {

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -536,6 +536,105 @@ fn identity_public_key_pins_to_consensus() {
     );
 }
 
+#[test]
+fn identity_transaction_data_reads_sled_metadata() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("id_tx_data")).unwrap());
+    let did = "did:zhtp:tx-data";
+    let did_hash = crate::storage::did_to_hash(did);
+    store.begin_block(0).unwrap();
+    store
+        .put_identity(
+            &did_hash,
+            &IdentityConsensus {
+                did_hash,
+                created_at: 42,
+                registration_fee: 7,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    store
+        .put_identity_metadata(
+            &did_hash,
+            &crate::storage::IdentityMetadata {
+                did: did.to_string(),
+                display_name: "Sled User".to_string(),
+                public_key: vec![0xAB; 2592],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    let got = bc
+        .identity_transaction_data(did)
+        .expect("sled-backed identity");
+    assert_eq!(got.display_name, "Sled User");
+    assert_eq!(got.created_at, 42);
+    assert_eq!(got.registration_fee, 7);
+}
+
+#[test]
+fn identity_registry_snapshot_includes_sled_without_in_memory() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("id_snapshot")).unwrap());
+    let did = "did:zhtp:snapshot-only";
+    let did_hash = crate::storage::did_to_hash(did);
+    store.begin_block(0).unwrap();
+    store
+        .put_identity(&did_hash, &IdentityConsensus { did_hash, ..Default::default() })
+        .unwrap();
+    store
+        .put_identity_metadata(
+            &did_hash,
+            &crate::storage::IdentityMetadata {
+                did: did.to_string(),
+                display_name: "Only Sled".to_string(),
+                public_key: vec![0xCD; 2592],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    let snap = bc.identity_registry_snapshot();
+    assert_eq!(snap.get(did).map(|d| d.display_name.as_str()), Some("Only Sled"));
+}
+
+#[test]
+fn identity_display_name_taken_reads_sled() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("id_name_taken")).unwrap());
+    let did = "did:zhtp:name-taken";
+    let did_hash = crate::storage::did_to_hash(did);
+    store.begin_block(0).unwrap();
+    store
+        .put_identity(&did_hash, &IdentityConsensus { did_hash, ..Default::default() })
+        .unwrap();
+    store
+        .put_identity_metadata(
+            &did_hash,
+            &crate::storage::IdentityMetadata {
+                did: did.to_string(),
+                display_name: "UniqueName".to_string(),
+                public_key: vec![0xEF; 2592],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    assert!(bc.identity_display_name_taken("uniquename"));
+    assert!(!bc.identity_display_name_taken("available"));
+}
+
 /// did_by_public_key() resolves a DID from a public key by scanning sled
 /// metadata even when the in-memory shadow is empty (restart case) — the read
 /// that lets council-membership / dedup checks work on a store-backed node

--- a/lib-blockchain/src/blockchain/validators.rs
+++ b/lib-blockchain/src/blockchain/validators.rs
@@ -172,6 +172,49 @@ impl Blockchain {
             .map(|rec| ValidatorInfo::from(&rec))
     }
 
+    /// Sled-first snapshot for backfill / iteration (#2639).
+    ///
+    /// Builds a map from durable validator records, then overlays the in-memory
+    /// shadow (pending / same-block registrations win).
+    pub fn validator_registry_snapshot(&self) -> HashMap<String, ValidatorInfo> {
+        let mut out = HashMap::new();
+        if let Some(store) = self.get_store() {
+            match store.iter_validator_records() {
+                Ok(iter) => {
+                    for rec in iter {
+                        out.insert(
+                            rec.consensus.identity_id.clone(),
+                            ValidatorInfo::from(&rec),
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        "validator_registry_snapshot: sled iter failed; using in-memory shadow only"
+                    );
+                }
+            }
+        }
+        for (did, info) in &self.validator_registry {
+            out.insert(did.clone(), info.clone());
+        }
+        out
+    }
+
+    /// Authoritative validator count from sled when attached (#2639).
+    pub fn validator_count(&self) -> usize {
+        if let Some(store) = self.get_store() {
+            match store.count_validator_records() {
+                Ok(n) => return n,
+                Err(e) => {
+                    warn!(error = %e, "validator_count: sled count failed; using in-memory shadow");
+                }
+            }
+        }
+        self.validator_registry.len()
+    }
+
     /// Authoritative active validator set for vote/propose/consensus sync (#56).
     ///
     /// Sled-first with in-memory overlay for same-block registrations. All

--- a/lib-blockchain/src/blockchain/validators.rs
+++ b/lib-blockchain/src/blockchain/validators.rs
@@ -203,6 +203,9 @@ impl Blockchain {
     }
 
     /// Authoritative validator count from sled when attached (#2639).
+    ///
+    /// Returns durable sled cardinality only — NOT a union with the in-memory
+    /// shadow (unlike [`validator_registry_snapshot`].len()).
     pub fn validator_count(&self) -> usize {
         if let Some(store) = self.get_store() {
             match store.count_validator_records() {

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -778,6 +778,10 @@ impl Blockchain {
         }
         if let Some(store) = self.get_store() {
             let Some(wallet_id_bytes) = Self::wallet_id_bytes_from_hex(wallet_id) else {
+                tracing::warn!(
+                    wallet_id = %wallet_id,
+                    "wallet_exists: invalid wallet_id hex; treating as absent"
+                );
                 return false;
             };
             match store.get_wallet_projection(&wallet_id_bytes) {
@@ -821,9 +825,17 @@ impl Blockchain {
     ) -> HashMap<String, crate::transaction::WalletTransactionData> {
         let mut out = HashMap::new();
         if let Some(store) = self.get_store() {
-            if let Ok(iter) = store.iter_wallet_projections() {
-                for (wallet_id, record) in iter {
-                    out.insert(hex::encode(wallet_id), record.wallet_data);
+            match store.iter_wallet_projections() {
+                Ok(iter) => {
+                    for (wallet_id, record) in iter {
+                        out.insert(hex::encode(wallet_id), record.wallet_data);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "wallet_registry_snapshot: sled iter failed; using in-memory shadow only"
+                    );
                 }
             }
         }
@@ -834,6 +846,10 @@ impl Blockchain {
     }
 
     /// Authoritative wallet count from sled when attached (#2639).
+    ///
+    /// Returns durable sled cardinality only — NOT a union with the in-memory
+    /// shadow (unlike [`wallet_registry_snapshot`].len()). Pending same-block
+    /// wallets are visible via the snapshot, not this count.
     pub fn wallet_count(&self) -> usize {
         if let Some(store) = self.get_store() {
             match store.count_wallet_projections() {

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -185,9 +185,9 @@ impl Blockchain {
 
         if let Some(owner) = owner_identity_id {
             let did = format!("did:zhtp:{}", hex::encode(owner.as_bytes()));
-            if let Some(identity) = self.identity_registry.get(&did) {
-                if identity.public_key.len() >= Self::MIN_DILITHIUM_PK_LEN {
-                    return Some(identity.public_key.clone());
+            if let Some(pk) = self.identity_public_key(&did) {
+                if pk.len() >= Self::MIN_DILITHIUM_PK_LEN {
+                    return Some(pk);
                 }
             }
         }
@@ -666,7 +666,7 @@ impl Blockchain {
         wallet_data: crate::transaction::WalletTransactionData,
     ) -> Result<Hash> {
         let wallet_id_str = hex::encode(wallet_data.wallet_id.as_bytes());
-        if self.wallet_registry.contains_key(&wallet_id_str) {
+        if self.wallet_exists(&wallet_id_str) {
             return Err(anyhow::anyhow!(
                 "Wallet {} already exists on blockchain",
                 wallet_id_str
@@ -757,8 +757,93 @@ impl Blockchain {
         self.wallet_registry.get(wallet_id)
     }
 
+    fn wallet_id_bytes_from_hex(wallet_id_hex: &str) -> Option<[u8; 32]> {
+        let bytes = hex::decode(wallet_id_hex).ok()?;
+        if bytes.len() != 32 {
+            return None;
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        Some(arr)
+    }
+
+    /// Union existence check across the in-memory shadow and durable sled (#2639).
+    ///
+    /// Checks the in-memory `wallet_registry` FIRST, then sled wallet projections.
+    /// Same ordering rationale as `identity_exists`: same-block / mempool wallets
+    /// are visible in-mem before commit; sled catches post-restart durable state.
     pub fn wallet_exists(&self, wallet_id: &str) -> bool {
-        self.wallet_registry.contains_key(wallet_id)
+        if self.wallet_registry.contains_key(wallet_id) {
+            return true;
+        }
+        if let Some(store) = self.get_store() {
+            let Some(wallet_id_bytes) = Self::wallet_id_bytes_from_hex(wallet_id) else {
+                return false;
+            };
+            match store.get_wallet_projection(&wallet_id_bytes) {
+                Ok(found) => return found.is_some(),
+                Err(e) => {
+                    tracing::warn!(
+                        wallet_id = %wallet_id,
+                        error = %e,
+                        "wallet_exists: sled read failed; treating as not-in-sled"
+                    );
+                }
+            }
+        }
+        false
+    }
+
+    /// Sled-first wallet record for handlers needing full `WalletTransactionData` (#2639).
+    ///
+    /// Returns an owned record from durable wallet projections when the store
+    /// is attached, with the in-memory shadow as the pre-commit / store-less fallback.
+    pub fn wallet_transaction_data(
+        &self,
+        wallet_id_hex: &str,
+    ) -> Option<crate::transaction::WalletTransactionData> {
+        if let Some(store) = self.get_store() {
+            if let Some(wallet_id_bytes) = Self::wallet_id_bytes_from_hex(wallet_id_hex) {
+                if let Ok(Some(record)) = store.get_wallet_projection(&wallet_id_bytes) {
+                    return Some(record.wallet_data);
+                }
+            }
+        }
+        self.wallet_registry.get(wallet_id_hex).cloned()
+    }
+
+    /// Sled-first snapshot for backfill / iteration (#2639).
+    ///
+    /// Builds a map from durable wallet projections, then overlays the in-memory
+    /// shadow (pending / same-block registrations win).
+    pub fn wallet_registry_snapshot(
+        &self,
+    ) -> HashMap<String, crate::transaction::WalletTransactionData> {
+        let mut out = HashMap::new();
+        if let Some(store) = self.get_store() {
+            if let Ok(iter) = store.iter_wallet_projections() {
+                for (wallet_id, record) in iter {
+                    out.insert(hex::encode(wallet_id), record.wallet_data);
+                }
+            }
+        }
+        for (wallet_id_hex, data) in &self.wallet_registry {
+            out.insert(wallet_id_hex.clone(), data.clone());
+        }
+        out
+    }
+
+    /// Authoritative wallet count from sled when attached (#2639).
+    pub fn wallet_count(&self) -> usize {
+        if let Some(store) = self.get_store() {
+            match store.count_wallet_projections() {
+                Ok(n) => return n,
+                Err(e) => {
+                    tracing::warn!(error = %e, "wallet_count: sled count failed; using in-memory shadow");
+                }
+            }
+        }
+        self.wallet_registry.len()
     }
 
     pub fn list_all_wallets(&self) -> Vec<&crate::transaction::WalletTransactionData> {

--- a/lib-blockchain/src/ipc/server.rs
+++ b/lib-blockchain/src/ipc/server.rs
@@ -167,7 +167,7 @@ async fn dispatch_request(
         }
         IpcRequest::QueryWallet { wallet_id } => {
             let bc = blockchain.read().await;
-            IpcResponse::Wallet(bc.query_wallet(wallet_id).cloned())
+            IpcResponse::Wallet(bc.wallet_transaction_data(wallet_id))
         }
         IpcRequest::QueryValidator { did } => {
             let bc = blockchain.read().await;

--- a/lib-blockchain/src/ipc/server.rs
+++ b/lib-blockchain/src/ipc/server.rs
@@ -171,7 +171,7 @@ async fn dispatch_request(
         }
         IpcRequest::QueryValidator { did } => {
             let bc = blockchain.read().await;
-            IpcResponse::Validator(bc.query_validator(did).cloned())
+            IpcResponse::Validator(bc.validator_info_by_did(did))
         }
         IpcRequest::QueryIsCouncilMember { did } => {
             let bc = blockchain.read().await;

--- a/lib-blockchain/src/ipc/server.rs
+++ b/lib-blockchain/src/ipc/server.rs
@@ -151,14 +151,13 @@ async fn dispatch_request(
         }
         IpcRequest::QueryIdentity { did } => {
             let bc = blockchain.read().await;
-            IpcResponse::Identity(bc.query_identity(did).cloned())
+            IpcResponse::Identity(bc.identity_transaction_data(did))
         }
         IpcRequest::QueryAllIdentities => {
             let bc = blockchain.read().await;
             let owned: Vec<(String, crate::transaction::IdentityTransactionData)> = bc
-                .query_all_identities()
+                .identity_registry_snapshot()
                 .into_iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
             IpcResponse::AllIdentities(owned)
         }

--- a/lib-blockchain/src/query_impl.rs
+++ b/lib-blockchain/src/query_impl.rs
@@ -47,10 +47,12 @@ impl BlockchainQuery for Blockchain {
     }
 
     fn query_identity(&self, did: &str) -> Option<&IdentityTransactionData> {
+        // In-memory ref only — sled-backed identities use identity_transaction_data().
         self.identity_registry.get(did)
     }
 
     fn query_all_identities(&self) -> Vec<(&String, &IdentityTransactionData)> {
+        // Legacy ref iterator — IPC uses identity_registry_snapshot() instead (#2639).
         self.identity_registry.iter().collect()
     }
 

--- a/lib-blockchain/src/query_impl.rs
+++ b/lib-blockchain/src/query_impl.rs
@@ -77,21 +77,13 @@ impl BlockchainQuery for Blockchain {
     }
 
     fn query_validator(&self, did: &str) -> Option<&ValidatorInfo> {
-        // #56: sled-first path returns owned data; query surface still serves
-        // in-memory refs when present (same-block overlay).
+        // In-memory ref only — sled-backed validators use validator_info_by_did().
         self.validator_registry.get(did)
     }
 
     fn query_validator_count(&self) -> usize {
-        if let Some(store) = self.get_store() {
-            match store.count_validator_records() {
-                Ok(n) => return n,
-                Err(e) => {
-                    tracing::warn!(error = %e, "query_validator_count: sled count failed; using in-memory shadow");
-                }
-            }
-        }
-        self.validator_registry.len()
+        // #2639: authoritative sled count (in-memory shadow is non-durable).
+        self.validator_count()
     }
 
     fn query_is_council_member(&self, did: &str) -> bool {
@@ -140,6 +132,7 @@ impl BlockchainQuery for Blockchain {
     }
 
     fn query_all_validators(&self) -> Vec<(&String, &crate::blockchain::ValidatorInfo)> {
+        // Legacy ref iterator — handlers use validator_registry_snapshot() instead (#2639).
         self.validator_registry.iter().collect()
     }
 

--- a/lib-blockchain/src/query_impl.rs
+++ b/lib-blockchain/src/query_impl.rs
@@ -62,15 +62,18 @@ impl BlockchainQuery for Blockchain {
     }
 
     fn query_wallet_exists(&self, wallet_id: &str) -> bool {
-        self.wallet_registry.contains_key(wallet_id)
+        // #2639: sled-first union — in-memory shadow can be empty after restart.
+        self.wallet_exists(wallet_id)
     }
 
     fn query_wallet(&self, wallet_id: &str) -> Option<&WalletTransactionData> {
+        // In-memory ref only — sled-backed wallets use wallet_transaction_data().
         self.wallet_registry.get(wallet_id)
     }
 
     fn query_wallet_count(&self) -> usize {
-        self.wallet_registry.len()
+        // #2639: authoritative sled count (in-memory shadow is non-durable).
+        self.wallet_count()
     }
 
     fn query_validator(&self, did: &str) -> Option<&ValidatorInfo> {
@@ -132,6 +135,7 @@ impl BlockchainQuery for Blockchain {
     }
 
     fn query_all_wallets(&self) -> Vec<(&String, &WalletTransactionData)> {
+        // Legacy ref iterator — handlers use wallet_registry_snapshot() instead (#2639).
         self.wallet_registry.iter().collect()
     }
 

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -1192,8 +1192,14 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     fn delete_wallet_projection(&self, wallet_id: &[u8; 32]) -> StorageResult<()>;
 
     /// Count wallet projection entries (authoritative sled cardinality).
+    ///
+    /// Implementations should override with an O(1) tree length when available;
+    /// the default deliberately errors rather than silently O(N)-scanning.
     fn count_wallet_projections(&self) -> StorageResult<usize> {
-        Ok(self.iter_wallet_projections()?.count())
+        Err(StorageError::Database(
+            "count_wallet_projections not implemented for this BlockchainStore backend"
+                .to_string(),
+        ))
     }
 
     /// Iterate all wallet projection entries.

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -1191,6 +1191,11 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     /// - MUST be called within begin_block/commit_block
     fn delete_wallet_projection(&self, wallet_id: &[u8; 32]) -> StorageResult<()>;
 
+    /// Count wallet projection entries (authoritative sled cardinality).
+    fn count_wallet_projections(&self) -> StorageResult<usize> {
+        Ok(self.iter_wallet_projections()?.count())
+    }
+
     /// Iterate all wallet projection entries.
     fn iter_wallet_projections(
         &self,

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -588,6 +588,11 @@ impl SledStore {
         Ok(())
     }
 
+    /// Count wallet projection entries.
+    pub fn count_wallet_projections(&self) -> StorageResult<usize> {
+        Ok(self.wallets.len())
+    }
+
     /// Iterate all wallet projection entries.
     pub fn iter_wallet_projections(&self) -> StorageResult<Vec<([u8; 32], WalletProjectionRecord)>> {
         let mut entries = Vec::new();
@@ -1736,6 +1741,10 @@ impl BlockchainStore for SledStore {
 
     fn delete_wallet_projection(&self, wallet_id: &[u8; 32]) -> StorageResult<()> {
         SledStore::delete_wallet_projection(self, wallet_id)
+    }
+
+    fn count_wallet_projections(&self) -> StorageResult<usize> {
+        SledStore::count_wallet_projections(self)
     }
 
     fn iter_wallet_projections(

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1696,8 +1696,8 @@ impl BlockchainHandler {
         let blockchain_arc = self.get_blockchain().await?;
         let blockchain = blockchain_arc.read().await;
 
-        // Get validators directly from blockchain validator_registry
-        let all_validators = blockchain.get_all_validators();
+        // Sled-first validator snapshot (#2639).
+        let all_validators = blockchain.validator_registry_snapshot();
 
         // Map validator info to API format
         let validators: Vec<ValidatorInfo> = all_validators

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1355,9 +1355,7 @@ impl BlockchainHandler {
                     }
                 }
                 "did" => {
-                    if let Some(identity) =
-                        blockchain.identity_transaction_data(&value.to_string())
-                    {
+                    if let Some(identity) = blockchain.identity_transaction_data(&value) {
                         let identity_mgr = self.identity_manager.read().await;
                         let view = identity_mgr.get_identity_view_by_did(&principal, &identity.did);
                         let (controlled_nodes, owned_wallets) = match view {
@@ -3103,7 +3101,7 @@ impl BlockchainHandler {
         let blockchain = blockchain_arc.read().await;
 
         // Query identity from registry
-        if let Some(identity) = blockchain.identity_transaction_data(&did.to_string()) {
+        if let Some(identity) = blockchain.identity_transaction_data(did) {
             let response_data = match view {
                 Some(lib_identity::types::IdentityView::Public(_)) => {
                     serde_json::json!({

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1355,7 +1355,9 @@ impl BlockchainHandler {
                     }
                 }
                 "did" => {
-                    if let Some(identity) = blockchain.query_identity(&value.to_string()) {
+                    if let Some(identity) =
+                        blockchain.identity_transaction_data(&value.to_string())
+                    {
                         let identity_mgr = self.identity_manager.read().await;
                         let view = identity_mgr.get_identity_view_by_did(&principal, &identity.did);
                         let (controlled_nodes, owned_wallets) = match view {
@@ -3101,7 +3103,7 @@ impl BlockchainHandler {
         let blockchain = blockchain_arc.read().await;
 
         // Query identity from registry
-        if let Some(identity) = blockchain.query_identity(&did.to_string()) {
+        if let Some(identity) = blockchain.identity_transaction_data(&did.to_string()) {
             let response_data = match view {
                 Some(lib_identity::types::IdentityView::Public(_)) => {
                     serde_json::json!({

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -1322,7 +1322,7 @@ impl BlockchainHandler {
         };
 
         let resolve_wallet = |wallet_id: &str| -> Option<serde_json::Value> {
-            let wallet = blockchain.query_wallet(wallet_id)?;
+            let wallet = blockchain.wallet_transaction_data(wallet_id)?;
             Some(serde_json::json!({
                 "wallet_id": wallet_id,
                 "wallet_name": wallet.wallet_name,
@@ -3220,7 +3220,7 @@ impl BlockchainHandler {
 
         // Collect wallets, optionally filtering by owner_identity_id
         let wallets: Vec<serde_json::Value> = blockchain
-            .wallet_registry
+            .wallet_registry_snapshot()
             .iter()
             .filter(|(_, wallet)| {
                 if let Some(ref owner_id) = owner_filter {

--- a/zhtp/src/api/handlers/dao/mod.rs
+++ b/zhtp/src/api/handlers/dao/mod.rs
@@ -806,15 +806,7 @@ impl DaoHandler {
             data.validate(current_epoch)
                 .map_err(|e| anyhow::anyhow!("Invalid oracle committee update payload: {}", e))?;
 
-            let active_validator_key_ids: std::collections::HashSet<[u8; 32]> = blockchain
-                .validator_registry
-                .values()
-                .filter(|v| v.status == "active")
-                .map(|v| {
-                    v.oracle_key_id
-                        .unwrap_or_else(|| lib_blockchain::blake3_hash(&v.consensus_key).as_array())
-                })
-                .collect();
+            let active_validator_key_ids = blockchain.active_validator_key_ids();
 
             for member in &data.new_members {
                 if !active_validator_key_ids.contains(member) {

--- a/zhtp/src/api/handlers/identity/backup_recovery.rs
+++ b/zhtp/src/api/handlers/identity/backup_recovery.rs
@@ -1527,7 +1527,7 @@ pub async fn handle_migrate_identity(
                 let token_opt = blockchain.query_token_contract(&sov_token_id);
                 _has_token_contract = token_opt.is_some();
 
-                for (wallet_id_str, wallet_data) in blockchain.query_all_wallets() {
+                for (wallet_id_str, wallet_data) in blockchain.wallet_registry_snapshot() {
                     if wallet_data.owner_identity_id == Some(old_identity_id_chain.clone()) {
                         registry_owned_count += 1;
                         wallet_ids_all.insert(wallet_id_str.clone());
@@ -1762,7 +1762,7 @@ pub async fn handle_migrate_identity(
                 .iter()
                 .map(|(wid, _, _)| hex::encode(wid.0))
                 .collect();
-            for (wallet_id_str, wallet_data) in blockchain.query_all_wallets() {
+            for (wallet_id_str, wallet_data) in blockchain.wallet_registry_snapshot() {
                 if wallet_data.owner_identity_id == Some(old_identity_id_chain.clone()) {
                     wallet_ids_all.insert(wallet_id_str.clone());
                 }
@@ -1816,7 +1816,7 @@ pub async fn handle_migrate_identity(
                     key_id: wallet_id_bytes,
                 };
 
-                if let Some(existing) = blockchain.query_wallet(wallet_id_str).cloned() {
+                if let Some(existing) = blockchain.wallet_transaction_data(wallet_id_str) {
                     let wallet_type = existing.wallet_type.clone();
                     let old_public_key = existing.public_key.clone();
                     let old_pk_is_short = old_public_key.len() < MIN_DILITHIUM_PK_LEN;

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1110,10 +1110,7 @@ impl IdentityHandler {
             let blockchain_arc =
                 crate::runtime::blockchain_provider::get_global_blockchain().await?;
             let blockchain = blockchain_arc.read().await;
-            blockchain
-                .identity_registry
-                .values()
-                .any(|id| id.display_name.to_lowercase() == username_lower)
+            blockchain.identity_display_name_taken(&username_lower)
         };
 
         let response_body = json!({

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -963,7 +963,7 @@ impl NetworkHandler {
         // whether *its own* identity has a chain-side tx — and the mobile
         // app reads this `state` field to decide whether the node is
         // reachable.
-        let node_is_known_validator = blockchain.query_validator(&node_did).is_some();
+        let node_is_known_validator = blockchain.validator_info_by_did(&node_did).is_some();
         let identity_known_to_chain = identity_registered || node_is_known_validator;
 
         let state = if node_did == "not_initialized" {
@@ -1170,11 +1170,11 @@ impl NetworkHandler {
         // Build validator entries from on-chain registry, with IP overlay
         let ip_overlay = crate::runtime::validator_ip::get_all_resolved_addresses();
         let validators: Vec<serde_json::Value> = blockchain
-            .validator_registry
-            .iter()
-            .filter(|(_, v)| v.status == "active")
-            .map(|(did, v)| {
-                let endpoint = ip_overlay.get(did).unwrap_or(&v.network_address);
+            .active_validator_infos()
+            .into_iter()
+            .map(|v| {
+                let did = v.identity_id.clone();
+                let endpoint = ip_overlay.get(&did).unwrap_or(&v.network_address);
                 let ip = Self::extract_host(endpoint);
                 let spki_pin = known_spki_pins.get(ip.as_str()).copied();
                 serde_json::json!({

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -911,7 +911,7 @@ impl NetworkHandler {
                 Ok(owner_bytes) => {
                     let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
 
-                    let wallet = blockchain.query_all_wallets().into_iter().find(|(_, w)| {
+                    let wallet = blockchain.wallet_registry_snapshot().into_iter().find(|(_, w)| {
                         w.owner_identity_id
                             .as_ref()
                             .map(|id| id.as_bytes() == owner_bytes.as_slice())

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -669,7 +669,7 @@ impl TokenHandler {
         use lib_blockchain::contracts::utils::generate_lib_token_id;
 
         let blockchain = self.blockchain.read().await;
-        let target_key_id = if let Some(wallet) = blockchain.query_wallet(address) {
+        let target_key_id = if let Some(wallet) = blockchain.wallet_transaction_data(address) {
             let wallet_pk = PublicKey::new(
                 wallet.public_key.as_slice().try_into().unwrap_or([0u8; 2592])
             );
@@ -850,7 +850,7 @@ impl TokenHandler {
 
         // Otherwise treat it as identity_id and try to find the Primary wallet.
         let identity_hash = lib_blockchain::Hash::from_slice(&bytes);
-        let primary_wallet = blockchain.query_all_wallets().into_iter().find(|(_, wallet)| {
+        let primary_wallet = blockchain.wallet_registry_snapshot().into_iter().find(|(_, wallet)| {
             wallet.owner_identity_id.as_ref() == Some(&identity_hash)
                 && wallet.wallet_type == "Primary"
         })?;

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -296,7 +296,7 @@ impl WalletHandler {
         if wallet_summaries.is_empty() {
             // Fallback: surface wallets from the on-chain registry that belong to this identity.
             let blockchain = self.blockchain.read().await;
-            for (wallet_id_hex, wallet_data) in blockchain.query_all_wallets() {
+            for (wallet_id_hex, wallet_data) in blockchain.wallet_registry_snapshot() {
                 let owned = wallet_data
                     .owner_identity_id
                     .map(|owner| owner.as_bytes() == identity_id_bytes.as_slice())
@@ -314,7 +314,7 @@ impl WalletHandler {
                 // here guarantees the mobile wallet displays the post-debit
                 // balance immediately after a domain registration fee_payment_tx
                 // commits.
-                let effective_balance = hex::decode(wallet_id_hex)
+                let effective_balance = hex::decode(&wallet_id_hex)
                     .ok()
                     .filter(|b| b.len() == 32)
                     .map(|bytes| {
@@ -525,7 +525,7 @@ impl WalletHandler {
                 // Prefer SOV token contract balance (live balance) for this wallet.
                 let blockchain = self.blockchain.read().await;
                 let wallet_id_hex = hex::encode(summary.id.0);
-                if let Some(wallet_data) = blockchain.query_wallet(&wallet_id_hex) {
+                if let Some(wallet_data) = blockchain.wallet_transaction_data(&wallet_id_hex) {
                     // #2637: sled-first SOV balance. Gate on the contract existing
                     // (preserves the prior "only override if SOV token present"
                     // behavior), then read via token_balance() keyed by key_id —
@@ -1303,7 +1303,7 @@ impl WalletHandler {
 
         // Include any wallet registry entries linked to this identity that may
         // not be present in the in-memory identity wallet manager.
-        for (wallet_id_hex, wallet_data) in blockchain.query_all_wallets() {
+        for (wallet_id_hex, wallet_data) in blockchain.wallet_registry_snapshot() {
             if wallet_data
                 .owner_identity_id
                 .as_ref()

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -1224,7 +1224,7 @@ async fn backfill_identities_from_blockchain(
 
     let bc = blockchain_arc.read().await;
     let identity_registry = bc.identity_registry_snapshot();
-    let wallet_registry = bc.wallet_registry.clone();
+    let wallet_registry = bc.wallet_registry_snapshot();
     drop(bc);
 
     if identity_registry.is_empty() {

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -1087,7 +1087,7 @@ async fn bootstrap_identities_from_dht(
                                 ) {
                                     if let Some(ref bc_arc) = blockchain_arc {
                                         let bc = bc_arc.read().await;
-                                        if let Some(wallet_data) = bc.wallet_registry.get(wid) {
+                                        if let Some(wallet_data) = bc.wallet_transaction_data(wid) {
                                             if let Some(wallet) =
                                                 identity.wallet_manager.get_wallet_mut(&wallet_id)
                                             {
@@ -1106,7 +1106,7 @@ async fn bootstrap_identities_from_dht(
                                 ) {
                                     if let Some(ref bc_arc) = blockchain_arc {
                                         let bc = bc_arc.read().await;
-                                        if let Some(wallet_data) = bc.wallet_registry.get(wid) {
+                                        if let Some(wallet_data) = bc.wallet_transaction_data(wid) {
                                             if let Some(wallet) =
                                                 identity.wallet_manager.get_wallet_mut(&wallet_id)
                                             {
@@ -1124,7 +1124,7 @@ async fn bootstrap_identities_from_dht(
                                 ) {
                                     if let Some(ref bc_arc) = blockchain_arc {
                                         let bc = bc_arc.read().await;
-                                        if let Some(wallet_data) = bc.wallet_registry.get(wid) {
+                                        if let Some(wallet_data) = bc.wallet_transaction_data(wid) {
                                             if let Some(wallet) =
                                                 identity.wallet_manager.get_wallet_mut(&wallet_id)
                                             {

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -568,7 +568,7 @@ async fn migrate_identities_to_blockchain() -> Result<(u32, u32)> {
         // Check if already on blockchain
         {
             let bc = blockchain_arc.read().await;
-            if bc.identity_registry.contains_key(did) {
+            if bc.identity_exists(did) {
                 debug!("Identity {} already on blockchain, skipping", id_preview);
                 skipped += 1;
                 continue;
@@ -1223,7 +1223,7 @@ async fn backfill_identities_from_blockchain(
     };
 
     let bc = blockchain_arc.read().await;
-    let identity_registry = bc.identity_registry.clone();
+    let identity_registry = bc.identity_registry_snapshot();
     let wallet_registry = bc.wallet_registry.clone();
     drop(bc);
 

--- a/zhtp/src/runtime/components/oracle.rs
+++ b/zhtp/src/runtime/components/oracle.rs
@@ -84,9 +84,9 @@ impl OracleComponent {
                 for _ in 0..60 {
                     let count = {
                         let b = bc.read().await;
-                        b.validator_registry
-                            .values()
-                            .filter(|v| v.status == "active" && !v.consensus_key.is_empty())
+                        b.active_validator_infos()
+                            .into_iter()
+                            .filter(|v| !v.consensus_key.is_empty())
                             .count()
                     };
                     if count >= 2 {
@@ -176,7 +176,7 @@ impl OracleComponent {
             // then validator_registry consensus keys as fallback.
             let oracle_pubkeys = bc.oracle_state.oracle_signing_pubkeys.clone();
             let key_map: Vec<([u8; 32], [u8; 2592])> = bc
-                .validator_registry
+                .validator_registry_snapshot()
                 .values()
                 .filter(|v| !v.consensus_key.is_empty())
                 .map(|v| {
@@ -521,7 +521,7 @@ impl OracleComponent {
                         let epoch2 = bc.oracle_state.epoch_id(bc.last_committed_timestamp());
                         let oracle_pubkeys2 = bc.oracle_state.oracle_signing_pubkeys.clone();
                         let key_map: Vec<([u8; 32], [u8; 2592])> = bc
-                            .validator_registry
+                            .validator_registry_snapshot()
                             .values()
                             .filter(|v| !v.consensus_key.is_empty())
                             .map(|v| {

--- a/zhtp/src/runtime/components/oracle.rs
+++ b/zhtp/src/runtime/components/oracle.rs
@@ -173,11 +173,13 @@ impl OracleComponent {
             }
 
             // Build key lookup: oracle_signing_pubkeys (from bootstrap) takes priority,
-            // then validator_registry consensus keys as fallback.
+            // then active validators' consensus keys as fallback. Use
+            // active_validator_infos (not validator_registry_snapshot) so
+            // deregistered validators' keys are excluded from attestation verification.
             let oracle_pubkeys = bc.oracle_state.oracle_signing_pubkeys.clone();
             let key_map: Vec<([u8; 32], [u8; 2592])> = bc
-                .validator_registry_snapshot()
-                .values()
+                .active_validator_infos()
+                .into_iter()
                 .filter(|v| !v.consensus_key.is_empty())
                 .map(|v| {
                     let kid = lib_blockchain::blake3_hash(&v.consensus_key).as_array();
@@ -520,9 +522,10 @@ impl OracleComponent {
                         let mut bc = blockchain.write().await;
                         let epoch2 = bc.oracle_state.epoch_id(bc.last_committed_timestamp());
                         let oracle_pubkeys2 = bc.oracle_state.oracle_signing_pubkeys.clone();
+                        // Active validators only — see consumer key_map comment above.
                         let key_map: Vec<([u8; 32], [u8; 2592])> = bc
-                            .validator_registry_snapshot()
-                            .values()
+                            .active_validator_infos()
+                            .into_iter()
                             .filter(|v| !v.consensus_key.is_empty())
                             .map(|v| {
                                 let kid = lib_blockchain::blake3_hash(&v.consensus_key).as_array();

--- a/zhtp/src/runtime/components/protocols.rs
+++ b/zhtp/src/runtime/components/protocols.rs
@@ -466,9 +466,8 @@ impl Component for ProtocolsComponent {
                         Ok(bc) => bc,
                         Err(_) => return fallback_ips.clone(),
                     };
-                    let ips: Vec<std::net::Ipv4Addr> = bc.validator_registry
-                        .values()
-                        .filter(|v| v.status == "active")
+                    let ips: Vec<std::net::Ipv4Addr> = bc.active_validator_infos()
+                        .into_iter()
                         .filter_map(|v| {
                             let host = v.network_address.split(':').next()?;
                             host.parse::<std::net::Ipv4Addr>().ok()

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -3605,9 +3605,8 @@ impl RuntimeOrchestrator {
         const DILITHIUM5_PK_LEN: usize = 2592;
 
         let mut committee_members_with_pubkeys: Vec<([u8; 32], Vec<u8>)> = blockchain
-            .validator_registry
-            .values()
-            .filter(|v| v.status == "active")
+            .active_validator_infos()
+            .into_iter()
             .filter_map(|v| {
                 if v.consensus_key == [0u8; 2592] {
                     return None;
@@ -3679,7 +3678,7 @@ impl RuntimeOrchestrator {
         let mut blockchain = blockchain_arc.write().await;
 
         // Idempotent: skip if this node is already in validator_registry
-        if blockchain.validator_registry.contains_key(&node_did) {
+        if blockchain.validator_exists(&node_did) {
             info!(
                 "ℹ️ Node {} already in validator_registry, skipping self-registration",
                 &node_did[..40]

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -3178,7 +3178,7 @@ impl RuntimeOrchestrator {
 
                                 // Check if wallet exists in registry
                                 if let Some(wallet_entry) =
-                                    blockchain_ref.wallet_registry.get(&wallet_id_hex)
+                                    blockchain_ref.wallet_transaction_data(&wallet_id_hex)
                                 {
                                     // Wallet exists - check if it needs funding
                                     if wallet_entry.initial_balance == 0

--- a/zhtp/src/runtime/validator_ip.rs
+++ b/zhtp/src/runtime/validator_ip.rs
@@ -74,7 +74,7 @@ pub async fn update_validator_ips(own_did: Option<&str>, stun_ip: Option<Ipv4Add
 
         // 1. Own entry with STUN-discovered IP
         if let (Some(did), Some(ip)) = (own_did, stun_ip) {
-            if let Some(validator) = blockchain.validator_registry.get(did) {
+            if let Some(validator) = blockchain.validator_info_by_did(did) {
                 let port = validator
                     .network_address
                     .split(':')
@@ -94,7 +94,7 @@ pub async fn update_validator_ips(own_did: Option<&str>, stun_ip: Option<Ipv4Add
 
         // 2. Collect hostname-based entries that need resolution
         blockchain
-            .validator_registry
+            .validator_registry_snapshot()
             .iter()
             .filter(|(did, _)| own_did.map_or(true, |own| *did != own))
             .filter(|(_, v)| {

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -2189,10 +2189,7 @@ struct BlockchainIdentityRegistryVerifier {
 impl IdentityRegistryVerifier for BlockchainIdentityRegistryVerifier {
     async fn is_registered(&self, did: &str) -> Result<bool> {
         let bc = self.blockchain.read().await;
-        // #2639: identity via sled-union (in-mem OR durable sled). Without this a
-        // restarted store-backed node has an empty in-mem registry and would
-        // reject EVERY peer (network partition). validator_registry stays in-mem
-        // pending its own sled write-path (#2639 deferral).
-        Ok(bc.identity_exists(did) || bc.validator_registry.contains_key(did))
+        // #2639: sled-union for both identity and validator registries.
+        Ok(bc.identity_exists(did) || bc.validator_exists(did))
     }
 }


### PR DESCRIPTION
## Summary

Completes #2639 read-migration for all three registries: identity, wallet, and validator. Handlers, IPC, and runtime read paths now use sled-first facades instead of direct in-memory HashMap access, which is empty or partial on store-backed nodes after restart.

## Phase 1 — Identity

New facades in `lib-blockchain/src/blockchain/identity.rs`: `identity_transaction_data`, `identity_registry_snapshot`, `identity_display_name_taken`. Migrated identity handlers, runtime backfill, blockchain search, IPC.

## Phase 2 — Wallet

New facades in `wallets.rs`: `wallet_exists`, `wallet_transaction_data`, `wallet_registry_snapshot`, `wallet_count`. Migrated query/IPC and zhtp wallet/token/network/backup_recovery handlers.

## Phase 3 — Validator

New facades in `validators.rs`: `validator_registry_snapshot`, `validator_count` (plus existing `validator_info_by_did`, `active_validator_infos`). Migrated network, oracle, protocols, unified_server peer verifier. Consensus sync unchanged (already sled-first).

## Tests

Facade tests for all three registries; `cargo build -p zhtp` passes.

## After merge

Soak on store-backed node, close #2639, proceed to #2640.

Closes #2639