### PR TITLE
fix(replay): g4 fresh-sync determinism — genesis SOV seed + canonical bootstrap

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -1078,7 +1078,15 @@ impl Blockchain {
 
             // Use BlockExecutor for state mutations
             // Note: executor.apply_block() handles begin_block/commit_block internally
-            match executor.apply_block(&block) {
+            let fee_floor = self.tx_fee_config.domain_registration_fee_atoms;
+            let treasury_wallet = self
+                .get_dao_treasury_wallet_id()
+                .map(|id| id.as_str());
+            match executor.apply_block_committing_domain_fees(
+                &block,
+                Some(fee_floor),
+                treasury_wallet,
+            ) {
                 Ok(_outcome) => {
                     // Block applied successfully through executor.
                     // Writes path: sync in-memory token_contracts from sled after apply

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -4636,6 +4636,9 @@ impl Blockchain {
             std::mem::swap(&mut self.event_publisher, &mut adopted.event_publisher);
             *self = adopted;
 
+            self.persist_genesis_sov_allocations_to_store()
+                .context("persisting genesis SOV allocations before verified import")?;
+
             // 3. Apply each imported block through the verified sync path.
             //    Continuity is checked explicitly; transaction validity and all
             //    state derivation are handled by `apply_block_trusted_for_sync`.

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1701,7 +1701,6 @@ impl Blockchain {
             crate::contracts::utils::wallet_key_for_sov(payload.fee_payer_wallet_id);
         let treasury_key =
             crate::contracts::utils::wallet_key_for_sov(treasury_wallet_id);
-        let store = self.get_store().map(std::sync::Arc::clone);
 
         let token = self
             .token_contracts
@@ -1725,26 +1724,100 @@ impl Blockchain {
             return Err(anyhow!("credit treasury: {}", e));
         }
 
-        // Executor balance checks read sled (#2637). Mirror the in-memory fee
-        // movement so replay-from-genesis matches incremental live applies.
-        if let Some(store) = store {
-            if let Err(e) = Self::mirror_domain_fee_to_store(
-                store.as_ref(),
-                sov_id,
-                payload.fee_payer_wallet_id,
-                treasury_wallet_id,
-                payload.fee_amount_atoms,
-            ) {
-                let _ = token.credit_balance(&payer_key, payload.fee_amount_atoms);
-                let _ = token.debit_balance(&treasury_key, payload.fee_amount_atoms);
-                return Err(anyhow!("mirror domain fee to sled: {}", e));
-            }
-        }
-
         Ok(())
     }
 
-    /// Dual-write domain registration SOV fees to the sled token_balances tree.
+    /// Apply V2 domain registration SOV fees to sled inside the executor's
+    /// `begin_block`/`commit_block` window. In-memory registry updates remain
+    /// in `process_domain_transactions` during `finish_block_processing`.
+    pub(crate) fn apply_domain_registration_fees_to_store(
+        store: &dyn crate::storage::BlockchainStore,
+        block: &Block,
+        fee_floor_atoms: u128,
+        treasury_wallet_id_hex: Option<&str>,
+    ) {
+        let block_height = block.height();
+        for tx in &block.transactions {
+            if tx.transaction_type != TransactionType::DomainRegistration {
+                continue;
+            }
+            let tx_signer_key_id = tx.signature.public_key.key_id;
+            match crate::transaction::DomainRegistrationPayload::decode_memo(&tx.memo) {
+                Ok(payload) => {
+                    let is_v2 = payload.fee_amount_atoms > 0
+                        || payload.fee_payer_wallet_id != [0u8; 32];
+                    if !is_v2 {
+                        continue;
+                    }
+                    if let Err(e) = Self::mirror_domain_registration_fee_to_store(
+                        store,
+                        &payload,
+                        tx_signer_key_id,
+                        fee_floor_atoms,
+                        treasury_wallet_id_hex,
+                        block_height,
+                    ) {
+                        warn!(
+                            "DomainRegistration {} at height {} sled fee skipped: {}",
+                            payload.domain, block_height, e
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to decode DomainRegistration memo at height {}: {}",
+                        block_height, e
+                    );
+                }
+            }
+        }
+    }
+
+    fn mirror_domain_registration_fee_to_store(
+        store: &dyn crate::storage::BlockchainStore,
+        payload: &crate::transaction::domain::DomainRegistrationPayload,
+        tx_signer_key_id: [u8; 32],
+        fee_floor_atoms: u128,
+        treasury_wallet_id_hex: Option<&str>,
+        block_height: u64,
+    ) -> Result<()> {
+        use anyhow::anyhow;
+
+        if payload.fee_amount_atoms < fee_floor_atoms {
+            return Err(anyhow!(
+                "fee below governance floor: payload {} < floor {} atoms",
+                payload.fee_amount_atoms,
+                fee_floor_atoms
+            ));
+        }
+        if payload.fee_payer_wallet_id != tx_signer_key_id {
+            return Err(anyhow!(
+                "fee payer mismatch at height {}: payload wallet does not derive from tx signer",
+                block_height
+            ));
+        }
+
+        let treasury_hex = treasury_wallet_id_hex
+            .ok_or_else(|| anyhow!("DAO treasury wallet is not configured"))?;
+        let treasury_bytes = hex::decode(treasury_hex)
+            .map_err(|_| anyhow!("DAO treasury wallet id is malformed hex"))?;
+        if treasury_bytes.len() != 32 {
+            return Err(anyhow!("DAO treasury wallet id must be 32 bytes"));
+        }
+        let mut treasury_wallet_id = [0u8; 32];
+        treasury_wallet_id.copy_from_slice(&treasury_bytes);
+
+        let sov_id = crate::contracts::utils::generate_lib_token_id();
+        Self::mirror_domain_fee_to_store(
+            store,
+            sov_id,
+            payload.fee_payer_wallet_id,
+            treasury_wallet_id,
+            payload.fee_amount_atoms,
+        )
+    }
+
+    /// Debit/credit domain registration SOV fees in the sled token_balances tree.
     fn mirror_domain_fee_to_store(
         store: &dyn crate::storage::BlockchainStore,
         sov_token_id: [u8; 32],
@@ -1775,7 +1848,7 @@ impl Blockchain {
 
         let treasury_bal = store
             .get_token_balance(&token, &treasury_addr)
-            .unwrap_or(0);
+            .map_err(|e| anyhow!("read treasury sled balance: {}", e))?;
         store
             .set_token_balance(
                 &token,

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1701,6 +1701,7 @@ impl Blockchain {
             crate::contracts::utils::wallet_key_for_sov(payload.fee_payer_wallet_id);
         let treasury_key =
             crate::contracts::utils::wallet_key_for_sov(treasury_wallet_id);
+        let store = self.get_store().map(std::sync::Arc::clone);
 
         let token = self
             .token_contracts
@@ -1723,6 +1724,66 @@ impl Blockchain {
             let _ = token.credit_balance(&payer_key, payload.fee_amount_atoms);
             return Err(anyhow!("credit treasury: {}", e));
         }
+
+        // Executor balance checks read sled (#2637). Mirror the in-memory fee
+        // movement so replay-from-genesis matches incremental live applies.
+        if let Some(store) = store {
+            if let Err(e) = Self::mirror_domain_fee_to_store(
+                store.as_ref(),
+                sov_id,
+                payload.fee_payer_wallet_id,
+                treasury_wallet_id,
+                payload.fee_amount_atoms,
+            ) {
+                let _ = token.credit_balance(&payer_key, payload.fee_amount_atoms);
+                let _ = token.debit_balance(&treasury_key, payload.fee_amount_atoms);
+                return Err(anyhow!("mirror domain fee to sled: {}", e));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Dual-write domain registration SOV fees to the sled token_balances tree.
+    fn mirror_domain_fee_to_store(
+        store: &dyn crate::storage::BlockchainStore,
+        sov_token_id: [u8; 32],
+        payer_wallet_id: [u8; 32],
+        treasury_wallet_id: [u8; 32],
+        fee_atoms: u128,
+    ) -> Result<()> {
+        use anyhow::anyhow;
+        use crate::storage::{Address, TokenId};
+
+        let token = TokenId::new(sov_token_id);
+        let payer_addr = Address::new(payer_wallet_id);
+        let treasury_addr = Address::new(treasury_wallet_id);
+
+        let payer_bal = store
+            .get_token_balance(&token, &payer_addr)
+            .map_err(|e| anyhow!("read payer sled balance: {}", e))?;
+        let new_payer = payer_bal.checked_sub(fee_atoms).ok_or_else(|| {
+            anyhow!(
+                "sled payer balance insufficient: have {}, need {}",
+                payer_bal,
+                fee_atoms
+            )
+        })?;
+        store
+            .set_token_balance(&token, &payer_addr, new_payer)
+            .map_err(|e| anyhow!("debit payer sled balance: {}", e))?;
+
+        let treasury_bal = store
+            .get_token_balance(&token, &treasury_addr)
+            .unwrap_or(0);
+        store
+            .set_token_balance(
+                &token,
+                &treasury_addr,
+                treasury_bal.saturating_add(fee_atoms),
+            )
+            .map_err(|e| anyhow!("credit treasury sled balance: {}", e))?;
+
         Ok(())
     }
 }

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -1013,6 +1013,21 @@ impl Blockchain {
         // Gated by schema version; regenerates from the loaded/replayed registry.
         blockchain.migrate_validator_records_schema();
 
+        // Genesis allocations are direct inserts in build_block0(), not block txs.
+        // After executor-only block-0 import the in-memory registries are empty until
+        // we re-apply embedded genesis metadata (replay determinism / g4 bootstrap).
+        if let Ok(cfg) = crate::genesis::GenesisConfig::from_embedded() {
+            if let Err(e) = cfg.apply_genesis_state(&mut blockchain) {
+                warn!(
+                    "apply_genesis_state during load_from_store failed (non-fatal): {}",
+                    e
+                );
+            }
+        }
+
+        blockchain.backfill_genesis_identities_to_store();
+        blockchain.migrate_identity_metadata_schema();
+
         Ok(Some(blockchain))
     }
 

--- a/lib-blockchain/src/blockchain/replay.rs
+++ b/lib-blockchain/src/blockchain/replay.rs
@@ -184,7 +184,7 @@ impl Blockchain {
     /// Idempotent: the persisted version gate makes repeat boots a no-op, and
     /// the rebuild itself is a clear + deterministic rewrite. A mid-way failure
     /// leaves the version behind so the next boot retries.
-    fn migrate_identity_metadata_schema(&self) {
+    pub(crate) fn migrate_identity_metadata_schema(&self) {
         let Some(ref store) = self.store else {
             return;
         };
@@ -337,7 +337,7 @@ impl Blockchain {
     /// Ensure every in-memory genesis identity is also present in the sled
     /// identity store. Idempotent — overwrites existing entries with the
     /// genesis-derived consensus + metadata.
-    fn backfill_genesis_identities_to_store(&self) {
+    pub(crate) fn backfill_genesis_identities_to_store(&self) {
         let Some(ref store) = self.store else {
             return;
         };

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -465,6 +465,41 @@ impl Blockchain {
         entries
     }
 
+    /// Idempotently persist in-memory genesis SOV mints to sled before the first
+    /// executor block apply (fresh-node import pins block 0 in-memory only).
+    pub fn persist_genesis_sov_allocations_to_store(&self) -> Result<()> {
+        let Some(store) = self.get_store() else {
+            return Ok(());
+        };
+        let sov_token_id = crate::contracts::utils::generate_lib_token_id();
+        let entries: Vec<([u8; 32], u128)> = self
+            .token_contracts
+            .get(&sov_token_id)
+            .map(|token| {
+                token
+                    .balances_iter()
+                    .map(|(pk, &bal)| (pk.key_id, bal))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let token_id = crate::storage::TokenId::new(sov_token_id);
+        match store.backfill_token_balances_from_contract(&token_id, &entries) {
+            Ok(n) if n > 0 => info!(
+                "💰 Persisted {} genesis SOV balances to token_balances tree",
+                n
+            ),
+            Ok(_) => {}
+            Err(e) => warn!(
+                "⚠️ Failed to persist genesis SOV balances to sled: {}",
+                e
+            ),
+        }
+        Ok(())
+    }
+
     /// Zero out SOV balances that were incorrectly minted to UBI and Savings wallets
     /// by a bug in the recovery migration.  The bug set `initial_balance = 5 000 SOV`
     /// for every wallet whose sled balance was 0, regardless of wallet type.  Only

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -537,33 +537,28 @@ impl BlockExecutor {
     /// Uses a scope guard to ensure rollback_block is called on both errors
     /// AND panics after begin_block.
     pub fn apply_block(&self, block: &Block) -> BlockApplyResult<ApplyOutcome> {
+        self.apply_block_committing_domain_fees(block, None, None)
+    }
+
+    /// Apply a block, optionally committing domain-registration SOV fees inside
+    /// the block transaction (before `append_block`/`commit_block`).
+    pub fn apply_block_committing_domain_fees(
+        &self,
+        block: &Block,
+        fee_floor_atoms: Option<u128>,
+        treasury_wallet_id_hex: Option<&str>,
+    ) -> BlockApplyResult<ApplyOutcome> {
         let block_height = block.header.height;
 
-        // =====================================================================
-        // Step 1: validate_header
-        // =====================================================================
         self.validate_header(block)?;
-
-        // =====================================================================
-        // Step 2: validate_block_resources
-        // =====================================================================
         self.validate_block_resources(block)?;
-
-        // =====================================================================
-        // Step 3: begin_block
-        // =====================================================================
         self.store.begin_block(block_height)?;
 
-        // Create rollback guard for panic safety.
-        // The guard will call rollback_block on Drop unless disarmed.
         let guard = RollbackGuard::new(self.store.as_ref());
+        let outcome =
+            self.apply_block_inner(block, fee_floor_atoms, treasury_wallet_id_hex)?;
 
-        // Apply the block (steps 4-6)
-        let outcome = self.apply_block_inner(block)?;
-
-        // Success - disarm the guard so it won't rollback on drop
         guard.disarm();
-
         Ok(outcome)
     }
 
@@ -631,7 +626,12 @@ impl BlockExecutor {
     /// Steps 4-6: Apply transactions, append block, commit
     ///
     /// Called after begin_block. Guard ensures rollback on error.
-    fn apply_block_inner(&self, block: &Block) -> BlockApplyResult<ApplyOutcome> {
+    fn apply_block_inner(
+        &self,
+        block: &Block,
+        fee_floor_atoms: Option<u128>,
+        treasury_wallet_id_hex: Option<&str>,
+    ) -> BlockApplyResult<ApplyOutcome> {
         let block_height = block.header.height;
         let block_timestamp = block.header.timestamp;
         let block_hash = BlockHash::new(block.hash().as_array());
@@ -738,15 +738,16 @@ impl BlockExecutor {
             // Genesis [allocations.sov_balances] are direct inserts in build_block0(),
             // not block transactions — replay must seed sled or executor balance checks
             // diverge from the historical chain (g4 @ h=74010, #2641 replay gap).
-            if let Ok(cfg) = crate::genesis::GenesisConfig::from_embedded() {
-                if let Err(e) = cfg.credit_sov_allocations_in_open_transaction(self.store.as_ref())
-                {
-                    return Err(BlockApplyError::PersistFailed(format!(
-                        "genesis SOV allocations: {}",
-                        e
-                    )));
-                }
-            }
+            let cfg = crate::genesis::GenesisConfig::from_embedded().map_err(|e| {
+                BlockApplyError::PersistFailed(format!(
+                    "embedded genesis config unavailable for SOV seeding: {}",
+                    e
+                ))
+            })?;
+            cfg.credit_sov_allocations_in_open_transaction(self.store.as_ref())
+                .map_err(|e| {
+                    BlockApplyError::PersistFailed(format!("genesis SOV allocations: {}", e))
+                })?;
 
             self.store
                 .append_block(block)
@@ -921,6 +922,17 @@ impl BlockExecutor {
                 })?;
 
             summary.utxos_created += coinbase_result.outputs_created;
+        }
+
+        // Domain registration fees must persist in the block transaction, not the
+        // post-commit metadata batch (token_balances are consensus state).
+        if let (Some(floor), Some(treasury)) = (fee_floor_atoms, treasury_wallet_id_hex) {
+            crate::Blockchain::apply_domain_registration_fees_to_store(
+                self.store.as_ref(),
+                block,
+                floor,
+                Some(treasury),
+            );
         }
 
         // =====================================================================

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -4016,6 +4016,85 @@ mod tests {
     }
 
     #[test]
+    fn test_domain_registration_fee_committed_in_executor_block_tx() {
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::storage::{Address, TokenId};
+        use crate::transaction::domain::DomainRegistrationPayload;
+        use crate::transaction::fee::DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS;
+
+        let store = create_test_store();
+        let executor = create_trusted_replay_executor(store.clone());
+
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let payer_wallet_id = [0xab; 32];
+        let fee = DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS;
+        let initial_balance = fee.saturating_mul(2);
+        let sov_token = TokenId::new(generate_lib_token_id());
+        store
+            .force_set_token_balances(&[(sov_token, Address::new(payer_wallet_id), initial_balance)])
+            .unwrap();
+
+        let treasury_id = crate::Blockchain::deterministic_treasury_wallet_id().as_array();
+        let treasury_hex = hex::encode(treasury_id);
+
+        let payload = DomainRegistrationPayload {
+            domain: "fee-test.sov".to_string(),
+            owner_did: "did:zhtp:fee-test".to_string(),
+            manifest_cid: String::new(),
+            build_hash: String::new(),
+            title: String::new(),
+            description: String::new(),
+            category: "test".to_string(),
+            tags: vec![],
+            duration_days: 365,
+            fee_tx_hash: String::new(),
+            fee_amount_atoms: fee,
+            fee_payer_wallet_id: payer_wallet_id,
+        };
+        let mut domain_tx = create_legacy_tx(TransactionType::DomainRegistration);
+        domain_tx.memo = payload.encode_memo().unwrap();
+        domain_tx.signature.public_key.key_id = payer_wallet_id;
+
+        let treasury_before = store
+            .get_token_balance(&sov_token, &Address::new(treasury_id))
+            .unwrap();
+
+        let block1 = Block::new(
+            BlockHeader {
+                version: 1,
+                previous_hash: genesis.header.block_hash.into(),
+                data_helix_root: Hash::default().into(),
+                timestamp: 1001,
+                height: 1,
+                verification_helix_root: [0u8; 32],
+                state_root: Hash::default().into(),
+                bft_quorum_root: [0u8; 32],
+                block_hash: Hash::new([0x02; 32]),
+            },
+            vec![domain_tx],
+        );
+
+        executor
+            .apply_block_committing_domain_fees(
+                &block1,
+                Some(fee),
+                Some(treasury_hex.as_str()),
+            )
+            .expect("domain fee must commit inside block transaction");
+
+        let payer_after = store
+            .get_token_balance(&sov_token, &Address::new(payer_wallet_id))
+            .unwrap();
+        let treasury_after = store
+            .get_token_balance(&sov_token, &Address::new(treasury_id))
+            .unwrap();
+        assert_eq!(payer_after, initial_balance - fee);
+        assert_eq!(treasury_after, treasury_before.saturating_add(fee));
+    }
+
+    #[test]
     fn test_apply_sequential_blocks() {
         let store = create_test_store();
         let executor = BlockExecutor::with_store(store.clone());

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -735,6 +735,19 @@ impl BlockExecutor {
                 );
             }
 
+            // Genesis [allocations.sov_balances] are direct inserts in build_block0(),
+            // not block transactions — replay must seed sled or executor balance checks
+            // diverge from the historical chain (g4 @ h=74010, #2641 replay gap).
+            if let Ok(cfg) = crate::genesis::GenesisConfig::from_embedded() {
+                if let Err(e) = cfg.credit_sov_allocations_in_open_transaction(self.store.as_ref())
+                {
+                    return Err(BlockApplyError::PersistFailed(format!(
+                        "genesis SOV allocations: {}",
+                        e
+                    )));
+                }
+            }
+
             self.store
                 .append_block(block)
                 .map_err(|e| BlockApplyError::PersistFailed(e.to_string()))?;
@@ -3962,6 +3975,32 @@ mod tests {
         assert_eq!(state.genesis_treasury_allocation, GENESIS_TREASURY_ALLOCATION);
         assert!(!state.graduated);
         assert!(!state.sell_enabled);
+    }
+
+    #[test]
+    fn test_genesis_persists_sov_allocations_to_sled() {
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::storage::{Address, TokenId};
+
+        let store = create_test_store();
+        let executor = BlockExecutor::with_store(store.clone());
+
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let cfg = crate::genesis::GenesisConfig::from_embedded().expect("embedded genesis");
+        let entries = cfg.sov_allocation_entries().expect("sov entries");
+        assert!(!entries.is_empty(), "test genesis must include sov_balances");
+
+        let token = TokenId::new(generate_lib_token_id());
+        let (wallet_id, expected_balance) = entries[0];
+        let bal = store
+            .get_token_balance(&token, &Address::new(wallet_id))
+            .expect("read sled balance");
+        assert_eq!(
+            bal, expected_balance,
+            "genesis replay must seed embedded sov_balances into sled"
+        );
     }
 
     #[test]

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -735,7 +735,9 @@ impl GenesisConfig {
 
         for (wallet_id, balance) in entries {
             let addr = Address::new(wallet_id);
-            let current = store.get_token_balance(&token_id, &addr).unwrap_or(0);
+            let current = store
+                .get_token_balance(&token_id, &addr)
+                .map_err(|e| anyhow::anyhow!("genesis SOV balance read failed: {}", e))?;
             if current > 0 {
                 continue;
             }
@@ -747,7 +749,10 @@ impl GenesisConfig {
         }
 
         if supply_delta > 0 {
-            let current_supply = store.get_token_supply(&token_id).unwrap_or(None).unwrap_or(0);
+            let current_supply = store
+                .get_token_supply(&token_id)
+                .map_err(|e| anyhow::anyhow!("genesis SOV supply read failed: {}", e))?
+                .unwrap_or(0);
             store
                 .put_token_supply(&token_id, current_supply.saturating_add(supply_delta))
                 .map_err(|e| anyhow::anyhow!("genesis SOV supply update failed: {}", e))?;

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -716,7 +716,12 @@ impl GenesisConfig {
     }
 
     /// Persist genesis SOV allocations during an open block/metadata transaction.
-    /// Idempotent: only credits addresses with zero sled balance.
+    ///
+    /// Idempotent for block-0 replay: skips any address whose sled balance is
+    /// already non-zero. That is correct because (a) a fresh wipe has zero
+    /// balances and receives the full genesis allocation set, and (b) a
+    /// non-zero balance means the address was already seeded or has had later
+    /// chain activity — re-crediting the genesis amount would double-mint.
     pub fn credit_sov_allocations_in_open_transaction(
         &self,
         store: &dyn crate::storage::BlockchainStore,

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -664,6 +664,104 @@ impl GenesisConfig {
         Ok(())
     }
 
+    /// Parsed `(wallet_id_bytes, balance_atoms)` pairs from `[allocations.sov_balances]`.
+    pub fn sov_allocation_entries(&self) -> Result<Vec<([u8; 32], u128)>> {
+        let mut entries = Vec::new();
+        for entry in &self.allocations.sov_balances {
+            let wallet_id_bytes = hex::decode(&entry.wallet_id).map_err(|e| {
+                anyhow::anyhow!(
+                    "invalid hex in sov_balance wallet_id '{}': {}",
+                    entry.wallet_id,
+                    e
+                )
+            })?;
+            if wallet_id_bytes.len() != 32 {
+                warn!(
+                    "Skipping sov_balance with invalid wallet_id length: {}",
+                    entry.wallet_id
+                );
+                continue;
+            }
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&wallet_id_bytes);
+            if entry.balance > 0 {
+                entries.push((arr, entry.balance));
+            }
+        }
+        Ok(entries)
+    }
+
+    /// Persist genesis SOV allocations into sled (startup / no active tx).
+    /// Idempotent: only fills addresses missing from `token_balances`.
+    pub fn credit_sov_allocations_to_store(
+        &self,
+        store: &dyn crate::storage::BlockchainStore,
+    ) -> Result<usize> {
+        let entries = self.sov_allocation_entries()?;
+        if entries.is_empty() {
+            return Ok(0);
+        }
+        use crate::contracts::utils::generate_lib_token_id;
+        let token_id = crate::storage::TokenId::new(generate_lib_token_id());
+        let written = store
+            .backfill_token_balances_from_contract(&token_id, &entries)
+            .map_err(|e| anyhow::anyhow!("genesis SOV backfill failed: {}", e))?;
+        if written > 0 {
+            info!(
+                "Genesis: persisted {} SOV allocation balances to token_balances tree",
+                written
+            );
+        }
+        Ok(written)
+    }
+
+    /// Persist genesis SOV allocations during an open block/metadata transaction.
+    /// Idempotent: only credits addresses with zero sled balance.
+    pub fn credit_sov_allocations_in_open_transaction(
+        &self,
+        store: &dyn crate::storage::BlockchainStore,
+    ) -> Result<usize> {
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::storage::{Address, TokenId};
+
+        let entries = self.sov_allocation_entries()?;
+        if entries.is_empty() {
+            return Ok(0);
+        }
+
+        let token_id = TokenId::new(generate_lib_token_id());
+        let mut credited = 0usize;
+        let mut supply_delta = 0u128;
+
+        for (wallet_id, balance) in entries {
+            let addr = Address::new(wallet_id);
+            let current = store.get_token_balance(&token_id, &addr).unwrap_or(0);
+            if current > 0 {
+                continue;
+            }
+            store
+                .set_token_balance(&token_id, &addr, balance)
+                .map_err(|e| anyhow::anyhow!("genesis SOV credit failed: {}", e))?;
+            supply_delta = supply_delta.saturating_add(balance);
+            credited += 1;
+        }
+
+        if supply_delta > 0 {
+            let current_supply = store.get_token_supply(&token_id).unwrap_or(None).unwrap_or(0);
+            store
+                .put_token_supply(&token_id, current_supply.saturating_add(supply_delta))
+                .map_err(|e| anyhow::anyhow!("genesis SOV supply update failed: {}", e))?;
+        }
+
+        if credited > 0 {
+            info!(
+                "Genesis: credited {} SOV allocation balances in block transaction",
+                credited
+            );
+        }
+        Ok(credited)
+    }
+
     /// Resolve the OPAQUE server-setup bytes from this config, if the
     /// `[opaque]` section is present. Pulled out into its own helper so
     /// every Blockchain construction path (apply_genesis_state, load_from_store)

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -317,13 +317,15 @@ impl ChainSync {
     where
         F: FnMut(u64, usize),
     {
-        let genesis_block = blocks[0].clone();
-        if genesis_block.header.height != 0 {
+        let mut blocks = blocks;
+        if blocks[0].header.height != 0 {
             return Err(SyncError::HeightMismatch {
                 expected: 0,
-                actual: genesis_block.header.height,
+                actual: blocks[0].header.height,
             });
         }
+
+        let genesis_block = blocks.remove(0);
 
         let executor = BlockExecutor::from_config_trusted_replay(
             Arc::clone(&self.store),
@@ -337,7 +339,7 @@ impl ChainSync {
             })?;
         on_progress(0, 1);
 
-        let rest: Vec<Block> = blocks.into_iter().skip(1).collect();
+        let rest = blocks;
         if rest.is_empty() {
             return Ok(ImportResult {
                 blocks_imported: 1,

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -309,6 +309,12 @@ impl ChainSync {
     /// sled), then canonical `Blockchain` runtime replays blocks 1+ so
     /// `finish_block_processing` hooks (domain fees, identity, wallet, …) match
     /// the incremental live-validator path.
+    ///
+    /// Correctness over speed: canonical import is slower than executor-only (~225
+    /// blocks/sec observed) but required because live validators built state via
+    /// `process_and_commit_block`, not raw `BlockExecutor::apply_block` alone.
+    /// A 177k-block fresh sync is on the order of tens of minutes — acceptable for
+    /// wipe-and-recover, not the steady-state hot path.
     fn import_blocks_from_genesis_bootstrap<F>(
         &self,
         blocks: Vec<Block>,
@@ -617,6 +623,55 @@ mod tests {
             memo: vec![],
             payload: crate::transaction::TransactionPayload::None,
         }
+    }
+
+    #[test]
+    fn test_domain_registration_triggers_canonical_import_path() {
+        use crate::transaction::domain::DomainRegistrationPayload;
+        use crate::transaction::fee::DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS;
+
+        let (_dir, store) = create_test_store();
+        let sync = ChainSync::new(Arc::clone(&store));
+
+        let genesis = create_genesis_block();
+        sync.import_blocks(vec![genesis.clone()]).unwrap();
+
+        let payer = [0xcd; 32];
+        let fee = DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS;
+        let sov_token = crate::storage::TokenId::new(crate::contracts::utils::generate_lib_token_id());
+        store
+            .force_set_token_balances(&[(
+                sov_token,
+                crate::storage::Address::new(payer),
+                fee.saturating_mul(2),
+            )])
+            .unwrap();
+
+        let payload = DomainRegistrationPayload {
+            domain: "canonical-path.sov".to_string(),
+            owner_did: "did:zhtp:canonical".to_string(),
+            manifest_cid: String::new(),
+            build_hash: String::new(),
+            title: String::new(),
+            description: String::new(),
+            category: "test".to_string(),
+            tags: vec![],
+            duration_days: 30,
+            fee_tx_hash: String::new(),
+            fee_amount_atoms: fee,
+            fee_payer_wallet_id: payer,
+        };
+        let mut domain_tx = create_test_tx(TransactionType::DomainRegistration);
+        domain_tx.memo = payload.encode_memo().unwrap();
+        domain_tx.signature.public_key.key_id = payer;
+
+        let block1 = create_block_at_height(1, genesis.header.block_hash);
+        let block1 = Block::new(block1.header, vec![domain_tx]);
+
+        sync.import_blocks(vec![block1]).expect(
+            "DomainRegistration batch must route through canonical runtime import",
+        );
+        assert_eq!(store.latest_height().unwrap(), 1);
     }
 
     #[test]

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -225,6 +225,24 @@ impl ChainSync {
             });
         }
 
+        let expected_start = match self.store.latest_height() {
+            Ok(h) => h + 1,
+            Err(StorageError::NotInitialized) => 0,
+            Err(e) => return Err(SyncError::Storage(e)),
+        };
+
+        let first_block_height = blocks[0].header.height;
+        if first_block_height != expected_start {
+            return Err(SyncError::HeightMismatch {
+                expected: expected_start,
+                actual: first_block_height,
+            });
+        }
+
+        if expected_start == 0 {
+            return self.import_blocks_from_genesis_bootstrap(blocks, on_progress);
+        }
+
         if Self::requires_canonical_runtime_import(&blocks) {
             return self.import_blocks_via_canonical_runtime(blocks, Some(&mut on_progress));
         }
@@ -233,22 +251,6 @@ impl ChainSync {
             Arc::clone(&self.store),
             self.executor_config.clone(),
         );
-
-        // Determine expected starting height
-        let expected_start = match self.store.latest_height() {
-            Ok(h) => h + 1,
-            Err(StorageError::NotInitialized) => 0,
-            Err(e) => return Err(SyncError::Storage(e)),
-        };
-
-        // Validate first block height
-        let first_block_height = blocks[0].header.height;
-        if first_block_height != expected_start {
-            return Err(SyncError::HeightMismatch {
-                expected: expected_start,
-                actual: first_block_height,
-            });
-        }
 
         // Track last committed block hash for chain continuity validation.
         // The executor uses trusted replay (skip_prev_hash_validation=true),
@@ -303,7 +305,58 @@ impl ChainSync {
         })
     }
 
-    /// Contract/DAO variants currently execute through canonical `Blockchain` flow,
+    /// Fresh bootstrap from genesis: executor applies block 0 (seeds genesis SOV to
+    /// sled), then canonical `Blockchain` runtime replays blocks 1+ so
+    /// `finish_block_processing` hooks (domain fees, identity, wallet, …) match
+    /// the incremental live-validator path.
+    fn import_blocks_from_genesis_bootstrap<F>(
+        &self,
+        blocks: Vec<Block>,
+        mut on_progress: F,
+    ) -> SyncResult<ImportResult>
+    where
+        F: FnMut(u64, usize),
+    {
+        let genesis_block = blocks[0].clone();
+        if genesis_block.header.height != 0 {
+            return Err(SyncError::HeightMismatch {
+                expected: 0,
+                actual: genesis_block.header.height,
+            });
+        }
+
+        let executor = BlockExecutor::from_config_trusted_replay(
+            Arc::clone(&self.store),
+            self.executor_config.clone(),
+        );
+        executor
+            .apply_block(&genesis_block)
+            .map_err(|e| SyncError::BlockApplyFailed {
+                height: 0,
+                error: e,
+            })?;
+        on_progress(0, 1);
+
+        let rest: Vec<Block> = blocks.into_iter().skip(1).collect();
+        if rest.is_empty() {
+            return Ok(ImportResult {
+                blocks_imported: 1,
+                final_height: Some(0),
+            });
+        }
+
+        let canonical = self.run_canonical_import(rest)?;
+        for (offset, height) in canonical.heights.iter().enumerate() {
+            on_progress(*height, offset + 2);
+        }
+
+        Ok(ImportResult {
+            blocks_imported: 1 + canonical.blocks_imported,
+            final_height: canonical.final_height,
+        })
+    }
+
+    /// Contract/DAO/domain variants currently execute through canonical `Blockchain` flow,
     /// not `BlockExecutor`'s phase-2 transaction applicator.
     fn requires_canonical_runtime_import(blocks: &[Block]) -> bool {
         blocks.iter().any(Self::block_needs_canonical_runtime)
@@ -397,6 +450,9 @@ impl ChainSync {
                     // DaoStake/DaoUnstake: move SOV between accounts, must go through full executor
                     | TransactionType::DaoStake
                     | TransactionType::DaoUnstake
+                    // Domain lifecycle: executor no-op; fees applied in finish_block.
+                    | TransactionType::DomainRegistration
+                    | TransactionType::DomainUpdate
             )
         })
     }
@@ -559,6 +615,32 @@ mod tests {
             memo: vec![],
             payload: crate::transaction::TransactionPayload::None,
         }
+    }
+
+    #[test]
+    fn test_genesis_bootstrap_import_seeds_sov_balances() {
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::genesis::GenesisConfig;
+        use crate::storage::{Address, TokenId};
+
+        let (_dir, store) = create_test_store();
+        let sync = ChainSync::new(Arc::clone(&store));
+
+        let genesis = create_genesis_block();
+        let block1 = create_block_at_height(1, genesis.header.block_hash);
+        sync.import_blocks(vec![genesis, block1]).unwrap();
+
+        let cfg = GenesisConfig::from_embedded().unwrap();
+        let entries = cfg.sov_allocation_entries().unwrap();
+        assert!(!entries.is_empty());
+
+        let token = TokenId::new(generate_lib_token_id());
+        let (wallet_id, expected_balance) = entries[0];
+        let bal = store
+            .get_token_balance(&token, &Address::new(wallet_id))
+            .unwrap();
+        assert_eq!(bal, expected_balance);
+        assert_eq!(store.latest_height().unwrap(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes g4 wipe-and-catch-up failing at **h=74010** with `Insufficient token balance`.

**Replay determinism only** — does NOT remove the per-block seed-sled safety net or replay-tolerance paths. #2641 Phase 4 is a separate stacked PR.

## Fix

1. Seed genesis `[allocations.sov_balances]` in executor block-0 apply
2. `import_blocks_from_genesis_bootstrap`: executor block 0 → canonical runtime blocks 1+
3. Domain registration SOV fees committed inside executor block transaction
4. `DomainRegistration` / `DomainUpdate` trigger canonical runtime import

## Tests (1948 pass)

- `test_genesis_persists_sov_allocations_to_sled`
- `test_genesis_bootstrap_import_seeds_sov_balances`
- `test_domain_registration_fee_committed_in_executor_block_tx`
- `test_domain_registration_triggers_canonical_import_path`

## Follow-up

Stacked PR: `arch/2641-delete-legacy-write-paths` → this branch (#2641 seed-sled removal).