### PR TITLE
GENESIS-1: unified SOV-native chain bootstrap at height 0

### DIFF
--- a/docs/arch/genesis-bootstrap-surface.md
+++ b/docs/arch/genesis-bootstrap-surface.md
@@ -31,22 +31,22 @@ Curve **parameters** and `BondingCurveEconomicState` are **DAO contract state** 
 
 ---
 
-## 3. Inventory (current → target)
+## 3. Inventory (current → target; bucket = §4)
 
-| State | Current writer | Sled on replay? | Target bucket |
-|-------|----------------|---------------|---------------|
-| `chain_id`, `genesis_time` | `genesis.toml` | N/A | Genesis config |
-| SOV native shell | `build_block0()` | Partial | **A** — h=0 projection |
-| `[[allocations.sov_balances]]` | `build_block0()` in-mem; #2725 sled | Yes (#2725) | **A** (testnet legacy → retire) |
-| CBE `TokenCreation` + balances | Should be founding tx | Partial (block-0 patch) | **B** |
-| CBE curve params | `genesis.toml` + `canonical.rs` + `build_block0()` deploy | No | **B** — contract state |
-| `BondingCurveEconomicState` | Executor block-0 special case | Yes | **B** — contract init tx |
-| BUBL / custom tokens | `TokenCreation` in chain | Yes if executor path | **B** |
-| Wallets / identities | `[[allocations.*]]`, `apply_genesis_state` | Partial | **B** — registration txs |
-| Bootstrap council | `genesis.toml` | In-mem only | **A** (governance sled TBD) |
-| `[opaque]` | `apply_genesis_state` | No | **C** — runtime auth |
-| `GenesisFundingService` welcome SOV | Bootstrap leader only | No | **C** — retire |
-| Reward streaks | `rewards.sled` | N/A | **C** |
+| State | Current writer | Sled on replay? | Target (§4) |
+|-------|----------------|-----------------|-------------|
+| `chain_id`, `genesis_time` | `genesis.toml` | N/A | A — genesis config |
+| SOV native shell | `build_block0()` in-mem only | Yes (#2741 `project_chain_bootstrap`) | A — h=0 projection |
+| `[[allocations.sov_balances]]` | `build_block0()` in-mem; #2725/#2741 sled | Yes | A — testnet legacy (see §8) |
+| CBE `TokenCreation` + balances | Should be founding tx | Partial (block-0 patch) | B — on-chain txs |
+| CBE curve params | `genesis.toml` + `canonical.rs` + `build_block0()` deploy | No | B — DAO contract state |
+| `BondingCurveEconomicState` | Executor block-0 special case (deprecated) | Yes | B — contract init tx |
+| BUBL / custom tokens | `TokenCreation` in chain | Yes if executor path | B — on-chain txs |
+| Wallets / identities | `[[allocations.*]]`, `apply_genesis_state` | Partial | B — registration txs |
+| Bootstrap council | `genesis.toml` | In-mem only | A — governance sled TBD |
+| `[opaque]` | `apply_genesis_state` | No | C — node-local |
+| `GenesisFundingService` welcome SOV | Bootstrap leader only | No | C — retire |
+| Reward streaks | `rewards.sled` | N/A | C — node-local |
 
 ---
 
@@ -104,3 +104,16 @@ After wipe + replay to height `H`:
 See [#2727](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2727): GENESIS-0 → GENESIS-1 (SOV h=0) → GENESIS-6 (CBE contract + DAO tokens) → GENESIS-2 (gate) → GENESIS-7+ (state unification).
 
 Do **not** land GENESIS-7 (delete seed-sled) until GENESIS-2 passes.
+
+---
+
+## 8. Migration / retirement plan (testnet)
+
+Retiring `[[allocations.sov_balances]]` (GENESIS-3 / #2731) requires a **coordinated testnet reset**, not a silent genesis.toml edit on a live chain:
+
+1. **Snapshot** current sled + document wallet balances to verify replay parity (GENESIS-2).
+2. **Reset** all validators together with shrunk `genesis.toml` (`[sov] initial_supply = 0`, no bulk allocations).
+3. **Re-seed** wallets via early-block `WalletRegistration` / UBI / coinbase — not genesis rows.
+4. **DAO tokens** (CBE, BUBL): founding `TokenCreation` + contract deploy txs in blocks 1..k (GENESIS-6).
+
+Mainnet uses a one-shot ceremony; testnet may repeat resets until GENESIS-2 gate is green.

--- a/docs/arch/genesis-bootstrap-surface.md
+++ b/docs/arch/genesis-bootstrap-surface.md
@@ -1,0 +1,106 @@
+# Genesis Bootstrap Surface Area
+
+**Epic:** [#2727 GENESIS](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2727)  
+**Status:** Draft (GENESIS-0)  
+**Companion:** [`state-unification.md`](./state-unification.md)
+
+---
+
+## 1. Rule of thumb
+
+| Layer | Height | What | Grows when DAO mints? |
+|-------|--------|------|------------------------|
+| **Genesis (native)** | h=0 | SOV policy + shell, chain params, council | No |
+| **On-chain txs** | h≥1 | All tokens, contracts, transfers, payroll | Yes — every DAO launch |
+| **Node-local** | N/A | rewards.sled, keystores, OPAQUE runtime | Per node |
+
+**Only SOV is native.** CBE, BUBL, and every other ticker are DAO tokens created via `TokenCreation`. CBE is special only in **economics**: its bonding-curve contract bootstraps SOV liquidity — not in **genesis shape**.
+
+---
+
+## 2. Token taxonomy
+
+| Token | Class | Genesis? | Bootstrap role |
+|-------|-------|----------|------------------|
+| **SOV** | Native (sole) | Policy + contract shell at h=0 | Fees, payroll, internal settlement |
+| **CBE** | DAO | No | Bonding-curve **contract** + `TokenCreation`; on-ramp buys mint SOV |
+| **BUBL** | DAO | No | Rewards `TokenCreation` |
+| **Others** | DAO | No | 20% treasury per `TokenCreationPayloadV1` |
+
+Curve **parameters** and `BondingCurveEconomicState` are **DAO contract state** (sled), initialized by founding deploy/init txs — not `[cbe_curve]` in `genesis.toml`. Immutable protocol **math** (band formula, debt ceiling rules) may remain in `canonical.rs`; deploy-time config and live economic state belong on-chain.
+
+---
+
+## 3. Inventory (current → target)
+
+| State | Current writer | Sled on replay? | Target bucket |
+|-------|----------------|---------------|---------------|
+| `chain_id`, `genesis_time` | `genesis.toml` | N/A | Genesis config |
+| SOV native shell | `build_block0()` | Partial | **A** — h=0 projection |
+| `[[allocations.sov_balances]]` | `build_block0()` in-mem; #2725 sled | Yes (#2725) | **A** (testnet legacy → retire) |
+| CBE `TokenCreation` + balances | Should be founding tx | Partial (block-0 patch) | **B** |
+| CBE curve params | `genesis.toml` + `canonical.rs` + `build_block0()` deploy | No | **B** — contract state |
+| `BondingCurveEconomicState` | Executor block-0 special case | Yes | **B** — contract init tx |
+| BUBL / custom tokens | `TokenCreation` in chain | Yes if executor path | **B** |
+| Wallets / identities | `[[allocations.*]]`, `apply_genesis_state` | Partial | **B** — registration txs |
+| Bootstrap council | `genesis.toml` | In-mem only | **A** (governance sled TBD) |
+| `[opaque]` | `apply_genesis_state` | No | **C** — runtime auth |
+| `GenesisFundingService` welcome SOV | Bootstrap leader only | No | **C** — retire |
+| Reward streaks | `rewards.sled` | N/A | **C** |
+
+---
+
+## 4. Buckets
+
+### A — Native genesis (h=0, fixed at reset)
+
+- Chain params (`chain_id`, `genesis_time`)
+- SOV native token contract record (zero supply on v2)
+- SOV policy (`[sov] initial_supply = 0` on clean testnet)
+- Bootstrap council, treasury **addresses** (not DAO balances)
+- Testnet-only: migrated `sov_balances` until GENESIS-3 reset
+
+**API:** `GenesisConfig::project_chain_bootstrap_to_store()` (GENESIS-1, #2729) — SOV-native scope only. Installs SOV contract shell + credits `[allocations.sov_balances]` during executor block-0 `begin_block`.
+
+### B — On-chain transactions (unbounded)
+
+- `TokenCreation` — CBE, BUBL, all DAO tokens (20% treasury)
+- CBE bonding-curve contract deploy + economic state init
+- `TokenTransfer`, payroll, CBE buy/sell, coinbase
+- `WalletRegistration`, `IdentityRegistration`, `ValidatorRegistration`
+
+### C — Node-local (never consensus)
+
+- `rewards.sled`, treasury signer keystore, per-node welcome bonus
+- OPAQUE server setup blob (runtime auth)
+
+---
+
+## 5. Never in genesis
+
+- CBE, BUBL, or any DAO token **balances**
+- CBE curve **deploy config** (belongs in contract state)
+- Per-DAO allocations that grow with each launch
+- Reward policy / streak state
+- Treasury private keys
+
+`genesis.toml` may retain **chain** and **SOV policy** sections only after testnet reset. `[cbe_curve]` / `[bonding_curve]` are retired in favour of founding contract txs (GENESIS-6).
+
+---
+
+## 6. Replay acceptance (GENESIS-2)
+
+After wipe + replay to height `H`:
+
+1. SOV native balances match live node at `H` (sample wallets)
+2. CBE treasury balance from **DAO tx replay**, not native h=0 patch
+3. BUBL treasury from `TokenCreation` replay if deployed before `H`
+4. No `Insufficient token balance` in executor at g4 checkpoint (~74010)
+
+---
+
+## 7. Implementation order
+
+See [#2727](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2727): GENESIS-0 → GENESIS-1 (SOV h=0) → GENESIS-6 (CBE contract + DAO tokens) → GENESIS-2 (gate) → GENESIS-7+ (state unification).
+
+Do **not** land GENESIS-7 (delete seed-sled) until GENESIS-2 passes.

--- a/docs/arch/state-unification.md
+++ b/docs/arch/state-unification.md
@@ -1,6 +1,6 @@
 # State Unification — Phase 0 Inventory & Decisions
 
-**Tracker:** [#2645](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2645) — `arch: unify state to single source of truth`
+**Tracker:** [#2727 GENESIS epic](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2727) — chain bootstrap, replay determinism, and state unification (supersedes [#2645](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2645))
 **This document delivers:** [#2634](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2634) — Phase 0
 **Status:** Draft (Phase 0, no code changes)
 
@@ -382,7 +382,7 @@ Recap of the ordering as it now relates to the catalog:
 
 ## 8. References
 
-- Parent tracker: [#2645](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2645)
+- Parent tracker: [#2727 GENESIS epic](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2727) (supersedes #2645)
 - Phase issues: [#2634](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2634) (this doc) through [#2644](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2644)
 - Key code paths cited:
   - `lib-blockchain/src/execution/` — clean architecture (BlockExecutor + StateView + StateMutator)

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -704,7 +704,9 @@ impl BlockExecutor {
             // migration path, or coordinating a breaking storage-format change.
             // Any such change without migration will corrupt deserialization of
             // existing chains.
-            // â”€â”€ Genesis economic state with 20B treasury allocation (#2127) â”€â”€
+            // GENESIS-6 (#2734): CBE is a DAO token — this block-0 seed is deprecated.
+            // Target: founding TokenCreation + curve contract deploy txs, not native h=0.
+            // â”€â”€ Legacy CBE DAO economic state with 20B treasury allocation (#2127) â”€â”€
             {
                 use crate::contracts::bonding_curve::canonical::GENESIS_TREASURY_ALLOCATION;
 
@@ -735,19 +737,27 @@ impl BlockExecutor {
                 );
             }
 
-            // Genesis [allocations.sov_balances] are direct inserts in build_block0(),
-            // not block transactions — replay must seed sled or executor balance checks
-            // diverge from the historical chain (g4 @ h=74010, #2641 replay gap).
+            // SOV-native bootstrap (GENESIS-1 / #2729): contract shell + migrated
+            // [allocations.sov_balances]. build_block0() inserts balances in-memory only;
+            // replay must project them to sled (g4 @ h=74010).
             let cfg = crate::genesis::GenesisConfig::from_embedded().map_err(|e| {
                 BlockApplyError::PersistFailed(format!(
-                    "embedded genesis config unavailable for SOV seeding: {}",
+                    "embedded genesis config unavailable for chain bootstrap: {}",
                     e
                 ))
             })?;
-            cfg.credit_sov_allocations_in_open_transaction(self.store.as_ref())
+            let bootstrap = cfg
+                .project_chain_bootstrap_to_store(self.store.as_ref())
                 .map_err(|e| {
-                    BlockApplyError::PersistFailed(format!("genesis SOV allocations: {}", e))
+                    BlockApplyError::PersistFailed(format!("genesis chain bootstrap: {}", e))
                 })?;
+            if bootstrap.sov_contract_installed || bootstrap.sov_balances_credited > 0 {
+                tracing::info!(
+                    sov_contract = bootstrap.sov_contract_installed,
+                    sov_balances = bootstrap.sov_balances_credited,
+                    "Genesis: SOV-native chain bootstrap projected to sled"
+                );
+            }
 
             self.store
                 .append_block(block)
@@ -4013,6 +4023,47 @@ mod tests {
             bal, expected_balance,
             "genesis replay must seed embedded sov_balances into sled"
         );
+    }
+
+    #[test]
+    fn test_genesis_installs_sov_native_contract_in_sled() {
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::storage::TokenId;
+
+        let store = create_test_store();
+        let executor = BlockExecutor::with_store(store.clone());
+
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let token_id = TokenId::new(generate_lib_token_id());
+        let contract = store
+            .get_token_contract(&token_id)
+            .expect("read contract")
+            .expect("SOV native contract must exist in sled after genesis");
+        assert_eq!(contract.symbol, "SOV");
+        assert_eq!(contract.token_id, generate_lib_token_id());
+    }
+
+    #[test]
+    fn test_genesis_bootstrap_skips_duplicate_sov_balances_in_block_tx() {
+        let store = create_test_store();
+        let cfg = crate::genesis::GenesisConfig::from_embedded().expect("embedded genesis");
+
+        store.begin_block(0).unwrap();
+        let first = cfg
+            .project_chain_bootstrap_to_store(store.as_ref())
+            .expect("first bootstrap");
+        let second = cfg
+            .project_chain_bootstrap_to_store(store.as_ref())
+            .expect("second bootstrap");
+        store.commit_block().unwrap();
+
+        assert!(first.sov_contract_installed);
+        assert!(first.sov_balances_credited > 0);
+        // Balance credits are idempotent within the open tx; contract install may
+        // report twice before commit because puts are not yet visible to reads.
+        assert_eq!(second.sov_balances_credited, 0);
     }
 
     #[test]

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -709,6 +709,15 @@ impl BlockExecutor {
             // â”€â”€ Legacy CBE DAO economic state with 20B treasury allocation (#2127) â”€â”€
             {
                 use crate::contracts::bonding_curve::canonical::GENESIS_TREASURY_ALLOCATION;
+                use std::sync::Once;
+
+                static CBE_GENESIS_SEED_DEPRECATION_WARNED: Once = Once::new();
+                CBE_GENESIS_SEED_DEPRECATION_WARNED.call_once(|| {
+                    tracing::warn!(
+                        "Genesis block-0 CBE treasury seed is deprecated (GENESIS-6 #2734); \
+                         migrate to DAO TokenCreation + curve contract deploy txs"
+                    );
+                });
 
                 let mut econ = lib_types::BondingCurveEconomicState::default();
                 econ.genesis_treasury_allocation = GENESIS_TREASURY_ALLOCATION;
@@ -751,11 +760,16 @@ impl BlockExecutor {
                 .map_err(|e| {
                     BlockApplyError::PersistFailed(format!("genesis chain bootstrap: {}", e))
                 })?;
-            if bootstrap.sov_contract_installed || bootstrap.sov_balances_credited > 0 {
+            if bootstrap.sov_contract_installed {
                 tracing::info!(
-                    sov_contract = bootstrap.sov_contract_installed,
+                    "Genesis: SOV native token contract record installed in sled \
+                     (fixes fresh-sync iter_token_contracts / get_token_contract gap)"
+                );
+            }
+            if bootstrap.sov_balances_credited > 0 {
+                tracing::info!(
                     sov_balances = bootstrap.sov_balances_credited,
-                    "Genesis: SOV-native chain bootstrap projected to sled"
+                    "Genesis: SOV allocation balances projected to sled"
                 );
             }
 
@@ -4036,17 +4050,27 @@ mod tests {
         let genesis = create_genesis_block();
         executor.apply_block(&genesis).unwrap();
 
-        let token_id = TokenId::new(generate_lib_token_id());
+        let sov_id = generate_lib_token_id();
+        let token_id = TokenId::new(sov_id);
         let contract = store
             .get_token_contract(&token_id)
             .expect("read contract")
             .expect("SOV native contract must exist in sled after genesis");
         assert_eq!(contract.symbol, "SOV");
-        assert_eq!(contract.token_id, generate_lib_token_id());
+        assert_eq!(contract.token_id, sov_id);
+
+        let enumerated: Vec<_> = store
+            .iter_token_contracts()
+            .expect("iter contracts")
+            .collect();
+        assert!(
+            enumerated.iter().any(|(id, _)| id.0 == sov_id),
+            "SOV must appear in iter_token_contracts after genesis replay"
+        );
     }
 
     #[test]
-    fn test_genesis_bootstrap_skips_duplicate_sov_balances_in_block_tx() {
+    fn test_genesis_bootstrap_idempotent_within_open_block_tx() {
         let store = create_test_store();
         let cfg = crate::genesis::GenesisConfig::from_embedded().expect("embedded genesis");
 
@@ -4061,9 +4085,23 @@ mod tests {
 
         assert!(first.sov_contract_installed);
         assert!(first.sov_balances_credited > 0);
-        // Balance credits are idempotent within the open tx; contract install may
-        // report twice before commit because puts are not yet visible to reads.
+        assert!(!second.sov_contract_installed);
         assert_eq!(second.sov_balances_credited, 0);
+    }
+
+    #[test]
+    fn test_project_chain_bootstrap_requires_open_block_transaction() {
+        let store = create_test_store();
+        let cfg = crate::genesis::GenesisConfig::from_embedded().expect("embedded genesis");
+
+        let err = cfg
+            .project_chain_bootstrap_to_store(store.as_ref())
+            .expect_err("must fail without begin_block");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("NoActiveTransaction") || msg.contains("transaction"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -336,6 +336,19 @@ impl GenesisStateSnapshot {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Chain bootstrap projection (GENESIS-1)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Outcome of [`GenesisConfig::project_chain_bootstrap_to_store`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ChainBootstrapOutcome {
+    /// `true` when the SOV native contract record was written to sled.
+    pub sov_contract_installed: bool,
+    /// Count of `[allocations.sov_balances]` addresses credited this call.
+    pub sov_balances_credited: usize,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // GenesisConfig implementation
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -691,6 +704,49 @@ impl GenesisConfig {
         Ok(entries)
     }
 
+    /// Project **SOV-native** chain bootstrap into sled during an open block transaction.
+    ///
+    /// Scope (GENESIS-1 / #2729): native SOV contract shell + `[allocations.sov_balances]`
+    /// only. CBE is a DAO token — its curve contract and 20B treasury allocation remain
+    /// on the legacy block-0 path until GENESIS-6 (#2734).
+    ///
+    /// Must be called while `begin_block` is active (executor block-0 apply/replay).
+    pub fn project_chain_bootstrap_to_store(
+        &self,
+        store: &dyn crate::storage::BlockchainStore,
+    ) -> Result<ChainBootstrapOutcome> {
+        let sov_contract_installed = self.ensure_sov_native_contract_in_store(store)?;
+        let sov_balances_credited = self.credit_sov_allocations_in_open_transaction(store)?;
+        Ok(ChainBootstrapOutcome {
+            sov_contract_installed,
+            sov_balances_credited,
+        })
+    }
+
+    /// Install the SOV native token contract metadata in sled if missing.
+    fn ensure_sov_native_contract_in_store(
+        &self,
+        store: &dyn crate::storage::BlockchainStore,
+    ) -> Result<bool> {
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::storage::TokenId;
+
+        let token_id = TokenId::new(generate_lib_token_id());
+        if store
+            .get_token_contract(&token_id)
+            .map_err(|e| anyhow::anyhow!("genesis SOV contract read failed: {}", e))?
+            .is_some()
+        {
+            return Ok(false);
+        }
+        let contract = crate::contracts::TokenContract::new_sov_native();
+        store
+            .put_token_contract(&contract)
+            .map_err(|e| anyhow::anyhow!("genesis SOV contract install failed: {}", e))?;
+        info!("Genesis: installed SOV native token contract in sled");
+        Ok(true)
+    }
+
     /// Persist genesis SOV allocations into sled (startup / no active tx).
     /// Idempotent: only fills addresses missing from `token_balances`.
     pub fn credit_sov_allocations_to_store(
@@ -716,6 +772,9 @@ impl GenesisConfig {
     }
 
     /// Persist genesis SOV allocations during an open block/metadata transaction.
+    ///
+    /// Prefer [`Self::project_chain_bootstrap_to_store`] at block 0 — it also installs
+    /// the SOV native contract shell.
     ///
     /// Idempotent for block-0 replay: skips any address whose sled balance is
     /// already non-zero. That is correct because (a) a fresh wipe has zero

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -341,6 +341,7 @@ impl GenesisStateSnapshot {
 
 /// Outcome of [`GenesisConfig::project_chain_bootstrap_to_store`].
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ChainBootstrapOutcome {
     /// `true` when the SOV native contract record was written to sled.
     pub sov_contract_installed: bool,
@@ -710,7 +711,13 @@ impl GenesisConfig {
     /// only. CBE is a DAO token — its curve contract and 20B treasury allocation remain
     /// on the legacy block-0 path until GENESIS-6 (#2734).
     ///
+    /// **Bug fix (latent):** `build_block0()` populated SOV in in-memory `token_contracts`
+    /// but block-0 replay never persisted the SOV contract record to sled. Fresh-sync
+    /// nodes had balances (post-#2725) but `get_token_contract` / `iter_token_contracts`
+    /// omitted SOV until this install path runs.
+    ///
     /// Must be called while `begin_block` is active (executor block-0 apply/replay).
+    /// `put_token_contract` returns `NoActiveTransaction` otherwise.
     pub fn project_chain_bootstrap_to_store(
         &self,
         store: &dyn crate::storage::BlockchainStore,
@@ -724,6 +731,10 @@ impl GenesisConfig {
     }
 
     /// Install the SOV native token contract metadata in sled if missing.
+    ///
+    /// Idempotent within an open block transaction: uses batch-aware
+    /// `get_token_contract` (CR #2658) so a second call in the same `begin_block`
+    /// returns `Ok(false)` after the first install.
     fn ensure_sov_native_contract_in_store(
         &self,
         store: &dyn crate::storage::BlockchainStore,

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1480,6 +1480,24 @@ impl BlockchainStore for SledStore {
 
     fn get_token_contract(&self, id: &TokenId) -> StorageResult<Option<TokenContract>> {
         let key = keys::token_contract_key(id);
+
+        // Write-through read (CR #2658): staged puts are visible within the open block
+        // batch so genesis bootstrap and multi-step applies observe their own writes.
+        {
+            let batch_guard = self.tx_batch.lock().unwrap();
+            if let Some(ref batch) = *batch_guard {
+                if let Some(staged) = batch.tree_lookup(TREE_TOKEN_CONTRACTS, key.as_ref()) {
+                    return match staged {
+                        Some(bytes) => {
+                            let contract: TokenContract = Self::deserialize(&bytes)?;
+                            Ok(Some(contract))
+                        }
+                        None => Ok(None),
+                    };
+                }
+            }
+        }
+
         match self.token_contracts.get(key) {
             Ok(Some(bytes)) => {
                 let contract: TokenContract = Self::deserialize(&bytes)?;


### PR DESCRIPTION
## Summary

Implements **GENESIS-1** ([#2729](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2729)) as the first structural step in the [**GENESIS epic** #2727](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2727).

Builds on merged replay fix #2725 by centralizing SOV-native height-0 sled projection instead of ad-hoc `credit_sov_allocations_in_open_transaction` at the call site.

## Changes

- **`GenesisConfig::project_chain_bootstrap_to_store()`** — single SOV-native bootstrap API
  - Installs SOV native token contract shell in sled
  - Credits `[allocations.sov_balances]` idempotently
  - Returns `ChainBootstrapOutcome`
- **Executor block-0** calls unified bootstrap; CBE block-0 seed left in place but marked **deprecated** (removal tracked in GENESIS-6 / #2734)
- **`docs/arch/genesis-bootstrap-surface.md`** — genesis vs on-chain tx boundary (GENESIS-0 / #2728)
- **`state-unification.md`** — tracker points at GENESIS epic #2727

## Token model (documented)

- **SOV** — sole native token; only token type in h=0 projection
- **CBE** — DAO token; curve params belong in contract state (GENESIS-6), not genesis.toml

## Tests

- `test_genesis_installs_sov_native_contract_in_sled`
- `test_genesis_bootstrap_skips_duplicate_sov_balances_in_block_tx`
- Existing genesis SOV + sync tests pass (`cargo test -p lib-blockchain --lib test_genesis`)

## Out of scope (follow-up issues)

- GENESIS-2 — g4 replay acceptance gate (#2730)
- GENESIS-6 — CBE DAO contract founding path (#2734)
- GENESIS-7 — delete seed-sled / legacy writers (#2735)

Closes #2729