### PR TITLE
fix(runtime): council cache wiped by load_from_store on restart

### DIFF
--- a/zhtp/src/runtime/blockchain_provider.rs
+++ b/zhtp/src/runtime/blockchain_provider.rs
@@ -49,17 +49,30 @@ impl BlockchainProvider {
     }
 
     /// Refresh the sync council cache from live `blockchain.council_members`.
+    ///
+    /// Council membership is in-memory only (not sled-persisted). A
+    /// `load_from_store` swap can temporarily leave `council_members` empty while
+    /// a config-seeded cache is still valid — do not clobber a non-empty cache
+    /// with an empty chain read (the 15s background refresh loop).
     pub async fn refresh_council_member_cache(&self) {
         let outer = self.blockchain.read().await;
         let Some(arc) = outer.as_ref() else {
             return;
         };
         let bc = arc.read().await;
-        self.store_council_member_cache(
-            bc.get_council_members()
-                .iter()
-                .map(|m| m.identity_id.clone()),
-        );
+        let members: HashSet<String> = bc
+            .get_council_members()
+            .iter()
+            .map(|m| m.identity_id.clone())
+            .collect();
+        if members.is_empty() {
+            if let Ok(cache) = self.council_member_cache.read() {
+                if !cache.is_empty() {
+                    return;
+                }
+            }
+        }
+        self.store_council_member_cache(members);
     }
 
     /// Seed the sync council cache from config (no blockchain lock). Call after
@@ -816,6 +829,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn refresh_council_cache_does_not_clobber_seeded_cache_when_chain_empty() {
+        let council_did = "did:zhtp:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        let mut bc = Blockchain::new().expect("genesis");
+        // load_from_store replaces bc; council_members is not sled-persisted.
+        bc.council_members.clear();
+        let bc_arc = Arc::new(RwLock::new(bc));
+        let provider = BlockchainProvider::new();
+        provider.set_blockchain(bc_arc.clone()).await.unwrap();
+        provider.seed_council_member_cache([council_did.to_string()]);
+        assert!(
+            provider
+                .council_member_cache
+                .read()
+                .expect("cache lock")
+                .contains(council_did),
+            "seed must populate cache before refresh"
+        );
+
+        // Simulate load_from_store replacing bc with empty council_members.
+        provider.refresh_council_member_cache().await;
+        assert_eq!(
+            provider.council_member_cache.read().expect("cache lock").len(),
+            1,
+            "refresh must not clobber config-seeded cache"
+        );
+
+        assert_eq!(
+            provider.is_council_member_blocking_one(council_did),
+            Some(true),
+            "cache hit must resolve council DID"
+        );
+        assert_eq!(
+            provider.is_council_member_blocking(council_did),
+            Some(true),
+            "periodic refresh must not wipe config-seeded cache when council_members is empty"
+        );
+    }
+
+    #[tokio::test]
     async fn seed_council_cache_after_bootstrap_startup_order() {
         use lib_blockchain::dao::{CouncilBootstrapConfig, CouncilBootstrapEntry};
 
@@ -824,7 +876,7 @@ mod tests {
         let bc_arc = Arc::new(RwLock::new(bc));
         let provider = BlockchainProvider::new();
 
-        // Mirrors runtime/mod.rs: set_global_blockchain before ensure_council_bootstrap.
+        // Mirrors runtime/mod.rs: set_global_blockchain, then bootstrap after any reload.
         provider.set_blockchain(bc_arc.clone()).await.unwrap();
         assert!(
             provider.is_council_member_blocking(council_did) != Some(true),

--- a/zhtp/src/runtime/blockchain_provider.rs
+++ b/zhtp/src/runtime/blockchain_provider.rs
@@ -72,7 +72,7 @@ impl BlockchainProvider {
                 }
             }
         }
-        self.store_council_member_cache(members);
+        self.replace_council_member_cache(members);
     }
 
     /// Seed the sync council cache from config (no blockchain lock). Call after
@@ -83,7 +83,10 @@ impl BlockchainProvider {
     }
 
     fn store_council_member_cache(&self, identity_ids: impl IntoIterator<Item = String>) {
-        let members: HashSet<String> = identity_ids.into_iter().collect();
+        self.replace_council_member_cache(identity_ids.into_iter().collect());
+    }
+
+    fn replace_council_member_cache(&self, members: HashSet<String>) {
         if let Ok(mut cache) = self.council_member_cache.write() {
             *cache = members;
         }

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -5602,16 +5602,10 @@ pub(super) fn try_restore_oracle_from_dat(
     }
 }
 
-/// Seed validators from bootstrap config when the authoritative active set is empty.
-///
-/// Bootstrap validators are not committed as on-chain transactions on testnet; this path
-/// installs them into the in-memory overlay **and** durable sled so consensus reads agree
-/// with the fleet (#2639).
-///
-/// Uses blake3 domain separation to derive distinct placeholder keys for the networking and
-/// rewards roles from the identity ID — these only need to be non-empty and mutually distinct
-/// for the in-memory registry; they are not used for actual signing.
 /// Idempotently bootstrap council members from config and warm the sync role cache.
+///
+/// Council membership is in-memory only (not sled-persisted). Must run after any
+/// `load_from_store` swap that replaces `*bc`, and after `set_user_wallet` on restart.
 pub(super) async fn ensure_council_bootstrap_and_cache(
     council_config: &lib_blockchain::dao::CouncilBootstrapConfig,
 ) -> Result<()> {
@@ -5633,6 +5627,15 @@ pub(super) async fn ensure_council_bootstrap_and_cache(
     Ok(())
 }
 
+/// Seed validators from bootstrap config when the authoritative active set is empty.
+///
+/// Bootstrap validators are not committed as on-chain transactions on testnet; this path
+/// installs them into the in-memory overlay **and** durable sled so consensus reads agree
+/// with the fleet (#2639).
+///
+/// Uses blake3 domain separation to derive distinct placeholder keys for the networking and
+/// rewards roles from the identity ID — these only need to be non-empty and mutually distinct
+/// for the in-memory registry; they are not used for actual signing.
 pub(super) fn seed_validators_from_bootstrap_config(
     bc: &mut lib_blockchain::Blockchain,
     bootstrap_validators: &[crate::config::aggregation::BootstrapValidator],

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -1263,6 +1263,7 @@ impl RuntimeOrchestrator {
                                 "Failed to seed bootstrap validators after load_from_store: {e}"
                             );
                         }
+                        bc.ensure_council_bootstrap(&self.config.consensus_config.council);
                         info!(
                             "Blockchain load complete: height={}, identities={}, validators={}, domains={}, credentials={}",
                             bc.height,
@@ -2631,25 +2632,6 @@ impl RuntimeOrchestrator {
             info!("✓ Blockchain provider initialized with fresh blockchain");
         }
 
-        // Bootstrap Council (dao-1): idempotently populate from config
-        {
-            let mut bc = blockchain_arc.write().await;
-            bc.ensure_council_bootstrap(&self.config.consensus_config.council);
-        }
-        // set_global_blockchain ran *before* bootstrap and warmed an empty cache.
-        if let Some(provider) = crate::runtime::blockchain_provider::get_global_blockchain_provider()
-        {
-            provider.seed_council_member_cache(
-                self.config
-                    .consensus_config
-                    .council
-                    .members
-                    .iter()
-                    .map(|m| m.identity_id.clone()),
-            );
-            provider.refresh_council_member_cache().await;
-        }
-
         if let Some(ref net_info) = network_info {
             info!(
                 "✓ Discovered network candidate with {} peers ({})",
@@ -2705,6 +2687,11 @@ impl RuntimeOrchestrator {
 
         // Store wallet result for blockchain component
         self.set_user_wallet(wallet_result.clone()).await?;
+
+        // Council membership is in-memory only. set_user_wallet may call
+        // load_from_store on restart (mod.rs ~1249), which replaces *bc and
+        // wipes council_members — bootstrap + cache seed must run AFTER that.
+        ensure_council_bootstrap_and_cache(&self.config.consensus_config.council).await?;
 
         // Derive deterministic NodeId from DID + device name and cache for runtime access
         let device_name = resolve_device_name(Some(&wallet_result.node_identity.primary_device))
@@ -5624,6 +5611,28 @@ pub(super) fn try_restore_oracle_from_dat(
 /// Uses blake3 domain separation to derive distinct placeholder keys for the networking and
 /// rewards roles from the identity ID — these only need to be non-empty and mutually distinct
 /// for the in-memory registry; they are not used for actual signing.
+/// Idempotently bootstrap council members from config and warm the sync role cache.
+pub(super) async fn ensure_council_bootstrap_and_cache(
+    council_config: &lib_blockchain::dao::CouncilBootstrapConfig,
+) -> Result<()> {
+    let blockchain_arc = crate::runtime::blockchain_provider::get_global_blockchain().await?;
+    {
+        let mut bc = blockchain_arc.write().await;
+        bc.ensure_council_bootstrap(council_config);
+    }
+    if let Some(provider) = crate::runtime::blockchain_provider::get_global_blockchain_provider()
+    {
+        provider.seed_council_member_cache(
+            council_config
+                .members
+                .iter()
+                .map(|m| m.identity_id.clone()),
+        );
+        provider.refresh_council_member_cache().await;
+    }
+    Ok(())
+}
+
 pub(super) fn seed_validators_from_bootstrap_config(
     bc: &mut lib_blockchain::Blockchain,
     bootstrap_validators: &[crate::config::aggregation::BootstrapValidator],


### PR DESCRIPTION
## Root cause

On g1 restart with existing chain data, startup order was:

1. `set_global_blockchain` + `ensure_council_bootstrap` (5 council members)
2. `set_user_wallet` → `load_from_store` → `*bc = reloaded` (**wipes** `council_members` — not sled-persisted)
3. `refresh_council_member_cache` reads empty `bc.council_members` → **empty cache**
4. 15s background refresh keeps cache empty → halt-consensus 403 (fail-closed)

#2720 seeded the cache after bootstrap, but the second `load_from_store` at `mod.rs:1254` runs **later** inside `set_user_wallet`.

## Fix

1. **Move** council bootstrap + cache seed to **after** `set_user_wallet` (post-reload)
2. **Re-run** `ensure_council_bootstrap` inside the `load_from_store` reload path (mirrors validator seed)
3. **Harden** `refresh_council_member_cache` — do not clobber a non-empty config-seeded cache when `council_members` is empty

## Tests

- `refresh_council_cache_does_not_clobber_seeded_cache_when_chain_empty`

Deploy this before re-testing halt on g1.