### PR TITLE
GENESIS-2: g4 replay acceptance gate — wipe sled parity (#2730)

### DIFF
--- a/docs/arch/genesis-bootstrap-surface.md
+++ b/docs/arch/genesis-bootstrap-surface.md
@@ -97,6 +97,52 @@ After wipe + replay to height `H`:
 3. BUBL treasury from `TokenCreation` replay if deployed before `H`
 4. No `Insufficient token balance` in executor at g4 checkpoint (~74010)
 
+### CI gate (synthetic)
+
+```bash
+./scripts/validate-genesis-replay-gate.sh
+```
+
+Runs `lib-blockchain/tests/g4_replay_acceptance_tests.rs`:
+
+- `test_genesis_bootstrap_checkpoint_balances` — SOV contract shell, ≥3 genesis `sov_balances`, CBE 20B treasury after block-0 bootstrap
+- `test_genesis_bootstrap_wipe_replay_parity` — live import → export → fresh sled → `import_blocks` (genesis bootstrap path); asserts SOV sample wallets + CBE treasury parity
+
+Failures print `token_id`, `address`, `have`, `need` via `common/replay_gate.rs`.
+
+### Manual g4 fixture (≥74010)
+
+1. On a live validator with sled, export blocks `0..=H` (bincode `Vec<Block>`):
+
+   ```ignore
+   // ChainSync::export_blocks(0, H) on the node store → write blocks.bin
+   ```
+
+2. Capture checkpoint snapshot JSON (`ReplayCheckpointSnapshot` in `lib-blockchain/tests/common/replay_gate.rs`):
+
+   ```json
+   {
+     "checkpoint_height": 74010,
+     "sov_wallets": [
+       {"wallet_id": "<hex>", "balance": "<atoms>"}
+     ],
+     "cbe_treasury_balance": "<atoms>",
+     "treasury_sov_balance": "<atoms>",
+     "tolerance_atoms": 0
+   }
+   ```
+
+3. Run the ignored test:
+
+   ```bash
+   export G4_REPLAY_BLOCKS_PATH=/path/to/blocks.bin
+   export G4_REPLAY_SNAPSHOT_PATH=/path/to/checkpoint.json
+   cargo test -p lib-blockchain --test g4_replay_acceptance_tests \
+     test_g4_checkpoint_replay_acceptance -- --ignored --nocapture
+   ```
+
+Run this gate before testnet deploy after genesis/replay changes; required before GENESIS-7 (delete seed-sled).
+
 ---
 
 ## 7. Implementation order

--- a/docs/arch/genesis-bootstrap-surface.md
+++ b/docs/arch/genesis-bootstrap-surface.md
@@ -97,51 +97,45 @@ After wipe + replay to height `H`:
 3. BUBL treasury from `TokenCreation` replay if deployed before `H`
 4. No `Insufficient token balance` in executor at g4 checkpoint (~74010)
 
-### CI gate (synthetic)
+### CI gate (synthetic — does not replace g4 fixture)
 
 ```bash
 ./scripts/validate-genesis-replay-gate.sh
 ```
 
-Runs `lib-blockchain/tests/g4_replay_acceptance_tests.rs`:
+Regression-tests replay **mechanics** on a short synthetic chain. A green CI badge does **not** prove empirical g4 parity at 74k+.
 
-- `test_genesis_bootstrap_checkpoint_balances` — SOV contract shell, ≥3 genesis `sov_balances`, CBE 20B treasury after block-0 bootstrap
-- `test_genesis_bootstrap_wipe_replay_parity` — live import → export → fresh sled → `import_blocks` (genesis bootstrap path); asserts SOV sample wallets + CBE treasury parity
+| Test | Scope |
+|------|-------|
+| `test_genesis_bootstrap_checkpoint_balances` | Block-0 SOV shell, ≥3 `sov_balances`, legacy CBE 20B treasury |
+| `test_sov_native_wipe_replay_parity` | SOV transfers — #2725/#2741 fix class |
+| `test_dao_token_creation_wipe_replay_parity` | `TokenCreation` + custom-token transfer (BUBL class) |
 
 Failures print `token_id`, `address`, `have`, `need` via `common/replay_gate.rs`.
 
-### Manual g4 fixture (≥74010)
+**Who runs CI:** every PR touching `lib-blockchain` execution/sync/genesis (CI or `./scripts/validate-genesis-replay-gate.sh` locally).
 
-1. On a live validator with sled, export blocks `0..=H` (bincode `Vec<Block>`):
+### Manual g4 fixture (≥ `G4_CHECKPOINT_HEIGHT_FLOOR` = 74_010)
 
-   ```ignore
-   // ChainSync::export_blocks(0, H) on the node store → write blocks.bin
-   ```
+Empirical gate for the live chain shape. **Who:** testnet maintainer / validator operator with sled SSH access. **When:** before each testnet binary deploy that touches genesis, replay, or executor paths; mandatory before GENESIS-7 (delete seed-sled). **On failure:** block deploy, file issue on [#2727](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2727) / [#2730](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2730) with height + `Insufficient token balance` line (token/address/have/need).
 
-2. Capture checkpoint snapshot JSON (`ReplayCheckpointSnapshot` in `lib-blockchain/tests/common/replay_gate.rs`):
+Export (versioned fixture — `blocks.v1.bin` + `checkpoint.json`):
 
-   ```json
-   {
-     "checkpoint_height": 74010,
-     "sov_wallets": [
-       {"wallet_id": "<hex>", "balance": "<atoms>"}
-     ],
-     "cbe_treasury_balance": "<atoms>",
-     "treasury_sov_balance": "<atoms>",
-     "tolerance_atoms": 0
-   }
-   ```
+```bash
+cargo run -p tools --bin export_replay_fixture -- \
+  /opt/zhtp/data/testnet/sled /tmp/g4-fixture --to-height 74010
+```
 
-3. Run the ignored test:
+Replay:
 
-   ```bash
-   export G4_REPLAY_BLOCKS_PATH=/path/to/blocks.bin
-   export G4_REPLAY_SNAPSHOT_PATH=/path/to/checkpoint.json
-   cargo test -p lib-blockchain --test g4_replay_acceptance_tests \
-     test_g4_checkpoint_replay_acceptance -- --ignored --nocapture
-   ```
+```bash
+export G4_REPLAY_BLOCKS_PATH=/tmp/g4-fixture/blocks.v1.bin
+export G4_REPLAY_SNAPSHOT_PATH=/tmp/g4-fixture/checkpoint.json
+cargo test -p lib-blockchain --test g4_replay_acceptance_tests \
+  test_g4_checkpoint_replay_acceptance -- --ignored --nocapture
+```
 
-Run this gate before testnet deploy after genesis/replay changes; required before GENESIS-7 (delete seed-sled).
+Large chains: use `--to-height` to cap memory (full `export_all_blocks` on 177k+ blocks materialises the window). Bump `REPLAY_BLOCKS_FIXTURE_VERSION` if the wrapper layout changes.
 
 ---
 

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -30,8 +30,12 @@
 //! snapshot_manager.restore(&snapshot_id)?;
 //! ```
 
+pub mod replay_fixture;
 pub mod snapshot;
 
+pub use replay_fixture::{
+    ReplayBlocksFixture, G4_CHECKPOINT_HEIGHT_FLOOR, REPLAY_BLOCKS_FIXTURE_VERSION,
+};
 pub use snapshot::{SnapshotError, SnapshotId, SnapshotInfo, SnapshotManager, SnapshotResult};
 
 use std::sync::Arc;

--- a/lib-blockchain/src/sync/replay_fixture.rs
+++ b/lib-blockchain/src/sync/replay_fixture.rs
@@ -1,0 +1,44 @@
+//! Versioned replay block fixtures for GENESIS-2 manual gates (#2730).
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::block::Block;
+
+/// Fixture format version — bump when `ReplayBlocksFixture` layout changes.
+pub const REPLAY_BLOCKS_FIXTURE_VERSION: u32 = 1;
+
+/// g4 wipe-and-replay first wedged here (Insufficient SOV @ payroll). Floor for manual gates.
+pub const G4_CHECKPOINT_HEIGHT_FLOOR: u64 = 74_010;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayBlocksFixture {
+    pub version: u32,
+    pub exported_to_height: u64,
+    pub blocks: Vec<Block>,
+}
+
+impl ReplayBlocksFixture {
+    pub fn encode(&self) -> Result<Vec<u8>, bincode::Error> {
+        bincode::serialize(self)
+    }
+
+    pub fn decode(data: &[u8]) -> Result<Self, bincode::Error> {
+        bincode::deserialize(data)
+    }
+
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let data = std::fs::read(path)?;
+        Self::decode(&data).map_err(|e| {
+            anyhow::anyhow!(
+                "replay fixture decode failed (version mismatch or corrupt file): {e}"
+            )
+        })
+    }
+
+    pub fn save(&self, path: &Path) -> anyhow::Result<()> {
+        std::fs::write(path, self.encode()?)?;
+        Ok(())
+    }
+}

--- a/lib-blockchain/tests/common/mod.rs
+++ b/lib-blockchain/tests/common/mod.rs
@@ -3,3 +3,4 @@
 pub mod block_builders;
 pub mod crypto_fixtures;
 pub mod oracle_harness;
+pub mod replay_gate;

--- a/lib-blockchain/tests/common/replay_gate.rs
+++ b/lib-blockchain/tests/common/replay_gate.rs
@@ -1,0 +1,208 @@
+//! Helpers for GENESIS-2 g4 replay acceptance gates (#2730).
+//!
+//! Captures balance checkpoints and produces actionable mismatch messages
+//! (`token_id`, `address`, `have`, `need`) when wipe-and-replay diverges.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use lib_blockchain::contracts::bonding_curve::canonical::GENESIS_TREASURY_ALLOCATION;
+use lib_blockchain::contracts::utils::generate_lib_token_id;
+use lib_blockchain::genesis::GenesisConfig;
+use lib_blockchain::storage::{Address, BlockchainStore, TokenId};
+use lib_blockchain::Blockchain;
+use serde::{Deserialize, Serialize};
+
+/// Balance checkpoint used to verify replay parity at a given height.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayCheckpointSnapshot {
+    pub checkpoint_height: u64,
+    pub sov_wallets: Vec<SovWalletBalance>,
+    pub cbe_treasury_balance: u128,
+    pub treasury_sov_balance: u128,
+    /// Allowed absolute drift per balance (testnet coinbase / rounding tolerance).
+    #[serde(default)]
+    pub tolerance_atoms: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SovWalletBalance {
+    pub wallet_id: String,
+    pub balance: u128,
+}
+
+impl ReplayCheckpointSnapshot {
+    pub fn from_store_at_height(
+        store: &dyn BlockchainStore,
+        checkpoint_height: u64,
+        sov_wallet_ids: &[[u8; 32]],
+    ) -> Self {
+        let sov_token = TokenId::new(generate_lib_token_id());
+        let cbe_token = TokenId::new(Blockchain::derive_cbe_token_id_pub());
+        let treasury_addr = Address::new([0u8; 32]); // default fee_sink / CBE treasury
+
+        let sov_wallets = sov_wallet_ids
+            .iter()
+            .map(|wallet_id| {
+                let balance = store
+                    .get_token_balance(&sov_token, &Address::new(*wallet_id))
+                    .unwrap_or(0);
+                SovWalletBalance {
+                    wallet_id: hex::encode(wallet_id),
+                    balance,
+                }
+            })
+            .collect();
+
+        Self {
+            checkpoint_height,
+            sov_wallets,
+            cbe_treasury_balance: store
+                .get_token_balance(&cbe_token, &treasury_addr)
+                .unwrap_or(0),
+            treasury_sov_balance: store
+                .get_token_balance(&sov_token, &treasury_addr)
+                .unwrap_or(0),
+            tolerance_atoms: 0,
+        }
+    }
+
+    pub fn load_json(path: &Path) -> anyhow::Result<Self> {
+        let data = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&data)?)
+    }
+
+    pub fn assert_matches_store(
+        &self,
+        store: &dyn BlockchainStore,
+        label: &str,
+    ) -> Result<(), String> {
+        let live = Self::from_store_at_height(
+            store,
+            self.checkpoint_height,
+            &self
+                .sov_wallets
+                .iter()
+                .map(|w| {
+                    let mut arr = [0u8; 32];
+                    let bytes = hex::decode(&w.wallet_id).map_err(|e| e.to_string())?;
+                    if bytes.len() != 32 {
+                        return Err(format!(
+                            "invalid wallet_id length in snapshot: {}",
+                            w.wallet_id
+                        ));
+                    }
+                    arr.copy_from_slice(&bytes);
+                    Ok(arr)
+                })
+                .collect::<Result<Vec<_>, String>>()?,
+        );
+
+        compare_snapshots(label, self, &live)
+    }
+}
+
+pub fn first_n_genesis_sov_wallets(n: usize) -> Vec<[u8; 32]> {
+    let cfg = GenesisConfig::from_embedded().expect("embedded genesis");
+    let entries = cfg.sov_allocation_entries().expect("sov entries");
+    assert!(
+        entries.len() >= n,
+        "embedded genesis must contain at least {n} sov_balances entries (have {})",
+        entries.len()
+    );
+    entries.into_iter().take(n).map(|(id, _)| id).collect()
+}
+
+pub fn compare_snapshots(
+    label: &str,
+    expected: &ReplayCheckpointSnapshot,
+    actual: &ReplayCheckpointSnapshot,
+) -> Result<(), String> {
+    let tol = expected.tolerance_atoms;
+
+    if expected.checkpoint_height != actual.checkpoint_height {
+        return Err(format!(
+            "{label}: checkpoint height mismatch (expected {}, got {})",
+            expected.checkpoint_height, actual.checkpoint_height
+        ));
+    }
+
+    if expected.sov_wallets.len() != actual.sov_wallets.len() {
+        return Err(format!(
+            "{label}: SOV wallet sample count mismatch (expected {}, got {})",
+            expected.sov_wallets.len(),
+            actual.sov_wallets.len()
+        ));
+    }
+
+    for (exp, act) in expected.sov_wallets.iter().zip(actual.sov_wallets.iter()) {
+        if exp.wallet_id != act.wallet_id {
+            return Err(format!(
+                "{label}: SOV wallet ordering mismatch (expected {}, got {})",
+                exp.wallet_id, act.wallet_id
+            ));
+        }
+        if !within_tolerance(exp.balance, act.balance, tol) {
+            let sov_token = hex::encode(generate_lib_token_id());
+            return Err(format!(
+                "{label}: SOV balance mismatch at height {} — token_id={sov_token} \
+                 address={} have={} need={} (tolerance={tol})",
+                expected.checkpoint_height, exp.wallet_id, act.balance, exp.balance
+            ));
+        }
+    }
+
+    if !within_tolerance(
+        expected.cbe_treasury_balance,
+        actual.cbe_treasury_balance,
+        tol,
+    ) {
+        let cbe_token = hex::encode(Blockchain::derive_cbe_token_id_pub());
+        return Err(format!(
+            "{label}: CBE DAO treasury mismatch at height {} — token_id={cbe_token} \
+             address={} have={} need={} (tolerance={tol}); \
+             expected genesis allocation={GENESIS_TREASURY_ALLOCATION}",
+            expected.checkpoint_height,
+            hex::encode([0u8; 32]),
+            actual.cbe_treasury_balance,
+            expected.cbe_treasury_balance
+        ));
+    }
+
+    if !within_tolerance(expected.treasury_sov_balance, actual.treasury_sov_balance, tol) {
+        let sov_token = hex::encode(generate_lib_token_id());
+        return Err(format!(
+            "{label}: treasury SOV mismatch at height {} — token_id={sov_token} \
+             address={} have={} need={} (tolerance={tol})",
+            expected.checkpoint_height,
+            hex::encode([0u8; 32]),
+            actual.treasury_sov_balance,
+            expected.treasury_sov_balance
+        ));
+    }
+
+    Ok(())
+}
+
+fn within_tolerance(expected: u128, actual: u128, tolerance: u128) -> bool {
+    if expected >= actual {
+        expected - actual <= tolerance
+    } else {
+        actual - expected <= tolerance
+    }
+}
+
+/// Load a bincode-serialised `Vec<Block>` fixture exported from a live node sled.
+pub fn load_blocks_fixture(path: &Path) -> anyhow::Result<Vec<lib_blockchain::block::Block>> {
+    let data = std::fs::read(path)?;
+    bincode::deserialize(&data).map_err(|e| anyhow::anyhow!("block fixture decode failed: {e}"))
+}
+
+pub fn open_fresh_store(
+    dir: &tempfile::TempDir,
+) -> Arc<dyn BlockchainStore> {
+    Arc::new(
+        lib_blockchain::storage::SledStore::open(dir.path())
+            .expect("open test sled store"),
+    )
+}

--- a/lib-blockchain/tests/common/replay_gate.rs
+++ b/lib-blockchain/tests/common/replay_gate.rs
@@ -1,17 +1,24 @@
-//! Helpers for GENESIS-2 g4 replay acceptance gates (#2730).
+//! Helpers for GENESIS-2 replay acceptance gates (#2730).
 //!
-//! Captures balance checkpoints and produces actionable mismatch messages
-//! (`token_id`, `address`, `have`, `need`) when wipe-and-replay diverges.
+//! **Test-only module.** `compare_snapshots` returns `Result<(), String>` deliberately —
+//! these helpers are for integration tests, not production runtime self-checks.
 
 use std::path::Path;
 use std::sync::Arc;
 
 use lib_blockchain::contracts::bonding_curve::canonical::GENESIS_TREASURY_ALLOCATION;
-use lib_blockchain::contracts::utils::generate_lib_token_id;
+use lib_blockchain::contracts::utils::{generate_custom_token_id, generate_lib_token_id};
 use lib_blockchain::genesis::GenesisConfig;
+use lib_blockchain::protocol::ProtocolParams;
 use lib_blockchain::storage::{Address, BlockchainStore, TokenId};
+use lib_blockchain::sync::{G4_CHECKPOINT_HEIGHT_FLOOR, ReplayBlocksFixture};
 use lib_blockchain::Blockchain;
 use serde::{Deserialize, Serialize};
+
+/// Treasury / fee-sink address — same source as executor block-0 CBE seed.
+pub fn cbe_treasury_address() -> Address {
+    *ProtocolParams::default().fee_sink_address()
+}
 
 /// Balance checkpoint used to verify replay parity at a given height.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -20,6 +27,9 @@ pub struct ReplayCheckpointSnapshot {
     pub sov_wallets: Vec<SovWalletBalance>,
     pub cbe_treasury_balance: u128,
     pub treasury_sov_balance: u128,
+    /// DAO tokens (BUBL class) — balances after `TokenCreation` + transfers.
+    #[serde(default)]
+    pub dao_tokens: Vec<DaoTokenBalance>,
     /// Allowed absolute drift per balance (testnet coinbase / rounding tolerance).
     #[serde(default)]
     pub tolerance_atoms: u128,
@@ -31,15 +41,24 @@ pub struct SovWalletBalance {
     pub balance: u128,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaoTokenBalance {
+    pub token_id: String,
+    pub symbol: String,
+    pub holder_wallet_id: String,
+    pub balance: u128,
+}
+
 impl ReplayCheckpointSnapshot {
     pub fn from_store_at_height(
         store: &dyn BlockchainStore,
         checkpoint_height: u64,
         sov_wallet_ids: &[[u8; 32]],
+        dao_tokens: &[DaoTokenExpectation],
     ) -> Self {
         let sov_token = TokenId::new(generate_lib_token_id());
         let cbe_token = TokenId::new(Blockchain::derive_cbe_token_id_pub());
-        let treasury_addr = Address::new([0u8; 32]); // default fee_sink / CBE treasury
+        let treasury_addr = cbe_treasury_address();
 
         let sov_wallets = sov_wallet_ids
             .iter()
@@ -54,6 +73,22 @@ impl ReplayCheckpointSnapshot {
             })
             .collect();
 
+        let dao_token_balances = dao_tokens
+            .iter()
+            .map(|expect| {
+                let token_id = TokenId::new(expect.token_id);
+                let balance = store
+                    .get_token_balance(&token_id, &Address::new(expect.holder_wallet_id))
+                    .unwrap_or(0);
+                DaoTokenBalance {
+                    token_id: hex::encode(expect.token_id),
+                    symbol: expect.symbol.to_string(),
+                    holder_wallet_id: hex::encode(expect.holder_wallet_id),
+                    balance,
+                }
+            })
+            .collect();
+
         Self {
             checkpoint_height,
             sov_wallets,
@@ -63,6 +98,7 @@ impl ReplayCheckpointSnapshot {
             treasury_sov_balance: store
                 .get_token_balance(&sov_token, &treasury_addr)
                 .unwrap_or(0),
+            dao_tokens: dao_token_balances,
             tolerance_atoms: 0,
         }
     }
@@ -77,29 +113,59 @@ impl ReplayCheckpointSnapshot {
         store: &dyn BlockchainStore,
         label: &str,
     ) -> Result<(), String> {
+        let dao_expectations: Vec<DaoTokenExpectation> = self
+            .dao_tokens
+            .iter()
+            .map(|d| {
+                let mut token_id = [0u8; 32];
+                let mut holder = [0u8; 32];
+                let tid = hex::decode(&d.token_id).map_err(|e| e.to_string())?;
+                let hid = hex::decode(&d.holder_wallet_id).map_err(|e| e.to_string())?;
+                if tid.len() != 32 || hid.len() != 32 {
+                    return Err("invalid hex length in dao_tokens snapshot".to_string());
+                }
+                token_id.copy_from_slice(&tid);
+                holder.copy_from_slice(&hid);
+                Ok(DaoTokenExpectation {
+                    token_id,
+                    symbol: d.symbol.clone(),
+                    holder_wallet_id: holder,
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+
+        let sov_ids: Vec<[u8; 32]> = self
+            .sov_wallets
+            .iter()
+            .map(|w| {
+                let mut arr = [0u8; 32];
+                let bytes = hex::decode(&w.wallet_id).map_err(|e| e.to_string())?;
+                if bytes.len() != 32 {
+                    return Err(format!(
+                        "invalid wallet_id length in snapshot: {}",
+                        w.wallet_id
+                    ));
+                }
+                arr.copy_from_slice(&bytes);
+                Ok(arr)
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+
         let live = Self::from_store_at_height(
             store,
             self.checkpoint_height,
-            &self
-                .sov_wallets
-                .iter()
-                .map(|w| {
-                    let mut arr = [0u8; 32];
-                    let bytes = hex::decode(&w.wallet_id).map_err(|e| e.to_string())?;
-                    if bytes.len() != 32 {
-                        return Err(format!(
-                            "invalid wallet_id length in snapshot: {}",
-                            w.wallet_id
-                        ));
-                    }
-                    arr.copy_from_slice(&bytes);
-                    Ok(arr)
-                })
-                .collect::<Result<Vec<_>, String>>()?,
+            &sov_ids,
+            &dao_expectations,
         );
 
         compare_snapshots(label, self, &live)
     }
+}
+
+pub struct DaoTokenExpectation {
+    pub token_id: [u8; 32],
+    pub symbol: String,
+    pub holder_wallet_id: [u8; 32],
 }
 
 pub fn first_n_genesis_sov_wallets(n: usize) -> Vec<[u8; 32]> {
@@ -113,12 +179,17 @@ pub fn first_n_genesis_sov_wallets(n: usize) -> Vec<[u8; 32]> {
     entries.into_iter().take(n).map(|(id, _)| id).collect()
 }
 
+pub fn bubl_like_token_id() -> [u8; 32] {
+    generate_custom_token_id("Bubble", "BUBL")
+}
+
 pub fn compare_snapshots(
     label: &str,
     expected: &ReplayCheckpointSnapshot,
     actual: &ReplayCheckpointSnapshot,
 ) -> Result<(), String> {
     let tol = expected.tolerance_atoms;
+    let treasury_hex = hex::encode(cbe_treasury_address().as_bytes());
 
     if expected.checkpoint_height != actual.checkpoint_height {
         return Err(format!(
@@ -152,6 +223,37 @@ pub fn compare_snapshots(
         }
     }
 
+    if expected.dao_tokens.len() != actual.dao_tokens.len() {
+        return Err(format!(
+            "{label}: DAO token sample count mismatch (expected {}, got {})",
+            expected.dao_tokens.len(),
+            actual.dao_tokens.len()
+        ));
+    }
+
+    for (exp, act) in expected.dao_tokens.iter().zip(actual.dao_tokens.iter()) {
+        if exp.token_id != act.token_id || exp.holder_wallet_id != act.holder_wallet_id {
+            return Err(format!(
+                "{label}: DAO token sample key mismatch (expected {}@{}, got {}@{})",
+                exp.token_id, exp.holder_wallet_id, act.token_id, act.holder_wallet_id
+            ));
+        }
+        if !within_tolerance(exp.balance, act.balance, tol) {
+            return Err(format!(
+                "{label}: DAO token balance mismatch at height {} — token_id={} symbol={} \
+                 address={} have={} need={} (tolerance={tol})",
+                expected.checkpoint_height,
+                exp.token_id,
+                exp.symbol,
+                exp.holder_wallet_id,
+                act.balance,
+                exp.balance
+            ));
+        }
+    }
+
+    // TODO(GENESIS-6, #2734): when block-0 CBE seed is removed, expect treasury from
+    // founding TokenCreation replay instead of GENESIS_TREASURY_ALLOCATION.
     if !within_tolerance(
         expected.cbe_treasury_balance,
         actual.cbe_treasury_balance,
@@ -160,10 +262,9 @@ pub fn compare_snapshots(
         let cbe_token = hex::encode(Blockchain::derive_cbe_token_id_pub());
         return Err(format!(
             "{label}: CBE DAO treasury mismatch at height {} — token_id={cbe_token} \
-             address={} have={} need={} (tolerance={tol}); \
-             expected genesis allocation={GENESIS_TREASURY_ALLOCATION}",
+             address={treasury_hex} have={} need={} (tolerance={tol}); \
+             legacy genesis allocation={GENESIS_TREASURY_ALLOCATION}",
             expected.checkpoint_height,
-            hex::encode([0u8; 32]),
             actual.cbe_treasury_balance,
             expected.cbe_treasury_balance
         ));
@@ -173,9 +274,8 @@ pub fn compare_snapshots(
         let sov_token = hex::encode(generate_lib_token_id());
         return Err(format!(
             "{label}: treasury SOV mismatch at height {} — token_id={sov_token} \
-             address={} have={} need={} (tolerance={tol})",
+             address={treasury_hex} have={} need={} (tolerance={tol})",
             expected.checkpoint_height,
-            hex::encode([0u8; 32]),
             actual.treasury_sov_balance,
             expected.treasury_sov_balance
         ));
@@ -184,7 +284,7 @@ pub fn compare_snapshots(
     Ok(())
 }
 
-fn within_tolerance(expected: u128, actual: u128, tolerance: u128) -> bool {
+pub fn within_tolerance(expected: u128, actual: u128, tolerance: u128) -> bool {
     if expected >= actual {
         expected - actual <= tolerance
     } else {
@@ -192,17 +292,66 @@ fn within_tolerance(expected: u128, actual: u128, tolerance: u128) -> bool {
     }
 }
 
-/// Load a bincode-serialised `Vec<Block>` fixture exported from a live node sled.
+/// Load a versioned replay fixture (`blocks.v1.bin`) or legacy raw `Vec<Block>` bincode.
 pub fn load_blocks_fixture(path: &Path) -> anyhow::Result<Vec<lib_blockchain::block::Block>> {
     let data = std::fs::read(path)?;
-    bincode::deserialize(&data).map_err(|e| anyhow::anyhow!("block fixture decode failed: {e}"))
+    if let Ok(fixture) = ReplayBlocksFixture::decode(&data) {
+        anyhow::ensure!(
+            fixture.version == lib_blockchain::sync::REPLAY_BLOCKS_FIXTURE_VERSION,
+            "unsupported fixture version {} (expected {})",
+            fixture.version,
+            lib_blockchain::sync::REPLAY_BLOCKS_FIXTURE_VERSION
+        );
+        return Ok(fixture.blocks);
+    }
+    // Legacy: unversioned Vec<Block> — may break across bincode layout changes.
+    bincode::deserialize(&data)
+        .map_err(|e| anyhow::anyhow!("block fixture decode failed (try re-exporting v1): {e}"))
 }
 
-pub fn open_fresh_store(
-    dir: &tempfile::TempDir,
-) -> Arc<dyn BlockchainStore> {
+pub fn open_fresh_store(dir: &tempfile::TempDir) -> Arc<dyn BlockchainStore> {
     Arc::new(
-        lib_blockchain::storage::SledStore::open(dir.path())
-            .expect("open test sled store"),
+        lib_blockchain::storage::SledStore::open(dir.path()).expect("open test sled store"),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn within_tolerance_exact_and_drift() {
+        assert!(within_tolerance(100, 100, 0));
+        assert!(within_tolerance(100, 98, 2));
+        assert!(within_tolerance(98, 100, 2));
+        assert!(!within_tolerance(100, 97, 2));
+        assert!(!within_tolerance(97, 100, 2));
+    }
+
+    #[test]
+    fn compare_snapshots_respects_tolerance_atoms() {
+        let expected = ReplayCheckpointSnapshot {
+            checkpoint_height: 1,
+            sov_wallets: vec![SovWalletBalance {
+                wallet_id: hex::encode([1u8; 32]),
+                balance: 1_000,
+            }],
+            cbe_treasury_balance: 500,
+            treasury_sov_balance: 0,
+            dao_tokens: vec![],
+            tolerance_atoms: 5,
+        };
+        let mut actual = expected.clone();
+        actual.sov_wallets[0].balance = 996;
+        compare_snapshots("tol-ok", &expected, &actual).expect("within tolerance");
+
+        actual.sov_wallets[0].balance = 994;
+        compare_snapshots("tol-fail", &expected, &actual)
+            .expect_err("outside tolerance must fail");
+    }
+
+    #[test]
+    fn g4_floor_documents_incident_height() {
+        assert_eq!(G4_CHECKPOINT_HEIGHT_FLOOR, 74_010);
+    }
 }

--- a/lib-blockchain/tests/g4_replay_acceptance_tests.rs
+++ b/lib-blockchain/tests/g4_replay_acceptance_tests.rs
@@ -1,20 +1,17 @@
-//! GENESIS-2 (#2730): g4 replay acceptance gate.
+//! GENESIS-2 (#2730): replay acceptance gates.
 //!
-//! Proves wipe-and-replay via `ChainSync::import_blocks` (genesis bootstrap path)
-//! matches incremental live state for SOV-native balances and CBE DAO treasury.
+//! ## CI scope (honest)
+//! - `test_sov_native_wipe_replay_parity` — SOV genesis bootstrap + SOV transfers (#2725/#2741 fix class)
+//! - `test_dao_token_creation_wipe_replay_parity` — `TokenCreation` + custom-token transfer (BUBL class)
 //!
-//! # CI (always on)
-//! `test_genesis_bootstrap_wipe_replay_parity` — synthetic chain with genesis
-//! SOV activity + token transfers; export → fresh sled → re-import.
+//! These do **not** replace the manual g4 fixture at ≥74k — they regression-test replay mechanics
+//! that g4's failure class depends on. Empirical g4 parity requires `test_g4_checkpoint_replay_acceptance`.
 //!
-//! # Manual g4 fixture (ignored)
-//! `test_g4_checkpoint_replay_acceptance` — replays a bincode block window
-//! exported from a live validator and asserts against a JSON balance snapshot.
-//!
+//! ## Manual g4 fixture
 //! ```bash
-//! export G4_REPLAY_BLOCKS_PATH=/path/to/blocks.bin
-//! export G4_REPLAY_SNAPSHOT_PATH=/path/to/checkpoint.json
-//! cargo test -p lib-blockchain --test g4_replay_acceptance_tests \
+//! cargo run -p tools --bin export_replay_fixture -- /opt/zhtp/data/testnet/sled /tmp/g4 --to-height 74010
+//! G4_REPLAY_BLOCKS_PATH=/tmp/g4/blocks.v1.bin G4_REPLAY_SNAPSHOT_PATH=/tmp/g4/checkpoint.json \
+//!   cargo test -p lib-blockchain --test g4_replay_acceptance_tests \
 //!   test_g4_checkpoint_replay_acceptance -- --ignored --nocapture
 //! ```
 
@@ -24,8 +21,11 @@ use lib_blockchain::contracts::bonding_curve::canonical::GENESIS_TREASURY_ALLOCA
 use lib_blockchain::contracts::utils::generate_lib_token_id;
 use lib_blockchain::genesis::GenesisConfig;
 use lib_blockchain::storage::{Address, TokenId};
-use lib_blockchain::sync::ChainSync;
-use lib_blockchain::transaction::{TokenTransferData, Transaction, TransactionPayload};
+use lib_blockchain::sync::G4_CHECKPOINT_HEIGHT_FLOOR;
+use lib_blockchain::transaction::{
+    token_creation::TokenCreationPayloadV1, TokenTransferData, Transaction, TransactionPayload,
+};
+use lib_blockchain::transaction::DEFAULT_TOKEN_CREATION_FEE;
 use lib_blockchain::types::TransactionType;
 use lib_blockchain::Blockchain;
 use tempfile::TempDir;
@@ -34,16 +34,13 @@ mod common;
 use common::block_builders::{block_at_height_with_txs, genesis_block};
 use common::crypto_fixtures::dummy_signature;
 use common::replay_gate::{
-    compare_snapshots, first_n_genesis_sov_wallets, load_blocks_fixture, open_fresh_store,
-    ReplayCheckpointSnapshot,
+    bubl_like_token_id, cbe_treasury_address, compare_snapshots, first_n_genesis_sov_wallets,
+    load_blocks_fixture, open_fresh_store, DaoTokenExpectation, ReplayCheckpointSnapshot,
 };
 
-fn create_token_transfer_tx(
-    from: [u8; 32],
-    to: [u8; 32],
-    amount: u128,
-    nonce: u64,
-) -> Transaction {
+use lib_blockchain::sync::ChainSync;
+
+fn create_sov_transfer_tx(from: [u8; 32], to: [u8; 32], amount: u128, nonce: u64) -> Transaction {
     Transaction {
         version: 1,
         chain_id: 0x03,
@@ -54,7 +51,7 @@ fn create_token_transfer_tx(
         signature: dummy_signature(),
         memo: vec![],
         payload: TransactionPayload::TokenTransfer(TokenTransferData {
-            token_id: [0u8; 32], // executor maps to canonical SOV
+            token_id: [0u8; 32],
             from,
             to,
             amount,
@@ -63,78 +60,189 @@ fn create_token_transfer_tx(
     }
 }
 
-/// Build a short chain: genesis bootstrap + SOV transfers among genesis wallets.
+fn create_token_creation_tx(
+    creator_key_id: [u8; 32],
+    treasury_recipient: [u8; 32],
+) -> Transaction {
+    let payload = TokenCreationPayloadV1 {
+        name: "Bubble".to_string(),
+        symbol: "BUBL".to_string(),
+        initial_supply: 1_000_000,
+        decimals: 8,
+        treasury_allocation_bps: 2_000,
+        treasury_recipient,
+    };
+    let mut sig = dummy_signature();
+    sig.public_key.key_id = creator_key_id;
+    Transaction {
+        version: 2,
+        chain_id: 0x03,
+        transaction_type: TransactionType::TokenCreation,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0, // subsidised — avoids coupling to SOV fee debit in this gate
+        signature: sig,
+        memo: payload.encode_memo().expect("token creation memo"),
+        payload: TransactionPayload::None,
+    }
+}
+
+fn create_dao_token_transfer_tx(
+    token_id: [u8; 32],
+    from: [u8; 32],
+    to: [u8; 32],
+    amount: u128,
+    nonce: u64,
+) -> Transaction {
+    let mut sig = dummy_signature();
+    sig.public_key.key_id = from;
+    Transaction {
+        version: 2,
+        chain_id: 0x03,
+        transaction_type: TransactionType::TokenTransfer,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: sig,
+        memo: vec![],
+        payload: TransactionPayload::TokenTransfer(TokenTransferData {
+            token_id,
+            from,
+            to,
+            amount,
+            nonce,
+        }),
+    }
+}
+
 fn build_sov_activity_chain() -> Vec<lib_blockchain::block::Block> {
     let wallets = first_n_genesis_sov_wallets(3);
     let genesis = genesis_block();
     let mut blocks = vec![genesis.clone()];
     let mut prev = genesis.header.block_hash;
-
     let mut sender_nonce = [0u64; 3];
+
     for height in 1..=6 {
         let from_idx = (height as usize - 1) % wallets.len();
         let to_idx = height as usize % wallets.len();
-        let from = wallets[from_idx];
-        let to = wallets[to_idx];
         let nonce = sender_nonce[from_idx];
         sender_nonce[from_idx] += 1;
-        let tx = create_token_transfer_tx(from, to, 50, nonce);
+        let tx = create_sov_transfer_tx(wallets[from_idx], wallets[to_idx], 50, nonce);
         let block = block_at_height_with_txs(height, prev, vec![tx]);
         blocks.push(block.clone());
         prev = block.header.block_hash;
     }
-
     blocks
 }
 
-/// GENESIS-2 CI gate: genesis bootstrap wipe-and-replay parity.
-#[test]
-fn test_genesis_bootstrap_wipe_replay_parity() {
+fn build_dao_token_activity_chain() -> (Vec<lib_blockchain::block::Block>, DaoTokenExpectation) {
+    let wallets = first_n_genesis_sov_wallets(3);
+    let creator = wallets[0];
+    let treasury = wallets[1];
+    let recipient = wallets[2];
+    let token_id = bubl_like_token_id();
+
+    let genesis = genesis_block();
+    let block1 = block_at_height_with_txs(
+        1,
+        genesis.header.block_hash,
+        vec![create_token_creation_tx(creator, treasury)],
+    );
+    // Creator holds 80% (800_000); transfer 10_000 to recipient.
+    let block2 = block_at_height_with_txs(
+        2,
+        block1.header.block_hash,
+        vec![create_dao_token_transfer_tx(token_id, creator, recipient, 10_000, 0)],
+    );
+
+    let expect = DaoTokenExpectation {
+        token_id,
+        symbol: "BUBL".to_string(),
+        holder_wallet_id: recipient,
+    };
+
+    (vec![genesis, block1, block2], expect)
+}
+
+fn run_wipe_replay_parity(
+    blocks: Vec<lib_blockchain::block::Block>,
+    checkpoint_height: u64,
+    sample_wallets: &[[u8; 32]],
+    dao_expectations: &[DaoTokenExpectation],
+) {
     let live_dir = TempDir::new().expect("live tempdir");
     let live_store = open_fresh_store(&live_dir);
     let live_sync = ChainSync::new(Arc::clone(&live_store));
 
-    let blocks = build_sov_activity_chain();
-    let import = live_sync
+    live_sync
         .import_blocks(blocks)
         .expect("live import must not hit Insufficient token balance");
-    assert_eq!(import.final_height, Some(6));
-
-    let sample_wallets = first_n_genesis_sov_wallets(3);
-    let reference = ReplayCheckpointSnapshot::from_store_at_height(&*live_store, 6, &sample_wallets);
-
-    // CBE treasury must be present after genesis block-0 seed (legacy path until GENESIS-6).
     assert_eq!(
-        reference.cbe_treasury_balance, GENESIS_TREASURY_ALLOCATION,
-        "CBE DAO treasury must equal 20B atoms after genesis replay seed"
-    );
-    assert!(
-        reference.sov_wallets.iter().all(|w| w.balance > 0),
-        "all sampled genesis SOV wallets must be non-zero after live import"
+        live_store.latest_height().expect("live height"),
+        checkpoint_height
     );
 
-    let exported = live_sync
-        .export_all_blocks()
-        .expect("export live chain");
+    let reference =
+        ReplayCheckpointSnapshot::from_store_at_height(
+            &*live_store,
+            checkpoint_height,
+            sample_wallets,
+            dao_expectations,
+        );
 
-    // Wipe sled: fresh store, replay from exported blocks (production import path).
+    let exported = live_sync.export_all_blocks().expect("export");
+
     let replay_dir = TempDir::new().expect("replay tempdir");
     let replay_store = open_fresh_store(&replay_dir);
     let replay_sync = ChainSync::new(Arc::clone(&replay_store));
 
-    let replay = replay_sync
+    replay_sync
         .import_blocks(exported)
         .expect("wipe-and-replay must not hit Insufficient token balance");
-    assert_eq!(replay.final_height, Some(6));
 
-    let replayed = ReplayCheckpointSnapshot::from_store_at_height(&*replay_store, 6, &sample_wallets);
+    let replayed = ReplayCheckpointSnapshot::from_store_at_height(
+        &*replay_store,
+        checkpoint_height,
+        sample_wallets,
+        dao_expectations,
+    );
 
     compare_snapshots("wipe-and-replay", &reference, &replayed).expect(
         "replay checkpoint must match live reference — see token_id/address/have/need above",
     );
 }
 
-/// Assert genesis-only bootstrap seeds SOV contract + allocations + CBE treasury.
+/// SOV-native genesis bootstrap + SOV transfer replay parity (#2725 / #2741 fix class).
+#[test]
+fn test_sov_native_wipe_replay_parity() {
+    let sample = first_n_genesis_sov_wallets(3);
+    run_wipe_replay_parity(build_sov_activity_chain(), 6, &sample, &[]);
+}
+
+/// DAO `TokenCreation` + custom-token transfer replay parity (BUBL class — g4-adjacent).
+#[test]
+fn test_dao_token_creation_wipe_replay_parity() {
+    let sample = first_n_genesis_sov_wallets(3);
+    let (blocks, dao_expect) = build_dao_token_activity_chain();
+    run_wipe_replay_parity(blocks, 2, &sample, &[dao_expect]);
+
+    // Post-creation recipient must hold transferred BUBL atoms.
+    let live_dir = TempDir::new().unwrap();
+    let store = open_fresh_store(&live_dir);
+    let sync = ChainSync::new(Arc::clone(&store));
+    let (blocks, dao_expect) = build_dao_token_activity_chain();
+    sync.import_blocks(blocks).unwrap();
+    let token = TokenId::new(dao_expect.token_id);
+    let bal = store
+        .get_token_balance(
+            &token,
+            &Address::new(dao_expect.holder_wallet_id),
+        )
+        .unwrap();
+    assert_eq!(bal, 10_000, "BUBL recipient balance after TokenCreation + transfer");
+}
+
+/// Genesis block-0 only: SOV shell, allocations, legacy CBE treasury seed.
 #[test]
 fn test_genesis_bootstrap_checkpoint_balances() {
     let dir = TempDir::new().expect("tempdir");
@@ -166,8 +274,9 @@ fn test_genesis_bootstrap_checkpoint_balances() {
         );
     }
 
+    // TODO(GENESIS-6, #2734): rewrite when CBE founding tx replaces block-0 seed.
     let cbe_token = TokenId::new(Blockchain::derive_cbe_token_id_pub());
-    let treasury = Address::new([0u8; 32]);
+    let treasury = cbe_treasury_address();
     let cbe_bal = store
         .get_token_balance(&cbe_token, &treasury)
         .expect("read CBE treasury");
@@ -175,31 +284,25 @@ fn test_genesis_bootstrap_checkpoint_balances() {
         cbe_bal, GENESIS_TREASURY_ALLOCATION,
         "CBE DAO treasury after genesis: have={cbe_bal} need={GENESIS_TREASURY_ALLOCATION}"
     );
+
+    // TokenCreation fee constant wired (sanity — not exercised when fee=0).
+    let _ = DEFAULT_TOKEN_CREATION_FEE;
 }
 
-/// Manual g4-class gate: requires fixture paths from a live validator export.
-///
-/// Export blocks (on a node with sled):
-/// ```ignore
-/// // Pseudocode — use ChainSync::export_blocks(0, checkpoint) on the node store
-/// let blocks = sync.export_blocks(0, 74_010)?;
-/// std::fs::write("blocks.bin", bincode::serialize(&blocks)?)?;
-/// ```
-///
-/// Snapshot JSON schema: see `ReplayCheckpointSnapshot` in `common/replay_gate.rs`.
+/// Manual g4 gate — export via `tools/export_replay_fixture`, replay here.
 #[test]
-#[ignore = "manual g4 fixture — set G4_REPLAY_BLOCKS_PATH and G4_REPLAY_SNAPSHOT_PATH"]
+#[ignore = "manual g4 fixture — export with tools/export_replay_fixture, set G4_REPLAY_* env vars"]
 fn test_g4_checkpoint_replay_acceptance() {
     let blocks_path = std::env::var("G4_REPLAY_BLOCKS_PATH")
-        .expect("G4_REPLAY_BLOCKS_PATH must point to bincode Vec<Block> fixture");
+        .expect("G4_REPLAY_BLOCKS_PATH must point to blocks.v1.bin fixture");
     let snapshot_path = std::env::var("G4_REPLAY_SNAPSHOT_PATH")
-        .expect("G4_REPLAY_SNAPSHOT_PATH must point to ReplayCheckpointSnapshot JSON");
+        .expect("G4_REPLAY_SNAPSHOT_PATH must point to checkpoint.json");
 
     let reference =
         ReplayCheckpointSnapshot::load_json(snapshot_path.as_ref()).expect("load snapshot");
     assert!(
-        reference.checkpoint_height >= 74_010,
-        "g4 gate expects checkpoint >= 74010 (got {})",
+        reference.checkpoint_height >= G4_CHECKPOINT_HEIGHT_FLOOR,
+        "g4 gate expects checkpoint >= {G4_CHECKPOINT_HEIGHT_FLOOR} (got {})",
         reference.checkpoint_height
     );
 
@@ -219,21 +322,13 @@ fn test_g4_checkpoint_replay_acceptance() {
     let replay_store = open_fresh_store(&replay_dir);
     let replay_sync = ChainSync::new(Arc::clone(&replay_store));
 
-    replay_sync
-        .import_blocks(blocks)
-        .unwrap_or_else(|e| {
-            panic!(
-                "g4 replay failed before checkpoint {}: {e} \
-                 (look for Insufficient token balance — token/address/have/need in error)",
-                reference.checkpoint_height
-            );
-        });
-
-    assert_eq!(
-        replay_store.latest_height().expect("replay height"),
-        last,
-        "replay must reach fixture tip"
-    );
+    replay_sync.import_blocks(blocks).unwrap_or_else(|e| {
+        panic!(
+            "g4 replay failed before checkpoint {}: {e} \
+             (look for Insufficient token balance — token/address/have/need in error)",
+            reference.checkpoint_height
+        );
+    });
 
     reference
         .assert_matches_store(&*replay_store, "g4-checkpoint")

--- a/lib-blockchain/tests/g4_replay_acceptance_tests.rs
+++ b/lib-blockchain/tests/g4_replay_acceptance_tests.rs
@@ -1,0 +1,241 @@
+//! GENESIS-2 (#2730): g4 replay acceptance gate.
+//!
+//! Proves wipe-and-replay via `ChainSync::import_blocks` (genesis bootstrap path)
+//! matches incremental live state for SOV-native balances and CBE DAO treasury.
+//!
+//! # CI (always on)
+//! `test_genesis_bootstrap_wipe_replay_parity` — synthetic chain with genesis
+//! SOV activity + token transfers; export → fresh sled → re-import.
+//!
+//! # Manual g4 fixture (ignored)
+//! `test_g4_checkpoint_replay_acceptance` — replays a bincode block window
+//! exported from a live validator and asserts against a JSON balance snapshot.
+//!
+//! ```bash
+//! export G4_REPLAY_BLOCKS_PATH=/path/to/blocks.bin
+//! export G4_REPLAY_SNAPSHOT_PATH=/path/to/checkpoint.json
+//! cargo test -p lib-blockchain --test g4_replay_acceptance_tests \
+//!   test_g4_checkpoint_replay_acceptance -- --ignored --nocapture
+//! ```
+
+use std::sync::Arc;
+
+use lib_blockchain::contracts::bonding_curve::canonical::GENESIS_TREASURY_ALLOCATION;
+use lib_blockchain::contracts::utils::generate_lib_token_id;
+use lib_blockchain::genesis::GenesisConfig;
+use lib_blockchain::storage::{Address, TokenId};
+use lib_blockchain::sync::ChainSync;
+use lib_blockchain::transaction::{TokenTransferData, Transaction, TransactionPayload};
+use lib_blockchain::types::TransactionType;
+use lib_blockchain::Blockchain;
+use tempfile::TempDir;
+
+mod common;
+use common::block_builders::{block_at_height_with_txs, genesis_block};
+use common::crypto_fixtures::dummy_signature;
+use common::replay_gate::{
+    compare_snapshots, first_n_genesis_sov_wallets, load_blocks_fixture, open_fresh_store,
+    ReplayCheckpointSnapshot,
+};
+
+fn create_token_transfer_tx(
+    from: [u8; 32],
+    to: [u8; 32],
+    amount: u128,
+    nonce: u64,
+) -> Transaction {
+    Transaction {
+        version: 1,
+        chain_id: 0x03,
+        transaction_type: TransactionType::TokenTransfer,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: dummy_signature(),
+        memo: vec![],
+        payload: TransactionPayload::TokenTransfer(TokenTransferData {
+            token_id: [0u8; 32], // executor maps to canonical SOV
+            from,
+            to,
+            amount,
+            nonce,
+        }),
+    }
+}
+
+/// Build a short chain: genesis bootstrap + SOV transfers among genesis wallets.
+fn build_sov_activity_chain() -> Vec<lib_blockchain::block::Block> {
+    let wallets = first_n_genesis_sov_wallets(3);
+    let genesis = genesis_block();
+    let mut blocks = vec![genesis.clone()];
+    let mut prev = genesis.header.block_hash;
+
+    let mut sender_nonce = [0u64; 3];
+    for height in 1..=6 {
+        let from_idx = (height as usize - 1) % wallets.len();
+        let to_idx = height as usize % wallets.len();
+        let from = wallets[from_idx];
+        let to = wallets[to_idx];
+        let nonce = sender_nonce[from_idx];
+        sender_nonce[from_idx] += 1;
+        let tx = create_token_transfer_tx(from, to, 50, nonce);
+        let block = block_at_height_with_txs(height, prev, vec![tx]);
+        blocks.push(block.clone());
+        prev = block.header.block_hash;
+    }
+
+    blocks
+}
+
+/// GENESIS-2 CI gate: genesis bootstrap wipe-and-replay parity.
+#[test]
+fn test_genesis_bootstrap_wipe_replay_parity() {
+    let live_dir = TempDir::new().expect("live tempdir");
+    let live_store = open_fresh_store(&live_dir);
+    let live_sync = ChainSync::new(Arc::clone(&live_store));
+
+    let blocks = build_sov_activity_chain();
+    let import = live_sync
+        .import_blocks(blocks)
+        .expect("live import must not hit Insufficient token balance");
+    assert_eq!(import.final_height, Some(6));
+
+    let sample_wallets = first_n_genesis_sov_wallets(3);
+    let reference = ReplayCheckpointSnapshot::from_store_at_height(&*live_store, 6, &sample_wallets);
+
+    // CBE treasury must be present after genesis block-0 seed (legacy path until GENESIS-6).
+    assert_eq!(
+        reference.cbe_treasury_balance, GENESIS_TREASURY_ALLOCATION,
+        "CBE DAO treasury must equal 20B atoms after genesis replay seed"
+    );
+    assert!(
+        reference.sov_wallets.iter().all(|w| w.balance > 0),
+        "all sampled genesis SOV wallets must be non-zero after live import"
+    );
+
+    let exported = live_sync
+        .export_all_blocks()
+        .expect("export live chain");
+
+    // Wipe sled: fresh store, replay from exported blocks (production import path).
+    let replay_dir = TempDir::new().expect("replay tempdir");
+    let replay_store = open_fresh_store(&replay_dir);
+    let replay_sync = ChainSync::new(Arc::clone(&replay_store));
+
+    let replay = replay_sync
+        .import_blocks(exported)
+        .expect("wipe-and-replay must not hit Insufficient token balance");
+    assert_eq!(replay.final_height, Some(6));
+
+    let replayed = ReplayCheckpointSnapshot::from_store_at_height(&*replay_store, 6, &sample_wallets);
+
+    compare_snapshots("wipe-and-replay", &reference, &replayed).expect(
+        "replay checkpoint must match live reference — see token_id/address/have/need above",
+    );
+}
+
+/// Assert genesis-only bootstrap seeds SOV contract + allocations + CBE treasury.
+#[test]
+fn test_genesis_bootstrap_checkpoint_balances() {
+    let dir = TempDir::new().expect("tempdir");
+    let store = open_fresh_store(&dir);
+    let sync = ChainSync::new(Arc::clone(&store));
+
+    sync.import_blocks(vec![genesis_block()])
+        .expect("genesis import");
+
+    let sov_token = TokenId::new(generate_lib_token_id());
+    let contract = store
+        .get_token_contract(&sov_token)
+        .expect("read SOV contract")
+        .expect("SOV native contract must exist after genesis bootstrap");
+    assert_eq!(contract.symbol, "SOV");
+
+    let cfg = GenesisConfig::from_embedded().expect("embedded genesis");
+    let entries = cfg.sov_allocation_entries().expect("sov entries");
+    assert!(entries.len() >= 3);
+
+    for (wallet_id, expected) in entries.iter().take(3) {
+        let have = store
+            .get_token_balance(&sov_token, &Address::new(*wallet_id))
+            .expect("read SOV balance");
+        assert_eq!(
+            have, *expected,
+            "SOV genesis wallet {} balance mismatch after bootstrap: have={have} need={expected}",
+            hex::encode(wallet_id)
+        );
+    }
+
+    let cbe_token = TokenId::new(Blockchain::derive_cbe_token_id_pub());
+    let treasury = Address::new([0u8; 32]);
+    let cbe_bal = store
+        .get_token_balance(&cbe_token, &treasury)
+        .expect("read CBE treasury");
+    assert_eq!(
+        cbe_bal, GENESIS_TREASURY_ALLOCATION,
+        "CBE DAO treasury after genesis: have={cbe_bal} need={GENESIS_TREASURY_ALLOCATION}"
+    );
+}
+
+/// Manual g4-class gate: requires fixture paths from a live validator export.
+///
+/// Export blocks (on a node with sled):
+/// ```ignore
+/// // Pseudocode — use ChainSync::export_blocks(0, checkpoint) on the node store
+/// let blocks = sync.export_blocks(0, 74_010)?;
+/// std::fs::write("blocks.bin", bincode::serialize(&blocks)?)?;
+/// ```
+///
+/// Snapshot JSON schema: see `ReplayCheckpointSnapshot` in `common/replay_gate.rs`.
+#[test]
+#[ignore = "manual g4 fixture — set G4_REPLAY_BLOCKS_PATH and G4_REPLAY_SNAPSHOT_PATH"]
+fn test_g4_checkpoint_replay_acceptance() {
+    let blocks_path = std::env::var("G4_REPLAY_BLOCKS_PATH")
+        .expect("G4_REPLAY_BLOCKS_PATH must point to bincode Vec<Block> fixture");
+    let snapshot_path = std::env::var("G4_REPLAY_SNAPSHOT_PATH")
+        .expect("G4_REPLAY_SNAPSHOT_PATH must point to ReplayCheckpointSnapshot JSON");
+
+    let reference =
+        ReplayCheckpointSnapshot::load_json(snapshot_path.as_ref()).expect("load snapshot");
+    assert!(
+        reference.checkpoint_height >= 74_010,
+        "g4 gate expects checkpoint >= 74010 (got {})",
+        reference.checkpoint_height
+    );
+
+    let blocks = load_blocks_fixture(blocks_path.as_ref()).expect("load block fixture");
+    assert!(
+        !blocks.is_empty() && blocks[0].header.height == 0,
+        "fixture must start at genesis (height 0)"
+    );
+    let last = blocks.last().expect("non-empty fixture").header.height;
+    assert!(
+        last >= reference.checkpoint_height,
+        "fixture must cover checkpoint height {} (last block {last})",
+        reference.checkpoint_height
+    );
+
+    let replay_dir = TempDir::new().expect("replay tempdir");
+    let replay_store = open_fresh_store(&replay_dir);
+    let replay_sync = ChainSync::new(Arc::clone(&replay_store));
+
+    replay_sync
+        .import_blocks(blocks)
+        .unwrap_or_else(|e| {
+            panic!(
+                "g4 replay failed before checkpoint {}: {e} \
+                 (look for Insufficient token balance — token/address/have/need in error)",
+                reference.checkpoint_height
+            );
+        });
+
+    assert_eq!(
+        replay_store.latest_height().expect("replay height"),
+        last,
+        "replay must reach fixture tip"
+    );
+
+    reference
+        .assert_matches_store(&*replay_store, "g4-checkpoint")
+        .expect("g4 checkpoint balance parity");
+}

--- a/scripts/validate-genesis-replay-gate.sh
+++ b/scripts/validate-genesis-replay-gate.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# GENESIS-2 (#2730): g4 replay acceptance gate (CI synthetic path).
+#
+# Proves wipe-and-replay via genesis bootstrap matches live SOV + CBE treasury
+# state. The full g4 74k+ fixture is a manual gate — see docs/arch/genesis-bootstrap-surface.md §6.
+set -euo pipefail
+
+echo "[genesis-replay-gate] Starting GENESIS-2 acceptance suite"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "[genesis-replay-gate] cargo not found on PATH" >&2
+  exit 2
+fi
+
+run_gate() {
+  local name="$1"
+  shift
+  echo ""
+  echo "[genesis-replay-gate] GATE: ${name}"
+  echo "[genesis-replay-gate] CMD : $*"
+  "$@"
+}
+
+run_gate \
+  "Genesis bootstrap checkpoint (SOV shell + allocations + CBE 20B)" \
+  cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \
+    test_genesis_bootstrap_checkpoint_balances -- --nocapture
+
+run_gate \
+  "Wipe-and-replay parity (export → fresh sled → import_blocks)" \
+  cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \
+    test_genesis_bootstrap_wipe_replay_parity -- --nocapture
+
+echo ""
+echo "[genesis-replay-gate] All GENESIS-2 CI gates passed"
+echo "[genesis-replay-gate] Manual g4 fixture (>=74010):"
+echo "  export G4_REPLAY_BLOCKS_PATH=/path/to/blocks.bin"
+echo "  export G4_REPLAY_SNAPSHOT_PATH=/path/to/checkpoint.json"
+echo "  cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \\"
+echo "    test_g4_checkpoint_replay_acceptance -- --ignored --nocapture"

--- a/scripts/validate-genesis-replay-gate.sh
+++ b/scripts/validate-genesis-replay-gate.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
-# GENESIS-2 (#2730): g4 replay acceptance gate (CI synthetic path).
-#
-# Proves wipe-and-replay via genesis bootstrap matches live SOV + CBE treasury
-# state. The full g4 74k+ fixture is a manual gate — see docs/arch/genesis-bootstrap-surface.md §6.
+# GENESIS-2 (#2730): replay acceptance gate (CI synthetic path).
 set -euo pipefail
 
 echo "[genesis-replay-gate] Starting GENESIS-2 acceptance suite"
@@ -22,19 +19,29 @@ run_gate() {
 }
 
 run_gate \
-  "Genesis bootstrap checkpoint (SOV shell + allocations + CBE 20B)" \
+  "Genesis bootstrap checkpoint (SOV shell + allocations + legacy CBE 20B)" \
   cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \
     test_genesis_bootstrap_checkpoint_balances -- --nocapture
 
 run_gate \
-  "Wipe-and-replay parity (export → fresh sled → import_blocks)" \
+  "SOV-native wipe-and-replay parity" \
   cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \
-    test_genesis_bootstrap_wipe_replay_parity -- --nocapture
+    test_sov_native_wipe_replay_parity -- --nocapture
+
+run_gate \
+  "DAO TokenCreation + custom-token wipe-and-replay parity" \
+  cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \
+    test_dao_token_creation_wipe_replay_parity -- --nocapture
+
+run_gate \
+  "replay_gate comparator unit tests" \
+  cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \
+    replay_gate::tests -- --nocapture
 
 echo ""
 echo "[genesis-replay-gate] All GENESIS-2 CI gates passed"
-echo "[genesis-replay-gate] Manual g4 fixture (>=74010):"
-echo "  export G4_REPLAY_BLOCKS_PATH=/path/to/blocks.bin"
-echo "  export G4_REPLAY_SNAPSHOT_PATH=/path/to/checkpoint.json"
-echo "  cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \\"
-echo "    test_g4_checkpoint_replay_acceptance -- --ignored --nocapture"
+echo "[genesis-replay-gate] Manual g4 fixture (testnet maintainer, pre-deploy):"
+echo "  cargo run -p tools --bin export_replay_fixture -- <sled-path> <out-dir> --to-height 74010"
+echo "  G4_REPLAY_BLOCKS_PATH=<out>/blocks.v1.bin G4_REPLAY_SNAPSHOT_PATH=<out>/checkpoint.json \\"
+echo "    cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \\"
+echo "      test_g4_checkpoint_replay_acceptance -- --ignored --nocapture"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -44,3 +44,7 @@ dirs = "5"
 [[bin]]
 name = "regen_cbe_key"
 path = "regen_cbe_key.rs"
+
+[[bin]]
+name = "export_replay_fixture"
+path = "export_replay_fixture.rs"

--- a/tools/export_replay_fixture.rs
+++ b/tools/export_replay_fixture.rs
@@ -1,0 +1,187 @@
+//! Export a versioned replay fixture (blocks + balance snapshot) from a live sled store.
+//!
+//! Used by GENESIS-2 manual g4 gate (#2730). Run on a validator with sled access:
+//!
+//! ```bash
+//! cargo run -p tools --bin export_replay_fixture -- \
+//!   /opt/zhtp/data/testnet/sled /tmp/g4-fixture --to-height 74010
+//! ```
+//!
+//! Writes:
+//!   - `blocks.v1.bin` — versioned block window (bincode)
+//!   - `checkpoint.json` — `ReplayCheckpointSnapshot` for balance parity
+//!
+//! For chains with 100k+ blocks, prefer `--to-height` over full export to limit memory.
+
+use anyhow::{Context, Result};
+use lib_blockchain::contracts::bonding_curve::canonical::GENESIS_TREASURY_ALLOCATION;
+use lib_blockchain::contracts::utils::generate_lib_token_id;
+use lib_blockchain::genesis::GenesisConfig;
+use lib_blockchain::protocol::ProtocolParams;
+use lib_blockchain::storage::{Address, BlockchainStore, SledStore, TokenId};
+use lib_blockchain::sync::{ChainSync, ReplayBlocksFixture, REPLAY_BLOCKS_FIXTURE_VERSION};
+use lib_blockchain::Blockchain;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::Arc;
+
+/// Mirrors `lib-blockchain/tests/common/replay_gate.rs` — keep field order stable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ReplayCheckpointSnapshot {
+    checkpoint_height: u64,
+    sov_wallets: Vec<SovWalletBalance>,
+    cbe_treasury_balance: u128,
+    treasury_sov_balance: u128,
+    #[serde(default)]
+    dao_tokens: Vec<DaoTokenBalance>,
+    #[serde(default)]
+    tolerance_atoms: u128,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SovWalletBalance {
+    wallet_id: String,
+    balance: u128,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DaoTokenBalance {
+    token_id: String,
+    symbol: String,
+    holder_wallet_id: String,
+    balance: u128,
+}
+
+fn treasury_address() -> Address {
+    *ProtocolParams::default().fee_sink_address()
+}
+
+fn main() -> Result<()> {
+    let sled_path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/opt/zhtp/data/testnet/sled".to_string());
+    let out_dir = std::env::args()
+        .nth(2)
+        .unwrap_or_else(|| "/tmp/g4-replay-fixture".to_string());
+    let mut to_height: Option<u64> = None;
+    let args: Vec<String> = std::env::args().collect();
+    let mut i = 3;
+    while i < args.len() {
+        if args[i] == "--to-height" {
+            to_height = Some(
+                args.get(i + 1)
+                    .context("--to-height requires a value")?
+                    .parse()
+                    .context("invalid --to-height")?,
+            );
+            i += 2;
+        } else if let Some(h) = args[i].strip_prefix("--to-height=") {
+            to_height = Some(h.parse().context("invalid --to-height=")?);
+            i += 1;
+        } else {
+            i += 1;
+        }
+    }
+
+    std::fs::create_dir_all(&out_dir)?;
+    export_fixture(Path::new(&sled_path), Path::new(&out_dir), to_height)
+}
+
+fn export_fixture(sled_path: &Path, out_dir: &Path, to_height: Option<u64>) -> Result<()> {
+    eprintln!("Opening sled: {}", sled_path.display());
+    let store: Arc<dyn BlockchainStore> = Arc::new(SledStore::open(sled_path)?);
+    let sync = ChainSync::new(Arc::clone(&store));
+
+    let latest = store.latest_height().context("sled has no committed height")?;
+    let checkpoint = to_height.unwrap_or(latest).min(latest);
+    eprintln!("Exporting blocks 0..={checkpoint} (chain tip {latest})");
+
+    if checkpoint > 50_000 {
+        eprintln!(
+            "WARNING: exporting {checkpoint} blocks materialises the full window in memory. \
+             Consider a lower --to-height for OOM safety on large chains."
+        );
+    }
+
+    let blocks = sync
+        .export_blocks(0, checkpoint)
+        .context("export_blocks failed")?;
+
+    let fixture = ReplayBlocksFixture {
+        version: REPLAY_BLOCKS_FIXTURE_VERSION,
+        exported_to_height: checkpoint,
+        blocks,
+    };
+    let blocks_path = out_dir.join(format!("blocks.v{REPLAY_BLOCKS_FIXTURE_VERSION}.bin"));
+    let encoded = bincode::serialize(&fixture).context("bincode encode fixture")?;
+    std::fs::write(&blocks_path, encoded)?;
+    eprintln!("Wrote {}", blocks_path.display());
+
+    let snapshot = build_snapshot(&*store, checkpoint)?;
+    let snapshot_path = out_dir.join("checkpoint.json");
+    let json = serde_json::to_string_pretty(&snapshot)?;
+    std::fs::write(&snapshot_path, json)?;
+    eprintln!("Wrote {}", snapshot_path.display());
+    eprintln!("Done. Run manual gate with:");
+    eprintln!(
+        "  G4_REPLAY_BLOCKS_PATH={} G4_REPLAY_SNAPSHOT_PATH={} \\",
+        blocks_path.display(),
+        snapshot_path.display()
+    );
+    eprintln!(
+        "  cargo test -p lib-blockchain --test g4_replay_acceptance_tests \\",
+    );
+    eprintln!("    test_g4_checkpoint_replay_acceptance -- --ignored --nocapture");
+    Ok(())
+}
+
+fn build_snapshot(store: &dyn BlockchainStore, checkpoint_height: u64) -> Result<ReplayCheckpointSnapshot> {
+    let cfg = GenesisConfig::from_embedded().context("embedded genesis")?;
+    let entries = cfg.sov_allocation_entries().context("sov entries")?;
+    anyhow::ensure!(
+        entries.len() >= 3,
+        "need >= 3 sov_balances in genesis for snapshot sample"
+    );
+
+    let sov_token = TokenId::new(generate_lib_token_id());
+    let cbe_token = TokenId::new(Blockchain::derive_cbe_token_id_pub());
+    let treasury = treasury_address();
+
+    let sov_wallets: Vec<SovWalletBalance> = entries
+        .iter()
+        .take(3)
+        .map(|(wallet_id, _)| {
+            let balance = store
+                .get_token_balance(&sov_token, &Address::new(*wallet_id))
+                .unwrap_or(0);
+            SovWalletBalance {
+                wallet_id: hex::encode(wallet_id),
+                balance,
+            }
+        })
+        .collect();
+
+    Ok(ReplayCheckpointSnapshot {
+        checkpoint_height,
+        sov_wallets,
+        cbe_treasury_balance: store
+            .get_token_balance(&cbe_token, &treasury)
+            .unwrap_or(0),
+        treasury_sov_balance: store
+            .get_token_balance(&sov_token, &treasury)
+            .unwrap_or(0),
+        dao_tokens: vec![],
+        tolerance_atoms: 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn genesis_treasury_constant_matches_export_expectation() {
+        // Sanity: export tool documents CBE 20B for pre-GENESIS-6 chains.
+        let _ = GENESIS_TREASURY_ALLOCATION;
+    }
+}


### PR DESCRIPTION
## Summary

Implements **GENESIS-2** (#2730) — regression gate for wipe-and-replay determinism after GENESIS-1 (#2741) merged.

## What

- **`g4_replay_acceptance_tests.rs`** — two CI tests + one manual g4 fixture test:
  - `test_genesis_bootstrap_checkpoint_balances` — SOV contract shell, ≥3 genesis `sov_balances`, CBE 20B treasury after block-0 bootstrap
  - `test_genesis_bootstrap_wipe_replay_parity` — live `import_blocks` → export → fresh sled → re-import; asserts SOV + CBE parity
  - `test_g4_checkpoint_replay_acceptance` (**ignored**) — replays bincode block fixture ≥74010 against JSON snapshot
- **`common/replay_gate.rs`** — `ReplayCheckpointSnapshot` with actionable mismatch messages (`token_id`, `address`, `have`, `need`)
- **`scripts/validate-genesis-replay-gate.sh`** — CI gate script
- **`docs/arch/genesis-bootstrap-surface.md` §6** — runbook for CI + manual g4 fixture

## Acceptance criteria (#2730)

- [x] Automated test replays without `Insufficient token balance` (synthetic chain)
- [x] SOV native balances asserted (≥3 wallets from embedded genesis)
- [x] CBE DAO treasury balance asserted (20B atoms via genesis block-0 seed)
- [x] CI gate script + documented manual g4 fixture path
- [x] Failure messages identify token_id + address + have/need

## Run

```bash
./scripts/validate-genesis-replay-gate.sh
```

Closes #2730. Part of epic #2727.