### PR TITLE
fix(#2638): fail closed on token nonce sled read errors

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2308,7 +2308,17 @@ impl Blockchain {
                 } else {
                     transfer.token_id
                 };
-                let expected = self.get_token_nonce(&token_id, &transfer.from);
+                let expected = match self.token_nonce(&token_id, &transfer.from) {
+                    Ok(n) => n,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            tx = %tx.hash(),
+                            "is_nonce_current: nonce read failed; failing closed (rejecting tx)"
+                        );
+                        return false;
+                    }
+                };
                 if transfer.nonce < expected {
                     tracing::debug!(
                         "Stale nonce: tx {} has nonce {} but chain expects {} for sender {}",
@@ -2679,6 +2689,11 @@ impl Blockchain {
     ///   (populated from the TokenStateSnapshot on restart and incremented
     ///   during `process_token_transactions`). The store is consulted only
     ///   when the HashMap has no entry yet (e.g. pre-snapshot-load).
+    /// Legacy convenience wrapper returning `0` on sled read failure.
+    ///
+    /// Prefer [`token_nonce`] for admission / write paths — swallowing errors
+    /// here can treat a failed read as nonce-0 and admit replayable transfers.
+    /// [`is_nonce_current`] uses `token_nonce` directly and fails closed.
     pub fn get_token_nonce(&self, token_id: &[u8; 32], address: &[u8; 32]) -> u64 {
         self.token_nonce(token_id, address).unwrap_or(0)
     }

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -121,6 +121,70 @@ fn token_nonce_reads_sled_when_store_attached() {
 }
 
 #[test]
+fn is_nonce_current_reads_sled_nonce_not_stale_in_memory() {
+    use crate::transaction::{TokenTransferData, Transaction, TransactionPayload};
+    use crate::types::TransactionType;
+
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("nonce_gate_store")).unwrap());
+    let token_id = [0xDDu8; 32];
+    let sender = [0xEEu8; 32];
+    let token = TokenId::new(token_id);
+    let addr = Address::new(sender);
+    store.begin_block(0).unwrap();
+    store.set_token_nonce(&token, &addr, 5).unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    bc.token_nonces.insert((token_id, sender), 0);
+
+    let current_tx = Transaction {
+        version: 2,
+        chain_id: 0x03,
+        transaction_type: TransactionType::TokenTransfer,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: crate::integration::crypto_integration::Signature::default(),
+        memo: vec![],
+        payload: TransactionPayload::TokenTransfer(TokenTransferData {
+            token_id,
+            from: sender,
+            to: [0x11; 32],
+            amount: 1,
+            nonce: 5,
+        }),
+    };
+    let stale_tx = Transaction {
+        version: 2,
+        chain_id: 0x03,
+        transaction_type: TransactionType::TokenTransfer,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: crate::integration::crypto_integration::Signature::default(),
+        memo: vec![],
+        payload: TransactionPayload::TokenTransfer(TokenTransferData {
+            token_id,
+            from: sender,
+            to: [0x11; 32],
+            amount: 1,
+            nonce: 0,
+        }),
+    };
+
+    assert!(
+        bc.is_nonce_current(&current_tx),
+        "nonce matching sled value must be accepted"
+    );
+    assert!(
+        !bc.is_nonce_current(&stale_tx),
+        "stale in-memory nonce-0 must be rejected when sled expects 5"
+    );
+}
+
+#[test]
 fn token_balance_reads_sled_when_store_attached() {
     let temp = tempfile::tempdir().unwrap();
     let store = Arc::new(SledStore::open(&temp.path().join("facade_bal_store")).unwrap());

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -465,7 +465,7 @@ impl RewardsHandler {
         let nonce = {
             let bc = self.blockchain.read().await;
             bc.token_nonce(&treasury.bubl_token_id, &treasury.signer_key_id)
-                .unwrap_or(0)
+                .map_err(|e| anyhow!("nonce lookup failed: {e}"))?
         };
 
         let data = TokenTransferData {

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -618,7 +618,15 @@ impl TokenHandler {
         address.copy_from_slice(&address_bytes);
 
         let blockchain = self.blockchain.read().await;
-        let nonce = blockchain.token_nonce(&token_id, &address).unwrap_or(0);
+        let nonce = match blockchain.token_nonce(&token_id, &address) {
+            Ok(n) => n,
+            Err(e) => {
+                return Ok(create_error_response(
+                    ZhtpStatus::InternalServerError,
+                    format!("nonce lookup failed: {e}"),
+                ));
+            }
+        };
 
         create_json_response(json!({
             "token_id": token_id_hex,


### PR DESCRIPTION
## Summary

Follow-up to #2714 (#2638 token nonce facade): closes the gap where sled nonce read failures were silently treated as nonce `0`, allowing replayable transfers through mempool admission, pending-tx recovery, and proposer filtering.

## Changes

### High — `is_nonce_current` fail-closed (`lib-blockchain/src/blockchain.rs`)

Switched from `get_token_nonce` (which collapses `token_nonce` errors via `unwrap_or(0)`) to `token_nonce` directly. On `Err`, logs a warning and returns `false` — the tx is rejected/evicted rather than treated as matching nonce 0.

Affects:
- Mempool admission (`add_pending_transaction`)
- Post-commit stale-nonce eviction
- Pending-tx recovery (`init.rs`)
- Proposer nonce filter (`consensus.rs`)

### Medium — API handlers surface storage failures

- **`rewards/mod.rs`** — `mint_to_user` returns `nonce lookup failed: {e}` instead of building a nonce-0 transfer
- **`token/mod.rs`** — `GET /api/v1/token/nonce/...` returns 500 with error message (matches observer admission pattern)

### Documentation

`get_token_nonce` doc warns it is a legacy convenience wrapper; admission/write paths should use `token_nonce`.

## Tests

- `is_nonce_current_reads_sled_nonce_not_stale_in_memory` — sled nonce 5 authoritative over stale in-memory 0

## Related

- #2714 / #2638 — token nonce facade introduction
- CONS-513 — sled-first nonce reads