### PR TITLE
fix(#2637): PR #2712 retroactive token-balance facade review

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -1072,8 +1072,10 @@ impl Blockchain {
             match executor.apply_block(&block) {
                 Ok(_outcome) => {
                     // Block applied successfully through executor.
-                    // Writes path: sync in-memory token_contracts from sled after apply.
-                    // Public reads must use token_balance() — not this HashMap (#2637).
+                    // Writes path: sync in-memory token_contracts from sled after apply
+                    // (SOV/CBE addresses touched in this block only). The HashMap is a
+                    // legacy-write cache — NOT authoritative for public reads; handlers
+                    // must use token_balance() (#2637).
                     if let Some(store) = &self.store {
                         let sov_id = crate::contracts::utils::generate_lib_token_id();
                         let storage_sov_id = crate::storage::TokenId(sov_id);
@@ -1896,6 +1898,15 @@ impl Blockchain {
             })
             .collect();
 
+        // Legacy-path fee debits write in-mem first; mirror to sled when attached so
+        // sled-first reads (token_balance) observe the debit (#2712 review).
+        let mirror_fee_to_sled = self.get_store().is_some();
+        let mut sled_fee_sync: Vec<(
+            crate::storage::TokenId,
+            crate::storage::Address,
+            u128,
+        )> = Vec::new();
+
         // Get mutable reference to SOV token contract
         let sov_token = match self.token_contracts.get_mut(&sov_token_id) {
             Some(token) => token,
@@ -1915,8 +1926,7 @@ impl Blockchain {
             let tx = &block.transactions[*i];
             let sender = &tx.signature.public_key;
 
-            // Check sender's balance before deduction.
-            // Writes path: legacy in-memory fee debit below; HashMap is authoritative here.
+            // Check sender's balance before deduction (legacy in-mem path).
             let sender_balance = sov_token.balance_of(&fee_payer);
             if sender_balance < tx.fee as u128 {
                 // This shouldn't happen if validation is working correctly
@@ -1936,6 +1946,13 @@ impl Blockchain {
             // but this historical fee deduction maintains existing behavior.
             let new_balance = sender_balance - tx.fee as u128;
             sov_token.set_balance(&fee_payer, new_balance);
+            if mirror_fee_to_sled {
+                sled_fee_sync.push((
+                    crate::storage::TokenId::new(sov_token_id),
+                    crate::storage::Address::new(fee_payer.key_id),
+                    new_balance,
+                ));
+            }
 
             total_fees = total_fees.saturating_add(tx.fee);
 
@@ -1958,8 +1975,16 @@ impl Blockchain {
                         treasury_id.copy_from_slice(&bytes);
                         let treasury_key = Self::wallet_key_for_sov(&treasury_id);
                         let treasury_balance = sov_token.balance_of(&treasury_key);
-                        sov_token
-                            .set_balance(&treasury_key, treasury_balance.saturating_add(total_fees as u128));
+                        let new_treasury_balance =
+                            treasury_balance.saturating_add(total_fees as u128);
+                        sov_token.set_balance(&treasury_key, new_treasury_balance);
+                        if mirror_fee_to_sled {
+                            sled_fee_sync.push((
+                                crate::storage::TokenId::new(sov_token_id),
+                                crate::storage::Address::new(treasury_id),
+                                new_treasury_balance,
+                            ));
+                        }
                         debug!(
                             "Block {} fees credited to DAO treasury: {} SOV",
                             block.height(),
@@ -1990,6 +2015,23 @@ impl Blockchain {
                     })
                     .count()
             );
+        }
+
+        if let Some(store) = self.get_store() {
+            if !sled_fee_sync.is_empty() {
+                match store.force_set_token_balances(&sled_fee_sync) {
+                    Ok(n) => debug!(
+                        "legacy fee path: synced {} sled balance(s) for block {}",
+                        n,
+                        block.height()
+                    ),
+                    Err(e) => warn!(
+                        error = %e,
+                        block = block.height(),
+                        "legacy fee path: failed to sync sled balances after in-mem debit"
+                    ),
+                }
+            }
         }
 
         Ok(total_fees)

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1250,8 +1250,14 @@ impl Blockchain {
     /// Sled-first `(token_id, metadata)` pairs for listing (#2637).
     pub fn iter_token_contract_entries(&self) -> Vec<([u8; 32], crate::contracts::TokenContract)> {
         if let Some(store) = self.get_store() {
-            if let Ok(iter) = store.iter_token_contracts() {
-                return iter.map(|(id, c)| (id.0, c)).collect();
+            match store.iter_token_contracts() {
+                Ok(iter) => return iter.map(|(id, c)| (id.0, c)).collect(),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "iter_token_contract_entries: sled iter failed — falling back to in-memory map"
+                    );
+                }
             }
         }
         self.token_contracts

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -848,6 +848,161 @@ fn validator_exists_union_inmem_or_sled() {
     assert_eq!(got.stake, 200_000);
 }
 
+/// Custom tokens (BUBL class): executor writes balances to the sled
+/// `token_balances` tree only — in-mem `TokenContract.balances` stays empty.
+/// sled-first `token_balance()` must return the sled value, not 0 from in-mem.
+#[test]
+fn custom_token_balance_reads_sled_not_in_memory() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("bubl_bal_store")).unwrap());
+    let token_id = [0xBB; 32];
+    let holder = [0x42; 32];
+    let creator = crate::integration::crypto_integration::PublicKey::new([1u8; 2592]);
+    let contract = crate::contracts::TokenContract::new(
+        token_id,
+        "Bubble".to_string(),
+        "BUBL".to_string(),
+        8,
+        1_000_000,
+        false,
+        0,
+        creator,
+    );
+    store.begin_block(0).unwrap();
+    store.put_token_contract(&contract).unwrap();
+    store
+        .set_token_balance(
+            &TokenId::new(token_id),
+            &Address::new(holder),
+            5_000,
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    // Simulate post-restart: no in-mem contract overlay.
+    assert!(
+        !bc.token_contracts.contains_key(&token_id),
+        "test premise: custom token exists only in sled"
+    );
+    assert_eq!(
+        bc.token_balance(&token_id, &holder).unwrap(),
+        5_000,
+        "facade must read sled balance for custom token (BUBL class)"
+    );
+    // In-mem-only read would wrongly return 0 — regression guard.
+    assert_eq!(
+        bc.token_contracts
+            .get(&token_id)
+            .map(|c| c.balance_of(&crate::integration::crypto_integration::PublicKey::new(
+                [0u8; 2592]
+            )))
+            .unwrap_or(0),
+        0,
+        "in-mem path absent/empty — the bug #2637 fixed"
+    );
+}
+
+/// Legacy fee path debits in-mem; sled must be updated so token_balance() agrees.
+#[test]
+fn legacy_fee_deduction_syncs_sled_balance() {
+    use crate::block::{Block, BlockHeader};
+    use crate::contracts::utils::generate_lib_token_id;
+    use crate::transaction::{
+        Transaction, TransactionInput, TransactionOutput, TransactionPayload,
+    };
+    use crate::types::TransactionType;
+    use lib_crypto::types::keys::PublicKey;
+    use lib_crypto::types::signatures::{Signature, SignatureAlgorithm};
+
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("fee_sled_sync")).unwrap());
+    let sov_id = generate_lib_token_id();
+    let sender_id = [0x11u8; 32];
+    let sender = PublicKey {
+        dilithium_pk: [0u8; 2592],
+        kyber_pk: [0u8; 1568],
+        key_id: sender_id,
+    };
+    let initial: u128 = 10_000;
+    let fee: u64 = 250;
+
+    store
+        .force_set_token_balances(&[(
+            TokenId::new(sov_id),
+            Address::new(sender_id),
+            initial,
+        )])
+        .unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store.clone());
+    let sov = crate::contracts::TokenContract::new_sov_native();
+    bc.token_contracts.insert(sov_id, sov);
+    bc.token_contracts
+        .get_mut(&sov_id)
+        .unwrap()
+        .set_balance(&sender, initial);
+
+    let tx = Transaction {
+        version: 1,
+        chain_id: 0x03,
+        transaction_type: TransactionType::Transfer,
+        inputs: vec![TransactionInput {
+            previous_output: crate::types::hash::Hash::new([1u8; 32]),
+            output_index: 0,
+            nullifier: crate::types::hash::Hash::new([2u8; 32]),
+            zk_proof: crate::integration::zk_integration::ZkTransactionProof::default(),
+        }],
+        outputs: vec![TransactionOutput {
+            commitment: crate::types::hash::Hash::new([3u8; 32]),
+            note: crate::types::hash::Hash::new([4u8; 32]),
+            recipient: PublicKey::new([5u8; 2592]),
+            merkle_leaf: crate::types::hash::Hash::default(),
+        }],
+        fee,
+        signature: Signature {
+            signature: vec![0u8; 64],
+            public_key: sender.clone(),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 0,
+        },
+        memo: vec![],
+        payload: TransactionPayload::None,
+    };
+    let block = Block::new(
+        BlockHeader {
+            version: 1,
+            previous_hash: crate::types::hash::Hash::zero().into(),
+            data_helix_root: crate::types::hash::Hash::zero().into(),
+            timestamp: 0,
+            height: 1,
+            verification_helix_root: [0u8; 32],
+            state_root: crate::types::hash::Hash::default().into(),
+            bft_quorum_root: [0u8; 32],
+            block_hash: crate::types::hash::Hash::zero(),
+        },
+        vec![tx],
+    );
+
+    let collected = bc.deduct_transaction_fees(&block).unwrap();
+    assert_eq!(collected, fee);
+
+    let expected = initial - fee as u128;
+    assert_eq!(
+        bc.token_balance(&sov_id, &sender_id).unwrap(),
+        expected,
+        "sled-first read must see legacy fee debit"
+    );
+    assert_eq!(
+        store
+            .get_token_balance(&TokenId::new(sov_id), &Address::new(sender_id))
+            .unwrap(),
+        expected
+    );
+}
+
 /// iter_token_contract_entries returns sled ids + metadata (#2637).
 #[test]
 fn iter_token_contract_entries_lists_sled_ids() {

--- a/lib-blockchain/src/query.rs
+++ b/lib-blockchain/src/query.rs
@@ -89,6 +89,10 @@ pub trait BlockchainQuery {
 
     /// Get token balance for an address. Reads from sled (authoritative) with
     /// in-memory fallback. Returns 0 if token or address not found.
+    ///
+    /// **Limitation:** sled I/O errors are swallowed as 0 (trait returns `u128`,
+    /// not `Result`). Callers needing fail-closed semantics should use
+    /// `Blockchain::token_balance` directly.
     fn query_token_balance(&self, token_id: &[u8; 32], key_id: &[u8; 32]) -> u128;
 
     /// Get a token contract by ID (from sled or in-memory).

--- a/lib-blockchain/src/query_impl.rs
+++ b/lib-blockchain/src/query_impl.rs
@@ -114,6 +114,7 @@ impl BlockchainQuery for Blockchain {
     }
 
     fn query_token_balance(&self, token_id: &[u8; 32], key_id: &[u8; 32]) -> u128 {
+        // Trait API returns u128 — sled errors surface as 0 (parity with pre-#2637).
         self.token_balance(token_id, key_id).unwrap_or(0)
     }
 

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -1258,11 +1258,17 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     /// Unlike `set_token_balance`, this does NOT require an active block transaction.
     /// Use ONLY in startup migrations (e.g., correcting backfill inflation), never
     /// during block execution.
+    ///
+    /// SledStore implements this path. Other backends must override or callers
+    /// receive an explicit error — never a silent `Ok(0)` no-write.
     fn force_set_token_balances(
         &self,
         _entries: &[(TokenId, Address, u128)],
     ) -> StorageResult<usize> {
-        Ok(0) // Default no-op
+        Err(StorageError::Database(
+            "force_set_token_balances not implemented for this BlockchainStore backend"
+                .to_string(),
+        ))
     }
 
     // =========================================================================

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -684,6 +684,8 @@ impl TokenHandler {
         let mut balances = Vec::new();
 
         // Collect balances from all token contracts (sled-first metadata list).
+        // TODO(#2637): O(N) sled reads per token — add caching/pagination if
+        // user-creatable tokens grow beyond a handful.
         for (token_id, token) in blockchain.iter_token_contract_entries() {
             let balance = if token_id == native_token_id {
                 sov_wallet_id

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -220,6 +220,11 @@ impl GenesisFundingService {
             wallet_id_bytes_arr.copy_from_slice(&wallet_id.0);
             let recipient_pk =
                 lib_blockchain::contracts::utils::wallet_key_for_sov(wallet_id_bytes_arr);
+            // Genesis-only dual-write: in-mem mint + sled force_set. Gated on
+            // current_balance == 0 (idempotent welcome bonus). Runtime balance
+            // mutations must NOT follow this pattern — executor/sled is authoritative.
+            // Must run before the consensus loop (force_set errors if tx_active).
+            // TODO(#2637): collapse to a single sled write once in-mem mint is removed.
             if blockchain.get_token_contract(&sov_token_id).is_some() {
                 let current_balance = blockchain
                     .token_balance(&sov_token_id, &wallet_id_bytes_arr)


### PR DESCRIPTION
## Summary

Retroactive follow-up to merged #2712 (token balance sled-first facade). Addresses review findings that were not blockers for merge but improve correctness, hygiene, and test coverage.

## Changes

| Finding | Fix |
|---------|-----|
| `force_set_token_balances` trait default `Ok(0)` silent no-op | Default → `Err` (matches `count_token_holders` / #2715 pattern) |
| `iter_token_contract_entries` silent sled-iter fallback | `warn!` on iter failure |
| Legacy fee path in-mem debit invisible to sled-first reads (#9) | Mirror debits to sled via `force_set_token_balances` when store attached |
| Contradictory in-mem cache comment (#8) | Clarify: legacy-write cache only, not authoritative for public reads |
| `genesis_funding.rs` dual-write (#2) | Explicit genesis-only comment + ordering constraint |
| `query_token_balance` error swallowing (#7) | Trait + impl doc comments |
| O(N) balance enumeration perf (#5) | TODO on `handle_get_balances_for_address` |
| Thin test coverage (#10) | `custom_token_balance_reads_sled_not_in_memory` (BUBL class) + `legacy_fee_deduction_syncs_sled_balance` |

**No action:** finding #1 (dead `create_domain_fee_system_tx` window — closed by #2713), finding #6 (double sled read — TODO deferred).

## Test plan

- [x] `cargo test -p lib-blockchain --lib custom_token_balance`
- [x] `cargo test -p lib-blockchain --lib legacy_fee_deduction`