### PR TITLE
arch(#2641): drop legacy write paths — stacked on replay fix

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -1295,7 +1295,7 @@ impl Blockchain {
             if using_executor {
                 warn!(
                     "process_validator_registration_transactions at height {}: {}",
-                    self.height, e
+                    block.header.height, e
                 );
             } else {
                 return Err(e);

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -1078,7 +1078,15 @@ impl Blockchain {
 
             // Use BlockExecutor for state mutations
             // Note: executor.apply_block() handles begin_block/commit_block internally
-            match executor.apply_block(&block) {
+            let fee_floor = self.tx_fee_config.domain_registration_fee_atoms;
+            let treasury_wallet = self
+                .get_dao_treasury_wallet_id()
+                .map(|id| id.as_str());
+            match executor.apply_block_committing_domain_fees(
+                &block,
+                Some(fee_floor),
+                treasury_wallet,
+            ) {
                 Ok(_outcome) => {
                     // Block applied successfully through executor.
                     // Writes path: sync in-memory token_contracts from sled after apply

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -4636,6 +4636,9 @@ impl Blockchain {
             std::mem::swap(&mut self.event_publisher, &mut adopted.event_publisher);
             *self = adopted;
 
+            self.persist_genesis_sov_allocations_to_store()
+                .context("persisting genesis SOV allocations before verified import")?;
+
             // 3. Apply each imported block through the verified sync path.
             //    Continuity is checked explicitly; transaction validity and all
             //    state derivation are handled by `apply_block_trusted_for_sync`.

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -1020,62 +1020,6 @@ impl Blockchain {
 
         // If BlockExecutor is configured, use it as single source of truth
         if let Some(ref executor) = self.executor {
-            // Seed SledStore with any in-memory token balances that were never persisted
-            // there. Wallets that received their initial balance via token.mint() (e.g.
-            // during register_wallet) only exist in the in-memory token_contracts HashMap;
-            // SledStore has 0 for them. The executor reads SledStore for debit_token and
-            // will abort the block if it sees 0, halting the network. backfill writes
-            // ONLY entries that are missing from the tree (idempotent, safe to call here
-            // before begin_block sets tx_active).
-            if let Some(store) = &self.store {
-                let mut seed_map: std::collections::HashMap<[u8; 32], Vec<([u8; 32], u128)>> =
-                    std::collections::HashMap::new();
-                for tx in &block.transactions {
-                    if let Some(data) = tx.token_transfer_data() {
-                        if let Some(token) = self.token_contracts.get(&data.token_id) {
-                            // Look up the sender's in-memory balance.
-                            // balances is keyed by PublicKey; the SledStore uses key_id as
-                            // the 32-byte address — they match for both SOV and custom tokens.
-                            let mem_balance = token
-                                .find_balance_by_key_id(&data.from)
-                                .map(|(_, b)| b)
-                                .unwrap_or(0);
-                            if mem_balance > 0 {
-                                let addr = crate::storage::Address::new(data.from);
-                                let storage_token = crate::storage::TokenId(data.token_id);
-                                // Writes path: compares in-mem vs sled to seed missing entries.
-                                let sled_bal =
-                                    store.get_token_balance(&storage_token, &addr).unwrap_or(0);
-                                if sled_bal == 0 {
-                                    seed_map
-                                        .entry(data.token_id)
-                                        .or_default()
-                                        .push((data.from, mem_balance));
-                                }
-                            }
-                        }
-                    }
-                }
-                for (token_id, entries) in &seed_map {
-                    let storage_token = crate::storage::TokenId(*token_id);
-                    match store.backfill_token_balances_from_contract(&storage_token, entries) {
-                        Ok(n) if n > 0 => tracing::info!(
-                            "[seed-sled] seeded {} missing balance(s) for token {} before block {}",
-                            n,
-                            hex::encode(&token_id[..8]),
-                            block.header.height
-                        ),
-                        Err(e) => tracing::warn!(
-                            "[seed-sled] backfill failed for token {} at block {}: {}",
-                            hex::encode(&token_id[..8]),
-                            block.header.height,
-                            e
-                        ),
-                        _ => {}
-                    }
-                }
-            }
-
             // Use BlockExecutor for state mutations
             // Note: executor.apply_block() handles begin_block/commit_block internally
             let fee_floor = self.tx_fee_config.domain_registration_fee_atoms;
@@ -1089,67 +1033,13 @@ impl Blockchain {
             ) {
                 Ok(_outcome) => {
                     // Block applied successfully through executor.
-                    // Writes path: sync in-memory token_contracts from sled after apply
-                    // (SOV/CBE addresses touched in this block only). The HashMap is a
-                    // legacy-write cache — NOT authoritative for public reads; handlers
-                    // must use token_balance() (#2637).
-                    if let Some(store) = &self.store {
-                        let sov_id = crate::contracts::utils::generate_lib_token_id();
-                        let storage_sov_id = crate::storage::TokenId(sov_id);
-                        let mut addrs_to_sync: Vec<[u8; 32]> = Vec::new();
-                        for tx in &block.transactions {
-                            match tx.transaction_type {
-                                TransactionType::TokenTransfer => {
-                                    if let Some(d) = tx.token_transfer_data() {
-                                        addrs_to_sync.push(d.from);
-                                        addrs_to_sync.push(d.to);
-                                    }
-                                }
-                                TransactionType::TokenMint => {
-                                    if let Some(d) = tx.token_mint_data() {
-                                        addrs_to_sync.push(d.to);
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-                        for addr_bytes in addrs_to_sync {
-                            let addr = crate::storage::Address::new(addr_bytes);
-                            if let Ok(balance) = store.get_token_balance(&storage_sov_id, &addr) {
-                                if let Some(token) = self.token_contracts.get_mut(&sov_id) {
-                                    let pk = Self::wallet_key_for_sov(&addr_bytes);
-                                    token.set_balance(&pk, balance as u128);
-                                }
-                            }
-                        }
-
-                    }
+                    // Token balances/nonces live in sled (#2637); in-memory caches are
+                    // not kept in sync on the live path. Post-executor registry hooks
+                    // run once in finish_block_processing (#2641).
 
                     // Update blockchain metadata
                     self.push_block_windowed(block.clone());
                     self.height += 1;
-                    if let Err(e) = self.process_validator_registration_transactions(&block) {
-                        warn!("process_validator_registration_transactions in executor path: {}", e);
-                    }
-                    self.process_gateway_transactions(&block);
-                    // Rebuild wallet_registry and in-memory SOV balances from WalletRegistration
-                    // transactions in this block. The BlockExecutor handles SledStore state but
-                    // does NOT update the in-memory wallet_registry or token_contracts mints.
-                    // Without this call, after a restart from an old .dat file the in-memory
-                    // balance stays at 0 for wallets whose registration block was applied in
-                    // executor mode — making transfers fail the mempool balance check.
-                    if let Err(e) = self.process_wallet_transactions(&block) {
-                        warn!("process_wallet_transactions in executor path: {}", e);
-                    }
-                    // Replay employment contract setup so executor has in-memory registry.
-                    if let Err(e) = self.process_employment_contract_transactions(&block) {
-                        warn!("process_employment_contract_transactions in executor path: {}", e);
-                    }
-                    self.process_domain_transactions(&block);
-                    self.process_nft_transactions(&block);
-                    for tx in &block.transactions {
-                        self.index_dao_registry_entry_from_tx(tx, block.header.height);
-                    }
                     self.adjust_difficulty()?;
 
                     debug!(
@@ -1392,13 +1282,30 @@ impl Blockchain {
                 .map_err(|e| anyhow::anyhow!("Failed to begin Sled transaction: {}", e))?;
         }
 
-        // Process identity transactions
+        // Legacy post-executor hooks (#2641): types the executor admits as no-ops but
+        // whose in-memory registries handlers still read. Consolidated here so the
+        // executor success path does not duplicate them.
         self.process_identity_transactions(&block)?;
         self.process_wallet_transactions(&block)?;
         self.process_entity_registry_transactions(&block)?;
         self.process_employment_contract_transactions(&block)?;
         self.process_domain_transactions(&block);
         self.process_credential_transactions(&block);
+        if let Err(e) = self.process_validator_registration_transactions(&block) {
+            if using_executor {
+                warn!(
+                    "process_validator_registration_transactions at height {}: {}",
+                    self.height, e
+                );
+            } else {
+                return Err(e);
+            }
+        }
+        self.process_gateway_transactions(&block);
+        self.process_nft_transactions(&block);
+        for tx in &block.transactions {
+            self.index_dao_registry_entry_from_tx(tx, block.header.height);
+        }
         // #56: validator sled writes use the metadata batch (executor path) or the
         // legacy begin_block window — same atomicity class as identity metadata.
         // A crash between executor commit_block and commit_metadata_write can leave

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -132,40 +132,12 @@ impl Blockchain {
     /// Process token transfer and mint transactions from a block, with **full
     /// enforcement** — every error propagates. Used by the new-block commit
     /// paths (`process_and_commit_block`, `finish_block_processing`) and by
-    /// tests. For boot replay use [`Self::process_token_transactions_replay`].
+    /// tests. Legacy path only when no BlockExecutor is configured (#2641).
     pub fn process_token_transactions(&mut self, block: &Block) -> Result<()> {
-        self.process_token_transactions_inner(block, false)
+        self.process_token_transactions_inner(block)
     }
 
-    /// Boot-replay variant: tolerates non-integrity `TokenTransfer` errors.
-    ///
-    /// During boot-time block replay the in-memory state rebuilt here is
-    /// approximate (the sled-backed `BlockExecutor` is the source of truth and
-    /// is attached AFTER replay completes). Refusing to boot because a
-    /// historical transfer can't be reproduced against this approximate state
-    /// would let any live-committed edge case (unsignable mint address,
-    /// amount > u64, etc.) bring the node down on restart — so such errors are
-    /// downgraded to a warning and the transfer is skipped. Tolerance is scoped
-    /// to `TokenTransfer`; every other transaction type still halts replay.
-    ///
-    /// **Replay-protection (nonce-mismatch) errors are NEVER tolerated**, even
-    /// here: they are integrity violations, not approximate-state reproduction
-    /// issues, and a committed block can never legitimately carry a duplicate
-    /// nonce. Silently skipping one would accept a replayed transfer on boot.
-    ///
-    /// Tolerance keys off this explicit parameter, NOT `self.store.is_none()` —
-    /// unit tests construct store-less blockchains as a harness and must get
-    /// full enforcement, not boot-replay tolerance.
-    pub(crate) fn process_token_transactions_replay(&mut self, block: &Block) -> Result<()> {
-        self.process_token_transactions_inner(block, true)
-    }
-
-    fn process_token_transactions_inner(
-        &mut self,
-        block: &Block,
-        replay_tolerant: bool,
-    ) -> Result<()> {
-        let is_replay = replay_tolerant;
+    fn process_token_transactions_inner(&mut self, block: &Block) -> Result<()> {
         let sov_token_id = crate::contracts::utils::generate_lib_token_id();
 
         'tx_loop: for transaction in &block.transactions {
@@ -799,52 +771,6 @@ impl Blockchain {
             Ok(())
             })();
             if let Err(e) = arm_result {
-                // Replay tolerance covers TokenTransfers that can't be
-                // reproduced against approximate in-memory state
-                // (insufficient balance, amount overflow, unsignable
-                // address, AND nonce-mismatched txes that earlier
-                // binaries committed under looser rules).
-                //
-                // In production (executor attached), the canonical nonce
-                // lives in sled — written by BlockExecutor on the live
-                // apply path. The read at the apply check
-                // (`get_token_nonce`) falls through to sled, so skipping
-                // a tx here has no consistency impact on subsequent
-                // checks.
-                //
-                // In legacy/store-less mode (tests, deprecated path),
-                // there is no sled. The in-memory map IS the nonce
-                // store, and a skipped tx that the chain committed must
-                // still advance the counter — otherwise the NEXT tx
-                // from the same sender shows up with nonce N+1 while
-                // our counter is still at N, cascading into bogus
-                // "nonce mismatch" errors that have nothing to do with
-                // replay protection (CR PR #2675).
-                if is_replay && tx_type == TransactionType::TokenTransfer {
-                    if !self.has_executor() {
-                        if let Some(transfer) = transaction.token_transfer_data() {
-                            let is_sov = Self::is_sov_token_id(&transfer.token_id);
-                            let token_id_key = if is_sov {
-                                sov_token_id
-                            } else {
-                                transfer.token_id
-                            };
-                            let nk = (token_id_key, transfer.from);
-                            let entry = self.token_nonces.entry(nk).or_insert(0);
-                            let target = transfer.nonce.saturating_add(1);
-                            if *entry < target {
-                                *entry = target;
-                            }
-                        }
-                    }
-                    warn!(
-                        "Replay: skipping TokenTransfer at height={} tx={}: {}",
-                        block.height(),
-                        hex::encode(&transaction.hash().as_bytes()[..4]),
-                        e,
-                    );
-                    continue 'tx_loop;
-                }
                 return Err(e);
             }
         }

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1701,7 +1701,6 @@ impl Blockchain {
             crate::contracts::utils::wallet_key_for_sov(payload.fee_payer_wallet_id);
         let treasury_key =
             crate::contracts::utils::wallet_key_for_sov(treasury_wallet_id);
-        let store = self.get_store().map(std::sync::Arc::clone);
 
         let token = self
             .token_contracts
@@ -1725,26 +1724,100 @@ impl Blockchain {
             return Err(anyhow!("credit treasury: {}", e));
         }
 
-        // Executor balance checks read sled (#2637). Mirror the in-memory fee
-        // movement so replay-from-genesis matches incremental live applies.
-        if let Some(store) = store {
-            if let Err(e) = Self::mirror_domain_fee_to_store(
-                store.as_ref(),
-                sov_id,
-                payload.fee_payer_wallet_id,
-                treasury_wallet_id,
-                payload.fee_amount_atoms,
-            ) {
-                let _ = token.credit_balance(&payer_key, payload.fee_amount_atoms);
-                let _ = token.debit_balance(&treasury_key, payload.fee_amount_atoms);
-                return Err(anyhow!("mirror domain fee to sled: {}", e));
-            }
-        }
-
         Ok(())
     }
 
-    /// Dual-write domain registration SOV fees to the sled token_balances tree.
+    /// Apply V2 domain registration SOV fees to sled inside the executor's
+    /// `begin_block`/`commit_block` window. In-memory registry updates remain
+    /// in `process_domain_transactions` during `finish_block_processing`.
+    pub(crate) fn apply_domain_registration_fees_to_store(
+        store: &dyn crate::storage::BlockchainStore,
+        block: &Block,
+        fee_floor_atoms: u128,
+        treasury_wallet_id_hex: Option<&str>,
+    ) {
+        let block_height = block.height();
+        for tx in &block.transactions {
+            if tx.transaction_type != TransactionType::DomainRegistration {
+                continue;
+            }
+            let tx_signer_key_id = tx.signature.public_key.key_id;
+            match crate::transaction::DomainRegistrationPayload::decode_memo(&tx.memo) {
+                Ok(payload) => {
+                    let is_v2 = payload.fee_amount_atoms > 0
+                        || payload.fee_payer_wallet_id != [0u8; 32];
+                    if !is_v2 {
+                        continue;
+                    }
+                    if let Err(e) = Self::mirror_domain_registration_fee_to_store(
+                        store,
+                        &payload,
+                        tx_signer_key_id,
+                        fee_floor_atoms,
+                        treasury_wallet_id_hex,
+                        block_height,
+                    ) {
+                        warn!(
+                            "DomainRegistration {} at height {} sled fee skipped: {}",
+                            payload.domain, block_height, e
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to decode DomainRegistration memo at height {}: {}",
+                        block_height, e
+                    );
+                }
+            }
+        }
+    }
+
+    fn mirror_domain_registration_fee_to_store(
+        store: &dyn crate::storage::BlockchainStore,
+        payload: &crate::transaction::domain::DomainRegistrationPayload,
+        tx_signer_key_id: [u8; 32],
+        fee_floor_atoms: u128,
+        treasury_wallet_id_hex: Option<&str>,
+        block_height: u64,
+    ) -> Result<()> {
+        use anyhow::anyhow;
+
+        if payload.fee_amount_atoms < fee_floor_atoms {
+            return Err(anyhow!(
+                "fee below governance floor: payload {} < floor {} atoms",
+                payload.fee_amount_atoms,
+                fee_floor_atoms
+            ));
+        }
+        if payload.fee_payer_wallet_id != tx_signer_key_id {
+            return Err(anyhow!(
+                "fee payer mismatch at height {}: payload wallet does not derive from tx signer",
+                block_height
+            ));
+        }
+
+        let treasury_hex = treasury_wallet_id_hex
+            .ok_or_else(|| anyhow!("DAO treasury wallet is not configured"))?;
+        let treasury_bytes = hex::decode(treasury_hex)
+            .map_err(|_| anyhow!("DAO treasury wallet id is malformed hex"))?;
+        if treasury_bytes.len() != 32 {
+            return Err(anyhow!("DAO treasury wallet id must be 32 bytes"));
+        }
+        let mut treasury_wallet_id = [0u8; 32];
+        treasury_wallet_id.copy_from_slice(&treasury_bytes);
+
+        let sov_id = crate::contracts::utils::generate_lib_token_id();
+        Self::mirror_domain_fee_to_store(
+            store,
+            sov_id,
+            payload.fee_payer_wallet_id,
+            treasury_wallet_id,
+            payload.fee_amount_atoms,
+        )
+    }
+
+    /// Debit/credit domain registration SOV fees in the sled token_balances tree.
     fn mirror_domain_fee_to_store(
         store: &dyn crate::storage::BlockchainStore,
         sov_token_id: [u8; 32],
@@ -1775,7 +1848,7 @@ impl Blockchain {
 
         let treasury_bal = store
             .get_token_balance(&token, &treasury_addr)
-            .unwrap_or(0);
+            .map_err(|e| anyhow!("read treasury sled balance: {}", e))?;
         store
             .set_token_balance(
                 &token,

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1701,6 +1701,7 @@ impl Blockchain {
             crate::contracts::utils::wallet_key_for_sov(payload.fee_payer_wallet_id);
         let treasury_key =
             crate::contracts::utils::wallet_key_for_sov(treasury_wallet_id);
+        let store = self.get_store().map(std::sync::Arc::clone);
 
         let token = self
             .token_contracts
@@ -1723,6 +1724,66 @@ impl Blockchain {
             let _ = token.credit_balance(&payer_key, payload.fee_amount_atoms);
             return Err(anyhow!("credit treasury: {}", e));
         }
+
+        // Executor balance checks read sled (#2637). Mirror the in-memory fee
+        // movement so replay-from-genesis matches incremental live applies.
+        if let Some(store) = store {
+            if let Err(e) = Self::mirror_domain_fee_to_store(
+                store.as_ref(),
+                sov_id,
+                payload.fee_payer_wallet_id,
+                treasury_wallet_id,
+                payload.fee_amount_atoms,
+            ) {
+                let _ = token.credit_balance(&payer_key, payload.fee_amount_atoms);
+                let _ = token.debit_balance(&treasury_key, payload.fee_amount_atoms);
+                return Err(anyhow!("mirror domain fee to sled: {}", e));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Dual-write domain registration SOV fees to the sled token_balances tree.
+    fn mirror_domain_fee_to_store(
+        store: &dyn crate::storage::BlockchainStore,
+        sov_token_id: [u8; 32],
+        payer_wallet_id: [u8; 32],
+        treasury_wallet_id: [u8; 32],
+        fee_atoms: u128,
+    ) -> Result<()> {
+        use anyhow::anyhow;
+        use crate::storage::{Address, TokenId};
+
+        let token = TokenId::new(sov_token_id);
+        let payer_addr = Address::new(payer_wallet_id);
+        let treasury_addr = Address::new(treasury_wallet_id);
+
+        let payer_bal = store
+            .get_token_balance(&token, &payer_addr)
+            .map_err(|e| anyhow!("read payer sled balance: {}", e))?;
+        let new_payer = payer_bal.checked_sub(fee_atoms).ok_or_else(|| {
+            anyhow!(
+                "sled payer balance insufficient: have {}, need {}",
+                payer_bal,
+                fee_atoms
+            )
+        })?;
+        store
+            .set_token_balance(&token, &payer_addr, new_payer)
+            .map_err(|e| anyhow!("debit payer sled balance: {}", e))?;
+
+        let treasury_bal = store
+            .get_token_balance(&token, &treasury_addr)
+            .unwrap_or(0);
+        store
+            .set_token_balance(
+                &token,
+                &treasury_addr,
+                treasury_bal.saturating_add(fee_atoms),
+            )
+            .map_err(|e| anyhow!("credit treasury sled balance: {}", e))?;
+
         Ok(())
     }
 }

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -1012,6 +1012,8 @@ impl Blockchain {
         // #56: backfill durable validators tree on normal startup (not replay-only).
         // Gated by schema version; regenerates from the loaded/replayed registry.
         blockchain.migrate_validator_records_schema();
+        blockchain.backfill_genesis_identities_to_store();
+        blockchain.migrate_identity_metadata_schema();
 
         // Genesis allocations are direct inserts in build_block0(), not block txs.
         // After executor-only block-0 import the in-memory registries are empty until

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -1013,6 +1013,21 @@ impl Blockchain {
         // Gated by schema version; regenerates from the loaded/replayed registry.
         blockchain.migrate_validator_records_schema();
 
+        // Genesis allocations are direct inserts in build_block0(), not block txs.
+        // After executor-only block-0 import the in-memory registries are empty until
+        // we re-apply embedded genesis metadata (replay determinism / g4 bootstrap).
+        if let Ok(cfg) = crate::genesis::GenesisConfig::from_embedded() {
+            if let Err(e) = cfg.apply_genesis_state(&mut blockchain) {
+                warn!(
+                    "apply_genesis_state during load_from_store failed (non-fatal): {}",
+                    e
+                );
+            }
+        }
+
+        blockchain.backfill_genesis_identities_to_store();
+        blockchain.migrate_identity_metadata_schema();
+
         Ok(Some(blockchain))
     }
 

--- a/lib-blockchain/src/blockchain/replay.rs
+++ b/lib-blockchain/src/blockchain/replay.rs
@@ -11,12 +11,13 @@ use crate::block::Block;
 use crate::blockchain::Blockchain;
 
 impl Blockchain {
-    /// Replay a single block's transactions to rebuild in-memory state.
+    /// Advance replay metadata for a block (genesis registries, oracle epochs,
+    /// governance). Does **not** replay transaction state — use
+    /// [`load_from_store`] / executor apply for balance reconstruction.
     ///
-    /// **Deprecated (#2641):** live chains hydrate from sled via
-    /// `load_from_store`. This path only advances chain metadata and applies
-    /// genesis/oracle/governance side-effects that are not yet executor-backed.
-    pub fn replay_block_state(&mut self, block: &Block) -> Result<()> {
+    /// Kept as `replay_block_state` for call-site compatibility; prefer
+    /// [`Self::advance_replay_metadata`] for new code.
+    pub fn advance_replay_metadata(&mut self, block: &Block) -> Result<()> {
         let height = block.height();
 
         if height == 0 {
@@ -47,6 +48,12 @@ impl Blockchain {
 
         self.height = height;
         Ok(())
+    }
+
+    /// Deprecated alias for [`Self::advance_replay_metadata`].
+    #[deprecated(note = "use advance_replay_metadata — this no longer replays tx state")]
+    pub fn replay_block_state(&mut self, block: &Block) -> Result<()> {
+        self.advance_replay_metadata(block)
     }
 
     /// Compatibility wrapper — delegates to [`load_from_store`].
@@ -257,16 +264,6 @@ impl Blockchain {
             .or_insert_with(crate::contracts::TokenContract::new_sov_native);
     }
 
-    /// Ensure treasury wallet is set during replay (idempotent).
-    fn replay_ensure_treasury(&mut self) {
-        if self.dao_treasury_wallet_id.is_none() {
-            if let Some(member) = self.council_members.first() {
-                if !member.wallet_id.is_empty() {
-                    self.dao_treasury_wallet_id = Some(member.wallet_id.clone());
-                }
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/lib-blockchain/src/blockchain/replay.rs
+++ b/lib-blockchain/src/blockchain/replay.rs
@@ -1,14 +1,11 @@
 //! Block replay for state reconstruction.
 //!
-//! On startup, if sled has blocks but in-memory registries are empty,
-//! replay all blocks to rebuild the full in-memory state. This is the
-//! single source of truth — block history defines all derived state.
-//!
-//! No sled writes happen during replay (self.store is None).
-//! No event publishing. No broadcast. Just state reconstruction.
+//! Production startup uses [`Blockchain::load_from_store`] (sled-first hydration
+//! with block-scan fallback). [`replay_from_store`] is retained as a thin
+//! compatibility wrapper.
 
 use anyhow::Result;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::block::Block;
 use crate::blockchain::Blockchain;
@@ -16,15 +13,12 @@ use crate::blockchain::Blockchain;
 impl Blockchain {
     /// Replay a single block's transactions to rebuild in-memory state.
     ///
-    /// Does NOT write to sled. Does NOT validate signatures or fees.
-    /// Assumes blocks are fed in order (height 0 to tip).
-    ///
-    /// For height 0: also applies genesis-specific state (council, allocations)
-    /// that was populated via direct inserts in build_block0(), not via transactions.
+    /// **Deprecated (#2641):** live chains hydrate from sled via
+    /// `load_from_store`. This path only advances chain metadata and applies
+    /// genesis/oracle/governance side-effects that are not yet executor-backed.
     pub fn replay_block_state(&mut self, block: &Block) -> Result<()> {
         let height = block.height();
 
-        // Genesis-specific state: council, allocations, SOV token
         if height == 0 {
             if let Ok(cfg) = crate::genesis::GenesisConfig::from_embedded() {
                 let _ = cfg.apply_genesis_state(self);
@@ -32,41 +26,7 @@ impl Blockchain {
             self.replay_ensure_sov_token();
         }
 
-        // Process all transaction types (same order as finish_block_processing)
-        self.process_identity_transactions(block)?;
-        self.process_wallet_transactions(block)?;
-        self.process_entity_registry_transactions(block)?;
-        self.process_employment_contract_transactions(block)?;
-        self.process_domain_transactions(block);
-        self.process_credential_transactions(block);
-        self.process_validator_registration_transactions(block)?;
-        self.process_gateway_transactions(block);
-        self.process_contract_transactions(block)?;
-        // Boot replay: tolerate non-integrity TokenTransfer errors (approximate
-        // in-memory state) but still enforce replay protection. See the method doc.
-        self.process_token_transactions_replay(block)?;
-        self.process_nft_transactions(block);
-
-        // DAO registry indexing
-        for tx in &block.transactions {
-            self.index_dao_registry_entry_from_tx(tx, height);
-        }
-
-        // On-ramp trades
-        self.process_on_ramp_trade_transactions(block);
-
-        // Oracle attestations
-        self.process_oracle_attestation_transactions(block, block.header.timestamp);
-
-        // Economic features
-        if let Err(e) = self.process_ubi_claim_transactions(block) {
-            debug!("Replay: UBI claim error at height {}: {} (non-fatal)", height, e);
-        }
-        if let Err(e) = self.process_profit_declarations(block) {
-            debug!("Replay: profit declaration error at height {}: {} (non-fatal)", height, e);
-        }
-
-        // Oracle epoch advancement
+        // Oracle epoch advancement (in-memory oracle_state — not in sled apply path)
         if self
             .oracle_state
             .should_process_epoch(block.header.timestamp, self.last_oracle_epoch_processed)
@@ -77,99 +37,29 @@ impl Blockchain {
             self.last_oracle_epoch_processed = block.header.timestamp;
         }
 
-        // Governance proposals
         if let Err(e) = self.process_approved_governance_proposals() {
-            debug!("Replay: governance error at height {}: {} (non-fatal)", height, e);
+            tracing::debug!(
+                "Replay: governance error at height {}: {} (non-fatal)",
+                height,
+                e
+            );
         }
 
-        // Update chain state
         self.height = height;
-
         Ok(())
     }
 
-    /// Replay all blocks from a store to fully reconstruct in-memory state.
+    /// Compatibility wrapper — delegates to [`load_from_store`].
     ///
-    /// Called on startup when sled has blocks. Creates a fully populated
-    /// Blockchain with all registries, validators, domains, credentials, etc.
+    /// Previously replayed every block through legacy `process_*_transactions`
+    /// writers. Phase 4 (#2641) makes sled the sole write path; startup state
+    /// is rebuilt by projection hydration or the scan fallback inside
+    /// `load_from_store`.
     pub fn replay_from_store(
         store: std::sync::Arc<dyn crate::storage::BlockchainStore>,
     ) -> Result<Option<Self>> {
-        let latest_height = match store.latest_height() {
-            Ok(h) => h,
-            Err(_) => return Ok(None),
-        };
-
-        // Check if store actually has block 0
-        if store.get_block_by_height(0)?.is_none() {
-            return Ok(None);
-        }
-
-        info!(
-            "Replaying {} blocks from sled to rebuild in-memory state...",
-            latest_height + 1
-        );
-
-        let start = std::time::Instant::now();
-        let mut bc = Self::new_runtime_state();
-        // store is None during replay — prevents sled writes from process_* functions
-        bc.blocks.clear();
-
-        for height in 0..=latest_height {
-            let block = store
-                .get_block_by_height(height)?
-                .ok_or_else(|| anyhow::anyhow!("Missing block at height {} — sled corrupted", height))?;
-
-            bc.replay_block_state(&block)?;
-            bc.blocks.push(block);
-        }
-
-        let elapsed = start.elapsed();
-        info!(
-            "Replay complete: {} blocks in {:.2}s — {} identities, {} wallets, {} validators, {} domains, {} credentials",
-            latest_height + 1,
-            elapsed.as_secs_f64(),
-            bc.identity_registry.len(),
-            bc.wallet_registry.len(),
-            bc.validator_registry.len(),
-            bc.domain_registry.len(),
-            bc.credential_registry.len(),
-        );
-
-        // Post-replay: attach store and executor
-        bc.replay_ensure_treasury();
-
-        // Now attach the store (enables sled writes for future blocks)
-        let executor = std::sync::Arc::new(
-            crate::execution::executor::BlockExecutor::new_catchup_sync(
-                store.clone(),
-                crate::execution::executor::FeeModelV2::default(),
-                Default::default(),
-            ),
-        );
-        bc.store = Some(store);
-        bc.executor = Some(executor);
-
-        // Rebuild the PoUW mint index from the replayed blocks so
-        // /api/v1/pouw/rewards reports the full on-chain history. (The
-        // per-block hook in process_token_transactions also populates it
-        // during replay; this is an idempotent, authoritative re-scan.)
-        bc.rebuild_pouw_mint_index();
-
-        // Backfill genesis-only identities into the sled store. Genesis
-        // populates bc.identity_registry directly without going through
-        // transactions, so identities created at genesis are absent from
-        // sled's identity tree. Any later IdentityUpdate against them halts
-        // consensus with "Cannot update non-existent identity".
-        bc.backfill_genesis_identities_to_store();
-
-        // Bring the sled `identity_metadata` tree up to the current schema
-        // (#58: adds kyber_public_key). Regenerates from the just-replayed
-        // in-memory registry; gated so it only runs once per upgrade.
-        bc.migrate_identity_metadata_schema();
-        bc.migrate_validator_records_schema();
-
-        Ok(Some(bc))
+        info!("replay_from_store: delegating to load_from_store (#2641)");
+        Self::load_from_store(store)
     }
 
     /// Version-gated regeneration of the sled `identity_metadata` tree (#58).
@@ -207,22 +97,11 @@ impl Blockchain {
             self.identity_registry.len()
         );
 
-        // Drop stale pre-v2 blobs first. If this fails we abort without having
-        // mutated anything, leaving the version unchanged for a clean retry.
         if let Err(e) = store.clear_identity_metadata() {
             warn!("identity_metadata schema migration: clear failed: {e} — aborting (version unchanged)");
             return;
         }
 
-        // CR PR #2679 (1): collect records and write them in ONE bulk call
-        // with a SINGLE flush at the end (the per-record direct write flushed
-        // per call → O(n) fsyncs).
-        //
-        // CR PR #2679 (2): if the bulk write fails partway, do NOT bump the
-        // version — the tree is partially rebuilt and the next boot must
-        // retry the full migration. Bumping the version here would suppress
-        // retries via the version gate and leave kyber permanently missing
-        // for the records that didn't make it.
         let records: Vec<([u8; 32], crate::storage::IdentityMetadata)> = self
             .identity_registry
             .iter()
@@ -261,10 +140,6 @@ impl Blockchain {
     }
 
     /// Version-gated regeneration of the sled `validators` tree (#56).
-    ///
-    /// Fully derivable from replayed blocks — never decodes legacy blobs.
-    /// Called from `replay_from_store` and `load_from_store` so existing chains
-    /// backfill the durable validators tree on normal startup, not replay-only.
     pub(crate) fn migrate_validator_records_schema(&self) {
         let Some(ref store) = self.store else {
             return;
@@ -344,8 +219,6 @@ impl Blockchain {
         let mut written = 0usize;
         for (did, data) in &self.identity_registry {
             let did_hash = crate::storage::did_to_hash(did);
-            // Skip if already present (avoids overwriting state that may have
-            // diverged via on-chain updates).
             match store.get_identity(&did_hash) {
                 Ok(Some(_)) => continue,
                 Ok(None) => {}

--- a/lib-blockchain/src/blockchain/replay.rs
+++ b/lib-blockchain/src/blockchain/replay.rs
@@ -184,7 +184,7 @@ impl Blockchain {
     /// Idempotent: the persisted version gate makes repeat boots a no-op, and
     /// the rebuild itself is a clear + deterministic rewrite. A mid-way failure
     /// leaves the version behind so the next boot retries.
-    fn migrate_identity_metadata_schema(&self) {
+    pub(crate) fn migrate_identity_metadata_schema(&self) {
         let Some(ref store) = self.store else {
             return;
         };
@@ -337,7 +337,7 @@ impl Blockchain {
     /// Ensure every in-memory genesis identity is also present in the sled
     /// identity store. Idempotent — overwrites existing entries with the
     /// genesis-derived consensus + metadata.
-    fn backfill_genesis_identities_to_store(&self) {
+    pub(crate) fn backfill_genesis_identities_to_store(&self) {
         let Some(ref store) = self.store else {
             return;
         };

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -977,7 +977,10 @@ impl Blockchain {
                     self.wallet_blocks
                         .insert(wallet_id_str.clone(), block.height());
 
-                    if transaction.transaction_type == TransactionType::WalletRegistration
+                    // Executor mode mints initial SOV to sled in apply_block; in-memory
+                    // mint here would be a second write source (#2641).
+                    if !self.has_executor()
+                        && transaction.transaction_type == TransactionType::WalletRegistration
                         && wallet_data.initial_balance > 0
                     {
                         let sov_token_id = crate::contracts::utils::generate_lib_token_id();

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -465,6 +465,41 @@ impl Blockchain {
         entries
     }
 
+    /// Idempotently persist in-memory genesis SOV mints to sled before the first
+    /// executor block apply (fresh-node import pins block 0 in-memory only).
+    pub fn persist_genesis_sov_allocations_to_store(&self) -> Result<()> {
+        let Some(store) = self.get_store() else {
+            return Ok(());
+        };
+        let sov_token_id = crate::contracts::utils::generate_lib_token_id();
+        let entries: Vec<([u8; 32], u128)> = self
+            .token_contracts
+            .get(&sov_token_id)
+            .map(|token| {
+                token
+                    .balances_iter()
+                    .map(|(pk, &bal)| (pk.key_id, bal))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let token_id = crate::storage::TokenId::new(sov_token_id);
+        match store.backfill_token_balances_from_contract(&token_id, &entries) {
+            Ok(n) if n > 0 => info!(
+                "💰 Persisted {} genesis SOV balances to token_balances tree",
+                n
+            ),
+            Ok(_) => {}
+            Err(e) => warn!(
+                "⚠️ Failed to persist genesis SOV balances to sled: {}",
+                e
+            ),
+        }
+        Ok(())
+    }
+
     /// Zero out SOV balances that were incorrectly minted to UBI and Savings wallets
     /// by a bug in the recovery migration.  The bug set `initial_balance = 5 000 SOV`
     /// for every wallet whose sled balance was 0, regardless of wallet type.  Only

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -537,33 +537,28 @@ impl BlockExecutor {
     /// Uses a scope guard to ensure rollback_block is called on both errors
     /// AND panics after begin_block.
     pub fn apply_block(&self, block: &Block) -> BlockApplyResult<ApplyOutcome> {
+        self.apply_block_committing_domain_fees(block, None, None)
+    }
+
+    /// Apply a block, optionally committing domain-registration SOV fees inside
+    /// the block transaction (before `append_block`/`commit_block`).
+    pub fn apply_block_committing_domain_fees(
+        &self,
+        block: &Block,
+        fee_floor_atoms: Option<u128>,
+        treasury_wallet_id_hex: Option<&str>,
+    ) -> BlockApplyResult<ApplyOutcome> {
         let block_height = block.header.height;
 
-        // =====================================================================
-        // Step 1: validate_header
-        // =====================================================================
         self.validate_header(block)?;
-
-        // =====================================================================
-        // Step 2: validate_block_resources
-        // =====================================================================
         self.validate_block_resources(block)?;
-
-        // =====================================================================
-        // Step 3: begin_block
-        // =====================================================================
         self.store.begin_block(block_height)?;
 
-        // Create rollback guard for panic safety.
-        // The guard will call rollback_block on Drop unless disarmed.
         let guard = RollbackGuard::new(self.store.as_ref());
+        let outcome =
+            self.apply_block_inner(block, fee_floor_atoms, treasury_wallet_id_hex)?;
 
-        // Apply the block (steps 4-6)
-        let outcome = self.apply_block_inner(block)?;
-
-        // Success - disarm the guard so it won't rollback on drop
         guard.disarm();
-
         Ok(outcome)
     }
 
@@ -631,7 +626,12 @@ impl BlockExecutor {
     /// Steps 4-6: Apply transactions, append block, commit
     ///
     /// Called after begin_block. Guard ensures rollback on error.
-    fn apply_block_inner(&self, block: &Block) -> BlockApplyResult<ApplyOutcome> {
+    fn apply_block_inner(
+        &self,
+        block: &Block,
+        fee_floor_atoms: Option<u128>,
+        treasury_wallet_id_hex: Option<&str>,
+    ) -> BlockApplyResult<ApplyOutcome> {
         let block_height = block.header.height;
         let block_timestamp = block.header.timestamp;
         let block_hash = BlockHash::new(block.hash().as_array());
@@ -738,15 +738,16 @@ impl BlockExecutor {
             // Genesis [allocations.sov_balances] are direct inserts in build_block0(),
             // not block transactions — replay must seed sled or executor balance checks
             // diverge from the historical chain (g4 @ h=74010, #2641 replay gap).
-            if let Ok(cfg) = crate::genesis::GenesisConfig::from_embedded() {
-                if let Err(e) = cfg.credit_sov_allocations_in_open_transaction(self.store.as_ref())
-                {
-                    return Err(BlockApplyError::PersistFailed(format!(
-                        "genesis SOV allocations: {}",
-                        e
-                    )));
-                }
-            }
+            let cfg = crate::genesis::GenesisConfig::from_embedded().map_err(|e| {
+                BlockApplyError::PersistFailed(format!(
+                    "embedded genesis config unavailable for SOV seeding: {}",
+                    e
+                ))
+            })?;
+            cfg.credit_sov_allocations_in_open_transaction(self.store.as_ref())
+                .map_err(|e| {
+                    BlockApplyError::PersistFailed(format!("genesis SOV allocations: {}", e))
+                })?;
 
             self.store
                 .append_block(block)
@@ -921,6 +922,17 @@ impl BlockExecutor {
                 })?;
 
             summary.utxos_created += coinbase_result.outputs_created;
+        }
+
+        // Domain registration fees must persist in the block transaction, not the
+        // post-commit metadata batch (token_balances are consensus state).
+        if let (Some(floor), Some(treasury)) = (fee_floor_atoms, treasury_wallet_id_hex) {
+            crate::Blockchain::apply_domain_registration_fees_to_store(
+                self.store.as_ref(),
+                block,
+                floor,
+                Some(treasury),
+            );
         }
 
         // =====================================================================

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -4016,6 +4016,85 @@ mod tests {
     }
 
     #[test]
+    fn test_domain_registration_fee_committed_in_executor_block_tx() {
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::storage::{Address, TokenId};
+        use crate::transaction::domain::DomainRegistrationPayload;
+        use crate::transaction::fee::DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS;
+
+        let store = create_test_store();
+        let executor = create_trusted_replay_executor(store.clone());
+
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let payer_wallet_id = [0xab; 32];
+        let fee = DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS;
+        let initial_balance = fee.saturating_mul(2);
+        let sov_token = TokenId::new(generate_lib_token_id());
+        store
+            .force_set_token_balances(&[(sov_token, Address::new(payer_wallet_id), initial_balance)])
+            .unwrap();
+
+        let treasury_id = crate::Blockchain::deterministic_treasury_wallet_id().as_array();
+        let treasury_hex = hex::encode(treasury_id);
+
+        let payload = DomainRegistrationPayload {
+            domain: "fee-test.sov".to_string(),
+            owner_did: "did:zhtp:fee-test".to_string(),
+            manifest_cid: String::new(),
+            build_hash: String::new(),
+            title: String::new(),
+            description: String::new(),
+            category: "test".to_string(),
+            tags: vec![],
+            duration_days: 365,
+            fee_tx_hash: String::new(),
+            fee_amount_atoms: fee,
+            fee_payer_wallet_id: payer_wallet_id,
+        };
+        let mut domain_tx = create_legacy_tx(TransactionType::DomainRegistration);
+        domain_tx.memo = payload.encode_memo().unwrap();
+        domain_tx.signature.public_key.key_id = payer_wallet_id;
+
+        let treasury_before = store
+            .get_token_balance(&sov_token, &Address::new(treasury_id))
+            .unwrap();
+
+        let block1 = Block::new(
+            BlockHeader {
+                version: 1,
+                previous_hash: genesis.header.block_hash.into(),
+                data_helix_root: Hash::default().into(),
+                timestamp: 1001,
+                height: 1,
+                verification_helix_root: [0u8; 32],
+                state_root: Hash::default().into(),
+                bft_quorum_root: [0u8; 32],
+                block_hash: Hash::new([0x02; 32]),
+            },
+            vec![domain_tx],
+        );
+
+        executor
+            .apply_block_committing_domain_fees(
+                &block1,
+                Some(fee),
+                Some(treasury_hex.as_str()),
+            )
+            .expect("domain fee must commit inside block transaction");
+
+        let payer_after = store
+            .get_token_balance(&sov_token, &Address::new(payer_wallet_id))
+            .unwrap();
+        let treasury_after = store
+            .get_token_balance(&sov_token, &Address::new(treasury_id))
+            .unwrap();
+        assert_eq!(payer_after, initial_balance - fee);
+        assert_eq!(treasury_after, treasury_before.saturating_add(fee));
+    }
+
+    #[test]
     fn test_apply_sequential_blocks() {
         let store = create_test_store();
         let executor = BlockExecutor::with_store(store.clone());

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -735,6 +735,19 @@ impl BlockExecutor {
                 );
             }
 
+            // Genesis [allocations.sov_balances] are direct inserts in build_block0(),
+            // not block transactions — replay must seed sled or executor balance checks
+            // diverge from the historical chain (g4 @ h=74010, #2641 replay gap).
+            if let Ok(cfg) = crate::genesis::GenesisConfig::from_embedded() {
+                if let Err(e) = cfg.credit_sov_allocations_in_open_transaction(self.store.as_ref())
+                {
+                    return Err(BlockApplyError::PersistFailed(format!(
+                        "genesis SOV allocations: {}",
+                        e
+                    )));
+                }
+            }
+
             self.store
                 .append_block(block)
                 .map_err(|e| BlockApplyError::PersistFailed(e.to_string()))?;
@@ -3962,6 +3975,32 @@ mod tests {
         assert_eq!(state.genesis_treasury_allocation, GENESIS_TREASURY_ALLOCATION);
         assert!(!state.graduated);
         assert!(!state.sell_enabled);
+    }
+
+    #[test]
+    fn test_genesis_persists_sov_allocations_to_sled() {
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::storage::{Address, TokenId};
+
+        let store = create_test_store();
+        let executor = BlockExecutor::with_store(store.clone());
+
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let cfg = crate::genesis::GenesisConfig::from_embedded().expect("embedded genesis");
+        let entries = cfg.sov_allocation_entries().expect("sov entries");
+        assert!(!entries.is_empty(), "test genesis must include sov_balances");
+
+        let token = TokenId::new(generate_lib_token_id());
+        let (wallet_id, expected_balance) = entries[0];
+        let bal = store
+            .get_token_balance(&token, &Address::new(wallet_id))
+            .expect("read sled balance");
+        assert_eq!(
+            bal, expected_balance,
+            "genesis replay must seed embedded sov_balances into sled"
+        );
     }
 
     #[test]

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -735,7 +735,9 @@ impl GenesisConfig {
 
         for (wallet_id, balance) in entries {
             let addr = Address::new(wallet_id);
-            let current = store.get_token_balance(&token_id, &addr).unwrap_or(0);
+            let current = store
+                .get_token_balance(&token_id, &addr)
+                .map_err(|e| anyhow::anyhow!("genesis SOV balance read failed: {}", e))?;
             if current > 0 {
                 continue;
             }
@@ -747,7 +749,10 @@ impl GenesisConfig {
         }
 
         if supply_delta > 0 {
-            let current_supply = store.get_token_supply(&token_id).unwrap_or(None).unwrap_or(0);
+            let current_supply = store
+                .get_token_supply(&token_id)
+                .map_err(|e| anyhow::anyhow!("genesis SOV supply read failed: {}", e))?
+                .unwrap_or(0);
             store
                 .put_token_supply(&token_id, current_supply.saturating_add(supply_delta))
                 .map_err(|e| anyhow::anyhow!("genesis SOV supply update failed: {}", e))?;

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -716,7 +716,12 @@ impl GenesisConfig {
     }
 
     /// Persist genesis SOV allocations during an open block/metadata transaction.
-    /// Idempotent: only credits addresses with zero sled balance.
+    ///
+    /// Idempotent for block-0 replay: skips any address whose sled balance is
+    /// already non-zero. That is correct because (a) a fresh wipe has zero
+    /// balances and receives the full genesis allocation set, and (b) a
+    /// non-zero balance means the address was already seeded or has had later
+    /// chain activity — re-crediting the genesis amount would double-mint.
     pub fn credit_sov_allocations_in_open_transaction(
         &self,
         store: &dyn crate::storage::BlockchainStore,

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -664,6 +664,104 @@ impl GenesisConfig {
         Ok(())
     }
 
+    /// Parsed `(wallet_id_bytes, balance_atoms)` pairs from `[allocations.sov_balances]`.
+    pub fn sov_allocation_entries(&self) -> Result<Vec<([u8; 32], u128)>> {
+        let mut entries = Vec::new();
+        for entry in &self.allocations.sov_balances {
+            let wallet_id_bytes = hex::decode(&entry.wallet_id).map_err(|e| {
+                anyhow::anyhow!(
+                    "invalid hex in sov_balance wallet_id '{}': {}",
+                    entry.wallet_id,
+                    e
+                )
+            })?;
+            if wallet_id_bytes.len() != 32 {
+                warn!(
+                    "Skipping sov_balance with invalid wallet_id length: {}",
+                    entry.wallet_id
+                );
+                continue;
+            }
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&wallet_id_bytes);
+            if entry.balance > 0 {
+                entries.push((arr, entry.balance));
+            }
+        }
+        Ok(entries)
+    }
+
+    /// Persist genesis SOV allocations into sled (startup / no active tx).
+    /// Idempotent: only fills addresses missing from `token_balances`.
+    pub fn credit_sov_allocations_to_store(
+        &self,
+        store: &dyn crate::storage::BlockchainStore,
+    ) -> Result<usize> {
+        let entries = self.sov_allocation_entries()?;
+        if entries.is_empty() {
+            return Ok(0);
+        }
+        use crate::contracts::utils::generate_lib_token_id;
+        let token_id = crate::storage::TokenId::new(generate_lib_token_id());
+        let written = store
+            .backfill_token_balances_from_contract(&token_id, &entries)
+            .map_err(|e| anyhow::anyhow!("genesis SOV backfill failed: {}", e))?;
+        if written > 0 {
+            info!(
+                "Genesis: persisted {} SOV allocation balances to token_balances tree",
+                written
+            );
+        }
+        Ok(written)
+    }
+
+    /// Persist genesis SOV allocations during an open block/metadata transaction.
+    /// Idempotent: only credits addresses with zero sled balance.
+    pub fn credit_sov_allocations_in_open_transaction(
+        &self,
+        store: &dyn crate::storage::BlockchainStore,
+    ) -> Result<usize> {
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::storage::{Address, TokenId};
+
+        let entries = self.sov_allocation_entries()?;
+        if entries.is_empty() {
+            return Ok(0);
+        }
+
+        let token_id = TokenId::new(generate_lib_token_id());
+        let mut credited = 0usize;
+        let mut supply_delta = 0u128;
+
+        for (wallet_id, balance) in entries {
+            let addr = Address::new(wallet_id);
+            let current = store.get_token_balance(&token_id, &addr).unwrap_or(0);
+            if current > 0 {
+                continue;
+            }
+            store
+                .set_token_balance(&token_id, &addr, balance)
+                .map_err(|e| anyhow::anyhow!("genesis SOV credit failed: {}", e))?;
+            supply_delta = supply_delta.saturating_add(balance);
+            credited += 1;
+        }
+
+        if supply_delta > 0 {
+            let current_supply = store.get_token_supply(&token_id).unwrap_or(None).unwrap_or(0);
+            store
+                .put_token_supply(&token_id, current_supply.saturating_add(supply_delta))
+                .map_err(|e| anyhow::anyhow!("genesis SOV supply update failed: {}", e))?;
+        }
+
+        if credited > 0 {
+            info!(
+                "Genesis: credited {} SOV allocation balances in block transaction",
+                credited
+            );
+        }
+        Ok(credited)
+    }
+
     /// Resolve the OPAQUE server-setup bytes from this config, if the
     /// `[opaque]` section is present. Pulled out into its own helper so
     /// every Blockchain construction path (apply_genesis_state, load_from_store)

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -317,13 +317,15 @@ impl ChainSync {
     where
         F: FnMut(u64, usize),
     {
-        let genesis_block = blocks[0].clone();
-        if genesis_block.header.height != 0 {
+        let mut blocks = blocks;
+        if blocks[0].header.height != 0 {
             return Err(SyncError::HeightMismatch {
                 expected: 0,
-                actual: genesis_block.header.height,
+                actual: blocks[0].header.height,
             });
         }
+
+        let genesis_block = blocks.remove(0);
 
         let executor = BlockExecutor::from_config_trusted_replay(
             Arc::clone(&self.store),
@@ -337,7 +339,7 @@ impl ChainSync {
             })?;
         on_progress(0, 1);
 
-        let rest: Vec<Block> = blocks.into_iter().skip(1).collect();
+        let rest = blocks;
         if rest.is_empty() {
             return Ok(ImportResult {
                 blocks_imported: 1,

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -309,6 +309,12 @@ impl ChainSync {
     /// sled), then canonical `Blockchain` runtime replays blocks 1+ so
     /// `finish_block_processing` hooks (domain fees, identity, wallet, …) match
     /// the incremental live-validator path.
+    ///
+    /// Correctness over speed: canonical import is slower than executor-only (~225
+    /// blocks/sec observed) but required because live validators built state via
+    /// `process_and_commit_block`, not raw `BlockExecutor::apply_block` alone.
+    /// A 177k-block fresh sync is on the order of tens of minutes — acceptable for
+    /// wipe-and-recover, not the steady-state hot path.
     fn import_blocks_from_genesis_bootstrap<F>(
         &self,
         blocks: Vec<Block>,
@@ -617,6 +623,55 @@ mod tests {
             memo: vec![],
             payload: crate::transaction::TransactionPayload::None,
         }
+    }
+
+    #[test]
+    fn test_domain_registration_triggers_canonical_import_path() {
+        use crate::transaction::domain::DomainRegistrationPayload;
+        use crate::transaction::fee::DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS;
+
+        let (_dir, store) = create_test_store();
+        let sync = ChainSync::new(Arc::clone(&store));
+
+        let genesis = create_genesis_block();
+        sync.import_blocks(vec![genesis.clone()]).unwrap();
+
+        let payer = [0xcd; 32];
+        let fee = DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS;
+        let sov_token = crate::storage::TokenId::new(crate::contracts::utils::generate_lib_token_id());
+        store
+            .force_set_token_balances(&[(
+                sov_token,
+                crate::storage::Address::new(payer),
+                fee.saturating_mul(2),
+            )])
+            .unwrap();
+
+        let payload = DomainRegistrationPayload {
+            domain: "canonical-path.sov".to_string(),
+            owner_did: "did:zhtp:canonical".to_string(),
+            manifest_cid: String::new(),
+            build_hash: String::new(),
+            title: String::new(),
+            description: String::new(),
+            category: "test".to_string(),
+            tags: vec![],
+            duration_days: 30,
+            fee_tx_hash: String::new(),
+            fee_amount_atoms: fee,
+            fee_payer_wallet_id: payer,
+        };
+        let mut domain_tx = create_test_tx(TransactionType::DomainRegistration);
+        domain_tx.memo = payload.encode_memo().unwrap();
+        domain_tx.signature.public_key.key_id = payer;
+
+        let block1 = create_block_at_height(1, genesis.header.block_hash);
+        let block1 = Block::new(block1.header, vec![domain_tx]);
+
+        sync.import_blocks(vec![block1]).expect(
+            "DomainRegistration batch must route through canonical runtime import",
+        );
+        assert_eq!(store.latest_height().unwrap(), 1);
     }
 
     #[test]

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -225,6 +225,24 @@ impl ChainSync {
             });
         }
 
+        let expected_start = match self.store.latest_height() {
+            Ok(h) => h + 1,
+            Err(StorageError::NotInitialized) => 0,
+            Err(e) => return Err(SyncError::Storage(e)),
+        };
+
+        let first_block_height = blocks[0].header.height;
+        if first_block_height != expected_start {
+            return Err(SyncError::HeightMismatch {
+                expected: expected_start,
+                actual: first_block_height,
+            });
+        }
+
+        if expected_start == 0 {
+            return self.import_blocks_from_genesis_bootstrap(blocks, on_progress);
+        }
+
         if Self::requires_canonical_runtime_import(&blocks) {
             return self.import_blocks_via_canonical_runtime(blocks, Some(&mut on_progress));
         }
@@ -233,22 +251,6 @@ impl ChainSync {
             Arc::clone(&self.store),
             self.executor_config.clone(),
         );
-
-        // Determine expected starting height
-        let expected_start = match self.store.latest_height() {
-            Ok(h) => h + 1,
-            Err(StorageError::NotInitialized) => 0,
-            Err(e) => return Err(SyncError::Storage(e)),
-        };
-
-        // Validate first block height
-        let first_block_height = blocks[0].header.height;
-        if first_block_height != expected_start {
-            return Err(SyncError::HeightMismatch {
-                expected: expected_start,
-                actual: first_block_height,
-            });
-        }
 
         // Track last committed block hash for chain continuity validation.
         // The executor uses trusted replay (skip_prev_hash_validation=true),
@@ -303,7 +305,58 @@ impl ChainSync {
         })
     }
 
-    /// Contract/DAO variants currently execute through canonical `Blockchain` flow,
+    /// Fresh bootstrap from genesis: executor applies block 0 (seeds genesis SOV to
+    /// sled), then canonical `Blockchain` runtime replays blocks 1+ so
+    /// `finish_block_processing` hooks (domain fees, identity, wallet, …) match
+    /// the incremental live-validator path.
+    fn import_blocks_from_genesis_bootstrap<F>(
+        &self,
+        blocks: Vec<Block>,
+        mut on_progress: F,
+    ) -> SyncResult<ImportResult>
+    where
+        F: FnMut(u64, usize),
+    {
+        let genesis_block = blocks[0].clone();
+        if genesis_block.header.height != 0 {
+            return Err(SyncError::HeightMismatch {
+                expected: 0,
+                actual: genesis_block.header.height,
+            });
+        }
+
+        let executor = BlockExecutor::from_config_trusted_replay(
+            Arc::clone(&self.store),
+            self.executor_config.clone(),
+        );
+        executor
+            .apply_block(&genesis_block)
+            .map_err(|e| SyncError::BlockApplyFailed {
+                height: 0,
+                error: e,
+            })?;
+        on_progress(0, 1);
+
+        let rest: Vec<Block> = blocks.into_iter().skip(1).collect();
+        if rest.is_empty() {
+            return Ok(ImportResult {
+                blocks_imported: 1,
+                final_height: Some(0),
+            });
+        }
+
+        let canonical = self.run_canonical_import(rest)?;
+        for (offset, height) in canonical.heights.iter().enumerate() {
+            on_progress(*height, offset + 2);
+        }
+
+        Ok(ImportResult {
+            blocks_imported: 1 + canonical.blocks_imported,
+            final_height: canonical.final_height,
+        })
+    }
+
+    /// Contract/DAO/domain variants currently execute through canonical `Blockchain` flow,
     /// not `BlockExecutor`'s phase-2 transaction applicator.
     fn requires_canonical_runtime_import(blocks: &[Block]) -> bool {
         blocks.iter().any(Self::block_needs_canonical_runtime)
@@ -397,6 +450,9 @@ impl ChainSync {
                     // DaoStake/DaoUnstake: move SOV between accounts, must go through full executor
                     | TransactionType::DaoStake
                     | TransactionType::DaoUnstake
+                    // Domain lifecycle: executor no-op; fees applied in finish_block.
+                    | TransactionType::DomainRegistration
+                    | TransactionType::DomainUpdate
             )
         })
     }
@@ -559,6 +615,32 @@ mod tests {
             memo: vec![],
             payload: crate::transaction::TransactionPayload::None,
         }
+    }
+
+    #[test]
+    fn test_genesis_bootstrap_import_seeds_sov_balances() {
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::genesis::GenesisConfig;
+        use crate::storage::{Address, TokenId};
+
+        let (_dir, store) = create_test_store();
+        let sync = ChainSync::new(Arc::clone(&store));
+
+        let genesis = create_genesis_block();
+        let block1 = create_block_at_height(1, genesis.header.block_hash);
+        sync.import_blocks(vec![genesis, block1]).unwrap();
+
+        let cfg = GenesisConfig::from_embedded().unwrap();
+        let entries = cfg.sov_allocation_entries().unwrap();
+        assert!(!entries.is_empty());
+
+        let token = TokenId::new(generate_lib_token_id());
+        let (wallet_id, expected_balance) = entries[0];
+        let bal = store
+            .get_token_balance(&token, &Address::new(wallet_id))
+            .unwrap();
+        assert_eq!(bal, expected_balance);
+        assert_eq!(store.latest_height().unwrap(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

#2641 Phase 4 — stacked on #2725 (g4 replay fix). **Merge #2725 first.**

Removes legacy per-block seed-sled reconciliation and replay-tolerance token paths now that genesis SOV seeding + canonical bootstrap make replay deterministic.

## Changes

- Consolidate post-executor hooks into `finish_block_processing`
- Remove per-block in-mem → sled token backfill before executor apply
- Remove `process_token_transactions_replay` boot-tolerance variant
- Gut `replay_block_state` → `advance_replay_metadata` (deprecated alias retained)
- Gate in-memory SOV mint in `process_wallet_transactions` behind `!has_executor()`

## Risk / review notes

- Assumes all wallet-init paths write SOV via executor (no in-mem-only mint gaps)
- Historic blocks must replay cleanly under current rules (no looser-rules tolerance)
- Does not block g4 recovery — that is #2725

## Tests

1948 `lib-blockchain` lib tests pass on this stack.