### PR TITLE
feat(#2640): privatize Blockchain registry fields and migrate callers

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -159,12 +159,14 @@ pub struct Blockchain {
     /// On-chain identity registry (DID -> Identity data). Legacy write shadow —
     /// external callers must use facades / `register_identity` (#2640).
     pub(crate) identity_registry: HashMap<String, IdentityTransactionData>,
-    /// Identity DID to block height mapping for verification
+    /// Identity DID → registration block height (height-index metadata, not
+    /// authoritative registry state). Privatization deferred past #2640.
     pub identity_blocks: HashMap<String, u64>,
     /// On-chain wallet registry (wallet_id -> Wallet data). Legacy write shadow —
     /// external callers must use facades / `register_wallet` (#2640).
     pub(crate) wallet_registry: HashMap<String, crate::transaction::WalletTransactionData>,
-    /// Wallet ID to block height mapping for verification
+    /// Wallet ID → registration block height (height-index metadata).
+    /// Privatization deferred past #2640.
     pub wallet_blocks: HashMap<String, u64>,
     /// Smart contract registry - Token contracts (contract_id -> TokenContract).
     /// Legacy write shadow — external callers must use facades / store APIs (#2640).
@@ -191,7 +193,8 @@ pub struct Blockchain {
     /// shadow — external callers must use facades / `register_validator` (#2640).
     #[serde(default)]
     pub(crate) validator_registry: HashMap<String, ValidatorInfo>,
-    /// Validator registration block heights (identity_id -> block_height)
+    /// Validator registration block heights (identity_id → block_height).
+    /// Height-index metadata; privatization deferred past #2640.
     #[serde(default)]
     pub validator_blocks: HashMap<String, u64>,
     /// Cached sled-first active set; invalidated by generation token or overlay fingerprint.

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -156,17 +156,20 @@ pub struct Blockchain {
     pub nullifier_set: HashSet<Hash>,
     /// Pending transactions waiting to be mined
     pub pending_transactions: Vec<Transaction>,
-    /// On-chain identity registry (DID -> Identity data)
-    pub identity_registry: HashMap<String, IdentityTransactionData>,
+    /// On-chain identity registry (DID -> Identity data). Legacy write shadow —
+    /// external callers must use facades / `register_identity` (#2640).
+    pub(crate) identity_registry: HashMap<String, IdentityTransactionData>,
     /// Identity DID to block height mapping for verification
     pub identity_blocks: HashMap<String, u64>,
-    /// On-chain wallet registry (wallet_id -> Wallet data)
-    pub wallet_registry: HashMap<String, crate::transaction::WalletTransactionData>,
+    /// On-chain wallet registry (wallet_id -> Wallet data). Legacy write shadow —
+    /// external callers must use facades / `register_wallet` (#2640).
+    pub(crate) wallet_registry: HashMap<String, crate::transaction::WalletTransactionData>,
     /// Wallet ID to block height mapping for verification
     pub wallet_blocks: HashMap<String, u64>,
-    /// Smart contract registry - Token contracts (contract_id -> TokenContract)
+    /// Smart contract registry - Token contracts (contract_id -> TokenContract).
+    /// Legacy write shadow — external callers must use facades / store APIs (#2640).
     #[serde(default)]
-    pub token_contracts: HashMap<[u8; 32], crate::contracts::TokenContract>,
+    pub(crate) token_contracts: HashMap<[u8; 32], crate::contracts::TokenContract>,
     /// Smart contract registry - Web4 Website contracts (contract_id -> Web4Contract)
     #[serde(default)]
     pub web4_contracts: HashMap<[u8; 32], crate::contracts::web4::Web4Contract>,
@@ -184,9 +187,10 @@ pub struct Blockchain {
     /// Indexed DAO registry (dao_id -> entry), updated incrementally per block.
     #[serde(default)]
     pub dao_registry_index: HashMap<[u8; 32], DaoRegistryIndexEntry>,
-    /// On-chain validator registry (identity_id -> Validator info)
+    /// On-chain validator registry (identity_id -> Validator info). Legacy write
+    /// shadow — external callers must use facades / `register_validator` (#2640).
     #[serde(default)]
-    pub validator_registry: HashMap<String, ValidatorInfo>,
+    pub(crate) validator_registry: HashMap<String, ValidatorInfo>,
     /// Validator registration block heights (identity_id -> block_height)
     #[serde(default)]
     pub validator_blocks: HashMap<String, u64>,
@@ -289,10 +293,10 @@ pub struct Blockchain {
     /// UBI registration block heights (identity_id -> block_height)
     #[serde(default)]
     pub ubi_blocks: HashMap<String, u64>,
-    /// Per-token, per-address nonce for token transfer replay protection
-    /// Key: (token_id, sender address) where address is wallet_id for SOV or key_id for custom tokens
+    /// Per-token, per-address nonce for token transfer replay protection.
+    /// Key: (token_id, sender address). External reads use `token_nonce()` (#2640).
     #[serde(default)]
-    pub token_nonces: HashMap<([u8; 32], [u8; 32]), u64>,
+    pub(crate) token_nonces: HashMap<([u8; 32], [u8; 32]), u64>,
     /// Block executor for state changes
     /// When present, this is the SINGLE SOURCE OF TRUTH for state mutations.
     /// All block applications should go through this executor.

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1299,6 +1299,40 @@ impl Blockchain {
         &self.token_contracts
     }
 
+    /// Number of in-memory token contract entries (metadata shadow; use
+    /// `iter_token_contract_entries` for sled-first listing).
+    pub fn token_contract_count(&self) -> usize {
+        self.token_contracts.len()
+    }
+
+    pub fn token_contracts_is_empty(&self) -> bool {
+        self.token_contracts.is_empty()
+    }
+
+    /// Legacy in-memory shadow insert — genesis/bootstrap only (#2640).
+    pub fn insert_token_contract(
+        &mut self,
+        contract_id: [u8; 32],
+        contract: crate::contracts::TokenContract,
+    ) {
+        self.token_contracts.insert(contract_id, contract);
+    }
+
+    /// Legacy in-memory shadow insert — genesis/bootstrap/tests (#2640).
+    pub fn insert_token_nonce_shadow(
+        &mut self,
+        token_id: [u8; 32],
+        sender: [u8; 32],
+        nonce: u64,
+    ) {
+        self.token_nonces.insert((token_id, sender), nonce);
+    }
+
+    /// Snapshot of in-memory token nonces (tests / persistence parity; reads use `token_nonce`).
+    pub fn token_nonces_snapshot(&self) -> HashMap<([u8; 32], [u8; 32]), u64> {
+        self.token_nonces.clone()
+    }
+
     pub fn get_all_web4_contracts(
         &self,
     ) -> &HashMap<[u8; 32], crate::contracts::web4::Web4Contract> {

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1295,8 +1295,33 @@ impl Blockchain {
         self.web4_contracts.get_mut(contract_id)
     }
 
-    pub fn get_all_token_contracts(&self) -> &HashMap<[u8; 32], crate::contracts::TokenContract> {
+    pub(crate) fn get_all_token_contracts(&self) -> &HashMap<[u8; 32], crate::contracts::TokenContract> {
         &self.token_contracts
+    }
+
+    /// In-memory shadow only — whether a token contract entry exists locally.
+    pub fn token_contract_shadow_contains_key(&self, contract_id: &[u8; 32]) -> bool {
+        self.token_contracts.contains_key(contract_id)
+    }
+
+    /// In-memory shadow only — read a token contract from the local map (audit/tests).
+    pub fn token_contract_shadow(
+        &self,
+        contract_id: &[u8; 32],
+    ) -> Option<&crate::contracts::TokenContract> {
+        self.token_contracts.get(contract_id)
+    }
+
+    /// Cardinality of the in-memory token-contract shadow (audit / divergence tooling).
+    pub fn token_contract_shadow_len(&self) -> usize {
+        self.token_contracts.len()
+    }
+
+    /// Iterate in-memory token contract shadow values (tests / audit only).
+    pub fn iter_token_contract_shadow_values(
+        &self,
+    ) -> impl Iterator<Item = &crate::contracts::TokenContract> {
+        self.token_contracts.values()
     }
 
     /// Number of in-memory token contract entries (metadata shadow; use
@@ -1328,7 +1353,8 @@ impl Blockchain {
         self.token_nonces.insert((token_id, sender), nonce);
     }
 
-    /// Snapshot of in-memory token nonces (tests / persistence parity; reads use `token_nonce`).
+    /// Clone of the in-memory token-nonce shadow. **Tests and persistence parity
+    /// only** — production reads must use `token_nonce()`. Clones the full map.
     pub fn token_nonces_snapshot(&self) -> HashMap<([u8; 32], [u8; 32]), u64> {
         self.token_nonces.clone()
     }

--- a/lib-blockchain/src/blockchain/identity.rs
+++ b/lib-blockchain/src/blockchain/identity.rs
@@ -1,6 +1,19 @@
 use super::*;
 
 impl Blockchain {
+    /// Legacy in-memory shadow insert — genesis/bootstrap only (#2640).
+    pub fn insert_identity_shadow(&mut self, did: String, data: IdentityTransactionData) {
+        self.identity_registry.insert(did, data);
+    }
+
+    /// Mutable access to the in-memory identity shadow (same-block / cache warmup).
+    pub fn identity_registry_entry_mut(
+        &mut self,
+        did: &str,
+    ) -> Option<&mut IdentityTransactionData> {
+        self.identity_registry.get_mut(did)
+    }
+
     pub fn register_identity(&mut self, identity_data: IdentityTransactionData) -> Result<Hash> {
         // #2639: union check — also catches a DID already committed to sled but
         // absent from the in-memory shadow after a restart, which the bare

--- a/lib-blockchain/src/blockchain/identity.rs
+++ b/lib-blockchain/src/blockchain/identity.rs
@@ -6,12 +6,58 @@ impl Blockchain {
         self.identity_registry.insert(did, data);
     }
 
-    /// Mutable access to the in-memory identity shadow (same-block / cache warmup).
-    pub fn identity_registry_entry_mut(
-        &mut self,
-        did: &str,
-    ) -> Option<&mut IdentityTransactionData> {
-        self.identity_registry.get_mut(did)
+    /// In-memory shadow only — test premises that must not use sled-first facades.
+    pub fn identity_shadow_contains_key(&self, did: &str) -> bool {
+        self.identity_registry.contains_key(did)
+    }
+
+    /// In-memory shadow only — whether any entry carries this exact public key bytes.
+    pub fn identity_shadow_any_public_key(&self, pk: &[u8]) -> bool {
+        self.identity_registry
+            .values()
+            .any(|identity| identity.public_key == pk)
+    }
+
+    /// Patch Kyber key in the in-memory identity shadow (cache warmup before tx commit).
+    pub fn update_identity_shadow_kyber_public_key(&mut self, did: &str, key: Vec<u8>) -> bool {
+        if let Some(entry) = self.identity_registry.get_mut(did) {
+            entry.kyber_public_key = key;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Patch display name in the in-memory identity shadow (username claim mirror).
+    pub fn update_identity_shadow_display_name(&mut self, did: &str, name: String) -> bool {
+        if let Some(entry) = self.identity_registry.get_mut(did) {
+            entry.display_name = name;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Append a controlled node id to the in-memory identity shadow.
+    pub fn push_identity_shadow_controlled_node(&mut self, did: &str, node_id: String) -> bool {
+        if let Some(entry) = self.identity_registry.get_mut(did) {
+            if !entry.controlled_nodes.contains(&node_id) {
+                entry.controlled_nodes.push(node_id);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Test/bootstrap helper: set identity_type on an in-memory shadow entry.
+    pub fn set_identity_shadow_type(&mut self, did: &str, identity_type: String) -> bool {
+        if let Some(entry) = self.identity_registry.get_mut(did) {
+            entry.identity_type = identity_type;
+            true
+        } else {
+            false
+        }
     }
 
     pub fn register_identity(&mut self, identity_data: IdentityTransactionData) -> Result<Hash> {

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -426,7 +426,7 @@ fn identity_exists_union_inmem_or_sled() {
     let mut bc2 = Blockchain::new().unwrap();
     bc2.set_store(store);
     assert!(
-        bc2.get_identity(did).is_none(),
+        !bc2.identity_shadow_contains_key(did),
         "test premise: this DID is sled-only (absent from the in-mem shadow)"
     );
     assert!(bc2.identity_exists(did), "sled-only identity found via union");
@@ -996,7 +996,7 @@ fn did_by_public_key_reads_sled_metadata() {
     let mut bc = Blockchain::new().unwrap();
     bc.set_store(store.clone());
     assert!(
-        bc.get_identity(did).is_none(),
+        !bc.identity_shadow_contains_key(did) && !bc.identity_shadow_any_public_key(&pk),
         "test premise: this pubkey is sled-only (in-mem shadow empty, like after restart)"
     );
     assert_eq!(
@@ -1090,7 +1090,7 @@ fn identity_controlled_nodes_reads_sled_metadata() {
     let mut bc = Blockchain::new().unwrap();
     bc.set_store(store);
     assert!(
-        bc.get_identity(did).is_none(),
+        !bc.identity_shadow_contains_key(did),
         "test premise: DID is sled-only (in-mem shadow empty, like after restart)"
     );
     assert_eq!(
@@ -1149,7 +1149,7 @@ fn did_by_device_key_id_reads_sled_metadata() {
     let mut bc = Blockchain::new().unwrap();
     bc.set_store(store.clone());
     assert!(
-        bc.get_identity(did).is_none(),
+        !bc.identity_shadow_contains_key(did) && !bc.identity_shadow_any_public_key(&pk),
         "test premise: this identity is sled-only (absent from the in-mem shadow, like after restart)"
     );
 
@@ -1286,7 +1286,7 @@ fn validator_exists_union_inmem_or_sled() {
         governance_proposal_id: None,
         oracle_key_id: None,
     };
-    bc.insert_validator_shadow_keyed(info.identity_id.clone(), info);
+    bc.insert_validator_shadow(info);
     assert!(bc.validator_exists("did:zhtp:val-inmem"));
     assert!(!bc.validator_exists("did:zhtp:ghost"));
 
@@ -1359,7 +1359,7 @@ fn custom_token_balance_reads_sled_not_in_memory() {
     bc.set_store(store);
     // Simulate post-restart: no in-mem contract overlay.
     assert!(
-        !bc.get_all_token_contracts().contains_key(&token_id),
+        !bc.token_contract_shadow_contains_key(&token_id),
         "test premise: custom token exists only in sled"
     );
     assert_eq!(
@@ -1369,8 +1369,7 @@ fn custom_token_balance_reads_sled_not_in_memory() {
     );
     // In-mem-only read would wrongly return 0 — regression guard.
     assert_eq!(
-        bc.get_all_token_contracts()
-            .get(&token_id)
+        bc.token_contract_shadow(&token_id)
             .map(|c| c.balance_of(&crate::integration::crypto_integration::PublicKey::new(
                 [0u8; 2592]
             )))
@@ -1541,27 +1540,24 @@ fn validator_registry_snapshot_overlay_in_memory_wins() {
         .unwrap();
     let mut bc = Blockchain::new_runtime_state();
     bc.store = Some(store);
-    bc.insert_validator_shadow_keyed(
-did.to_string(),
-        ValidatorInfo {
-            identity_id: did.to_string(),
-            stake: 999_000,
-            storage_provided: 1 << 40,
-            consensus_key: [5u8; 2592],
-            networking_key: vec![],
-            rewards_key: vec![],
-            network_address: "overlay:1".to_string(),
-            commission_rate: 0,
-            status: "active".to_string(),
-            registered_at: 0,
-            last_activity: 0,
-            blocks_validated: 0,
-            slash_count: 0,
-            admission_source: "test".to_string(),
-            governance_proposal_id: None,
-            oracle_key_id: None,
-        },
-    );
+    bc.insert_validator_shadow(ValidatorInfo {
+        identity_id: did.to_string(),
+        stake: 999_000,
+        storage_provided: 1 << 40,
+        consensus_key: [5u8; 2592],
+        networking_key: vec![],
+        rewards_key: vec![],
+        network_address: "overlay:1".to_string(),
+        commission_rate: 0,
+        status: "active".to_string(),
+        registered_at: 0,
+        last_activity: 0,
+        blocks_validated: 0,
+        slash_count: 0,
+        admission_source: "test".to_string(),
+        governance_proposal_id: None,
+        oracle_key_id: None,
+    });
     let snap = bc.validator_registry_snapshot();
     assert_eq!(
         snap.get(did).map(|v| v.stake),
@@ -1761,27 +1757,24 @@ fn active_validator_infos_inmem_unregister_evicts_sled_active() {
 
     let mut bc = Blockchain::new_runtime_state();
     bc.store = Some(store);
-    bc.insert_validator_shadow_keyed(
-did.to_string(),
-        ValidatorInfo {
-            identity_id: did.to_string(),
-            stake: 100_000,
-            storage_provided: 1 << 40,
-            consensus_key: [5u8; 2592],
-            networking_key: vec![],
-            rewards_key: vec![],
-            network_address: "h:1".to_string(),
-            commission_rate: 0,
-            status: "inactive".to_string(),
-            registered_at: 1,
-            last_activity: 2,
-            blocks_validated: 0,
-            slash_count: 0,
-            admission_source: "test".to_string(),
-            governance_proposal_id: None,
-            oracle_key_id: None,
-        },
-    );
+    bc.insert_validator_shadow(ValidatorInfo {
+        identity_id: did.to_string(),
+        stake: 100_000,
+        storage_provided: 1 << 40,
+        consensus_key: [5u8; 2592],
+        networking_key: vec![],
+        rewards_key: vec![],
+        network_address: "h:1".to_string(),
+        commission_rate: 0,
+        status: "inactive".to_string(),
+        registered_at: 1,
+        last_activity: 2,
+        blocks_validated: 0,
+        slash_count: 0,
+        admission_source: "test".to_string(),
+        governance_proposal_id: None,
+        oracle_key_id: None,
+    });
 
     let active: Vec<_> = bc
         .active_validator_infos()

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -111,7 +111,7 @@ fn token_nonce_reads_sled_when_store_attached() {
 
     let mut bc = Blockchain::new().expect("blockchain construct");
     bc.set_store(store);
-    bc.token_nonces.insert(([5u8; 32], [0xCC; 32]), 7);
+    bc.insert_token_nonce_shadow([5u8; 32], [0xCC; 32], 7);
 
     assert_eq!(
         bc.token_nonce(&[5u8; 32], &[0xCC; 32]).unwrap(),
@@ -137,7 +137,7 @@ fn is_nonce_current_reads_sled_nonce_not_stale_in_memory() {
 
     let mut bc = Blockchain::new().expect("blockchain construct");
     bc.set_store(store);
-    bc.token_nonces.insert((token_id, sender), 0);
+    bc.insert_token_nonce_shadow(token_id, sender, 0);
 
     let current_tx = Transaction {
         version: 2,
@@ -245,7 +245,7 @@ fn count_token_holders_uses_in_memory_in_storeless_mode() {
         key_id: [0x11; 32],
     };
     token.mint(&holder, 1_000).unwrap();
-    bc.token_contracts.insert(token_id, token);
+    bc.insert_token_contract(token_id, token);
 
     assert_eq!(bc.count_token_holders(&token_id), 1);
 }
@@ -304,11 +304,10 @@ fn calculate_user_voting_power_reads_sled_not_in_memory() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     bc.set_store(store);
     bc.voting_power_mode = crate::dao::VotingPowerMode::Linear;
-    bc.token_contracts
-        .insert(sov_id, crate::contracts::TokenContract::new_sov_native());
+    bc.insert_token_contract(sov_id, crate::contracts::TokenContract::new_sov_native());
 
     let wallet_id_hash = Hash::new(wallet_id);
-    bc.wallet_registry.insert(
+    bc.insert_wallet_shadow(
         hex::encode(wallet_id),
         WalletTransactionData {
             wallet_id: wallet_id_hash,
@@ -408,8 +407,7 @@ fn put_sled_identity(store: &SledStore, height: u64, did: &str, consensus: Ident
 fn identity_exists_union_inmem_or_sled() {
     // store-less: answers from the in-memory shadow.
     let mut bc = Blockchain::new().unwrap();
-    bc.identity_registry
-        .insert("did:zhtp:inmem".to_string(), mk_inmem_identity("did:zhtp:inmem"));
+    bc.insert_identity_shadow("did:zhtp:inmem".to_string(), mk_inmem_identity("did:zhtp:inmem"));
     assert!(bc.identity_exists("did:zhtp:inmem"), "in-mem present -> true");
     assert!(!bc.identity_exists("did:zhtp:ghost"), "absent everywhere -> false");
 
@@ -428,7 +426,7 @@ fn identity_exists_union_inmem_or_sled() {
     let mut bc2 = Blockchain::new().unwrap();
     bc2.set_store(store);
     assert!(
-        !bc2.identity_registry.contains_key(did),
+        bc2.get_identity(did).is_none(),
         "test premise: this DID is sled-only (absent from the in-mem shadow)"
     );
     assert!(bc2.identity_exists(did), "sled-only identity found via union");
@@ -651,7 +649,7 @@ fn identity_display_name_taken_reads_sled() {
 fn identity_display_name_taken_sees_in_memory_pending_registration() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     let did = "did:zhtp:pending-name";
-    bc.identity_registry.insert(
+    bc.insert_identity_shadow(
         did.to_string(),
         crate::transaction::IdentityTransactionData {
             did: did.to_string(),
@@ -738,7 +736,7 @@ fn identity_registry_snapshot_overlay_in_memory_wins() {
 
     let mut bc = Blockchain::new().expect("blockchain construct");
     bc.set_store(store);
-    bc.identity_registry.insert(
+    bc.insert_identity_shadow(
         did.to_string(),
         crate::transaction::IdentityTransactionData {
             did: did.to_string(),
@@ -784,7 +782,7 @@ fn wallet_exists_union_inmem_or_sled() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     let wallet_id = [0x77u8; 32];
     let wallet_id_hex = hex::encode(wallet_id);
-    bc.wallet_registry.insert(
+    bc.insert_wallet_shadow(
         wallet_id_hex.clone(),
         test_wallet_data(wallet_id, "In-Mem"),
     );
@@ -905,8 +903,7 @@ fn wallet_count_ignores_in_memory_only_entries() {
     bc.set_store(store);
     let sled_hex = hex::encode([1u8; 32]);
     let inmem_hex = hex::encode([2u8; 32]);
-    bc.wallet_registry
-        .insert(inmem_hex.clone(), test_wallet_data([2u8; 32], "InMemOnly"));
+    bc.insert_wallet_shadow(inmem_hex.clone(), test_wallet_data([2u8; 32], "InMemOnly"));
     assert_eq!(bc.wallet_count(), 1, "count is sled cardinality, not union");
     let snap = bc.wallet_registry_snapshot();
     assert_eq!(
@@ -940,7 +937,7 @@ fn wallet_registry_snapshot_overlay_in_memory_wins() {
 
     let mut bc = Blockchain::new().expect("blockchain construct");
     bc.set_store(store);
-    bc.wallet_registry.insert(
+    bc.insert_wallet_shadow(
         wallet_id_hex.clone(),
         test_wallet_data(wallet_id, "From InMem"),
     );
@@ -999,7 +996,7 @@ fn did_by_public_key_reads_sled_metadata() {
     let mut bc = Blockchain::new().unwrap();
     bc.set_store(store.clone());
     assert!(
-        !bc.identity_registry.values().any(|i| i.public_key == pk),
+        bc.get_identity(did).is_none(),
         "test premise: this pubkey is sled-only (in-mem shadow empty, like after restart)"
     );
     assert_eq!(
@@ -1093,7 +1090,7 @@ fn identity_controlled_nodes_reads_sled_metadata() {
     let mut bc = Blockchain::new().unwrap();
     bc.set_store(store);
     assert!(
-        !bc.identity_registry.contains_key(did),
+        bc.get_identity(did).is_none(),
         "test premise: DID is sled-only (in-mem shadow empty, like after restart)"
     );
     assert_eq!(
@@ -1152,8 +1149,7 @@ fn did_by_device_key_id_reads_sled_metadata() {
     let mut bc = Blockchain::new().unwrap();
     bc.set_store(store.clone());
     assert!(
-        !bc.identity_registry.contains_key(did)
-            && !bc.identity_registry.values().any(|i| i.public_key == pk),
+        bc.get_identity(did).is_none(),
         "test premise: this identity is sled-only (absent from the in-mem shadow, like after restart)"
     );
 
@@ -1290,7 +1286,7 @@ fn validator_exists_union_inmem_or_sled() {
         governance_proposal_id: None,
         oracle_key_id: None,
     };
-    bc.validator_registry.insert(info.identity_id.clone(), info);
+    bc.insert_validator_shadow_keyed(info.identity_id.clone(), info);
     assert!(bc.validator_exists("did:zhtp:val-inmem"));
     assert!(!bc.validator_exists("did:zhtp:ghost"));
 
@@ -1363,7 +1359,7 @@ fn custom_token_balance_reads_sled_not_in_memory() {
     bc.set_store(store);
     // Simulate post-restart: no in-mem contract overlay.
     assert!(
-        !bc.token_contracts.contains_key(&token_id),
+        !bc.get_all_token_contracts().contains_key(&token_id),
         "test premise: custom token exists only in sled"
     );
     assert_eq!(
@@ -1373,7 +1369,7 @@ fn custom_token_balance_reads_sled_not_in_memory() {
     );
     // In-mem-only read would wrongly return 0 — regression guard.
     assert_eq!(
-        bc.token_contracts
+        bc.get_all_token_contracts()
             .get(&token_id)
             .map(|c| c.balance_of(&crate::integration::crypto_integration::PublicKey::new(
                 [0u8; 2592]
@@ -1419,10 +1415,9 @@ fn legacy_fee_deduction_syncs_sled_balance() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     bc.set_store(store.clone());
     let sov = crate::contracts::TokenContract::new_sov_native();
-    bc.token_contracts.insert(sov_id, sov);
-    bc.token_contracts
-        .get_mut(&sov_id)
-        .unwrap()
+    bc.insert_token_contract(sov_id, sov);
+    bc.get_token_contract_mut(&sov_id)
+        .expect("SOV token shadow")
         .set_balance(&sender, initial);
 
     let tx = Transaction {
@@ -1546,8 +1541,8 @@ fn validator_registry_snapshot_overlay_in_memory_wins() {
         .unwrap();
     let mut bc = Blockchain::new_runtime_state();
     bc.store = Some(store);
-    bc.validator_registry.insert(
-        did.to_string(),
+    bc.insert_validator_shadow_keyed(
+did.to_string(),
         ValidatorInfo {
             identity_id: did.to_string(),
             stake: 999_000,
@@ -1766,8 +1761,8 @@ fn active_validator_infos_inmem_unregister_evicts_sled_active() {
 
     let mut bc = Blockchain::new_runtime_state();
     bc.store = Some(store);
-    bc.validator_registry.insert(
-        did.to_string(),
+    bc.insert_validator_shadow_keyed(
+did.to_string(),
         ValidatorInfo {
             identity_id: did.to_string(),
             stake: 100_000,

--- a/lib-blockchain/src/blockchain/tests/genesis_allocation_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/genesis_allocation_tests.rs
@@ -15,12 +15,12 @@ fn test_sov_wallet_registration_deficit_minting() {
     wallet_id_bytes[..13].copy_from_slice(b"test-wallet-1");
     let recipient_pk = Blockchain::wallet_key_for_sov(&wallet_id_bytes);
 
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.mint(&recipient_pk, 3000).expect("Pre-mint should succeed");
     }
 
     let current_balance = blockchain
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .map(|token| token.balance_of(&recipient_pk))
         .unwrap_or(0);
@@ -60,7 +60,7 @@ fn test_sov_wallet_registration_deficit_minting() {
         .expect("Should process successfully");
 
     let final_balance = blockchain
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .map(|token| token.balance_of(&recipient_pk))
         .unwrap_or(0);

--- a/lib-blockchain/src/blockchain/tests/oracle_storage_migration_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/oracle_storage_migration_tests.rs
@@ -186,7 +186,7 @@ fn load_from_file_does_not_mint_or_repair_sov_balances() {
         (missing_wallet, missing_initial_balance),
         (partial_wallet, partial_initial_balance),
     ] {
-        bc.wallet_registry.insert(
+        bc.insert_wallet_shadow(
             hex::encode(wallet_id),
             crate::transaction::WalletTransactionData {
                 wallet_id: Hash::new(wallet_id),
@@ -209,11 +209,9 @@ fn load_from_file_does_not_mint_or_repair_sov_balances() {
     let partial_recipient = Blockchain::wallet_key_for_sov(&partial_wallet);
     {
         let token = bc
-            .token_contracts
-            .get_mut(&sov_token_id)
+            .get_token_contract_mut(&sov_token_id)
             .expect("SOV token should exist");
-        token
-            .set_balance(&partial_recipient, partial_existing_balance);
+        token.set_balance(&partial_recipient, partial_existing_balance);
         token.total_supply = partial_existing_balance;
     }
 
@@ -227,7 +225,7 @@ fn load_from_file_does_not_mint_or_repair_sov_balances() {
     let loaded = Blockchain::load_from_file(&path).expect("load should succeed");
 
     let token = loaded
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .expect("loaded SOV token should exist");
     assert_eq!(

--- a/lib-blockchain/src/blockchain/tests/replay_contract_execution_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/replay_contract_execution_tests.rs
@@ -100,11 +100,11 @@ fn contract_execution_is_deterministic() {
     }
 
     let direct_token = direct
-        .token_contracts
+        .get_all_token_contracts()
         .get(&token_id)
         .expect("token should exist in direct path");
     let replayed_token = replayed
-        .token_contracts
+        .get_all_token_contracts()
         .get(&token_id)
         .expect("token should exist in replay path");
 
@@ -157,7 +157,7 @@ fn contract_blocks_populated_during_replay() {
         .expect("contract execution should succeed");
 
     assert!(
-        blockchain.token_contracts.contains_key(&token_id),
+        blockchain.get_token_contract(&token_id).is_some(),
         "Token contract should exist"
     );
     assert_eq!(

--- a/lib-blockchain/src/blockchain/tests/store_backed_blockchain_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/store_backed_blockchain_tests.rs
@@ -98,7 +98,7 @@ async fn test_get_token_nonce_reads_sled_first_under_executor() {
     // Deliberately seed the in-memory HashMap with the STALE value the bug
     // produced in production. Pre-fix `get_token_nonce` returned this 2279
     // (HashMap-first), causing the mempool to accept a tx with nonce 2279.
-    bc.token_nonces.insert((token_id, sender), 2279);
+    bc.insert_token_nonce_shadow(token_id, sender, 2279);
 
     // CONS-513: under executor mode, sled wins.
     assert_eq!(
@@ -124,6 +124,6 @@ async fn test_get_token_nonce_uses_hashmap_in_storeless_mode() {
     assert_eq!(bc.get_token_nonce(&token_id, &sender), 0);
 
     // Populate HashMap → that value is the answer.
-    bc.token_nonces.insert((token_id, sender), 7);
+    bc.insert_token_nonce_shadow(token_id, sender, 7);
     assert_eq!(bc.get_token_nonce(&token_id, &sender), 7);
 }

--- a/lib-blockchain/src/blockchain/validators.rs
+++ b/lib-blockchain/src/blockchain/validators.rs
@@ -491,6 +491,20 @@ impl Blockchain {
         Ok(written)
     }
 
+    /// Legacy in-memory shadow insert — genesis/bootstrap/tests (#2640).
+    pub fn insert_validator_shadow(&mut self, info: ValidatorInfo) {
+        self.validator_registry.insert(info.identity_id.clone(), info);
+    }
+
+    /// Test/helper compat: ignores redundant `identity_id` key when it matches `info`.
+    #[doc(hidden)]
+    pub fn insert_validator_shadow_keyed(&mut self, identity_id: String, mut info: ValidatorInfo) {
+        if info.identity_id.is_empty() {
+            info.identity_id = identity_id.clone();
+        }
+        self.validator_registry.insert(identity_id, info);
+    }
+
     pub fn register_validator(&mut self, validator_info: ValidatorInfo) -> Result<Hash> {
         if self.validator_exists(&validator_info.identity_id) {
             return Err(anyhow::anyhow!(

--- a/lib-blockchain/src/blockchain/validators.rs
+++ b/lib-blockchain/src/blockchain/validators.rs
@@ -492,17 +492,10 @@ impl Blockchain {
     }
 
     /// Legacy in-memory shadow insert — genesis/bootstrap/tests (#2640).
+    /// `info.identity_id` is the map key; callers must keep it consistent.
     pub fn insert_validator_shadow(&mut self, info: ValidatorInfo) {
-        self.validator_registry.insert(info.identity_id.clone(), info);
-    }
-
-    /// Test/helper compat: ignores redundant `identity_id` key when it matches `info`.
-    #[doc(hidden)]
-    pub fn insert_validator_shadow_keyed(&mut self, identity_id: String, mut info: ValidatorInfo) {
-        if info.identity_id.is_empty() {
-            info.identity_id = identity_id.clone();
-        }
-        self.validator_registry.insert(identity_id, info);
+        self.validator_registry
+            .insert(info.identity_id.clone(), info);
     }
 
     pub fn register_validator(&mut self, validator_info: ValidatorInfo) -> Result<Hash> {

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl Blockchain {
     /// Ensure the native SOV token contract exists in the in-memory shadow (#2640).
-    pub fn ensure_sov_token_contract(&mut self) {
+    pub(super) fn ensure_sov_token_contract(&mut self) {
         let sov_token_id = crate::contracts::utils::generate_lib_token_id();
         if !self.token_contracts.contains_key(&sov_token_id) {
             let sov_token = crate::contracts::TokenContract::new_sov_native();
@@ -671,22 +671,32 @@ impl Blockchain {
         self.wallet_registry.insert(wallet_id, data);
     }
 
-    /// Mutable access to the in-memory wallet shadow (welcome-bonus patch paths).
-    pub fn wallet_registry_entry_mut(
-        &mut self,
-        wallet_id: &str,
-    ) -> Option<&mut crate::transaction::WalletTransactionData> {
-        self.wallet_registry.get_mut(wallet_id)
+    /// Cardinality of the in-memory wallet shadow only (audit / divergence tooling).
+    pub fn wallet_registry_shadow_len(&self) -> usize {
+        self.wallet_registry.len()
     }
 
-    /// Wallets owned by an identity (in-memory shadow; sled union via snapshot).
+    /// Patch initial_balance on an in-memory wallet shadow entry (welcome-bonus warmup).
+    pub fn update_wallet_shadow_initial_balance(&mut self, wallet_id: &str, balance: u128) -> bool {
+        if let Some(entry) = self.wallet_registry.get_mut(wallet_id) {
+            entry.initial_balance = balance;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Wallets owned by an identity in the in-memory shadow only (O(N) over
+    /// `wallet_registry`, not sled). Do not call per-identity inside tight loops
+    /// on store-backed nodes with large wallet projections.
     pub fn wallets_for_owner(
         &self,
         owner_identity_id: &crate::types::Hash,
     ) -> Vec<(String, crate::transaction::WalletTransactionData)> {
-        self.wallet_registry_snapshot()
-            .into_iter()
-            .filter(|(_, w)| w.owner_identity_id.as_ref() == Some(owner_identity_id))
+        self.wallet_registry
+            .iter()
+            .filter(|(_, wallet)| wallet.owner_identity_id.as_ref() == Some(owner_identity_id))
+            .map(|(wallet_id, wallet)| (wallet_id.clone(), wallet.clone()))
             .collect()
     }
 

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -1,7 +1,8 @@
 use super::*;
 
 impl Blockchain {
-    pub(super) fn ensure_sov_token_contract(&mut self) {
+    /// Ensure the native SOV token contract exists in the in-memory shadow (#2640).
+    pub fn ensure_sov_token_contract(&mut self) {
         let sov_token_id = crate::contracts::utils::generate_lib_token_id();
         if !self.token_contracts.contains_key(&sov_token_id) {
             let sov_token = crate::contracts::TokenContract::new_sov_native();
@@ -659,6 +660,34 @@ impl Blockchain {
             }
         }
         count
+    }
+
+    /// Legacy in-memory shadow insert — genesis/bootstrap only (#2640).
+    pub fn insert_wallet_shadow(
+        &mut self,
+        wallet_id: String,
+        data: crate::transaction::WalletTransactionData,
+    ) {
+        self.wallet_registry.insert(wallet_id, data);
+    }
+
+    /// Mutable access to the in-memory wallet shadow (welcome-bonus patch paths).
+    pub fn wallet_registry_entry_mut(
+        &mut self,
+        wallet_id: &str,
+    ) -> Option<&mut crate::transaction::WalletTransactionData> {
+        self.wallet_registry.get_mut(wallet_id)
+    }
+
+    /// Wallets owned by an identity (in-memory shadow; sled union via snapshot).
+    pub fn wallets_for_owner(
+        &self,
+        owner_identity_id: &crate::types::Hash,
+    ) -> Vec<(String, crate::transaction::WalletTransactionData)> {
+        self.wallet_registry_snapshot()
+            .into_iter()
+            .filter(|(_, w)| w.owner_identity_id.as_ref() == Some(owner_identity_id))
+            .collect()
     }
 
     pub fn register_wallet(

--- a/lib-blockchain/tests/blockchain_tests.rs
+++ b/lib-blockchain/tests/blockchain_tests.rs
@@ -80,9 +80,7 @@ fn register_validator_identity(blockchain: &mut Blockchain, id: &str) -> Result<
         1000,
         100,
     );
-    blockchain
-        .identity_registry
-        .insert(id.to_string(), identity_data);
+    blockchain.insert_identity_shadow(id.to_string(), identity_data);
     Ok(())
 }
 
@@ -166,9 +164,7 @@ async fn test_identity_registration() -> Result<()> {
     );
 
     // Register the identity directly in registry (bypass transaction validation for test)
-    blockchain
-        .identity_registry
-        .insert(identity_data.did.clone(), identity_data.clone());
+    blockchain.insert_identity_shadow(identity_data.did.clone(), identity_data.clone());
     blockchain
         .identity_blocks
         .insert(identity_data.did.clone(), blockchain.height + 1);
@@ -199,9 +195,7 @@ async fn test_identity_update() -> Result<()> {
         100,
     );
 
-    blockchain
-        .identity_registry
-        .insert(original_data.did.clone(), original_data);
+    blockchain.insert_identity_shadow(original_data.did.clone(), original_data);
     blockchain
         .identity_blocks
         .insert("did:zhtp:update_test".to_string(), blockchain.height);
@@ -219,9 +213,7 @@ async fn test_identity_update() -> Result<()> {
     );
 
     // Update directly for test
-    blockchain
-        .identity_registry
-        .insert(updated_data.did.clone(), updated_data);
+    blockchain.insert_identity_shadow(updated_data.did.clone(), updated_data);
 
     // Verify update
     let updated_identity = blockchain.get_identity("did:zhtp:update_test").unwrap();
@@ -247,29 +239,21 @@ async fn test_identity_revocation() -> Result<()> {
         100,
     );
 
-    blockchain
-        .identity_registry
-        .insert(identity_data.did.clone(), identity_data);
+    blockchain.insert_identity_shadow(identity_data.did.clone(), identity_data);
     blockchain
         .identity_blocks
         .insert("did:zhtp:revoke_test".to_string(), blockchain.height);
     assert!(blockchain.identity_exists("did:zhtp:revoke_test"));
 
-    // Revoke the identity directly for test
-    if let Some(mut identity_data) = blockchain.identity_registry.remove("did:zhtp:revoke_test") {
+    // Revoke the identity directly for test (in-place via shadow mut API)
+    if let Some(identity_data) = blockchain.identity_registry_entry_mut("did:zhtp:revoke_test") {
         identity_data.identity_type = "revoked".to_string();
-        blockchain
-            .identity_registry
-            .insert("did:zhtp:revoke_test_revoked".to_string(), identity_data);
     }
 
     // Verify revocation
-    assert!(!blockchain.identity_exists("did:zhtp:revoke_test"));
-    assert!(blockchain.identity_exists("did:zhtp:revoke_test_revoked"));
+    assert!(blockchain.identity_exists("did:zhtp:revoke_test"));
 
-    let revoked_identity = blockchain
-        .get_identity("did:zhtp:revoke_test_revoked")
-        .unwrap();
+    let revoked_identity = blockchain.get_identity("did:zhtp:revoke_test").unwrap();
     assert_eq!(revoked_identity.identity_type, "revoked");
 
     Ok(())
@@ -454,9 +438,7 @@ async fn test_identity_confirmations() -> Result<()> {
                 Err(validation_error) => {
                     println!("Transaction validation failed: {:?}", validation_error);
                     // For now, let's bypass the validation issue and manually test confirmations
-                    blockchain
-                        .identity_registry
-                        .insert(identity_data.did.clone(), identity_data.clone());
+                    blockchain.insert_identity_shadow(identity_data.did.clone(), identity_data.clone());
                     blockchain
                         .identity_blocks
                         .insert(identity_data.did.clone(), blockchain.height + 1);
@@ -608,9 +590,7 @@ async fn test_register_validator_added_to_blockchain() -> Result<()> {
 
     // Directly add validator to registry for testing
     let validator_info = create_test_validator("validator_001", 5000);
-    blockchain
-        .validator_registry
-        .insert("validator_001".to_string(), validator_info.clone());
+    blockchain.insert_validator_shadow_keyed("validator_001".to_string(), validator_info.clone());
     blockchain
         .validator_blocks
         .insert("validator_001".to_string(), blockchain.height + 1);
@@ -638,16 +618,16 @@ async fn test_consensus_queries_validator_set() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_003")?;
 
     // Directly add validators to registry for testing
-    blockchain.validator_registry.insert(
-        "validator_001".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_001".to_string(),
         create_test_validator("validator_001", 5000),
     );
-    blockchain.validator_registry.insert(
-        "validator_002".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_002".to_string(),
         create_test_validator("validator_002", 3000),
     );
-    blockchain.validator_registry.insert(
-        "validator_003".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_003".to_string(),
         create_test_validator("validator_003", 2000),
     );
 
@@ -680,12 +660,12 @@ async fn test_validator_set_in_sync() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_003")?;
 
     // Add initial validators
-    blockchain.validator_registry.insert(
-        "validator_001".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_001".to_string(),
         create_test_validator("validator_001", 5000),
     );
-    blockchain.validator_registry.insert(
-        "validator_002".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_002".to_string(),
         create_test_validator("validator_002", 3000),
     );
 
@@ -694,8 +674,8 @@ async fn test_validator_set_in_sync() -> Result<()> {
     assert_eq!(initial_set.len(), 2);
 
     // Add a new validator
-    blockchain.validator_registry.insert(
-        "validator_003".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_003".to_string(),
         create_test_validator("validator_003", 2000),
     );
 
@@ -718,8 +698,8 @@ async fn test_validator_stake_update_propagates() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_001")?;
 
     // Add a validator
-    blockchain.validator_registry.insert(
-        "validator_001".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_001".to_string(),
         create_test_validator("validator_001", 5000),
     );
 
@@ -733,8 +713,8 @@ async fn test_validator_stake_update_propagates() -> Result<()> {
     assert_eq!(initial_stake, 5000);
 
     // Update validator stake directly in registry
-    blockchain.validator_registry.insert(
-        "validator_001".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_001".to_string(),
         create_test_validator("validator_001", 7500),
     );
 
@@ -760,16 +740,16 @@ async fn test_total_validator_stake_calculation() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_003")?;
 
     // Add validators with specific stakes
-    blockchain.validator_registry.insert(
-        "validator_001".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_001".to_string(),
         create_test_validator("validator_001", 5000),
     );
-    blockchain.validator_registry.insert(
-        "validator_002".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_002".to_string(),
         create_test_validator("validator_002", 3000),
     );
-    blockchain.validator_registry.insert(
-        "validator_003".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_003".to_string(),
         create_test_validator("validator_003", 2000),
     );
 
@@ -790,8 +770,8 @@ async fn test_is_validator_active_check() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_001")?;
 
     // Add a validator
-    blockchain.validator_registry.insert(
-        "validator_001".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_001".to_string(),
         create_test_validator("validator_001", 5000),
     );
 
@@ -819,12 +799,12 @@ async fn test_sync_validator_set_to_consensus() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_002")?;
 
     // Add validators
-    blockchain.validator_registry.insert(
-        "validator_001".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_001".to_string(),
         create_test_validator("validator_001", 5000),
     );
-    blockchain.validator_registry.insert(
-        "validator_002".to_string(),
+    blockchain.insert_validator_shadow_keyed(
+"validator_002".to_string(),
         create_test_validator("validator_002", 3000),
     );
 

--- a/lib-blockchain/tests/blockchain_tests.rs
+++ b/lib-blockchain/tests/blockchain_tests.rs
@@ -224,7 +224,7 @@ async fn test_identity_update() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_identity_revocation() -> Result<()> {
+async fn test_identity_shadow_type_update_in_place() -> Result<()> {
     let mut blockchain = Blockchain::new()?;
 
     // Register an identity first directly
@@ -245,16 +245,15 @@ async fn test_identity_revocation() -> Result<()> {
         .insert("did:zhtp:revoke_test".to_string(), blockchain.height);
     assert!(blockchain.identity_exists("did:zhtp:revoke_test"));
 
-    // Revoke the identity directly for test (in-place via shadow mut API)
-    if let Some(identity_data) = blockchain.identity_registry_entry_mut("did:zhtp:revoke_test") {
-        identity_data.identity_type = "revoked".to_string();
-    }
+    // Shadow-only type patch (not production revocation semantics).
+    assert!(blockchain.set_identity_shadow_type(
+        "did:zhtp:revoke_test",
+        "revoked".to_string()
+    ));
 
-    // Verify revocation
     assert!(blockchain.identity_exists("did:zhtp:revoke_test"));
-
-    let revoked_identity = blockchain.get_identity("did:zhtp:revoke_test").unwrap();
-    assert_eq!(revoked_identity.identity_type, "revoked");
+    let updated = blockchain.get_identity("did:zhtp:revoke_test").unwrap();
+    assert_eq!(updated.identity_type, "revoked");
 
     Ok(())
 }
@@ -590,7 +589,7 @@ async fn test_register_validator_added_to_blockchain() -> Result<()> {
 
     // Directly add validator to registry for testing
     let validator_info = create_test_validator("validator_001", 5000);
-    blockchain.insert_validator_shadow_keyed("validator_001".to_string(), validator_info.clone());
+    blockchain.insert_validator_shadow(validator_info.clone());
     blockchain
         .validator_blocks
         .insert("validator_001".to_string(), blockchain.height + 1);
@@ -618,18 +617,9 @@ async fn test_consensus_queries_validator_set() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_003")?;
 
     // Directly add validators to registry for testing
-    blockchain.insert_validator_shadow_keyed(
-"validator_001".to_string(),
-        create_test_validator("validator_001", 5000),
-    );
-    blockchain.insert_validator_shadow_keyed(
-"validator_002".to_string(),
-        create_test_validator("validator_002", 3000),
-    );
-    blockchain.insert_validator_shadow_keyed(
-"validator_003".to_string(),
-        create_test_validator("validator_003", 2000),
-    );
+    blockchain.insert_validator_shadow(create_test_validator("validator_001", 5000));
+    blockchain.insert_validator_shadow(create_test_validator("validator_002", 3000));
+    blockchain.insert_validator_shadow(create_test_validator("validator_003", 2000));
 
     // Query the active validator set for consensus
     let active_set = blockchain.get_active_validator_set_for_consensus();
@@ -660,24 +650,15 @@ async fn test_validator_set_in_sync() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_003")?;
 
     // Add initial validators
-    blockchain.insert_validator_shadow_keyed(
-"validator_001".to_string(),
-        create_test_validator("validator_001", 5000),
-    );
-    blockchain.insert_validator_shadow_keyed(
-"validator_002".to_string(),
-        create_test_validator("validator_002", 3000),
-    );
+    blockchain.insert_validator_shadow(create_test_validator("validator_001", 5000));
+    blockchain.insert_validator_shadow(create_test_validator("validator_002", 3000));
 
     // Get initial set
     let initial_set = blockchain.get_active_validator_set_for_consensus();
     assert_eq!(initial_set.len(), 2);
 
     // Add a new validator
-    blockchain.insert_validator_shadow_keyed(
-"validator_003".to_string(),
-        create_test_validator("validator_003", 2000),
-    );
+    blockchain.insert_validator_shadow(create_test_validator("validator_003", 2000));
 
     // Get updated set
     let updated_set = blockchain.get_active_validator_set_for_consensus();
@@ -698,10 +679,7 @@ async fn test_validator_stake_update_propagates() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_001")?;
 
     // Add a validator
-    blockchain.insert_validator_shadow_keyed(
-"validator_001".to_string(),
-        create_test_validator("validator_001", 5000),
-    );
+    blockchain.insert_validator_shadow(create_test_validator("validator_001", 5000));
 
     // Get initial set
     let initial_set = blockchain.get_active_validator_set_for_consensus();
@@ -713,10 +691,7 @@ async fn test_validator_stake_update_propagates() -> Result<()> {
     assert_eq!(initial_stake, 5000);
 
     // Update validator stake directly in registry
-    blockchain.insert_validator_shadow_keyed(
-"validator_001".to_string(),
-        create_test_validator("validator_001", 7500),
-    );
+    blockchain.insert_validator_shadow(create_test_validator("validator_001", 7500));
 
     // Get updated set
     let updated_set = blockchain.get_active_validator_set_for_consensus();
@@ -740,18 +715,9 @@ async fn test_total_validator_stake_calculation() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_003")?;
 
     // Add validators with specific stakes
-    blockchain.insert_validator_shadow_keyed(
-"validator_001".to_string(),
-        create_test_validator("validator_001", 5000),
-    );
-    blockchain.insert_validator_shadow_keyed(
-"validator_002".to_string(),
-        create_test_validator("validator_002", 3000),
-    );
-    blockchain.insert_validator_shadow_keyed(
-"validator_003".to_string(),
-        create_test_validator("validator_003", 2000),
-    );
+    blockchain.insert_validator_shadow(create_test_validator("validator_001", 5000));
+    blockchain.insert_validator_shadow(create_test_validator("validator_002", 3000));
+    blockchain.insert_validator_shadow(create_test_validator("validator_003", 2000));
 
     // Calculate total stake
     let total_stake = blockchain.get_total_validator_stake();
@@ -770,10 +736,7 @@ async fn test_is_validator_active_check() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_001")?;
 
     // Add a validator
-    blockchain.insert_validator_shadow_keyed(
-"validator_001".to_string(),
-        create_test_validator("validator_001", 5000),
-    );
+    blockchain.insert_validator_shadow(create_test_validator("validator_001", 5000));
 
     // Should be active
     assert!(
@@ -799,14 +762,8 @@ async fn test_sync_validator_set_to_consensus() -> Result<()> {
     register_validator_identity(&mut blockchain, "validator_002")?;
 
     // Add validators
-    blockchain.insert_validator_shadow_keyed(
-"validator_001".to_string(),
-        create_test_validator("validator_001", 5000),
-    );
-    blockchain.insert_validator_shadow_keyed(
-"validator_002".to_string(),
-        create_test_validator("validator_002", 3000),
-    );
+    blockchain.insert_validator_shadow(create_test_validator("validator_001", 5000));
+    blockchain.insert_validator_shadow(create_test_validator("validator_002", 3000));
 
     // Call sync - should log active validators
     // This method is primarily for logging/event emission, so we just verify it doesn't panic

--- a/lib-blockchain/tests/dao_freeze_tests.rs
+++ b/lib-blockchain/tests/dao_freeze_tests.rs
@@ -23,7 +23,7 @@ fn add_validator(bc: &mut Blockchain, did: &str) {
         governance_proposal_id: None,
         oracle_key_id: None,
     };
-    bc.insert_validator_shadow_keyed(did.to_string(), vinfo);
+    bc.insert_validator_shadow(vinfo);
 }
 
 // ── default values ────────────────────────────────────────────────────────────

--- a/lib-blockchain/tests/dao_freeze_tests.rs
+++ b/lib-blockchain/tests/dao_freeze_tests.rs
@@ -23,7 +23,7 @@ fn add_validator(bc: &mut Blockchain, did: &str) {
         governance_proposal_id: None,
         oracle_key_id: None,
     };
-    bc.validator_registry.insert(did.to_string(), vinfo);
+    bc.insert_validator_shadow_keyed(did.to_string(), vinfo);
 }
 
 // ── default values ────────────────────────────────────────────────────────────

--- a/lib-blockchain/tests/fresh_node_safety_tests.rs
+++ b/lib-blockchain/tests/fresh_node_safety_tests.rs
@@ -189,7 +189,7 @@ async fn fresh_node_ignores_forged_state_maps() -> Result<()> {
 
     // …but the attacker's forged validator must NOT have leaked into state.
     assert!(
-        !node.validator_registry.contains_key("attacker_validator"),
+        !node.validator_exists("attacker_validator"),
         "forged validator from the import map must be ignored — state is \
          derived from blocks, not copied from the import"
     );

--- a/lib-blockchain/tests/integration_tests.rs
+++ b/lib-blockchain/tests/integration_tests.rs
@@ -469,9 +469,7 @@ fn test_full_integration_workflow() -> Result<()> {
                 e
             );
             // Manually add to registry for the rest of the test
-            blockchain
-                .identity_registry
-                .insert(identity_data.did.clone(), identity_data.clone());
+            blockchain.insert_identity_shadow(identity_data.did.clone(), identity_data.clone());
             blockchain
                 .identity_blocks
                 .insert(identity_data.did.clone(), blockchain.height + 1);
@@ -554,8 +552,8 @@ fn test_full_integration_workflow() -> Result<()> {
     let deserialized_state = storage_integration::deserialize_blockchain_state(&serialized_state)?;
 
     assert_eq!(
-        deserialized_state.identity_registry.len(),
-        blockchain.identity_registry.len()
+        deserialized_state.identity_count(),
+        blockchain.identity_count()
     );
     println!("Successfully serialized and deserialized blockchain state");
 

--- a/lib-blockchain/tests/issue_1016_fee_deduction_tests.rs
+++ b/lib-blockchain/tests/issue_1016_fee_deduction_tests.rs
@@ -77,7 +77,7 @@ fn test_fee_deduction_reduces_sender_balance() {
     let sov_token_id = generate_lib_token_id();
 
     // Register the SOV token
-    blockchain.token_contracts.insert(sov_token_id, sov_token);
+    blockchain.insert_token_contract(sov_token_id, sov_token);
 
     // Setup sender with initial balance
     let sender = create_test_pubkey(1);
@@ -85,13 +85,13 @@ fn test_fee_deduction_reduces_sender_balance() {
     let fee: u64 = 100;
 
     // Credit initial balance to sender
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.set_balance(&sender, initial_balance);
     }
 
     // Verify initial balance
     let balance_before = blockchain
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .map(|t| t.balance_of(&sender))
         .unwrap_or(0);
@@ -115,7 +115,7 @@ fn test_fee_deduction_reduces_sender_balance() {
 
     // Verify: sender balance was reduced
     let balance_after = blockchain
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .map(|t| t.balance_of(&sender))
         .unwrap_or(0);
@@ -140,7 +140,7 @@ fn test_fee_deduction_skips_system_transactions() {
     let sov_token_id = generate_lib_token_id();
 
     // Register the SOV token
-    blockchain.token_contracts.insert(sov_token_id, sov_token);
+    blockchain.insert_token_contract(sov_token_id, sov_token);
 
     // Create a system transaction (empty inputs = UBI distribution)
     let sender = create_test_pubkey(1);
@@ -171,7 +171,7 @@ fn test_fee_deduction_handles_insufficient_balance() {
     let sov_token_id = generate_lib_token_id();
 
     // Register the SOV token
-    blockchain.token_contracts.insert(sov_token_id, sov_token);
+    blockchain.insert_token_contract(sov_token_id, sov_token);
 
     // Setup sender with low balance (less than fee)
     let sender = create_test_pubkey(1);
@@ -179,7 +179,7 @@ fn test_fee_deduction_handles_insufficient_balance() {
     let fee: u64 = 100; // More than balance
 
     // Credit low balance to sender
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.set_balance(&sender, initial_balance);
     }
 
@@ -200,7 +200,7 @@ fn test_fee_deduction_handles_insufficient_balance() {
 
     // Verify: sender balance unchanged
     let balance_after = blockchain
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .map(|t| t.balance_of(&sender))
         .unwrap_or(0);
@@ -222,7 +222,7 @@ fn test_fee_deduction_accumulates_multiple_transactions() {
     let sov_token_id = generate_lib_token_id();
 
     // Register the SOV token
-    blockchain.token_contracts.insert(sov_token_id, sov_token);
+    blockchain.insert_token_contract(sov_token_id, sov_token);
 
     // Setup multiple senders with balances
     let sender1 = create_test_pubkey(1);
@@ -231,7 +231,7 @@ fn test_fee_deduction_accumulates_multiple_transactions() {
     let initial_balance: u128 = 10_000;
 
     // Credit initial balances
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.set_balance(&sender1, initial_balance);
         token.set_balance(&sender2, initial_balance);
         token.set_balance(&sender3, initial_balance);
@@ -261,7 +261,7 @@ fn test_fee_deduction_accumulates_multiple_transactions() {
     );
 
     // Verify: each sender's balance was reduced correctly
-    let token = blockchain.token_contracts.get(&sov_token_id).unwrap();
+    let token = blockchain.get_token_contract(&sov_token_id).unwrap();
     assert_eq!(token.balance_of(&sender1), initial_balance - fee1 as u128);
     assert_eq!(token.balance_of(&sender2), initial_balance - fee2 as u128);
     assert_eq!(token.balance_of(&sender3), initial_balance - fee3 as u128);

--- a/lib-blockchain/tests/issue_1016_fee_deduction_tests.rs
+++ b/lib-blockchain/tests/issue_1016_fee_deduction_tests.rs
@@ -91,8 +91,7 @@ fn test_fee_deduction_reduces_sender_balance() {
 
     // Verify initial balance
     let balance_before = blockchain
-        .get_all_token_contracts()
-        .get(&sov_token_id)
+        .token_contract_shadow(&sov_token_id)
         .map(|t| t.balance_of(&sender))
         .unwrap_or(0);
     assert_eq!(balance_before, initial_balance);
@@ -115,8 +114,7 @@ fn test_fee_deduction_reduces_sender_balance() {
 
     // Verify: sender balance was reduced
     let balance_after = blockchain
-        .get_all_token_contracts()
-        .get(&sov_token_id)
+        .token_contract_shadow(&sov_token_id)
         .map(|t| t.balance_of(&sender))
         .unwrap_or(0);
 
@@ -200,8 +198,7 @@ fn test_fee_deduction_handles_insufficient_balance() {
 
     // Verify: sender balance unchanged
     let balance_after = blockchain
-        .get_all_token_contracts()
-        .get(&sov_token_id)
+        .token_contract_shadow(&sov_token_id)
         .map(|t| t.balance_of(&sender))
         .unwrap_or(0);
 

--- a/lib-blockchain/tests/issue_1018_treasury_balance_tests.rs
+++ b/lib-blockchain/tests/issue_1018_treasury_balance_tests.rs
@@ -37,9 +37,7 @@ fn setup_blockchain_with_treasury() -> (Blockchain, PublicKey) {
     };
 
     // Register the treasury wallet
-    blockchain
-        .wallet_registry
-        .insert("dao_treasury".to_string(), treasury_wallet);
+    blockchain.insert_wallet_shadow("dao_treasury".to_string(), treasury_wallet);
     blockchain.dao_treasury_wallet_id = Some("dao_treasury".to_string());
 
     // Create SOV token with kernel authority
@@ -48,7 +46,7 @@ fn setup_blockchain_with_treasury() -> (Blockchain, PublicKey) {
     let sov_token_id = generate_lib_token_id();
 
     // Register the SOV token
-    blockchain.token_contracts.insert(sov_token_id, sov_token);
+    blockchain.insert_token_contract(sov_token_id, sov_token);
 
     (blockchain, treasury_pubkey)
 }
@@ -65,7 +63,7 @@ fn test_treasury_balance_uses_token_contract() {
     let sov_token_id = generate_lib_token_id();
     let treasury_amount: u128 = 1_000_000;
 
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token
             .set_balance(&treasury_pubkey, treasury_amount);
     }
@@ -88,7 +86,7 @@ fn test_treasury_balance_not_placeholder() {
     let sov_token_id = generate_lib_token_id();
     let expected_amount: u128 = 5_555_555;
 
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token
             .set_balance(&treasury_pubkey, expected_amount);
     }
@@ -126,9 +124,7 @@ fn test_treasury_balance_returns_zero_without_token_contract() {
         initial_balance: 0,
     };
 
-    blockchain
-        .wallet_registry
-        .insert("dao_treasury".to_string(), treasury_wallet);
+    blockchain.insert_wallet_shadow("dao_treasury".to_string(), treasury_wallet);
     blockchain.dao_treasury_wallet_id = Some("dao_treasury".to_string());
 
     // No SOV token contract registered - should return 0 (not panic)
@@ -149,7 +145,7 @@ fn test_treasury_balance_updates_after_transactions() {
     assert_eq!(balance1, 0);
 
     // Add some tokens
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.set_balance(&treasury_pubkey, 100_000);
     }
 
@@ -157,7 +153,7 @@ fn test_treasury_balance_updates_after_transactions() {
     assert_eq!(balance2, 100_000);
 
     // Add more tokens
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.set_balance(&treasury_pubkey, 250_000);
     }
 
@@ -165,7 +161,7 @@ fn test_treasury_balance_updates_after_transactions() {
     assert_eq!(balance3, 250_000);
 
     // Reduce tokens (simulating spending)
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.set_balance(&treasury_pubkey, 150_000);
     }
 

--- a/lib-blockchain/tests/issue_954_no_reorg_after_commit_tests.rs
+++ b/lib-blockchain/tests/issue_954_no_reorg_after_commit_tests.rs
@@ -51,7 +51,7 @@ fn register_n_validators(blockchain: &mut Blockchain, n: usize) {
             governance_proposal_id: None,
             oracle_key_id: None,
         };
-        blockchain.insert_validator_shadow_keyed(id, info);
+        blockchain.insert_validator_shadow(info);
     }
 }
 

--- a/lib-blockchain/tests/issue_954_no_reorg_after_commit_tests.rs
+++ b/lib-blockchain/tests/issue_954_no_reorg_after_commit_tests.rs
@@ -27,7 +27,7 @@ use lib_blockchain::{Block, BlockHeader, Blockchain, ValidatorInfo};
 // Helpers
 // ============================================================================
 
-/// Register `n` validators directly into `blockchain.validator_registry`.
+/// Register `n` validators via the public shadow-insert API.
 ///
 /// BFT requires ≥4 validators (f=1, quorum=3).  The test registers exactly 4.
 fn register_n_validators(blockchain: &mut Blockchain, n: usize) {
@@ -51,7 +51,7 @@ fn register_n_validators(blockchain: &mut Blockchain, n: usize) {
             governance_proposal_id: None,
             oracle_key_id: None,
         };
-        blockchain.validator_registry.insert(id, info);
+        blockchain.insert_validator_shadow_keyed(id, info);
     }
 }
 
@@ -99,7 +99,7 @@ async fn test_no_reorg_after_commit_with_four_validators() -> Result<()> {
     // Register ≥4 validators — required for BFT (3f+1, f=1 ⟹ n≥4).
     register_n_validators(&mut local_chain, 4);
     assert_eq!(
-        local_chain.validator_registry.len(),
+        local_chain.validator_count(),
         4,
         "Must have exactly 4 validators registered"
     );

--- a/lib-blockchain/tests/oracle_governance_tx_tests.rs
+++ b/lib-blockchain/tests/oracle_governance_tx_tests.rs
@@ -55,8 +55,8 @@ fn create_block_with_txs(
 }
 
 fn insert_active_validator(blockchain: &mut Blockchain, identity: &str, key_id: [u8; 32]) {
-    blockchain.validator_registry.insert(
-        identity.to_string(),
+    blockchain.insert_validator_shadow_keyed(
+identity.to_string(),
         ValidatorInfo {
             identity_id: identity.to_string(),
             stake: 10_000,

--- a/lib-blockchain/tests/oracle_governance_tx_tests.rs
+++ b/lib-blockchain/tests/oracle_governance_tx_tests.rs
@@ -55,27 +55,24 @@ fn create_block_with_txs(
 }
 
 fn insert_active_validator(blockchain: &mut Blockchain, identity: &str, key_id: [u8; 32]) {
-    blockchain.insert_validator_shadow_keyed(
-identity.to_string(),
-        ValidatorInfo {
-            identity_id: identity.to_string(),
-            stake: 10_000,
-            storage_provided: 0,
-            consensus_key: key_id.to_vec(),
-            networking_key: Vec::new(),
-            rewards_key: Vec::new(),
-            network_address: "127.0.0.1:0".to_string(),
-            commission_rate: 0,
-            status: "active".to_string(),
-            registered_at: 0,
-            last_activity: 0,
-            blocks_validated: 0,
-            slash_count: 0,
-            admission_source: "test".to_string(),
-            governance_proposal_id: None,
-            oracle_key_id: Some(key_id),
-        },
-    );
+    blockchain.insert_validator_shadow(ValidatorInfo {
+        identity_id: identity.to_string(),
+        stake: 10_000,
+        storage_provided: 0,
+        consensus_key: key_id.to_vec(),
+        networking_key: Vec::new(),
+        rewards_key: Vec::new(),
+        network_address: "127.0.0.1:0".to_string(),
+        commission_rate: 0,
+        status: "active".to_string(),
+        registered_at: 0,
+        last_activity: 0,
+        blocks_validated: 0,
+        slash_count: 0,
+        admission_source: "test".to_string(),
+        governance_proposal_id: None,
+        oracle_key_id: Some(key_id),
+    });
 }
 
 /// Test that UpdateOracleCommittee transaction type exists and has correct value.

--- a/lib-blockchain/tests/oracle_slashing_tests.rs
+++ b/lib-blockchain/tests/oracle_slashing_tests.rs
@@ -40,9 +40,7 @@ fn slashing_reduces_stake_by_one_percent() {
     let consensus_key = [1u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 1_000_000);
 
-    blockchain
-        .validator_registry
-        .insert(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
 
     // Default config is 1%
     assert_eq!(blockchain.oracle_slashing_config.slash_fraction_bps, 100);
@@ -56,8 +54,7 @@ fn slashing_reduces_stake_by_one_percent() {
 
     // Verify stake reduced
     let v = blockchain
-        .validator_registry
-        .get(&hex::encode(key_id))
+        .validator_info_by_did(&hex::encode(key_id))
         .unwrap();
     assert_eq!(v.stake, 990_000); // 1M - 10K
 }
@@ -70,9 +67,7 @@ fn custom_slash_fraction() {
     let consensus_key = [2u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 1_000_000);
 
-    blockchain
-        .validator_registry
-        .insert(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
 
     // Use 5% slash fraction
     blockchain.oracle_slashing_config = OracleSlashingConfig::with_slash_fraction(500);
@@ -83,8 +78,7 @@ fn custom_slash_fraction() {
     assert_eq!(slashed, 50_000);
 
     let v = blockchain
-        .validator_registry
-        .get(&hex::encode(key_id))
+        .validator_info_by_did(&hex::encode(key_id))
         .unwrap();
     assert_eq!(v.stake, 950_000);
 }
@@ -97,9 +91,7 @@ fn slashing_records_event() {
     let consensus_key = [3u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 500_000);
 
-    blockchain
-        .validator_registry
-        .insert(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
 
     blockchain.slash_oracle_validator(key_id, OracleSlashReason::ConflictingAttestation, 42);
 
@@ -122,9 +114,7 @@ fn slashing_bans_validator() {
     let consensus_key = [4u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 100_000);
 
-    blockchain
-        .validator_registry
-        .insert(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
 
     // Initially not banned
     assert!(!blockchain.oracle_banned_validators.contains(&key_id));
@@ -143,9 +133,7 @@ fn slashing_removes_from_committee() {
     let consensus_key = [5u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 100_000);
 
-    blockchain
-        .validator_registry
-        .insert(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
 
     // Setup committee with validator
     blockchain.oracle_state = OracleState::default();
@@ -177,9 +165,7 @@ fn slashing_events_survive_restart() {
     let consensus_key = [6u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 100_000);
 
-    blockchain
-        .validator_registry
-        .insert(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
 
     blockchain.slash_oracle_validator(key_id, OracleSlashReason::ConflictingAttestation, 100);
 
@@ -227,9 +213,7 @@ fn slashing_zero_stake() {
     let consensus_key = [7u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 0);
 
-    blockchain
-        .validator_registry
-        .insert(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
 
     let slashed = blockchain.slash_oracle_validator(key_id, OracleSlashReason::WrongEpoch, 100);
 
@@ -253,12 +237,8 @@ fn multiple_slashes_recorded() {
     let (validator1, key_id1) = create_validator_info(consensus_key1, 100_000);
     let (validator2, key_id2) = create_validator_info(consensus_key2, 200_000);
 
-    blockchain
-        .validator_registry
-        .insert(hex::encode(key_id1), validator1);
-    blockchain
-        .validator_registry
-        .insert(hex::encode(key_id2), validator2);
+    blockchain.insert_validator_shadow_keyed(hex::encode(key_id1), validator1);
+    blockchain.insert_validator_shadow_keyed(hex::encode(key_id2), validator2);
 
     // Slash both
     blockchain.slash_oracle_validator(key_id1, OracleSlashReason::ConflictingAttestation, 100);

--- a/lib-blockchain/tests/oracle_slashing_tests.rs
+++ b/lib-blockchain/tests/oracle_slashing_tests.rs
@@ -40,7 +40,7 @@ fn slashing_reduces_stake_by_one_percent() {
     let consensus_key = [1u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 1_000_000);
 
-    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow(validator);
 
     // Default config is 1%
     assert_eq!(blockchain.oracle_slashing_config.slash_fraction_bps, 100);
@@ -67,7 +67,7 @@ fn custom_slash_fraction() {
     let consensus_key = [2u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 1_000_000);
 
-    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow(validator);
 
     // Use 5% slash fraction
     blockchain.oracle_slashing_config = OracleSlashingConfig::with_slash_fraction(500);
@@ -91,7 +91,7 @@ fn slashing_records_event() {
     let consensus_key = [3u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 500_000);
 
-    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow(validator);
 
     blockchain.slash_oracle_validator(key_id, OracleSlashReason::ConflictingAttestation, 42);
 
@@ -114,7 +114,7 @@ fn slashing_bans_validator() {
     let consensus_key = [4u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 100_000);
 
-    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow(validator);
 
     // Initially not banned
     assert!(!blockchain.oracle_banned_validators.contains(&key_id));
@@ -133,7 +133,7 @@ fn slashing_removes_from_committee() {
     let consensus_key = [5u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 100_000);
 
-    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow(validator);
 
     // Setup committee with validator
     blockchain.oracle_state = OracleState::default();
@@ -165,7 +165,7 @@ fn slashing_events_survive_restart() {
     let consensus_key = [6u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 100_000);
 
-    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow(validator);
 
     blockchain.slash_oracle_validator(key_id, OracleSlashReason::ConflictingAttestation, 100);
 
@@ -213,7 +213,7 @@ fn slashing_zero_stake() {
     let consensus_key = [7u8; 2592];
     let (validator, key_id) = create_validator_info(consensus_key, 0);
 
-    blockchain.insert_validator_shadow_keyed(hex::encode(key_id), validator);
+    blockchain.insert_validator_shadow(validator);
 
     let slashed = blockchain.slash_oracle_validator(key_id, OracleSlashReason::WrongEpoch, 100);
 
@@ -237,8 +237,8 @@ fn multiple_slashes_recorded() {
     let (validator1, key_id1) = create_validator_info(consensus_key1, 100_000);
     let (validator2, key_id2) = create_validator_info(consensus_key2, 200_000);
 
-    blockchain.insert_validator_shadow_keyed(hex::encode(key_id1), validator1);
-    blockchain.insert_validator_shadow_keyed(hex::encode(key_id2), validator2);
+    blockchain.insert_validator_shadow(validator1);
+    blockchain.insert_validator_shadow(validator2);
 
     // Slash both
     blockchain.slash_oracle_validator(key_id1, OracleSlashReason::ConflictingAttestation, 100);

--- a/lib-blockchain/tests/phase4_api_completeness_tests.rs
+++ b/lib-blockchain/tests/phase4_api_completeness_tests.rs
@@ -12,10 +12,10 @@ mod tests {
 
         // Fresh v2 genesis seeds identity allocations for API/query surfaces
         // (mirrors test_wallet_registry_structure below).
-        assert!(!blockchain.identity_registry.is_empty());
+        assert!(blockchain.identity_count() > 0);
 
-        let identity = blockchain
-            .identity_registry
+        let identity_snapshot = blockchain.identity_registry_snapshot();
+        let identity = identity_snapshot
             .values()
             .next()
             .expect("Expected seeded identity allocation");
@@ -28,10 +28,10 @@ mod tests {
         let blockchain = Blockchain::new().expect("Failed to create blockchain");
 
         // Fresh genesis seeds wallet allocations for API/query surfaces.
-        assert!(!blockchain.wallet_registry.is_empty());
+        let wallet_snapshot = blockchain.wallet_registry_snapshot();
+        assert!(!wallet_snapshot.is_empty());
 
-        let wallet = blockchain
-            .wallet_registry
+        let wallet = wallet_snapshot
             .values()
             .next()
             .expect("Expected seeded wallet allocation");
@@ -112,8 +112,8 @@ mod tests {
         // Fresh v2 genesis seeds identities; verify a seeded record carries
         // the fields the API/query layer depends on. Structural check only —
         // actual data querying happens in the API layer.
-        let identity = blockchain
-            .identity_registry
+        let identity_snapshot = blockchain.identity_registry_snapshot();
+        let identity = identity_snapshot
             .values()
             .next()
             .expect("Expected seeded identity allocation");
@@ -135,8 +135,8 @@ mod tests {
         // - capabilities
         // - created_at
 
-        let wallet = blockchain
-            .wallet_registry
+        let wallet_snapshot = blockchain.wallet_registry_snapshot();
+        let wallet = wallet_snapshot
             .values()
             .next()
             .expect("Expected seeded wallet allocation");

--- a/lib-blockchain/tests/token_regression_tests.rs
+++ b/lib-blockchain/tests/token_regression_tests.rs
@@ -174,7 +174,7 @@ fn register_wallet(
     initial_balance: u128,
 ) {
     let wallet_id_hex = hex::encode(wallet_id);
-    blockchain.wallet_registry.insert(
+    blockchain.insert_wallet_shadow(
         wallet_id_hex.clone(),
         WalletTransactionData {
             wallet_id: Hash::new(wallet_id),
@@ -196,7 +196,7 @@ fn register_wallet(
 /// Register an identity directly in the blockchain state.
 fn register_identity(blockchain: &mut Blockchain, identity_id: &str, pubkey: &PublicKey) {
     use lib_blockchain::transaction::IdentityTransactionData;
-    blockchain.identity_registry.insert(
+    blockchain.insert_identity_shadow(
         identity_id.to_string(),
         IdentityTransactionData {
             did: identity_id.to_string(),
@@ -228,10 +228,7 @@ fn wallet_key(wallet_id: &[u8; 32]) -> PublicKey {
 /// Insert the native SOV token contract into the blockchain (replaces private ensure_sov_token_contract).
 fn insert_sov_token(blockchain: &mut Blockchain) {
     let sov_token_id = generate_lib_token_id();
-    if !blockchain.token_contracts.contains_key(&sov_token_id) {
-        let sov_token = TokenContract::new_sov_native();
-        blockchain.token_contracts.insert(sov_token_id, sov_token);
-    }
+    blockchain.ensure_sov_token_contract();
 }
 
 // ============================================================================
@@ -269,8 +266,7 @@ fn test_create_custom_token() {
     // Verify token was created
     let token_id = generate_custom_token_id("CarbonBlue", "CBE");
     let token = blockchain
-        .token_contracts
-        .get(&token_id)
+        .get_token_contract(&token_id)
         .expect("Token should exist after creation");
 
     assert_eq!(token.name, "CarbonBlue");
@@ -301,7 +297,7 @@ fn test_mint_custom_token_by_creator() {
         creator.clone(),
     );
     let token_id = token.token_id;
-    blockchain.token_contracts.insert(token_id, token);
+    blockchain.insert_token_contract(token_id, token);
 
     // Build TokenMint transaction signed by creator
     let tx = token_mint_tx(&creator, token_id, recipient.key_id, 500_000);
@@ -309,7 +305,7 @@ fn test_mint_custom_token_by_creator() {
 
     blockchain.process_token_transactions(&block).unwrap();
 
-    let token = blockchain.token_contracts.get(&token_id).unwrap();
+    let token = blockchain.get_token_contract(&token_id).unwrap();
     assert_eq!(
         token.balance_of(&recipient),
         500_000,
@@ -340,7 +336,7 @@ fn test_mint_custom_token_unauthorized_rejected() {
         creator.clone(),
     );
     let token_id = token.token_id;
-    blockchain.token_contracts.insert(token_id, token);
+    blockchain.insert_token_contract(token_id, token);
 
     // Attacker signs a TokenMint — must be rejected
     let tx = token_mint_tx(&attacker, token_id, recipient.key_id, 999_999);
@@ -351,7 +347,7 @@ fn test_mint_custom_token_unauthorized_rejected() {
     assert!(result.unwrap_err().to_string().contains("unauthorized"));
 
     // Verify no tokens were minted
-    let token = blockchain.token_contracts.get(&token_id).unwrap();
+    let token = blockchain.get_token_contract(&token_id).unwrap();
     assert_eq!(
         token.balance_of(&recipient),
         0,
@@ -379,7 +375,7 @@ fn test_kernel_controlled_tokenmint_bypass_rejected() {
     );
     token.kernel_mint_authority = Some(kernel_authority.clone());
     let token_id = token.token_id;
-    blockchain.token_contracts.insert(token_id, token);
+    blockchain.insert_token_contract(token_id, token);
 
     let tx = token_mint_tx(&attacker, token_id, recipient.key_id, 1_000);
     let block = test_block(1, vec![tx]);
@@ -410,14 +406,14 @@ fn test_kernel_controlled_tokenmint_via_kernel_authority_succeeds() {
     );
     token.kernel_mint_authority = Some(kernel_authority.clone());
     let token_id = token.token_id;
-    blockchain.token_contracts.insert(token_id, token);
+    blockchain.insert_token_contract(token_id, token);
 
     let tx = token_mint_tx(&kernel_authority, token_id, recipient.key_id, 1_000);
     let block = test_block(1, vec![tx]);
 
     blockchain.process_token_transactions(&block).unwrap();
 
-    let token = blockchain.token_contracts.get(&token_id).unwrap();
+    let token = blockchain.get_token_contract(&token_id).unwrap();
     assert_eq!(token.balance_of(&recipient), 1_000);
 }
 
@@ -442,7 +438,7 @@ fn test_sov_wallet_transfer() {
 
     // Mint SOV to sender wallet (using synthetic wallet key)
     let sender_wallet_key = wallet_key(&sender_wallet_id);
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.mint(&sender_wallet_key, 10_000).unwrap();
     }
 
@@ -459,7 +455,7 @@ fn test_sov_wallet_transfer() {
 
     blockchain.process_token_transactions(&block).unwrap();
 
-    let token = blockchain.token_contracts.get(&sov_token_id).unwrap();
+    let token = blockchain.get_token_contract(&sov_token_id).unwrap();
     let sender_balance = token.balance_of(&wallet_key(&sender_wallet_id));
     let recipient_balance = token.balance_of(&wallet_key(&recipient_wallet_id));
 
@@ -493,7 +489,7 @@ fn test_custom_token_transfer() {
         creator.clone(),
     );
     let token_id = token.token_id;
-    blockchain.token_contracts.insert(token_id, token);
+    blockchain.insert_token_contract(token_id, token);
 
     // Transfer using key_id addressing (not wallet_id — this is a custom token)
     let tx = token_transfer_tx(
@@ -508,7 +504,7 @@ fn test_custom_token_transfer() {
 
     blockchain.process_token_transactions(&block).unwrap();
 
-    let token = blockchain.token_contracts.get(&token_id).unwrap();
+    let token = blockchain.get_token_contract(&token_id).unwrap();
     assert_eq!(
         token.balance_of(&creator),
         750_000,
@@ -537,7 +533,7 @@ fn test_contract_execution_burn_rejected() {
     );
     let token_id = token.token_id;
     let initial_supply = token.total_supply;
-    blockchain.token_contracts.insert(token_id, token);
+    blockchain.insert_token_contract(token_id, token);
 
     // Burn via ContractExecution
     #[derive(serde::Serialize)]
@@ -559,7 +555,7 @@ fn test_contract_execution_burn_rejected() {
         "process_contract_transactions must not abort on a rejected ContractExecution"
     );
 
-    let token = blockchain.token_contracts.get(&token_id).unwrap();
+    let token = blockchain.get_token_contract(&token_id).unwrap();
     assert_eq!(
         token.balance_of(&creator),
         1_000_000,
@@ -595,7 +591,7 @@ fn test_contract_execution_mint_rejected_for_kernel_controlled_token() {
     );
     token.kernel_mint_authority = Some(kernel_authority);
     let token_id = token.token_id;
-    blockchain.token_contracts.insert(token_id, token);
+    blockchain.insert_token_contract(token_id, token);
 
     let params = MintParams {
         token_id,
@@ -611,7 +607,7 @@ fn test_contract_execution_mint_rejected_for_kernel_controlled_token() {
         "process_contract_transactions currently swallows contract-execution errors"
     );
 
-    let token = blockchain.token_contracts.get(&token_id).unwrap();
+    let token = blockchain.get_token_contract(&token_id).unwrap();
     assert_eq!(
         token.balance_of(&recipient),
         0,
@@ -640,7 +636,7 @@ fn test_contract_execution_burn_rejected_for_kernel_controlled_token() {
     );
     token.kernel_mint_authority = Some(kernel_authority);
     let token_id = token.token_id;
-    blockchain.token_contracts.insert(token_id, token);
+    blockchain.insert_token_contract(token_id, token);
 
     let params = BurnParams {
         token_id,
@@ -655,7 +651,7 @@ fn test_contract_execution_burn_rejected_for_kernel_controlled_token() {
         "process_contract_transactions currently swallows contract-execution errors"
     );
 
-    let token = blockchain.token_contracts.get(&token_id).unwrap();
+    let token = blockchain.get_token_contract(&token_id).unwrap();
     assert_eq!(
         token.total_supply, 1_000_000,
         "Kernel-protected burn bypass must not mutate supply"
@@ -676,7 +672,7 @@ fn test_contract_execution_transfer_rejected() {
         creator.clone(),
     );
     let token_id = token.token_id;
-    blockchain.token_contracts.insert(token_id, token);
+    blockchain.insert_token_contract(token_id, token);
 
     #[derive(serde::Serialize)]
     struct TransferParams {
@@ -698,7 +694,7 @@ fn test_contract_execution_transfer_rejected() {
         "ContractExecution token transfer must be rejected"
     );
 
-    let token = blockchain.token_contracts.get(&token_id).unwrap();
+    let token = blockchain.get_token_contract(&token_id).unwrap();
     assert_eq!(
         token.balance_of(&creator),
         1_000_000,
@@ -728,7 +724,7 @@ fn test_balance_queries_after_operations() {
 
     // Mint SOV to wallet A
     let wallet_a_key = wallet_key(&wallet_a);
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.mint(&wallet_a_key, 50_000).unwrap();
     }
 
@@ -742,7 +738,7 @@ fn test_balance_queries_after_operations() {
     let block2 = test_block(2, vec![tx2]);
     blockchain.process_token_transactions(&block2).unwrap();
 
-    let token = blockchain.token_contracts.get(&sov_token_id).unwrap();
+    let token = blockchain.get_token_contract(&sov_token_id).unwrap();
     assert_eq!(
         token.balance_of(&wallet_key(&wallet_a)),
         25_000,
@@ -772,11 +768,11 @@ fn test_token_list() {
         TokenContract::new_custom("Beta".to_string(), "BET".to_string(), 200, creator.clone());
     let id1 = token1.token_id;
     let id2 = token2.token_id;
-    blockchain.token_contracts.insert(id1, token1);
-    blockchain.token_contracts.insert(id2, token2);
+    blockchain.insert_token_contract(id1, token1);
+    blockchain.insert_token_contract(id2, token2);
 
     // Verify all tokens are listed
-    let contracts = &blockchain.token_contracts;
+    let contracts = blockchain.get_all_token_contracts();
     assert!(
         contracts.contains_key(&generate_lib_token_id()),
         "SOV should be in list"
@@ -809,7 +805,7 @@ fn test_wallet_registration_mints_initial_balance() {
 
     blockchain.process_wallet_transactions(&block).unwrap();
 
-    let token = blockchain.token_contracts.get(&sov_token_id).unwrap();
+    let token = blockchain.get_token_contract(&sov_token_id).unwrap();
     let balance = token.balance_of(&wallet_key(&wallet_id));
     assert_eq!(
         balance, initial_balance,
@@ -834,7 +830,7 @@ fn test_transfer_insufficient_balance() {
 
     // Mint only 100 SOV to sender
     let sender_key = wallet_key(&sender_wallet);
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.mint(&sender_key, 100).unwrap();
     }
 
@@ -870,7 +866,7 @@ fn test_transfer_to_nonexistent_wallet_fails() {
     register_wallet(&mut blockchain, sender_wallet, &sender_pk, 0);
 
     let sender_key = wallet_key(&sender_wallet);
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         token.mint(&sender_key, 10_000).unwrap();
     }
 
@@ -904,7 +900,7 @@ fn test_duplicate_symbol_rejected() {
         1000,
         creator.clone(),
     );
-    blockchain.token_contracts.insert(token.token_id, token);
+    blockchain.insert_token_contract(token.token_id, token);
 
     // Try creating another token with same symbol via ContractExecution
     #[derive(serde::Serialize)]
@@ -932,7 +928,7 @@ fn test_duplicate_symbol_rejected() {
 
     // Verify only the original token exists (no duplicate created)
     let count = blockchain
-        .token_contracts
+        .get_all_token_contracts()
         .values()
         .filter(|t| t.symbol.to_uppercase() == "CBE")
         .count();
@@ -961,8 +957,7 @@ fn test_replay_protection_rejects_duplicate_nonce() {
     // Mint SOV to sender
     let sender_key = wallet_key(&sender_wid);
     blockchain
-        .token_contracts
-        .get_mut(&sov_token_id)
+        .get_token_contract_mut(&sov_token_id)
         .unwrap()
         .mint(&sender_key, 1_000_000)
         .unwrap();
@@ -1016,8 +1011,7 @@ fn test_sequential_nonces() {
     // Mint SOV to sender
     let sender_key = wallet_key(&sender_wid);
     blockchain
-        .token_contracts
-        .get_mut(&sov_token_id)
+        .get_token_contract_mut(&sov_token_id)
         .unwrap()
         .mint(&sender_key, 1_000_000)
         .unwrap();
@@ -1042,7 +1036,7 @@ fn test_sequential_nonces() {
     }
 
     // Verify final balances
-    let token = blockchain.token_contracts.get(&sov_token_id).unwrap();
+    let token = blockchain.get_token_contract(&sov_token_id).unwrap();
     assert_eq!(
         token.balance_of(&wallet_key(&sender_wid)),
         1_000_000 - 30_000
@@ -1074,12 +1068,9 @@ fn test_nonces_are_per_token() {
         sender_pk.clone(),
     );
     let custom_token_id = custom_token.token_id;
+    blockchain.insert_token_contract(custom_token_id, custom_token);
     blockchain
-        .token_contracts
-        .insert(custom_token_id, custom_token);
-    blockchain
-        .token_contracts
-        .get_mut(&custom_token_id)
+        .get_token_contract_mut(&custom_token_id)
         .unwrap()
         .mint(&sender_pk, 500_000)
         .unwrap();
@@ -1087,8 +1078,7 @@ fn test_nonces_are_per_token() {
     // Mint SOV to sender wallet
     let sender_key = wallet_key(&sender_wid);
     blockchain
-        .token_contracts
-        .get_mut(&sov_token_id)
+        .get_token_contract_mut(&sov_token_id)
         .unwrap()
         .mint(&sender_key, 1_000_000)
         .unwrap();

--- a/lib-blockchain/tests/token_regression_tests.rs
+++ b/lib-blockchain/tests/token_regression_tests.rs
@@ -225,10 +225,12 @@ fn wallet_key(wallet_id: &[u8; 32]) -> PublicKey {
     pk
 }
 
-/// Insert the native SOV token contract into the blockchain (replaces private ensure_sov_token_contract).
+/// Insert the native SOV token contract into the blockchain in-memory shadow.
 fn insert_sov_token(blockchain: &mut Blockchain) {
     let sov_token_id = generate_lib_token_id();
-    blockchain.ensure_sov_token_contract();
+    if !blockchain.token_contract_shadow_contains_key(&sov_token_id) {
+        blockchain.insert_token_contract(sov_token_id, TokenContract::new_sov_native());
+    }
 }
 
 // ============================================================================
@@ -771,22 +773,33 @@ fn test_token_list() {
     blockchain.insert_token_contract(id1, token1);
     blockchain.insert_token_contract(id2, token2);
 
-    // Verify all tokens are listed
-    let contracts = blockchain.get_all_token_contracts();
+    // Verify all tokens are listed in the in-memory shadow
     assert!(
-        contracts.contains_key(&generate_lib_token_id()),
+        blockchain.token_contract_shadow_contains_key(&generate_lib_token_id()),
         "SOV should be in list"
     );
-    assert!(contracts.contains_key(&id1), "Alpha should be in list");
-    assert!(contracts.contains_key(&id2), "Beta should be in list");
     assert!(
-        contracts.len() >= 3,
+        blockchain.token_contract_shadow_contains_key(&id1),
+        "Alpha should be in list"
+    );
+    assert!(
+        blockchain.token_contract_shadow_contains_key(&id2),
+        "Beta should be in list"
+    );
+    assert!(
+        blockchain.token_contract_shadow_len() >= 3,
         "Should have at least SOV + 2 custom tokens"
     );
 
     // Verify metadata
-    assert_eq!(contracts[&id1].symbol, "ALP");
-    assert_eq!(contracts[&id2].symbol, "BET");
+    assert_eq!(
+        blockchain.token_contract_shadow(&id1).unwrap().symbol,
+        "ALP"
+    );
+    assert_eq!(
+        blockchain.token_contract_shadow(&id2).unwrap().symbol,
+        "BET"
+    );
 }
 
 /// Test 9: Wallet registration via block processing mints initial SOV balance.
@@ -928,8 +941,7 @@ fn test_duplicate_symbol_rejected() {
 
     // Verify only the original token exists (no duplicate created)
     let count = blockchain
-        .get_all_token_contracts()
-        .values()
+        .iter_token_contract_shadow_values()
         .filter(|t| t.symbol.to_uppercase() == "CBE")
         .count();
     assert_eq!(

--- a/lib-blockchain/tests/token_snapshot_restart_tests.rs
+++ b/lib-blockchain/tests/token_snapshot_restart_tests.rs
@@ -137,7 +137,7 @@ fn test_restart_replays_committed_token_state_and_nonces() -> Result<()> {
         .expect("Expected blockchain to load from committed block replay");
 
     let token = reloaded
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .expect("SOV token must be reconstructed from committed block replay");
     assert_eq!(token.balance_of(&wallet_key(&sender_wallet)), 8_500);
@@ -198,11 +198,11 @@ fn test_cross_node_loads_converge_to_identical_token_state() -> Result<()> {
     let node_b = lib_blockchain::Blockchain::load_from_store(store)?.expect("node B should load");
 
     let token_a = node_a
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .expect("node A token missing");
     let token_b = node_b
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .expect("node B token missing");
 
@@ -212,8 +212,8 @@ fn test_cross_node_loads_converge_to_identical_token_state() -> Result<()> {
     assert_eq!(token_b.balance_of(&wallet_key(&recipient_wallet)), 2_500);
     assert_eq!(node_a.get_token_nonce(&sov_token_id, &sender_wallet), 1);
     assert_eq!(node_b.get_token_nonce(&sov_token_id, &sender_wallet), 1);
-    assert_eq!(node_a.token_nonces, node_b.token_nonces);
-    assert_eq!(node_a.token_contracts.len(), node_b.token_contracts.len());
+    assert_eq!(node_a.token_nonces_snapshot(), node_b.token_nonces_snapshot());
+    assert_eq!(node_a.token_contract_count(), node_b.token_contract_count());
 
     Ok(())
 }
@@ -269,11 +269,11 @@ fn test_restart_preserves_sov_supply_and_recipient_count() -> Result<()> {
         .expect("after restart should load from committed replay");
 
     let before_token = before_restart
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .expect("before restart SOV token should exist");
     let after_token = after_restart
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .expect("after restart SOV token should exist");
 
@@ -366,7 +366,7 @@ fn test_uncommitted_block_does_not_leak_token_state_after_restart() -> Result<()
         .expect("recovery load should succeed");
 
     let token = recovered
-        .token_contracts
+        .get_all_token_contracts()
         .get(&sov_token_id)
         .expect("SOV token should exist after recovery");
     assert_eq!(token.balance_of(&wallet_key(&sender_wallet)), 9_000);

--- a/lib-blockchain/tests/token_snapshot_restart_tests.rs
+++ b/lib-blockchain/tests/token_snapshot_restart_tests.rs
@@ -137,8 +137,7 @@ fn test_restart_replays_committed_token_state_and_nonces() -> Result<()> {
         .expect("Expected blockchain to load from committed block replay");
 
     let token = reloaded
-        .get_all_token_contracts()
-        .get(&sov_token_id)
+        .token_contract_shadow(&sov_token_id)
         .expect("SOV token must be reconstructed from committed block replay");
     assert_eq!(token.balance_of(&wallet_key(&sender_wallet)), 8_500);
     assert_eq!(token.balance_of(&wallet_key(&recipient_wallet)), 1_500);
@@ -198,12 +197,10 @@ fn test_cross_node_loads_converge_to_identical_token_state() -> Result<()> {
     let node_b = lib_blockchain::Blockchain::load_from_store(store)?.expect("node B should load");
 
     let token_a = node_a
-        .get_all_token_contracts()
-        .get(&sov_token_id)
+        .token_contract_shadow(&sov_token_id)
         .expect("node A token missing");
     let token_b = node_b
-        .get_all_token_contracts()
-        .get(&sov_token_id)
+        .token_contract_shadow(&sov_token_id)
         .expect("node B token missing");
 
     assert_eq!(token_a.balance_of(&wallet_key(&sender_wallet)), 17_500);
@@ -269,12 +266,10 @@ fn test_restart_preserves_sov_supply_and_recipient_count() -> Result<()> {
         .expect("after restart should load from committed replay");
 
     let before_token = before_restart
-        .get_all_token_contracts()
-        .get(&sov_token_id)
+        .token_contract_shadow(&sov_token_id)
         .expect("before restart SOV token should exist");
     let after_token = after_restart
-        .get_all_token_contracts()
-        .get(&sov_token_id)
+        .token_contract_shadow(&sov_token_id)
         .expect("after restart SOV token should exist");
 
     assert_eq!(
@@ -366,8 +361,7 @@ fn test_uncommitted_block_does_not_leak_token_state_after_restart() -> Result<()
         .expect("recovery load should succeed");
 
     let token = recovered
-        .get_all_token_contracts()
-        .get(&sov_token_id)
+        .token_contract_shadow(&sov_token_id)
         .expect("SOV token should exist after recovery");
     assert_eq!(token.balance_of(&wallet_key(&sender_wallet)), 9_000);
     assert_eq!(token.balance_of(&wallet_key(&recipient_wallet)), 0);

--- a/lib-blockchain/tests/treasury_dao_bootstrap_tests.rs
+++ b/lib-blockchain/tests/treasury_dao_bootstrap_tests.rs
@@ -138,7 +138,8 @@ fn test_treasury_wallet_survives_round_trip() {
     let mut blockchain = Blockchain::default();
 
     // Ensure SOV token contract is present (needed for persistence tests).
-    blockchain.ensure_sov_token_contract();
+    let sov_token_id = generate_lib_token_id();
+    blockchain.insert_token_contract(sov_token_id, TokenContract::new_sov_native());
 
     let original_id = blockchain.dao_treasury_wallet_id.clone().unwrap();
 
@@ -182,8 +183,8 @@ fn test_block_fees_credited_to_treasury() {
     treasury_id.copy_from_slice(&treasury_id_bytes);
 
     // Ensure SOV token contract exists.
-    blockchain.ensure_sov_token_contract();
     let sov_token_id = generate_lib_token_id();
+    blockchain.insert_token_contract(sov_token_id, TokenContract::new_sov_native());
 
     // v2 genesis may pre-fund the treasury, so capture the starting balance
     // rather than assuming zero — the invariant under test is that a credited

--- a/lib-blockchain/tests/treasury_dao_bootstrap_tests.rs
+++ b/lib-blockchain/tests/treasury_dao_bootstrap_tests.rs
@@ -50,11 +50,13 @@ fn test_treasury_wallet_initialized_on_new_blockchain() {
 
     // Registry entry must exist
     assert!(
-        blockchain.wallet_registry.contains_key(wallet_id),
+        blockchain.wallet_exists(wallet_id),
         "Treasury wallet must be present in wallet_registry"
     );
 
-    let entry = &blockchain.wallet_registry[wallet_id];
+    let entry = blockchain
+        .wallet_transaction_data(wallet_id)
+        .expect("treasury wallet entry");
     // The treasury wallet is either created fresh by `ensure_treasury_wallet`
     // ("DAO Treasury", initial_balance 0) OR pre-seeded by v2 genesis as a
     // migrated, pre-funded allocation — `ensure_treasury_wallet`'s
@@ -90,7 +92,7 @@ fn test_treasury_wallet_idempotent() {
     let wallet_id = blockchain.dao_treasury_wallet_id.as_ref().unwrap().clone();
 
     let count = blockchain
-        .wallet_registry
+        .wallet_registry_snapshot()
         .keys()
         .filter(|k| *k == &wallet_id)
         .count();
@@ -115,7 +117,7 @@ fn test_treasury_wallet_idempotent() {
     let loaded = Blockchain::load_from_file(&path).expect("load_from_file");
 
     let reloaded_count = loaded
-        .wallet_registry
+        .wallet_registry_snapshot()
         .keys()
         .filter(|k| *k == &wallet_id)
         .count();
@@ -136,12 +138,7 @@ fn test_treasury_wallet_survives_round_trip() {
     let mut blockchain = Blockchain::default();
 
     // Ensure SOV token contract is present (needed for persistence tests).
-    let sov_token_id = generate_lib_token_id();
-    if !blockchain.token_contracts.contains_key(&sov_token_id) {
-        blockchain
-            .token_contracts
-            .insert(sov_token_id, TokenContract::new_sov_native());
-    }
+    blockchain.ensure_sov_token_contract();
 
     let original_id = blockchain.dao_treasury_wallet_id.clone().unwrap();
 
@@ -164,7 +161,7 @@ fn test_treasury_wallet_survives_round_trip() {
 
     // Registry entry must also survive.
     assert!(
-        loaded.wallet_registry.contains_key(&original_id),
+        loaded.wallet_exists(&original_id),
         "Treasury wallet registry entry must survive persistence round-trip"
     );
 }
@@ -185,11 +182,8 @@ fn test_block_fees_credited_to_treasury() {
     treasury_id.copy_from_slice(&treasury_id_bytes);
 
     // Ensure SOV token contract exists.
+    blockchain.ensure_sov_token_contract();
     let sov_token_id = generate_lib_token_id();
-    blockchain
-        .token_contracts
-        .entry(sov_token_id)
-        .or_insert_with(TokenContract::new_sov_native);
 
     // v2 genesis may pre-fund the treasury, so capture the starting balance
     // rather than assuming zero — the invariant under test is that a credited
@@ -201,7 +195,7 @@ fn test_block_fees_credited_to_treasury() {
     // Simulate what process_token_transactions does: credit fees via wallet_key_for_sov.
     let fee_amount: u128 = 42_000_000;
     let treasury_key = wallet_key_for_sov(&treasury_id);
-    if let Some(token) = blockchain.token_contracts.get_mut(&sov_token_id) {
+    if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
         let current = token.balance_of(&treasury_key);
         token
             .set_balance(&treasury_key, current.saturating_add(fee_amount));

--- a/lib-blockchain/tests/wallet_projection_restart_tests.rs
+++ b/lib-blockchain/tests/wallet_projection_restart_tests.rs
@@ -97,8 +97,8 @@ fn test_wallet_projection_loaded_state_matches_replay_rebuilt_state() -> Result<
 
     let wallet_id_hex = hex::encode(wallet_id);
     assert_eq!(
-        projection_loaded.wallet_registry.get(&wallet_id_hex),
-        replay_rebuilt.wallet_registry.get(&wallet_id_hex)
+        projection_loaded.wallet_transaction_data(&wallet_id_hex),
+        replay_rebuilt.wallet_transaction_data(&wallet_id_hex)
     );
     assert_eq!(
         projection_loaded.wallet_blocks.get(&wallet_id_hex),
@@ -166,7 +166,7 @@ fn test_uncommitted_wallet_projection_update_does_not_leak_after_restart() -> Re
 
     let wallet_id_hex = hex::encode(wallet_id);
     assert_eq!(recovered.height, 0);
-    assert_eq!(recovered.wallet_registry.get(&wallet_id_hex), Some(&wallet));
+    assert_eq!(recovered.wallet_transaction_data(&wallet_id_hex), Some(wallet));
     assert_eq!(recovered.wallet_blocks.get(&wallet_id_hex), Some(&0));
     assert_eq!(
         recovered_store.get_wallet_projection(&wallet_id)?,

--- a/tools/chain_audit.rs
+++ b/tools/chain_audit.rs
@@ -161,8 +161,7 @@ fn main() -> Result<()> {
     let sov_id = lib_blockchain::contracts::utils::generate_lib_token_id();
     let sov_balance_count = bc.count_token_holders(&sov_id);
     let sov_total: u128 = bc
-        .get_all_token_contracts()
-        .get(&sov_id)
+        .token_contract_shadow(&sov_id)
         .map(|t| t.total_balance_sum())
         .unwrap_or(0);
     println!("  SOV token balance entries:  {}", sov_balance_count);

--- a/tools/chain_audit.rs
+++ b/tools/chain_audit.rs
@@ -141,12 +141,13 @@ fn main() -> Result<()> {
         }
     };
 
-    println!("  identity_registry entries:  {}", bc.identity_registry.len());
-    println!("  wallet_registry entries:    {}", bc.wallet_registry.len());
+    println!("  identity_registry entries:  {}", bc.identity_count());
+    println!("  wallet_registry entries:    {}", bc.wallet_count());
 
     println!();
     println!("=== IDENTITY → WALLET MAPPING ===");
-    let mut sorted_ids: Vec<_> = bc.identity_registry.values().collect();
+    let identity_snapshot = bc.identity_registry_snapshot();
+    let mut sorted_ids: Vec<_> = identity_snapshot.values().collect();
     sorted_ids.sort_by(|a, b| a.did.cmp(&b.did));
     for id in &sorted_ids {
         println!("  SID:     {}", id.did);
@@ -158,11 +159,9 @@ fn main() -> Result<()> {
     }
 
     let sov_id = lib_blockchain::contracts::utils::generate_lib_token_id();
-    let sov_balance_count = bc.token_contracts
-        .get(&sov_id)
-        .map(|t| t.balances_len())
-        .unwrap_or(0);
-    let sov_total: u128 = bc.token_contracts
+    let sov_balance_count = bc.count_token_holders(&sov_id);
+    let sov_total: u128 = bc
+        .get_all_token_contracts()
         .get(&sov_id)
         .map(|t| t.total_balance_sum())
         .unwrap_or(0);
@@ -171,14 +170,14 @@ fn main() -> Result<()> {
     println!();
 
     println!("=== DIVERGENCE ANALYSIS ===");
-    let identity_divergence = bc.identity_registry.len() as i64 - identity_dids_in_blocks.len() as i64;
-    let wallet_divergence = bc.wallet_registry.len() as i64 - wallet_ids_in_blocks.len() as i64;
+    let identity_divergence = bc.identity_count() as i64 - identity_dids_in_blocks.len() as i64;
+    let wallet_divergence = bc.wallet_count() as i64 - wallet_ids_in_blocks.len() as i64;
     let balance_divergence = sov_balance_count as i64 - token_mint_wallets.len() as i64;
 
     println!("  Identities: {} in memory vs {} in blocks  -> divergence: {}",
-        bc.identity_registry.len(), identity_dids_in_blocks.len(), identity_divergence);
+        bc.identity_count(), identity_dids_in_blocks.len(), identity_divergence);
     println!("  Wallets:    {} in memory vs {} in blocks  -> divergence: {}",
-        bc.wallet_registry.len(), wallet_ids_in_blocks.len(), wallet_divergence);
+        bc.wallet_count(), wallet_ids_in_blocks.len(), wallet_divergence);
     println!("  Balances:   {} in memory vs {} minted in blocks -> divergence: {}",
         sov_balance_count, token_mint_wallets.len(), balance_divergence);
 
@@ -195,8 +194,8 @@ fn main() -> Result<()> {
     if identity_divergence > 0 {
         println!();
         println!("=== IDENTITIES IN MEMORY BUT NOT IN ANY BLOCK ===");
-        for (did, _) in &bc.identity_registry {
-            if !identity_dids_in_blocks.contains(did) {
+        for (did, _) in bc.identity_registry_snapshot() {
+            if !identity_dids_in_blocks.contains(&did) {
                 println!("  {}", did);
             }
         }
@@ -206,8 +205,8 @@ fn main() -> Result<()> {
     if wallet_divergence > 0 {
         println!();
         println!("=== WALLETS IN MEMORY BUT NOT IN ANY BLOCK ===");
-        for (wallet_id, wallet) in &bc.wallet_registry {
-            if !wallet_ids_in_blocks.contains(wallet_id) {
+        for (wallet_id, wallet) in bc.wallet_registry_snapshot() {
+            if !wallet_ids_in_blocks.contains(&wallet_id) {
                 println!("  {} (type: {}, initial_balance: {})",
                     wallet_id, wallet.wallet_type, wallet.initial_balance);
             }

--- a/tools/testnet_reset.rs
+++ b/tools/testnet_reset.rs
@@ -97,9 +97,9 @@ fn main() -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("No committed blocks in source sled"))?;
 
     let identities: Vec<IdentityTransactionData> =
-        bc.identity_registry.values().cloned().collect();
+        bc.identity_registry_snapshot().into_values().collect();
     let wallets: Vec<WalletTransactionData> =
-        bc.wallet_registry.values().cloned().collect();
+        bc.wallet_registry_snapshot().into_values().collect();
 
     println!("  Identities extracted:  {}", identities.len());
     println!("  Wallets extracted:     {}", wallets.len());

--- a/tools/wallet_probe.rs
+++ b/tools/wallet_probe.rs
@@ -38,8 +38,8 @@ fn main() -> Result<()> {
 
     println!(
         "Post-tx-replay (no genesis): identities={} wallets={}",
-        blockchain.identity_registry.len(),
-        blockchain.wallet_registry.len()
+        blockchain.identity_count(),
+        blockchain.wallet_count()
     );
 
     // load_from_store replays transactions only — genesis identities/wallets
@@ -55,13 +55,13 @@ fn main() -> Result<()> {
     }
 
     println!("Chain height: {}", blockchain.get_height());
-    println!("identity_registry entries: {}", blockchain.identity_registry.len());
-    println!("wallet_registry   entries: {}", blockchain.wallet_registry.len());
+    println!("identity_registry entries: {}", blockchain.identity_count());
+    println!("wallet_registry   entries: {}", blockchain.wallet_count());
     println!("target id/did: {}\n", target);
 
     // ── Locate the identity ────────────────────────────────────────────────
     let mut matched: Option<(String, [u8; 32], [u8; 32])> = None; // (did, dil_hash, combined_hash)
-    for (did, id) in blockchain.identity_registry.iter() {
+    for (did, id) in blockchain.identity_registry_snapshot() {
         if id.public_key.len() < 32 {
             continue;
         }
@@ -105,7 +105,7 @@ fn main() -> Result<()> {
     println!("\n=== WALLETS OWNED BY EITHER DERIVATION ===");
     let did_bytes = hex::decode(did.trim_start_matches("did:zhtp:")).unwrap_or_default();
     let mut hits = 0;
-    for (wallet_id_hex, w) in blockchain.wallet_registry.iter() {
+    for (wallet_id_hex, w) in blockchain.wallet_registry_snapshot() {
         let owner = match &w.owner_identity_id {
             Some(o) => o.as_bytes().to_vec(),
             None => continue,
@@ -137,7 +137,7 @@ fn main() -> Result<()> {
     // ── Also: every distinct owner_identity_id in the registry (sample) ────
     if hits == 0 {
         println!("\n=== SAMPLE: first 10 wallet owners in registry (for derivation comparison) ===");
-        for (wid, w) in blockchain.wallet_registry.iter().take(10) {
+        for (wid, w) in blockchain.wallet_registry_snapshot().into_iter().take(10) {
             println!(
                 "  wallet {} owner={:?}",
                 wid,

--- a/zhtp-cli/src/commands/blockchain.rs
+++ b/zhtp-cli/src/commands/blockchain.rs
@@ -222,16 +222,15 @@ fn audit_wallet_migration(
     let report = WalletMigrationAuditReport {
         dat_file: dat_path.display().to_string(),
         chain_height: blockchain.height,
-        total_wallets_in_local_state: blockchain.wallet_registry.len(),
+        total_wallets_in_local_state: blockchain.wallet_count(),
         noncanonical_wallet_count: blockchain.collect_noncanonical_wallets().len(),
         treasury_wallet_id: treasury_wallet_id_hex.clone(),
         treasury_wallet_present_in_local_state: blockchain
-            .wallet_registry
-            .contains_key(&treasury_wallet_id_hex),
+            .wallet_exists(&treasury_wallet_id_hex),
         treasury_wallet_canonical_in_history: blockchain.dao_treasury_wallet_is_canonical(),
         treasury_wallet_requires_schema_change: blockchain
-            .wallet_registry
-            .get(&treasury_wallet_id_hex)
+            .wallet_transaction_data(&treasury_wallet_id_hex)
+            .as_ref()
             .map(|wallet| build_wallet_migration_tx(wallet).is_none())
             .unwrap_or(false),
         candidates,

--- a/zhtp-cli/src/commands/blockchain.rs
+++ b/zhtp-cli/src/commands/blockchain.rs
@@ -222,7 +222,7 @@ fn audit_wallet_migration(
     let report = WalletMigrationAuditReport {
         dat_file: dat_path.display().to_string(),
         chain_height: blockchain.height,
-        total_wallets_in_local_state: blockchain.wallet_count(),
+        total_wallets_in_local_state: blockchain.wallet_registry_shadow_len(),
         noncanonical_wallet_count: blockchain.collect_noncanonical_wallets().len(),
         treasury_wallet_id: treasury_wallet_id_hex.clone(),
         treasury_wallet_present_in_local_state: blockchain

--- a/zhtp-cli/src/commands/genesis.rs
+++ b/zhtp-cli/src/commands/genesis.rs
@@ -73,8 +73,8 @@ fn cmd_export_state(dat_file: Option<PathBuf>, output: PathBuf) -> Result<()> {
     println!(
         "Loaded blockchain: height={}, wallets={}, identities={}, web4={}",
         bc.height,
-        bc.wallet_registry.len(),
-        bc.identity_registry.len(),
+        bc.wallet_count(),
+        bc.identity_count(),
         bc.web4_contracts.len(),
     );
 

--- a/zhtp/src/api/handlers/dao/mod.rs
+++ b/zhtp/src/api/handlers/dao/mod.rs
@@ -3745,9 +3745,7 @@ mod tests {
     }
 
     fn insert_active_validator(blockchain: &mut Blockchain, did: &str, key_id: [u8; 32]) {
-        blockchain.validator_registry.insert(
-            did.to_string(),
-            ValidatorInfo {
+        blockchain.insert_validator_shadow(ValidatorInfo {
                 identity_id: did.to_string(),
                 stake: 10_000,
                 storage_provided: 0,
@@ -3768,8 +3766,7 @@ mod tests {
                 admission_source: "test".to_string(),
                 governance_proposal_id: None,
                 oracle_key_id: Some(key_id),
-            },
-        );
+            });
     }
 
     #[test]

--- a/zhtp/src/api/handlers/identity/backup_recovery.rs
+++ b/zhtp/src/api/handlers/identity/backup_recovery.rs
@@ -630,14 +630,9 @@ async fn migrate_wallets_for_identity(
         let token_id_storage = lib_blockchain::storage::TokenId::new(sov_token_id);
 
         let owned: Vec<_> = blockchain
-            .wallet_registry
-            .values()
-            .filter(|w| {
-                w.owner_identity_id
-                    .map(|owner| owner.as_bytes() == identity_id.0.as_slice())
-                    .unwrap_or(false)
-            })
-            .cloned()
+            .wallets_for_owner(&lib_blockchain::Hash::from_slice(&identity_id.0))
+            .into_iter()
+            .map(|(_, w)| w)
             .collect();
 
         let any_wallet_exists = !owned.is_empty();
@@ -791,9 +786,7 @@ async fn create_fallback_wallet(
 
     match blockchain.add_system_transaction(reg_tx, "recovery_fallback_wallet") {
         Ok(_) => {
-            blockchain
-                .wallet_registry
-                .insert(wallet_id_hex.clone(), wallet_data);
+            blockchain.insert_wallet_shadow(wallet_id_hex.clone(), wallet_data);
             tracing::info!(
                 "Recovery: created fallback wallet {} ({} SOV)",
                 &wallet_id_hex[..16.min(wallet_id_hex.len())],
@@ -1931,9 +1924,7 @@ pub async fn handle_migrate_identity(
                         );
                     } else {
                         // Update in-memory view immediately (the block will make it durable).
-                        blockchain
-                            .wallet_registry
-                            .insert(wallet_id_str.clone(), updated);
+                        blockchain.insert_wallet_shadow(wallet_id_str.clone(), updated);
                     }
                 } else {
                     tracing::warn!(
@@ -2611,9 +2602,7 @@ mod tests {
         rewards_key_arr.iter_mut().for_each(|b| *b = b.wrapping_add(1)); // distinct from others
         let rewards_key = rewards_key_arr.to_vec();
         // Test scaffold: direct insert for test setup (not production code)
-        bc.validator_registry.insert(
-            validator_did.clone(),
-            lib_blockchain::ValidatorInfo {
+        bc.insert_validator_shadow(lib_blockchain::ValidatorInfo {
                 identity_id: validator_did,
                 stake: 1_000,
                 storage_provided: 0,
@@ -2633,8 +2622,7 @@ mod tests {
                     .to_string(),
                 governance_proposal_id: None,
                 oracle_key_id: None,
-            },
-        );
+            });
 
         for (wid, wtype, name, alias, pk, created_at, balance) in &wallet_summaries {
             let wallet_id_hex = hex::encode(wid.0);
@@ -2644,7 +2632,7 @@ mod tests {
                 format!("seed_commitment:{}", wallet_id_hex).as_bytes(),
             );
             // Test scaffold: direct insert for test setup (not production code)
-            bc.wallet_registry.insert(
+            bc.insert_wallet_shadow(
                 wallet_id_hex,
                 lib_blockchain::transaction::WalletTransactionData {
                     wallet_id: wallet_hash,

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1624,9 +1624,7 @@ impl IdentityHandler {
             let mut blockchain = blockchain_arc.write().await;
 
             // Update in-memory immediately (cache warmup)
-            if let Some(id) = blockchain.identity_registry_entry_mut(&req.did) {
-                id.kyber_public_key = kyber_pk.clone();
-            }
+            blockchain.update_identity_shadow_kyber_public_key(&req.did, kyber_pk.clone());
 
             // Submit IdentityUpdate system transaction for block persistence
             let mut identity_data = blockchain
@@ -1822,9 +1820,7 @@ impl IdentityHandler {
             blockchain
                 .did_to_username
                 .insert(did.clone(), username.clone());
-            if let Some(id) = blockchain.identity_registry_entry_mut(&did) {
-                id.display_name = username.clone();
-            }
+            blockchain.update_identity_shadow_display_name(&did, username.clone());
         }
 
         tracing::info!(

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1624,15 +1624,13 @@ impl IdentityHandler {
             let mut blockchain = blockchain_arc.write().await;
 
             // Update in-memory immediately (cache warmup)
-            if let Some(id) = blockchain.identity_registry.get_mut(&req.did) {
+            if let Some(id) = blockchain.identity_registry_entry_mut(&req.did) {
                 id.kyber_public_key = kyber_pk.clone();
             }
 
             // Submit IdentityUpdate system transaction for block persistence
             let mut identity_data = blockchain
-                .identity_registry
-                .get(&req.did)
-                .cloned()
+                .identity_transaction_data(&req.did)
                 .unwrap_or_else(|| lib_blockchain::transaction::IdentityTransactionData::new(
                     req.did.clone(), String::new(), identity_pk.clone(),
                     vec![], "human".to_string(),
@@ -1824,7 +1822,7 @@ impl IdentityHandler {
             blockchain
                 .did_to_username
                 .insert(did.clone(), username.clone());
-            if let Some(id) = blockchain.identity_registry.get_mut(&did) {
+            if let Some(id) = blockchain.identity_registry_entry_mut(&did) {
                 id.display_name = username.clone();
             }
         }
@@ -2031,10 +2029,7 @@ impl IdentityHandler {
             {
                 let blockchain = blockchain_arc.read().await;
                 let id_hash = lib_blockchain::Hash::from_slice(&identity_id.0);
-                blockchain
-                    .wallet_registry
-                    .values()
-                    .any(|w| w.owner_identity_id.as_ref() == Some(&id_hash))
+                !blockchain.wallets_for_owner(&id_hash).is_empty()
             } else {
                 false
             };

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -1686,7 +1686,7 @@ impl WalletHandler {
                 // bridges the gap until block commit. Note: identity_blocks height will
                 // be the current chain height (not the future block height where the tx
                 // lands), but this is acceptable for the handshake check.
-                blockchain.identity_registry.insert(did.clone(), identity_data);
+                blockchain.insert_identity_shadow(did.clone(), identity_data);
                 let current_height = blockchain.get_height();
                 blockchain.identity_blocks.insert(did.clone(), current_height);
                 tracing::info!(

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -416,13 +416,10 @@ impl Web4Handler {
                     ));
                 }
                 let wallet_id = blockchain
-                    .wallet_registry
-                    .values()
-                    .find(|wallet| {
-                        wallet.owner_identity_id.as_ref() == Some(&owner_identity_hash)
-                            && wallet.wallet_type == "Primary"
-                    })
-                    .map(|wallet| wallet.wallet_id)
+                    .wallets_for_owner(&owner_identity_hash)
+                    .into_iter()
+                    .find(|(_, wallet)| wallet.wallet_type == "Primary")
+                    .map(|(_, wallet)| wallet.wallet_id)
                     .ok_or_else(|| anyhow!("Primary wallet not found for identity"))?;
                 let mut bytes = [0u8; 32];
                 bytes.copy_from_slice(wallet_id.as_bytes());
@@ -1061,13 +1058,10 @@ impl Web4Handler {
                 let owner_wallet_id_bytes: [u8; 32] = {
                     let bc = self.blockchain.read().await;
                     let wallet_id = bc
-                        .wallet_registry
-                        .values()
-                        .find(|w| {
-                            w.owner_identity_id.as_ref() == Some(&owner_identity_hash)
-                                && w.wallet_type == "Primary"
-                        })
-                        .map(|w| w.wallet_id)
+                        .wallets_for_owner(&owner_identity_hash)
+                        .into_iter()
+                        .find(|(_, w)| w.wallet_type == "Primary")
+                        .map(|(_, w)| w.wallet_id)
                         .ok_or_else(|| {
                             anyhow!("Primary wallet not found for identity (manifest path)")
                         })?;
@@ -2374,7 +2368,7 @@ mod tests {
         // Set wallet public key deterministically for fee tx signer check.
         let owner_wallet_pk = owner_identity.public_key.dilithium_pk.clone();
         // Test scaffold: direct insert for test setup (not production code)
-        blockchain.wallet_registry.insert(
+        blockchain.insert_wallet_shadow(
             hex::encode(owner_wallet_id),
             wallet_data(
                 owner_wallet_id,
@@ -2384,7 +2378,7 @@ mod tests {
             ),
         );
         // Test scaffold: direct insert for test setup (not production code)
-        blockchain.wallet_registry.insert(
+        blockchain.insert_wallet_shadow(
             hex::encode(treasury_wallet_id),
             wallet_data(treasury_wallet_id, "Treasury", None, vec![8u8; 32]),
         );
@@ -2399,9 +2393,7 @@ mod tests {
         };
         // 11 SOV — enough to cover the 10 SOV domain registration fee (atoms).
         sov.mint(&owner_wallet_key, lib_types::sov::atoms(11)).unwrap();
-        blockchain
-            .token_contracts
-            .insert(generate_lib_token_id(), sov);
+        blockchain.insert_token_contract(generate_lib_token_id(), sov);
 
         let blockchain = Arc::new(RwLock::new(blockchain));
         let owner_private = owner_identity
@@ -2610,7 +2602,7 @@ mod tests {
         {
             let mut bc = blockchain.write().await;
             let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
-            let token = bc.token_contracts.get_mut(&sov_token_id).unwrap();
+            let token = bc.get_token_contract_mut(&sov_token_id).unwrap();
             let sender_key = BcPublicKey {
                 dilithium_pk: [0u8; 2592],
                 kyber_pk: [0u8; 1568],
@@ -2665,7 +2657,7 @@ mod tests {
         {
             let mut bc = blockchain.write().await;
             let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
-            let token = bc.token_contracts.get_mut(&sov_token_id).unwrap();
+            let token = bc.get_token_contract_mut(&sov_token_id).unwrap();
             let sender_key = BcPublicKey {
                 dilithium_pk: [0u8; 2592],
                 kyber_pk: [0u8; 1568],

--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -166,14 +166,11 @@ impl BlockchainComponent {
         match crate::runtime::blockchain_provider::get_global_blockchain().await {
             Ok(blockchain_arc) => {
                 let mut blockchain = blockchain_arc.write().await;
-                if let Some(identity_data) = blockchain.identity_registry_entry_mut(&user_did) {
-                    if !identity_data.controlled_nodes.contains(&node_id_hex) {
-                        identity_data.controlled_nodes.push(node_id_hex.clone());
-                        info!(
-                            " Added node {} to user's controlled_nodes list",
-                            &node_id_hex[..32]
-                        );
-                    }
+                if blockchain.push_identity_shadow_controlled_node(&user_did, node_id_hex.clone()) {
+                    info!(
+                        " Added node {} to user's controlled_nodes list",
+                        &node_id_hex[..32]
+                    );
                 }
             }
             Err(e) => {

--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -166,7 +166,7 @@ impl BlockchainComponent {
         match crate::runtime::blockchain_provider::get_global_blockchain().await {
             Ok(blockchain_arc) => {
                 let mut blockchain = blockchain_arc.write().await;
-                if let Some(identity_data) = blockchain.identity_registry.get_mut(&user_did) {
+                if let Some(identity_data) = blockchain.identity_registry_entry_mut(&user_did) {
                     if !identity_data.controlled_nodes.contains(&node_id_hex) {
                         identity_data.controlled_nodes.push(node_id_hex.clone());
                         info!(

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -970,7 +970,7 @@ async fn bootstrap_identities_from_dht(
 
                             // Migrate primary wallet if missing
                             if let Some(wid) = primary_wallet_id {
-                                if !bc.wallet_registry.contains_key(wid) {
+                                if !bc.wallet_exists(wid) {
                                     let wallet_bytes = hex::decode(wid).unwrap_or_default();
                                     if wallet_bytes.len() >= 32 {
                                         const WELCOME_BONUS: u128 = SOV_WELCOME_BONUS;
@@ -1012,7 +1012,7 @@ async fn bootstrap_identities_from_dht(
 
                             // Migrate UBI wallet if missing
                             if let Some(wid) = ubi_wallet_id {
-                                if !bc.wallet_registry.contains_key(wid) {
+                                if !bc.wallet_exists(wid) {
                                     let wallet_bytes = hex::decode(wid).unwrap_or_default();
                                     if wallet_bytes.len() >= 32 {
                                         let wallet_data =
@@ -1045,7 +1045,7 @@ async fn bootstrap_identities_from_dht(
 
                             // Migrate savings wallet if missing
                             if let Some(wid) = savings_wallet_id {
-                                if !bc.wallet_registry.contains_key(wid) {
+                                if !bc.wallet_exists(wid) {
                                     let wallet_bytes = hex::decode(wid).unwrap_or_default();
                                     if wallet_bytes.len() >= 32 {
                                         let wallet_data =

--- a/zhtp/src/runtime/components/oracle.rs
+++ b/zhtp/src/runtime/components/oracle.rs
@@ -750,9 +750,7 @@ mod tests {
 
         // Register the validator in the registry so the stateful validator can look it up
         let validator_info = make_validator_info("test-validator", dilithium_pk);
-        blockchain
-            .validator_registry
-            .insert("test-validator".to_string(), validator_info);
+        blockchain.insert_validator_shadow(validator_info);
 
         // Initialize oracle committee with only this validator's pubkey hash
         blockchain

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1285,7 +1285,10 @@ impl RuntimeOrchestrator {
 
                 let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
                 if blockchain.get_token_contract(&sov_token_id).is_none() {
-                    blockchain.ensure_sov_token_contract();
+                    blockchain.insert_token_contract(
+                        sov_token_id,
+                        lib_blockchain::contracts::TokenContract::new_sov_native(),
+                    );
                     info!(
                         "🪙 SOV token contract initialized (upgrade migration): {}",
                         hex::encode(&sov_token_id[..8])
@@ -2253,7 +2256,10 @@ impl RuntimeOrchestrator {
                 // This handles upgrades from older blockchain data that didn't have the SOV token
                 let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
                 if bc.get_token_contract(&sov_token_id).is_none() {
-                    bc.ensure_sov_token_contract();
+                    bc.insert_token_contract(
+                        sov_token_id,
+                        lib_blockchain::contracts::TokenContract::new_sov_native(),
+                    );
 
                     info!("🪙 SOV token contract initialized (persistence deferred to next block commit): {}", hex::encode(&sov_token_id[..8]));
                 }
@@ -2936,11 +2942,11 @@ impl RuntimeOrchestrator {
                                     let welcome_bonus = SOV_WELCOME_BONUS;
 
                                     // Update wallet registry balance
-                                    if let Some(wallet_entry) =
-                                        blockchain_ref.wallet_registry_entry_mut(&wallet_id_hex)
-                                    {
-                                        wallet_entry.initial_balance = welcome_bonus;
-                                    }
+                                    blockchain_ref
+                                        .update_wallet_shadow_initial_balance(
+                                            &wallet_id_hex,
+                                            welcome_bonus,
+                                        );
 
                                     // Create spendable UTXO for the welcome bonus
                                     let utxo_output =
@@ -3129,11 +3135,11 @@ impl RuntimeOrchestrator {
                                                 let welcome_bonus = SOV_WELCOME_BONUS;
 
                                                 // Update wallet registry balance
-                                                if let Some(wallet_entry) = blockchain_ref
-                                                    .wallet_registry_entry_mut(&wallet_id_hex)
-                                                {
-                                                    wallet_entry.initial_balance = welcome_bonus;
-                                                }
+                                                blockchain_ref
+                                                    .update_wallet_shadow_initial_balance(
+                                                        &wallet_id_hex,
+                                                        welcome_bonus,
+                                                    );
 
                                                 // Create spendable UTXO for the welcome bonus
                                                 let utxo_output = lib_blockchain::transaction::TransactionOutput {
@@ -3189,11 +3195,10 @@ impl RuntimeOrchestrator {
                                         let welcome_bonus = SOV_WELCOME_BONUS;
 
                                         // Update wallet registry
-                                        if let Some(wallet_mut) =
-                                            blockchain_ref.wallet_registry_entry_mut(&wallet_id_hex)
-                                        {
-                                            wallet_mut.initial_balance = welcome_bonus;
-                                        }
+                                        blockchain_ref.update_wallet_shadow_initial_balance(
+                                            &wallet_id_hex,
+                                            welcome_bonus,
+                                        );
 
                                         // Create spendable UTXO
                                         let utxo_output =
@@ -3291,11 +3296,11 @@ impl RuntimeOrchestrator {
                                                 let welcome_bonus = SOV_WELCOME_BONUS;
 
                                                 // Update wallet registry balance
-                                                if let Some(wallet_entry) = blockchain_ref
-                                                    .wallet_registry_entry_mut(&wallet_id_hex)
-                                                {
-                                                    wallet_entry.initial_balance = welcome_bonus;
-                                                }
+                                                blockchain_ref
+                                                    .update_wallet_shadow_initial_balance(
+                                                        &wallet_id_hex,
+                                                        welcome_bonus,
+                                                    );
 
                                                 // Create spendable UTXO for the welcome bonus
                                                 let utxo_output = lib_blockchain::transaction::TransactionOutput {

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1209,13 +1209,13 @@ impl RuntimeOrchestrator {
                     let blockchain = blockchain_arc.read().await;
                     let has_data = blockchain.height > 0
                         || !blockchain.utxo_set.is_empty()
-                        || !blockchain.token_contracts.is_empty();
+                        || !blockchain.token_contracts_is_empty();
                     if has_data {
                         info!(
                             "✓ Global blockchain has data (height: {}, UTXOs: {}, tokens: {})",
                             blockchain.height,
                             blockchain.utxo_set.len(),
-                            blockchain.token_contracts.len()
+                            blockchain.token_contract_count()
                         );
                     }
                     has_data
@@ -1284,9 +1284,8 @@ impl RuntimeOrchestrator {
                 let mut blockchain = blockchain_arc.write().await;
 
                 let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
-                if !blockchain.token_contracts.contains_key(&sov_token_id) {
-                    let sov_token = lib_blockchain::contracts::TokenContract::new_sov_native();
-                    blockchain.token_contracts.insert(sov_token_id, sov_token);
+                if blockchain.get_token_contract(&sov_token_id).is_none() {
+                    blockchain.ensure_sov_token_contract();
                     info!(
                         "🪙 SOV token contract initialized (upgrade migration): {}",
                         hex::encode(&sov_token_id[..8])
@@ -1434,7 +1433,7 @@ impl RuntimeOrchestrator {
             // (idempotent) ensures every restart finds the correct genesis balances.
             if let Some(store) = blockchain.store.as_ref() {
                 let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
-                if let Some(sov_contract) = blockchain.token_contracts.get(&sov_token_id) {
+                if let Some(sov_contract) = blockchain.get_token_contract(&sov_token_id) {
                     let entries: Vec<([u8; 32], u128)> = sov_contract
                         .balances_iter()
                         .map(|(pk, &bal)| (pk.key_id, bal))
@@ -2247,15 +2246,14 @@ impl RuntimeOrchestrator {
                 info!(
                     "📂 Loaded existing blockchain from SledStore (height: {}, tokens: {})",
                     bc.height,
-                    bc.token_contracts.len()
+                    bc.token_contract_count()
                 );
 
                 // CRITICAL: Ensure SOV token contract is always initialized
                 // This handles upgrades from older blockchain data that didn't have the SOV token
                 let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
-                if !bc.token_contracts.contains_key(&sov_token_id) {
-                    let sov_token = lib_blockchain::contracts::TokenContract::new_sov_native();
-                    bc.token_contracts.insert(sov_token_id, sov_token.clone());
+                if bc.get_token_contract(&sov_token_id).is_none() {
+                    bc.ensure_sov_token_contract();
 
                     info!("🪙 SOV token contract initialized (persistence deferred to next block commit): {}", hex::encode(&sov_token_id[..8]));
                 }
@@ -2939,7 +2937,7 @@ impl RuntimeOrchestrator {
 
                                     // Update wallet registry balance
                                     if let Some(wallet_entry) =
-                                        blockchain_ref.wallet_registry.get_mut(&wallet_id_hex)
+                                        blockchain_ref.wallet_registry_entry_mut(&wallet_id_hex)
                                     {
                                         wallet_entry.initial_balance = welcome_bonus;
                                     }
@@ -3132,8 +3130,7 @@ impl RuntimeOrchestrator {
 
                                                 // Update wallet registry balance
                                                 if let Some(wallet_entry) = blockchain_ref
-                                                    .wallet_registry
-                                                    .get_mut(&wallet_id_hex)
+                                                    .wallet_registry_entry_mut(&wallet_id_hex)
                                                 {
                                                     wallet_entry.initial_balance = welcome_bonus;
                                                 }
@@ -3193,7 +3190,7 @@ impl RuntimeOrchestrator {
 
                                         // Update wallet registry
                                         if let Some(wallet_mut) =
-                                            blockchain_ref.wallet_registry.get_mut(&wallet_id_hex)
+                                            blockchain_ref.wallet_registry_entry_mut(&wallet_id_hex)
                                         {
                                             wallet_mut.initial_balance = welcome_bonus;
                                         }
@@ -3295,8 +3292,7 @@ impl RuntimeOrchestrator {
 
                                                 // Update wallet registry balance
                                                 if let Some(wallet_entry) = blockchain_ref
-                                                    .wallet_registry
-                                                    .get_mut(&wallet_id_hex)
+                                                    .wallet_registry_entry_mut(&wallet_id_hex)
                                                 {
                                                     wallet_entry.initial_balance = welcome_bonus;
                                                 }
@@ -4662,10 +4658,10 @@ impl RuntimeOrchestrator {
 
             info!(
                 " Scanning blockchain wallet_registry (total entries: {})...",
-                blockchain.wallet_registry.len()
+                blockchain.wallet_count()
             );
 
-            for (wallet_id_hex, wallet_data) in blockchain.wallet_registry.iter() {
+            for (wallet_id_hex, wallet_data) in blockchain.wallet_registry_snapshot() {
                 if wallet_data.initial_balance > 0 {
                     info!(
                         "   Found funded wallet: {} → {} SOV",
@@ -5685,9 +5681,8 @@ pub(super) fn try_restore_validators_from_dat(
     match load_validated_blockchain_dat(dat_path, allow_genesis_mismatch)? {
         Some(dat_bc) if !dat_bc.get_active_validators().is_empty() => {
             let restored: Vec<_> = dat_bc
-                .validator_registry
-                .values()
-                .cloned()
+                .validator_registry_snapshot()
+                .into_values()
                 .collect();
             let count = restored.len();
             bc.validator_blocks = dat_bc.validator_blocks;
@@ -6480,9 +6475,7 @@ mod oracle_startup_tests {
         // Insert an active validator with a Dilithium5-sized consensus key.
         let consensus_key = [0xABu8; 2592];
         let key_id = lib_blockchain::blake3_hash(&consensus_key).as_array();
-        bc.validator_registry.insert(
-            "did:zhtp:validator-test".to_string(),
-            ValidatorInfo {
+        bc.insert_validator_shadow(ValidatorInfo {
                 identity_id: "did:zhtp:validator-test".to_string(),
                 stake: 1_000_000,
                 storage_provided: 0,
@@ -6499,13 +6492,12 @@ mod oracle_startup_tests {
                 admission_source: "test".to_string(),
                 governance_proposal_id: None,
                 oracle_key_id: None,
-            },
-        );
+            });
 
         // Replicate the bootstrap logic from seed_blockchain_validator_registry.
         // Type system now enforces 2592-byte keys, no length check needed.
         let mut committee_members: Vec<([u8; 32], Vec<u8>)> = bc
-            .validator_registry
+            .validator_registry_snapshot()
             .values()
             .filter(|v| v.status == "active")
             .map(|v| {
@@ -6529,9 +6521,7 @@ mod oracle_startup_tests {
 
         // Insert a validator with an all-zeros consensus key (invalid).
         // Type system enforces 2592-byte size, but we can still test for invalid content.
-        bc.validator_registry.insert(
-            "did:zhtp:bad-validator".to_string(),
-            ValidatorInfo {
+        bc.insert_validator_shadow(ValidatorInfo {
                 identity_id: "did:zhtp:bad-validator".to_string(),
                 stake: 1_000_000,
                 storage_provided: 0,
@@ -6548,12 +6538,11 @@ mod oracle_startup_tests {
                 admission_source: "test".to_string(),
                 governance_proposal_id: None,
                 oracle_key_id: None,
-            },
-        );
+            });
 
         // Filter out validators with all-zeros keys (invalid)
         let committee_members: Vec<([u8; 32], [u8; 2592])> = bc
-            .validator_registry
+            .validator_registry_snapshot()
             .values()
             .filter(|v| v.status == "active")
             .filter(|v| v.consensus_key != [0u8; 2592]) // skip all-zeros
@@ -6612,10 +6601,8 @@ mod validator_startup_tests {
         let sled_path = dir.path().join("sled");
 
         let mut src = Blockchain::new().expect("Blockchain::new");
-        src.validator_registry
-            .insert("validator-1".to_string(), make_validator("validator-1"));
-        src.validator_registry
-            .insert("validator-2".to_string(), make_validator("validator-2"));
+        src.insert_validator_shadow(make_validator("validator-1"));
+        src.insert_validator_shadow(make_validator("validator-2"));
         #[allow(deprecated)]
         src.save_to_file(&dat_path).expect("save_to_file");
 

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -56,14 +56,11 @@ impl GenesisFundingService {
 
         // Initialize SOV token contract FIRST so we can credit balances during genesis
         let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
-        if !blockchain.token_contracts.contains_key(&sov_token_id) {
-            let sov_token = lib_blockchain::contracts::TokenContract::new_sov_native();
-            blockchain.token_contracts.insert(sov_token_id, sov_token);
-            info!(
-                "🪙 SOV token contract initialized: {}",
-                hex::encode(&sov_token_id[..8])
-            );
-        }
+        blockchain.ensure_sov_token_contract();
+        info!(
+            "🪙 SOV token contract initialized: {}",
+            hex::encode(&sov_token_id[..8])
+        );
 
         // DETERMINISM: Sort genesis validators by identity_id so that every node
         // produces the same genesis_tx output ordering regardless of the order
@@ -209,9 +206,7 @@ impl GenesisFundingService {
                 initial_balance: SOV_WELCOME_BONUS, // 5,000 SOV welcome bonus (atomic units)
             };
 
-            blockchain
-                .wallet_registry
-                .insert(hex::encode(&wallet_id.0), wallet_data);
+            blockchain.insert_wallet_shadow(hex::encode(&wallet_id.0), wallet_data);
             blockchain
                 .wallet_blocks
                 .insert(hex::encode(&wallet_id.0), 0);
@@ -232,19 +227,9 @@ impl GenesisFundingService {
                         anyhow::anyhow!("failed to read genesis wallet SOV balance: {e}")
                     })?;
                 if current_balance == 0 {
-                    if !blockchain.token_contracts.contains_key(&sov_token_id) {
-                        let contract = blockchain
-                            .get_token_contract(&sov_token_id)
-                            .ok_or_else(|| {
-                                anyhow::anyhow!(
-                                    "SOV token contract missing from overlay for genesis mint"
-                                )
-                            })?;
-                        blockchain.token_contracts.insert(sov_token_id, contract);
-                    }
+                    blockchain.ensure_sov_token_contract();
                     let token = blockchain
-                        .token_contracts
-                        .get_mut(&sov_token_id)
+                        .get_token_contract_mut(&sov_token_id)
                         .ok_or_else(|| {
                             anyhow::anyhow!("SOV token contract missing for genesis mint")
                         })?;
@@ -380,7 +365,7 @@ impl GenesisFundingService {
             "   Genesis block finalized - Height: {}, UTXOs: {}, Identities: {}, Pending: {}",
             blockchain.height,
             blockchain.utxo_set.len(),
-            blockchain.identity_registry.len(),
+            blockchain.identity_count(),
             blockchain.pending_transactions.len()
         );
 
@@ -443,15 +428,13 @@ impl GenesisFundingService {
                 kyber_public_key: vec![],
             };
 
-            if blockchain.identity_registry.contains_key(&user_did) {
+            if blockchain.identity_exists(&user_did) {
                 warn!(
                     "  User identity {} already present in genesis state",
                     user_did
                 );
             } else {
-                blockchain
-                    .identity_registry
-                    .insert(user_did.clone(), user_identity_data);
+                blockchain.insert_identity_shadow(user_did.clone(), user_identity_data);
                 blockchain.identity_blocks.insert(user_did.clone(), 0);
                 info!(" Genesis USER identity registered directly in genesis state");
                 info!("   - DID: {}", user_did);
@@ -513,8 +496,8 @@ impl GenesisFundingService {
                 oracle_key_id: None,
             };
 
-            if !blockchain.identity_registry.contains_key(&validator_did) {
-                blockchain.identity_registry.insert(
+            if !blockchain.identity_exists(&validator_did) {
+                blockchain.insert_identity_shadow(
                     validator_did.clone(),
                     IdentityTransactionData {
                         did: validator_did.clone(),
@@ -540,9 +523,7 @@ impl GenesisFundingService {
                 blockchain.identity_blocks.insert(validator_did.clone(), 0);
             }
 
-            blockchain
-                .validator_registry
-                .insert(validator_did.clone(), validator_info);
+            blockchain.insert_validator_shadow(validator_info);
             blockchain.validator_blocks.insert(validator_did.clone(), 0);
             registered_validators += 1;
             info!(
@@ -569,7 +550,7 @@ impl GenesisFundingService {
         );
         info!(
             "   - Identities in registry: {}",
-            blockchain.identity_registry.len()
+            blockchain.identity_count()
         );
 
         Ok(())

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -56,7 +56,10 @@ impl GenesisFundingService {
 
         // Initialize SOV token contract FIRST so we can credit balances during genesis
         let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
-        blockchain.ensure_sov_token_contract();
+        blockchain.insert_token_contract(
+            sov_token_id,
+            lib_blockchain::contracts::TokenContract::new_sov_native(),
+        );
         info!(
             "🪙 SOV token contract initialized: {}",
             hex::encode(&sov_token_id[..8])
@@ -227,7 +230,6 @@ impl GenesisFundingService {
                         anyhow::anyhow!("failed to read genesis wallet SOV balance: {e}")
                     })?;
                 if current_balance == 0 {
-                    blockchain.ensure_sov_token_contract();
                     let token = blockchain
                         .get_token_contract_mut(&sov_token_id)
                         .ok_or_else(|| {


### PR DESCRIPTION
## Summary

Phase 3 of state-unification (#2640): now that sled-first read migration (#2636–#2639) is complete, privatize the in-memory registry fields on `Blockchain` so external crates cannot access them directly.

**Fields changed from `pub` → `pub(crate)`:**
- `identity_registry`
- `wallet_registry`
- `token_contracts`
- `validator_registry`
- `token_nonces`

**Facade APIs added** for genesis/bootstrap/test paths:
- `insert_identity_shadow`, `identity_registry_entry_mut`
- `insert_wallet_shadow`, `wallet_registry_entry_mut`, `wallets_for_owner`, `ensure_sov_token_contract`
- `insert_validator_shadow`, `insert_validator_shadow_keyed`
- `insert_token_contract`, `token_contract_count`, `token_contracts_is_empty`, `insert_token_nonce_shadow`, `token_nonces_snapshot`

**Callers migrated** across lib-blockchain tests, zhtp runtime, API handlers, zhtp-cli, and tools.

## Test plan

- [x] `cargo check -p lib-blockchain -p zhtp -p zhtp-cli`
- [x] `cargo test -p lib-blockchain --lib --tests` (all pass)

Closes #2640