### PR TITLE
feat(#2662): sled-first utxo facade + handler read migration

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -41,8 +41,10 @@ mod projections;
 mod validators;
 mod gateways;
 mod wallets;
+mod utxo;
 
 pub use persistence::PersistenceStats;
+pub use utxo::SpendableOutputView;
 
 /// Validator was bootstrapped from off-chain genesis configuration at height 0.
 pub const ADMISSION_SOURCE_OFFCHAIN_GENESIS: &str = "offchain_genesis";
@@ -2044,12 +2046,9 @@ impl Blockchain {
         Ok(total_fees)
     }
 
-    /// Calculate output ID from transaction hash and index
+    /// Calculate output ID from transaction hash and index (delegates to #2662 facade).
     fn calculate_output_id(&self, tx_hash: &Hash, index: usize) -> Hash {
-        let mut data = Vec::new();
-        data.extend_from_slice(tx_hash.as_bytes());
-        data.extend_from_slice(&index.to_le_bytes());
-        crate::types::hash::blake3_hash(&data)
+        Self::legacy_utxo_hash(tx_hash, index)
     }
 
     /// Adjust blockchain difficulty based on block time targets.

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -1786,3 +1786,61 @@ fn active_validator_infos_inmem_unregister_evicts_sled_active() {
         "inactive in-mem overlay must not leave sled-active in consensus set"
     );
 }
+
+/// #2662: utxo_count reads sled when a store is attached.
+#[test]
+fn utxo_count_reads_sled() {
+    use crate::storage::{OutPoint, TxHash, Utxo};
+
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("utxo_count_store")).unwrap());
+    let owner = Address::new([0xAB; 32]);
+    let op = OutPoint::new(TxHash::new([0x11; 32]), 0);
+
+    store.begin_block(0).unwrap();
+    store
+        .put_utxo(
+            &op,
+            &Utxo::native(1_000, owner, 0),
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+    assert_eq!(bc.utxo_count(), 1, "count comes from sled, not in-mem shadow");
+    assert!(!bc.utxo_set_is_empty());
+}
+
+/// #2662: collect_spendable_outputs is sled-first and maps OutPoint → legacy hash.
+#[test]
+fn collect_spendable_outputs_reads_sled() {
+    use crate::storage::{OutPoint, TxHash, Utxo};
+
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("utxo_scan_store")).unwrap());
+    let owner = Address::new([0xCD; 32]);
+    let tx = TxHash::new([0x22; 32]);
+    let op = OutPoint::new(tx, 1);
+
+    store.begin_block(0).unwrap();
+    store
+        .put_utxo(&op, &Utxo::native(500, owner, 0))
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+
+    let tx_hash = Hash::from_slice(tx.as_bytes());
+    let expected_legacy = Blockchain::legacy_utxo_hash(&tx_hash, 1);
+    let views = bc.collect_spendable_outputs();
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].legacy_hash, expected_legacy);
+    assert_eq!(views[0].output_index, 1);
+    assert_eq!(views[0].owner_key_id, [0xCD; 32]);
+
+    let owned = bc.spendable_outputs_for_owner(&[0xCD; 32]);
+    assert_eq!(owned.len(), 1);
+    assert!(bc.spendable_outputs_for_owner(&[0xEE; 32]).is_empty());
+}

--- a/lib-blockchain/src/blockchain/utxo.rs
+++ b/lib-blockchain/src/blockchain/utxo.rs
@@ -1,0 +1,139 @@
+//! Sled-first UTXO read facades (#2662).
+//!
+//! In-memory `utxo_set` keys are legacy `blake3(tx_hash ‖ index_le)` hashes
+//! (see [`Blockchain::legacy_utxo_hash`]). Sled keys are canonical
+//! [`OutPoint`] `{ tx, index }` with [`Utxo`] values. Handlers must use these
+//! facades instead of reading `utxo_set` directly.
+
+use super::*;
+use crate::storage::{Address, BlockchainStore, OutPoint, StorageResult, Utxo};
+
+/// Normalized spendable output for handler scans (marketplace, wallet payments).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpendableOutputView {
+    /// Legacy in-mem map key — use as `TransactionInput.previous_output`.
+    pub legacy_hash: Hash,
+    /// Output index within the creating transaction (0 when unknown on in-mem path).
+    pub output_index: u32,
+    /// Owner id for wallet matching (`PublicKey::key_id` / sled `Address`).
+    pub owner_key_id: [u8; 32],
+}
+
+impl Blockchain {
+    /// Legacy in-memory UTXO map key: `blake3(tx_hash ‖ index_le)`.
+    ///
+    /// Sled uses [`OutPoint`] instead; this hash is **not reversible**. Genesis
+    /// bootstrap may insert entries under ad-hoc hashes — those appear only on
+    /// the in-mem fallback scan path.
+    pub fn legacy_utxo_hash(tx_hash: &Hash, output_index: usize) -> Hash {
+        let mut data = Vec::new();
+        data.extend_from_slice(tx_hash.as_bytes());
+        data.extend_from_slice(&(output_index as u64).to_le_bytes());
+        crate::types::hash::blake3_hash(&data)
+    }
+
+    /// Sled-first UTXO count for metrics / bootstrap probes.
+    pub fn utxo_count(&self) -> usize {
+        if let Some(store) = self.get_store() {
+            match store.iter_utxos() {
+                Ok(iter) => {
+                    let mut n = 0usize;
+                    for row in iter {
+                        match row {
+                            Ok(_) => n += 1,
+                            Err(e) => {
+                                tracing::warn!(error = %e, "utxo_count: sled scan error; using in-memory shadow");
+                                return self.utxo_set.len();
+                            }
+                        }
+                    }
+                    return n;
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "utxo_count: sled iter failed; using in-memory shadow");
+                }
+            }
+        }
+        self.utxo_set.len()
+    }
+
+    pub fn utxo_set_is_empty(&self) -> bool {
+        self.utxo_count() == 0
+    }
+
+    /// Sled-first single-UTXO lookup by canonical outpoint.
+    pub fn utxo_at_outpoint(&self, outpoint: &OutPoint) -> StorageResult<Option<Utxo>> {
+        if let Some(store) = self.get_store() {
+            return store.get_utxo(outpoint);
+        }
+        let tx_hash = Hash::from_slice(outpoint.tx.as_bytes());
+        let legacy = Self::legacy_utxo_hash(&tx_hash, outpoint.index as usize);
+        Ok(self.utxo_set.get(&legacy).map(|output| Utxo {
+            amount: 0,
+            owner: Address::new(output.recipient.key_id),
+            token: crate::storage::TokenId::NATIVE,
+            created_at_height: 0,
+            script: None,
+            merkle_leaf: if output.merkle_leaf == Hash::default() {
+                None
+            } else {
+                Some(output.merkle_leaf.as_array())
+            },
+        }))
+    }
+
+    /// Collect spendable outputs for handler scans. Sled-first when a store is
+    /// attached; falls back to the in-memory `utxo_set` shadow in store-less
+    /// mode or on sled scan failure.
+    pub fn collect_spendable_outputs(&self) -> Vec<SpendableOutputView> {
+        if let Some(store) = self.get_store() {
+            match store.iter_utxos() {
+                Ok(iter) => {
+                    let mut out = Vec::new();
+                    for row in iter {
+                        let Ok((op, utxo)) = row else {
+                            tracing::warn!("collect_spendable_outputs: sled row error; using in-memory shadow");
+                            return self.collect_spendable_outputs_in_mem();
+                        };
+                        let tx_hash = Hash::from_slice(op.tx.as_bytes());
+                        out.push(SpendableOutputView {
+                            legacy_hash: Self::legacy_utxo_hash(
+                                &tx_hash,
+                                op.index as usize,
+                            ),
+                            output_index: op.index,
+                            owner_key_id: utxo.owner.0,
+                        });
+                    }
+                    return out;
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "collect_spendable_outputs: sled iter failed; using in-memory shadow");
+                }
+            }
+        }
+        self.collect_spendable_outputs_in_mem()
+    }
+
+    /// Outputs owned by `owner_key_id` (`PublicKey::key_id` / wallet id bytes).
+    pub fn spendable_outputs_for_owner(
+        &self,
+        owner_key_id: &[u8; 32],
+    ) -> Vec<SpendableOutputView> {
+        self.collect_spendable_outputs()
+            .into_iter()
+            .filter(|v| v.owner_key_id == *owner_key_id)
+            .collect()
+    }
+
+    fn collect_spendable_outputs_in_mem(&self) -> Vec<SpendableOutputView> {
+        self.utxo_set
+            .iter()
+            .map(|(legacy_hash, output)| SpendableOutputView {
+                legacy_hash: *legacy_hash,
+                output_index: 0,
+                owner_key_id: output.recipient.key_id,
+            })
+            .collect()
+    }
+}

--- a/lib-blockchain/src/blockchain/utxo.rs
+++ b/lib-blockchain/src/blockchain/utxo.rs
@@ -6,7 +6,7 @@
 //! facades instead of reading `utxo_set` directly.
 
 use super::*;
-use crate::storage::{Address, BlockchainStore, OutPoint, StorageResult, Utxo};
+use crate::storage::{Address, OutPoint, StorageResult, Utxo};
 
 /// Normalized spendable output for handler scans (marketplace, wallet payments).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,8 +57,23 @@ impl Blockchain {
         self.utxo_set.len()
     }
 
+    /// Early-exit emptiness probe — does not deserialize every UTXO row.
     pub fn utxo_set_is_empty(&self) -> bool {
-        self.utxo_count() == 0
+        if let Some(store) = self.get_store() {
+            match store.iter_utxos() {
+                Ok(mut iter) => match iter.next() {
+                    None => return true,
+                    Some(Ok(_)) => return false,
+                    Some(Err(e)) => {
+                        tracing::warn!(error = %e, "utxo_set_is_empty: sled scan error; using in-memory shadow");
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(error = %e, "utxo_set_is_empty: sled iter failed; using in-memory shadow");
+                }
+            }
+        }
+        self.utxo_set.is_empty()
     }
 
     /// Sled-first single-UTXO lookup by canonical outpoint.
@@ -116,13 +131,66 @@ impl Blockchain {
     }
 
     /// Outputs owned by `owner_key_id` (`PublicKey::key_id` / wallet id bytes).
+    ///
+    /// Filters while iterating the sled store — does not materialize the full
+    /// UTXO set when a store is attached.
     pub fn spendable_outputs_for_owner(
         &self,
         owner_key_id: &[u8; 32],
     ) -> Vec<SpendableOutputView> {
-        self.collect_spendable_outputs()
-            .into_iter()
-            .filter(|v| v.owner_key_id == *owner_key_id)
+        if let Some(store) = self.get_store() {
+            match store.iter_utxos() {
+                Ok(iter) => {
+                    let mut out = Vec::new();
+                    for row in iter {
+                        let Ok((op, utxo)) = row else {
+                            tracing::warn!(
+                                "spendable_outputs_for_owner: sled row error; using in-memory shadow"
+                            );
+                            return self.spendable_outputs_for_owner_in_mem(owner_key_id);
+                        };
+                        if utxo.owner.0 != *owner_key_id {
+                            continue;
+                        }
+                        let tx_hash = Hash::from_slice(op.tx.as_bytes());
+                        out.push(SpendableOutputView {
+                            legacy_hash: Self::legacy_utxo_hash(
+                                &tx_hash,
+                                op.index as usize,
+                            ),
+                            output_index: op.index,
+                            owner_key_id: utxo.owner.0,
+                        });
+                    }
+                    return out;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "spendable_outputs_for_owner: sled iter failed; using in-memory shadow"
+                    );
+                }
+            }
+        }
+        self.spendable_outputs_for_owner_in_mem(owner_key_id)
+    }
+
+    fn spendable_outputs_for_owner_in_mem(
+        &self,
+        owner_key_id: &[u8; 32],
+    ) -> Vec<SpendableOutputView> {
+        self.utxo_set
+            .iter()
+            .filter_map(|(legacy_hash, output)| {
+                if output.recipient.key_id != *owner_key_id {
+                    return None;
+                }
+                Some(SpendableOutputView {
+                    legacy_hash: *legacy_hash,
+                    output_index: 0,
+                    owner_key_id: output.recipient.key_id,
+                })
+            })
             .collect()
     }
 

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -3038,7 +3038,7 @@ impl BlockchainHandler {
         let storage_bytes = headers_count * 200;
 
         // Count UTXOs
-        let utxos_tracked = blockchain.utxo_set.len();
+        let utxos_tracked = blockchain.utxo_count();
 
         // Network height is same as current height in this context
         // In a full implementation, this would query other peers

--- a/zhtp/src/api/handlers/marketplace/mod.rs
+++ b/zhtp/src/api/handlers/marketplace/mod.rs
@@ -452,13 +452,14 @@ impl MarketplaceHandler {
         let blockchain = self.blockchain.read().await;
         let mut wallet_utxos: Vec<(lib_blockchain::Hash, u32, u128)> = Vec::new();
 
+        let owned_outputs = blockchain.spendable_outputs_for_owner(&wallet_key_id);
         info!(
-            " Scanning {} UTXOs for wallet key_id: {}",
-            blockchain.utxo_count(),
-            hex::encode(&wallet_key_id[..8])
+            " Scanning spendable outputs for wallet key_id: {} ({} owned)",
+            hex::encode(&wallet_key_id[..8]),
+            owned_outputs.len()
         );
 
-        for view in blockchain.spendable_outputs_for_owner(&wallet_key_id) {
+        for view in owned_outputs {
             let utxo_amount = SOV_WELCOME_BONUS;
             wallet_utxos.push((view.legacy_hash, view.output_index, utxo_amount));
             info!(

--- a/zhtp/src/api/handlers/marketplace/mod.rs
+++ b/zhtp/src/api/handlers/marketplace/mod.rs
@@ -441,10 +441,11 @@ impl MarketplaceHandler {
         let identity_private_key_bytes = private_key.dilithium_sk.clone();
         let identity_seed = [0u8; 32]; // TODO: P1-7 - seed not directly accessible, may need to be stored separately
         let wallet_pubkey = identity.public_key.dilithium_pk.clone();
+        let wallet_key_id = identity.public_key.key_id;
         drop(identity_mgr);
 
         // ========================================================================
-        // STEP 1: Scan blockchain.utxo_set for UTXOs owned by buyer's wallet
+        // STEP 1: Scan spendable outputs for UTXOs owned by buyer's wallet
         // ========================================================================
         info!(" Scanning blockchain UTXO set for buyer wallet's spendable outputs...");
 
@@ -452,22 +453,18 @@ impl MarketplaceHandler {
         let mut wallet_utxos: Vec<(lib_blockchain::Hash, u32, u128)> = Vec::new();
 
         info!(
-            " Scanning {} UTXOs for wallet pubkey: {}",
-            blockchain.utxo_set.len(),
-            hex::encode(&wallet_pubkey[..8.min(wallet_pubkey.len())])
+            " Scanning {} UTXOs for wallet key_id: {}",
+            blockchain.utxo_count(),
+            hex::encode(&wallet_key_id[..8])
         );
 
-        for (utxo_hash, output) in &blockchain.utxo_set {
-            // Check if this UTXO belongs to buyer's wallet by comparing public keys
-            if output.recipient.as_bytes() == wallet_pubkey {
-                // NOTE: Amount is hidden in Pedersen commitment
-                // For genesis UTXOs, we know the amount is the welcome bonus
-                // In production, wallet would track amounts or decrypt notes
-                let utxo_amount = SOV_WELCOME_BONUS; // Genesis wallet funding amount (atomic units)
-
-                wallet_utxos.push((*utxo_hash, 0, utxo_amount));
-                info!("    Found UTXO: {}", hex::encode(utxo_hash.as_bytes()));
-            }
+        for view in blockchain.spendable_outputs_for_owner(&wallet_key_id) {
+            let utxo_amount = SOV_WELCOME_BONUS;
+            wallet_utxos.push((view.legacy_hash, view.output_index, utxo_amount));
+            info!(
+                "    Found UTXO: {}",
+                hex::encode(view.legacy_hash.as_bytes())
+            );
         }
 
         if wallet_utxos.is_empty() {
@@ -607,9 +604,9 @@ impl MarketplaceHandler {
                 commitment: change_commitment,
                 note: change_note,
                 recipient: lib_crypto::PublicKey {
-                    dilithium_pk: wallet_pubkey.as_slice().try_into().unwrap_or([0u8; 2592]),
+                    dilithium_pk: wallet_pubkey.clone(),
                     kyber_pk: [0u8; 1568],
-                    key_id: [0; 32],
+                    key_id: wallet_key_id,
                 },
                             merkle_leaf: lib_blockchain::Hash::default(),
 };
@@ -636,7 +633,7 @@ impl MarketplaceHandler {
 
         let private_key = PrivateKey {
             dilithium_sk: identity_private_key_bytes.as_slice().try_into().unwrap_or([0u8; 4896]),
-            dilithium_pk: wallet_pubkey.as_slice().try_into().unwrap_or([0u8; 2592]),
+            dilithium_pk: wallet_pubkey,
             kyber_sk: [0u8; 3168],
             master_seed: identity_seed.as_slice().try_into().unwrap_or([0u8; 64]),
         };

--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -859,7 +859,7 @@ impl Component for BlockchainComponent {
                 "pending_transactions".to_string(),
                 blockchain.pending_transactions.len() as f64,
             );
-            metrics.insert("utxo_count".to_string(), blockchain.utxo_set.len() as f64);
+            metrics.insert("utxo_count".to_string(), blockchain.utxo_count() as f64);
             metrics.insert(
                 "identity_count".to_string(),
                 blockchain.identity_count() as f64, // #2639: sled-authoritative count
@@ -889,7 +889,7 @@ impl Component for BlockchainComponent {
                 "pending_transactions".to_string(),
                 blockchain.pending_transactions.len() as f64,
             );
-            metrics.insert("utxo_count".to_string(), blockchain.utxo_set.len() as f64);
+            metrics.insert("utxo_count".to_string(), blockchain.utxo_count() as f64);
             metrics.insert(
                 "identity_count".to_string(),
                 blockchain.identity_count() as f64, // #2639: sled-authoritative count

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1208,13 +1208,13 @@ impl RuntimeOrchestrator {
                 Ok(blockchain_arc) => {
                     let blockchain = blockchain_arc.read().await;
                     let has_data = blockchain.height > 0
-                        || !blockchain.utxo_set.is_empty()
+                        || !blockchain.utxo_set_is_empty()
                         || !blockchain.token_contracts_is_empty();
                     if has_data {
                         info!(
                             "✓ Global blockchain has data (height: {}, UTXOs: {}, tokens: {})",
                             blockchain.height,
-                            blockchain.utxo_set.len(),
+                            blockchain.utxo_count(),
                             blockchain.token_contract_count()
                         );
                     }
@@ -4779,26 +4779,33 @@ impl RuntimeOrchestrator {
         // Scan UTXO set for outputs owned by this wallet
         let mut wallet_utxos: Vec<(lib_blockchain::Hash, u32, u128)> = Vec::new();
 
+        let owner_key_id = if wallet_pubkey.len() == 32 {
+            let mut id = [0u8; 32];
+            id.copy_from_slice(wallet_pubkey);
+            id
+        } else if wallet_pubkey.len() == 2592 {
+            let mut dilithium = [0u8; 2592];
+            dilithium.copy_from_slice(wallet_pubkey);
+            lib_crypto::hash_blake3(&dilithium)
+        } else {
+            return Err(anyhow::anyhow!(
+                "wallet_pubkey must be 32-byte key_id or 2592-byte Dilithium public key"
+            ));
+        };
+
         info!(
-            " Scanning {} UTXOs for wallet pubkey: {}",
-            blockchain.utxo_set.len(),
-            hex::encode(&wallet_pubkey[..8.min(wallet_pubkey.len())])
+            " Scanning {} UTXOs for wallet key_id: {}",
+            blockchain.utxo_count(),
+            hex::encode(&owner_key_id[..8])
         );
 
-        for (utxo_hash, output) in &blockchain.utxo_set {
-            // Check if this UTXO belongs to our wallet
-            // Compare recipient public key bytes with wallet pubkey
-            if output.recipient.as_bytes() == wallet_pubkey {
-                // NOTE: Amount is hidden in Pedersen commitment, so we need to get it from wallet_registry
-                // For genesis UTXOs, we know the amount from wallet_registry initial_balance
-                // In production, we'd need to decrypt the note or track amounts separately
-
-                // For now, use a placeholder amount - this would come from wallet's UTXO tracking
-                let utxo_amount = SOV_WELCOME_BONUS; // Genesis wallet funding amount
-
-                wallet_utxos.push((*utxo_hash, 0, utxo_amount));
-                info!("   Found UTXO: {}", hex::encode(utxo_hash.as_bytes()));
-            }
+        for view in blockchain.spendable_outputs_for_owner(&owner_key_id) {
+            let utxo_amount = SOV_WELCOME_BONUS;
+            wallet_utxos.push((view.legacy_hash, view.output_index, utxo_amount));
+            info!(
+                "   Found UTXO: {}",
+                hex::encode(view.legacy_hash.as_bytes())
+            );
         }
 
         if wallet_utxos.is_empty() {

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1207,14 +1207,21 @@ impl RuntimeOrchestrator {
             match crate::runtime::blockchain_provider::get_global_blockchain().await {
                 Ok(blockchain_arc) => {
                     let blockchain = blockchain_arc.read().await;
-                    let has_data = blockchain.height > 0
-                        || !blockchain.utxo_set_is_empty()
-                        || !blockchain.token_contracts_is_empty();
+                    let height = blockchain.height;
+                    let tokens_empty = blockchain.token_contracts_is_empty();
+                    let utxo_n = if height > 0 || !tokens_empty {
+                        blockchain.utxo_count()
+                    } else if blockchain.utxo_set_is_empty() {
+                        0
+                    } else {
+                        blockchain.utxo_count()
+                    };
+                    let has_data = height > 0 || utxo_n > 0 || !tokens_empty;
                     if has_data {
                         info!(
                             "✓ Global blockchain has data (height: {}, UTXOs: {}, tokens: {})",
-                            blockchain.height,
-                            blockchain.utxo_count(),
+                            height,
+                            utxo_n,
                             blockchain.token_contract_count()
                         );
                     }
@@ -4793,13 +4800,14 @@ impl RuntimeOrchestrator {
             ));
         };
 
+        let owned_outputs = blockchain.spendable_outputs_for_owner(&owner_key_id);
         info!(
-            " Scanning {} UTXOs for wallet key_id: {}",
-            blockchain.utxo_count(),
-            hex::encode(&owner_key_id[..8])
+            " Scanning spendable outputs for wallet key_id: {} ({} owned)",
+            hex::encode(&owner_key_id[..8]),
+            owned_outputs.len()
         );
 
-        for view in blockchain.spendable_outputs_for_owner(&owner_key_id) {
+        for view in owned_outputs {
             let utxo_amount = SOV_WELCOME_BONUS;
             wallet_utxos.push((view.legacy_hash, view.output_index, utxo_amount));
             info!(

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -347,7 +347,7 @@ impl GenesisFundingService {
         info!("   - Mining Pool: 300,000 SOV");
         info!("   - Development Pool: 200,000 SOV");
         info!("   - Total validator stake: {} SOV", total_validator_stake);
-        info!("   - Total UTXO entries: {}", blockchain.utxo_set.len());
+        info!("   - Total UTXO entries: {}", blockchain.utxo_count());
 
         // Register USER identity on blockchain (not just validators)
         Self::register_user_identity(
@@ -366,7 +366,7 @@ impl GenesisFundingService {
         info!(
             "   Genesis block finalized - Height: {}, UTXOs: {}, Identities: {}, Pending: {}",
             blockchain.height,
-            blockchain.utxo_set.len(),
+            blockchain.utxo_count(),
             blockchain.identity_count(),
             blockchain.pending_transactions.len()
         );

--- a/zhtp/src/runtime/services/mining_service.rs
+++ b/zhtp/src/runtime/services/mining_service.rs
@@ -185,7 +185,7 @@ impl MiningService {
                 info!("Block Hash: {:?}", new_block.hash());
                 info!("Block Height: {}", blockchain.height);
                 info!("Transactions in Block: {}", new_block.transactions.len());
-                info!("Total UTXOs: {}", blockchain.utxo_set.len());
+                info!("Total UTXOs: {}", blockchain.utxo_count());
                 info!(
                     "Identity Registry: {} entries",
                     blockchain.identity_count() // #2639: sled-authoritative
@@ -235,7 +235,7 @@ impl MiningService {
                         block_counter,
                         current_height,
                         pending_count,
-                        blockchain_guard.utxo_set.len(),
+                        blockchain_guard.utxo_count(),
                         blockchain_guard.identity_count() // #2639: sled-authoritative
                     );
 

--- a/zhtp/src/runtime/services/mining_service.rs
+++ b/zhtp/src/runtime/services/mining_service.rs
@@ -231,12 +231,16 @@ impl MiningService {
                     let current_height = blockchain_guard.height;
 
                     info!(
-                        "Mining check #{} - Height: {}, Pending: {}, UTXOs: {}, Identities: {}",
+                        "Mining check #{} - Height: {}, Pending: {}, Identities: {}",
                         block_counter,
                         current_height,
                         pending_count,
-                        blockchain_guard.utxo_count(),
                         blockchain_guard.identity_count() // #2639: sled-authoritative
+                    );
+                    debug!(
+                        "Mining check #{} - UTXOs: {}",
+                        block_counter,
+                        blockchain_guard.utxo_count()
                     );
 
                     // Check if we have pending transactions


### PR DESCRIPTION
## Summary

Phase 2 utxo read migration (#2662): adds sled-first UTXO facades on `Blockchain` and migrates zhtp handler/metrics read sites off direct `utxo_set` access.

## Facade API

- `legacy_utxo_hash(tx, index)` — documents in-mem key (`blake3(tx ‖ index_le)`) vs sled `OutPoint`
- `utxo_count()` / `utxo_set_is_empty()` — sled iter count with in-mem fallback
- `utxo_at_outpoint()` — single lookup
- `collect_spendable_outputs()` / `spendable_outputs_for_owner()` — marketplace + wallet payment scans

## Migrated read sites

- `marketplace/mod.rs` — UTXO scan via `spendable_outputs_for_owner(key_id)`
- `runtime/mod.rs` — bootstrap probe + wallet payment scan
- `genesis_funding.rs`, `mining_service.rs`, `components/blockchain.rs`, `handlers/blockchain/mod.rs` — metrics/logs

## Deferred

- `utxo_set.insert` mutations (genesis bootstrap) → Phase 4 (#2641)

## Tests

- `utxo_count_reads_sled`
- `collect_spendable_outputs_reads_sled`

Closes #2662