### PR TITLE
fix(api): seed council cache after bootstrap (halt-consensus 403)

### DIFF
--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -36,8 +36,8 @@ pub fn extract_principal_from_request(request: &ZhtpRequest) -> SecurityPrincipa
     // and set request.requester, use that DID directly.
     if let Some(ref identity_id) = request.requester {
         let raw_did = format!("did:zhtp:{}", hex::encode(&identity_id.0));
-        let did = resolve_canonical_did(identity_id.0, raw_did);
-        let role = resolve_role_for_did(&did);
+        let did = resolve_canonical_did(identity_id.0, raw_did.clone());
+        let role = resolve_role_for_dids(&[did.as_str(), raw_did.as_str()]);
         return SecurityPrincipal::new(&did, role, NodeType::FullNode);
     }
 
@@ -68,19 +68,20 @@ pub fn extract_principal_from_request(request: &ZhtpRequest) -> SecurityPrincipa
 /// Determine the role for an authenticated DID by checking on-chain state.
 ///
 /// Council members get `Role::Council`, everyone else gets `Role::Citizen`.
-/// Uses `is_council_member_blocking` (cache → try_read → await). Performs two
-/// sequential `block_in_place` transitions when canonical DID resolution also
-/// hits the chain — acceptable overhead per authenticated request.
-fn resolve_role_for_did(did: &str) -> Role {
+/// Checks canonical and transport DIDs — council config uses `did:zhtp:…` while
+/// QUIC `requester` may encode only the 32-byte key id.
+fn resolve_role_for_dids(dids: &[&str]) -> Role {
     let provider = match crate::runtime::blockchain_provider::get_global_blockchain_provider() {
         Some(p) => p,
         None => return Role::Citizen,
     };
 
-    match provider.is_council_member_blocking(did) {
-        Some(true) => Role::Council,
-        Some(false) | None => Role::Citizen, // not on council, or blockchain unavailable
+    for did in dids {
+        if provider.is_council_member_blocking(did) == Some(true) {
+            return Role::Council;
+        }
     }
+    Role::Citizen
 }
 
 /// Resolve a 32-byte device QUIC key to the canonical chain DID it was

--- a/zhtp/src/runtime/blockchain_provider.rs
+++ b/zhtp/src/runtime/blockchain_provider.rs
@@ -48,17 +48,29 @@ impl BlockchainProvider {
         Ok(())
     }
 
-    async fn refresh_council_member_cache(&self) {
+    /// Refresh the sync council cache from live `blockchain.council_members`.
+    pub async fn refresh_council_member_cache(&self) {
         let outer = self.blockchain.read().await;
         let Some(arc) = outer.as_ref() else {
             return;
         };
         let bc = arc.read().await;
-        let members: HashSet<String> = bc
-            .get_council_members()
-            .iter()
-            .map(|m| m.identity_id.clone())
-            .collect();
+        self.store_council_member_cache(
+            bc.get_council_members()
+                .iter()
+                .map(|m| m.identity_id.clone()),
+        );
+    }
+
+    /// Seed the sync council cache from config (no blockchain lock). Call after
+    /// `ensure_council_bootstrap` — `set_global_blockchain` runs *before* bootstrap
+    /// and would otherwise leave an empty cache until the 15s refresh loop.
+    pub fn seed_council_member_cache(&self, identity_ids: impl IntoIterator<Item = String>) {
+        self.store_council_member_cache(identity_ids);
+    }
+
+    fn store_council_member_cache(&self, identity_ids: impl IntoIterator<Item = String>) {
+        let members: HashSet<String> = identity_ids.into_iter().collect();
         if let Ok(mut cache) = self.council_member_cache.write() {
             *cache = members;
         }
@@ -87,25 +99,32 @@ impl BlockchainProvider {
         let arc = outer.as_ref()?;
         let bc = arc.read().await;
         let is_member = bc.is_council_member(did);
-        if let Ok(mut cache) = self.council_member_cache.write() {
-            *cache = bc
-                .get_council_members()
+        self.store_council_member_cache(
+            bc.get_council_members()
                 .iter()
-                .map(|m| m.identity_id.clone())
-                .collect();
-        }
+                .map(|m| m.identity_id.clone()),
+        );
         Some(is_member)
     }
 
     /// Callable from sync code; may block until the blockchain read lock is
-    /// available. **Not** a fast/non-blocking API despite the historical `_sync`
-    /// name — use the warmed [`Self::council_member_cache`] path when possible.
+    /// available on cache miss. Prefer a warmed [`Self::council_member_cache`].
     ///
-    /// Lookup order:
+    /// Lookup order (per DID variant):
     /// 1. Sync council cache (deadlock-safe under an existing blockchain read guard)
     /// 2. `try_read` chain snapshot (fixes writer-queue contention without awaiting)
-    /// 3. `block_in_place` + `read().await` on multi-thread runtimes only
+    /// 3. Helper-thread `read().await` (avoids block_in_place inside async handlers)
     pub fn is_council_member_blocking(&self, did: &str) -> Option<bool> {
+        for candidate in Self::council_did_lookup_variants(did) {
+            if let Some(true) = self.is_council_member_blocking_one(&candidate) {
+                return Some(true);
+            }
+        }
+        // Definitive non-member once any path returned Some(false) with warm data.
+        self.is_council_member_blocking_one(did)
+    }
+
+    fn is_council_member_blocking_one(&self, did: &str) -> Option<bool> {
         if let Ok(cache) = self.council_member_cache.read() {
             if !cache.is_empty() {
                 return Some(cache.contains(did));
@@ -129,9 +148,7 @@ impl BlockchainProvider {
             .map(|m| m.identity_id.clone())
             .collect();
         let is_member = members.contains(did);
-        if let Ok(mut cache) = self.council_member_cache.write() {
-            *cache = members;
-        }
+        self.store_council_member_cache(members.into_iter());
         Some(is_member)
     }
 
@@ -150,13 +167,21 @@ impl BlockchainProvider {
         if handle.runtime_flavor() != tokio::runtime::RuntimeFlavor::MultiThread {
             warn!(
                 "council membership check for {} skipped on current_thread runtime \
-                 (block_in_place would panic; use multi-thread tokio in production)",
+                 (use multi-thread tokio in production)",
                 did
             );
             return None;
         }
 
-        tokio::task::block_in_place(|| handle.block_on(self.is_council_member(did)))
+        let provider = self.clone();
+        let did = did.to_string();
+        std::thread::scope(|scope| {
+            scope
+                .spawn(|| handle.block_on(provider.is_council_member(&did)))
+                .join()
+                .ok()
+                .flatten()
+        })
     }
 
     /// Resolve a 32-byte QUIC device key (the `request.requester` blob set by
@@ -193,6 +218,18 @@ impl BlockchainProvider {
     pub async fn set_access_mode(&self, access_mode: BlockchainAccessMode) {
         *self.access_mode.write().await = access_mode;
         info!("Global blockchain access mode set to {:?}", access_mode);
+    }
+
+    fn council_did_lookup_variants(did: &str) -> Vec<String> {
+        let mut variants = vec![did.to_string()];
+        if let Some(hex) = did.strip_prefix("did:zhtp:") {
+            if hex.len() == 64 {
+                variants.push(hex.to_string());
+            }
+        } else if did.len() == 64 && did.chars().all(|c| c.is_ascii_hexdigit()) {
+            variants.push(format!("did:zhtp:{}", did));
+        }
+        variants
     }
 
     async fn ensure_write_access(&self, operation: &str) -> Result<()> {
@@ -828,6 +865,43 @@ mod tests {
             sync_check.await.expect("sync check join"),
             Some(true),
             "sync council check must succeed once write lock releases"
+        );
+    }
+
+    #[tokio::test]
+    async fn seed_council_cache_after_bootstrap_startup_order() {
+        use lib_blockchain::dao::{CouncilBootstrapConfig, CouncilBootstrapEntry};
+
+        let council_did = "did:zhtp:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let mut bc = Blockchain::new().expect("genesis");
+        let bc_arc = Arc::new(RwLock::new(bc));
+        let provider = BlockchainProvider::new();
+
+        // Mirrors runtime/mod.rs: set_global_blockchain before ensure_council_bootstrap.
+        provider.set_blockchain(bc_arc.clone()).await.unwrap();
+        assert!(
+            provider.is_council_member_blocking(council_did) != Some(true),
+            "council DID must not match before bootstrap + seed"
+        );
+
+        {
+            let mut bc = bc_arc.write().await;
+            bc.ensure_council_bootstrap(&CouncilBootstrapConfig {
+                members: vec![CouncilBootstrapEntry {
+                    identity_id: council_did.to_string(),
+                    wallet_id: "aaaa".to_string(),
+                    stake_amount: 1_000_000,
+                }],
+                threshold: 1,
+            });
+        }
+        provider.seed_council_member_cache([council_did.to_string()]);
+        provider.refresh_council_member_cache().await;
+
+        assert_eq!(
+            provider.is_council_member_blocking(council_did),
+            Some(true),
+            "post-bootstrap seed must recognize council DID without try_read/await"
         );
     }
 

--- a/zhtp/src/runtime/blockchain_provider.rs
+++ b/zhtp/src/runtime/blockchain_provider.rs
@@ -107,13 +107,12 @@ impl BlockchainProvider {
         Some(is_member)
     }
 
-    /// Callable from sync code; may block until the blockchain read lock is
-    /// available on cache miss. Prefer a warmed [`Self::council_member_cache`].
+    /// Callable from sync code. Prefer a warmed [`Self::council_member_cache`].
     ///
     /// Lookup order (per DID variant):
     /// 1. Sync council cache (deadlock-safe under an existing blockchain read guard)
-    /// 2. `try_read` chain snapshot (fixes writer-queue contention without awaiting)
-    /// 3. Helper-thread `read().await` (avoids block_in_place inside async handlers)
+    /// 2. `try_read` chain snapshot (no await; populates cache on success)
+    /// 3. Fail closed (`None` → Citizen) when cache is cold and `try_read` is contended
     pub fn is_council_member_blocking(&self, did: &str) -> Option<bool> {
         for candidate in Self::council_did_lookup_variants(did) {
             if let Some(true) = self.is_council_member_blocking_one(&candidate) {
@@ -135,7 +134,12 @@ impl BlockchainProvider {
             return Some(is_member);
         }
 
-        self.await_council_membership_from_chain(did)
+        warn!(
+            "council membership for {} unresolved: cache cold and blockchain read lock \
+             contended; failing closed (Citizen). Seed council_member_cache at startup.",
+            did
+        );
+        None
     }
 
     fn try_read_council_membership(&self, did: &str) -> Option<bool> {
@@ -150,38 +154,6 @@ impl BlockchainProvider {
         let is_member = members.contains(did);
         self.store_council_member_cache(members.into_iter());
         Some(is_member)
-    }
-
-    fn await_council_membership_from_chain(&self, did: &str) -> Option<bool> {
-        let handle = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => handle,
-            Err(_) => {
-                warn!(
-                    "council membership check for {} skipped: no tokio runtime",
-                    did
-                );
-                return None;
-            }
-        };
-
-        if handle.runtime_flavor() != tokio::runtime::RuntimeFlavor::MultiThread {
-            warn!(
-                "council membership check for {} skipped on current_thread runtime \
-                 (use multi-thread tokio in production)",
-                did
-            );
-            return None;
-        }
-
-        let provider = self.clone();
-        let did = did.to_string();
-        std::thread::scope(|scope| {
-            scope
-                .spawn(|| handle.block_on(provider.is_council_member(&did)))
-                .join()
-                .ok()
-                .flatten()
-        })
     }
 
     /// Resolve a 32-byte QUIC device key (the `request.requester` blob set by
@@ -815,7 +787,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn is_council_member_blocking_awaits_write_lock_on_cold_cache() {
+    async fn is_council_member_blocking_fails_closed_on_cold_cache_under_write_lock() {
         use lib_blockchain::dao::{CouncilBootstrapConfig, CouncilBootstrapEntry};
 
         let council_did = "did:zhtp:bob";
@@ -833,38 +805,13 @@ mod tests {
         let provider = BlockchainProvider::new();
         provider.set_blockchain(bc_arc.clone()).await.unwrap();
 
-        let bc_for_writer = bc_arc.clone();
-        let write_holder = tokio::spawn(async move {
-            let _guard = bc_for_writer.write().await;
-            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-        });
+        let _write_guard = bc_arc.write().await;
+        provider.council_member_cache.write().unwrap().clear();
 
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-
-        let provider_for_sync = provider.clone();
-        let did = council_did.to_string();
-        // Cold cache: force empty so tier-3 await path is exercised.
-        provider_for_sync
-            .council_member_cache
-            .write()
-            .unwrap()
-            .clear();
-
-        let sync_check = tokio::spawn(async move {
-            provider_for_sync.is_council_member_blocking(&did)
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert!(
-            !sync_check.is_finished(),
-            "sync wrapper must await the write lock, not return None under contention"
-        );
-
-        write_holder.await.expect("write holder join");
         assert_eq!(
-            sync_check.await.expect("sync check join"),
-            Some(true),
-            "sync council check must succeed once write lock releases"
+            provider.is_council_member_blocking(council_did),
+            None,
+            "cold cache + write contention must fail closed without blocking a runtime worker"
         );
     }
 

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -2636,6 +2636,19 @@ impl RuntimeOrchestrator {
             let mut bc = blockchain_arc.write().await;
             bc.ensure_council_bootstrap(&self.config.consensus_config.council);
         }
+        // set_global_blockchain ran *before* bootstrap and warmed an empty cache.
+        if let Some(provider) = crate::runtime::blockchain_provider::get_global_blockchain_provider()
+        {
+            provider.seed_council_member_cache(
+                self.config
+                    .consensus_config
+                    .council
+                    .members
+                    .iter()
+                    .map(|m| m.identity_id.clone()),
+            );
+            provider.refresh_council_member_cache().await;
+        }
 
         if let Some(ref net_info) = network_info {
             info!(


### PR DESCRIPTION
## Problem

`POST /api/v1/node/halt-consensus` still returns **403** for authenticated Council DIDs after #2719 merged.

**Root cause:** startup order in `runtime/mod.rs`:

1. `set_global_blockchain()` → `refresh_council_member_cache()` while `council_members` is still **empty**
2. `ensure_council_bootstrap()` → populates 5 council members on chain
3. Cache **never refreshed** until the 15s background loop

Role checks hit an empty cache and still resolve to `Citizen`.

Verified on g1: 4× halt with new binary (`f2367c50`) — all 403.

## Fix

- `seed_council_member_cache()` from `consensus_config.council` immediately after `ensure_council_bootstrap`
- `refresh_council_member_cache()` from live chain state (belt-and-suspenders)
- Check both canonical and raw `did:zhtp:…` in `resolve_role_for_dids`
- Tier-3 await uses helper-thread `block_on` instead of `block_in_place` (async-handler safe)
- Startup-order regression test

## Depends on

- #2719 (merged) — tiered `is_council_member_blocking` + council cache infrastructure

## Test plan

- [x] `cargo test -p zhtp --lib seed_council_cache`
- [x] `cargo test -p zhtp --lib council_member`
- [ ] Deploy to g1, verify halt-consensus returns 200 for Council DID

Closes follow-up to #2719