### PR TITLE
fix(sync): canonical import for paginated sync + g4 h=74010 forensics (#2730)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7377,6 +7377,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sled",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7366,6 +7366,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "blake3",
+ "clap",
  "dirs",
  "hex",
  "lib-blockchain",

--- a/docs/arch/genesis-bootstrap-surface.md
+++ b/docs/arch/genesis-bootstrap-surface.md
@@ -115,7 +115,7 @@ Failures print `token_id`, `address`, `have`, `need` via `common/replay_gate.rs`
 
 **Who runs CI:** every PR touching `lib-blockchain` execution/sync/genesis (CI or `./scripts/validate-genesis-replay-gate.sh` locally).
 
-### Manual g4 fixture (≥ `G4_CHECKPOINT_HEIGHT_FLOOR` = 74_010)
+### Manual g4 fixture (≥ h = 74_010 — pre-GENESIS-3 incident height)
 
 Empirical gate for the live chain shape. **Who:** testnet maintainer / validator operator with sled SSH access. **When:** before each testnet binary deploy that touches genesis, replay, or executor paths; mandatory before GENESIS-7 (delete seed-sled). **On failure:** block deploy, file issue on [#2727](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2727) / [#2730](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2730) with height + `Insufficient token balance` line (token/address/have/need).
 

--- a/docs/arch/genesis-bootstrap-surface.md
+++ b/docs/arch/genesis-bootstrap-surface.md
@@ -157,3 +157,5 @@ Retiring `[[allocations.sov_balances]]` (GENESIS-3 / #2731) requires a **coordin
 4. **DAO tokens** (CBE, BUBL): founding `TokenCreation` + contract deploy txs in blocks 1..k (GENESIS-6).
 
 Mainnet uses a one-shot ceremony; testnet may repeat resets until GENESIS-2 gate is green.
+
+**Operator runbook:** [`docs/protocol/genesis-3-testnet-reset.md`](../protocol/genesis-3-testnet-reset.md)

--- a/docs/arch/genesis-bootstrap-surface.md
+++ b/docs/arch/genesis-bootstrap-surface.md
@@ -122,8 +122,9 @@ Empirical gate for the live chain shape. **Who:** testnet maintainer / validator
 Export (versioned fixture — `blocks.v1.bin` + `checkpoint.json`):
 
 ```bash
+# <sled-path>: common locations are /opt/zhtp/.zhtp/data/testnet/sled or /opt/zhtp/data/testnet/sled
 cargo run -p tools --bin export_replay_fixture -- \
-  /opt/zhtp/data/testnet/sled /tmp/g4-fixture --to-height 74010
+  <sled-path> /tmp/g4-fixture --to-height 74010
 ```
 
 Replay:

--- a/docs/protocol/genesis-3-testnet-reset.md
+++ b/docs/protocol/genesis-3-testnet-reset.md
@@ -1,0 +1,214 @@
+# GENESIS-3 Testnet Reset Runbook
+
+**Issue:** [#2731 GENESIS-3](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2731)  
+**Epic:** [#2727 GENESIS](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2727)  
+**Status:** Draft — execute only after GENESIS-2 gates are green  
+**Audience:** Testnet operators (validators g1–g5, gateways)
+
+---
+
+## Purpose
+
+Retire bulk `[[allocations.sov_balances]]` from active `genesis.toml` and align testnet with v2 clean-slate SOV policy (`[sov] initial_supply = 0`). DAO tokens (CBE, BUBL, …) enter via founding block txs (GENESIS-6), not genesis rows.
+
+This is a **coordinated wipe-and-restart**, not an in-place `genesis.toml` edit on a live chain.
+
+---
+
+## Prerequisites (blockers)
+
+Do **not** reset until every item is checked:
+
+- [ ] **GENESIS-1 merged** — `project_chain_bootstrap_to_store()` at h=0 ([#2741](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/pull/2741))
+- [ ] **GENESIS-2 CI green** — `./scripts/validate-genesis-replay-gate.sh`
+- [ ] **Pagination sync fix deployed** — `ChainSync::import_blocks` uses canonical runtime on page 2+ (fixes g4 @ h=74010 wipe failure)
+- [ ] **Manual g4 fixture green** — export from live sled, replay to checkpoint:
+  ```bash
+  cargo run --release -p tools --bin export_replay_fixture -- \
+    <source-sled> /tmp/g4-fixture --to-height 74010
+  G4_REPLAY_BLOCKS_PATH=/tmp/g4-fixture/blocks.v1.bin \
+  G4_REPLAY_SNAPSHOT_PATH=/tmp/g4-fixture/checkpoint.json \
+    cargo test --release -p lib-blockchain --test g4_replay_acceptance_tests \
+      test_g4_checkpoint_replay_acceptance -- --ignored --nocapture
+  # Paginated mirror of production initial sync (optional; 3–6h): test_g4_checkpoint_paginated_replay_acceptance
+  ```
+- [ ] **Binary built and recorded** — `cargo build --release -p zhtp` on reset commit; SHA-256 logged
+- [ ] **Operators notified** — ≥48h notice; reset datetime in UTC recorded below
+
+---
+
+## Reset datetime
+
+```
+GENESIS-3 reset_time (UTC):  2026-07-02T12:00:00Z   (Wednesday — adjust if needed)
+halt_lead_time:              T-30 minutes (stop accepting user txs / announce maintenance)
+```
+
+---
+
+## Validator inventory
+
+| Host | IP | sudo | Role |
+|------|-----|------|------|
+| zhtp-g1 | 77.42.37.161 | no | bootstrap leader |
+| zhtp-g2 | 77.42.74.80 | no | validator |
+| zhtp-g3 | 51.75.62.133 | no | validator |
+| zhtp-g4 | 148.113.140.176 | yes | validator |
+| zhtp-g5 | 178.105.9.247 | yes | validator |
+
+Data path (all nodes): `/opt/zhtp/.zhtp/data/testnet/sled`
+
+---
+
+## Phase 0 — Pre-reset snapshot (T-24h)
+
+1. On **g1** (canonical tip), export forensic snapshot:
+   ```bash
+   cargo run --release -p tools --bin export_replay_fixture -- \
+     /opt/zhtp/.zhtp/data/testnet/sled /tmp/pre-genesis3-fixture --to-height 74010
+   ```
+2. Archive sled backup on each validator (do not delete until reset verified):
+   ```bash
+   sudo systemctl stop zhtp
+   sudo cp -a /opt/zhtp/.zhtp/data/testnet/sled \
+     /opt/zhtp/.zhtp/data/testnet/sled.pre-genesis3.$(date +%s)
+   sudo systemctl start zhtp
+   ```
+3. Record chain tip height + hash from g1 logs or API.
+
+---
+
+## Phase 1 — Halt (T-30m)
+
+Run **simultaneously** on all validators:
+
+```bash
+for node in zhtp-g1 zhtp-g2 zhtp-g3 zhtp-g4 zhtp-g5; do
+  ssh $node 'sudo systemctl stop zhtp' &
+done
+wait
+```
+
+Verify all stopped:
+
+```bash
+for node in zhtp-g1 zhtp-g2 zhtp-g3 zhtp-g4 zhtp-g5; do
+  ssh $node 'sudo systemctl is-active zhtp || echo stopped'
+done
+```
+
+---
+
+## Phase 2 — Deploy binary (T-0)
+
+From dev machine with built binary:
+
+```bash
+./scripts/deploy-validators.sh target/release/zhtp
+```
+
+Or per-node rsync (g4/g5 need sudo):
+
+```bash
+rsync -az target/release/zhtp zhtp-g1:/opt/zhtp/zhtp
+# repeat for g2–g5
+```
+
+---
+
+## Phase 3 — Wipe sled (T+0)
+
+**All validators together** — empty sled triggers peer catch-up from block 0:
+
+```bash
+for node in zhtp-g1 zhtp-g2 zhtp-g3 zhtp-g4 zhtp-g5; do
+  ssh $node 'sudo rm -rf /opt/zhtp/.zhtp/data/testnet/sled && sudo mkdir -p /opt/zhtp/.zhtp/data/testnet/sled'
+done
+```
+
+Do **not** use `recover-fork.sh` for this reset — it assumes fork recovery, not genesis replay.
+
+---
+
+## Phase 4 — Start bootstrap leader (T+2m)
+
+```bash
+ssh zhtp-g1 'sudo systemctl start zhtp'
+sleep 30
+ssh zhtp-g1 'sudo journalctl -u zhtp -n 30 --no-pager | grep -iE "genesis|height|Loaded blockchain"'
+```
+
+Confirm g1 loads genesis and begins producing blocks.
+
+---
+
+## Phase 5 — Start followers (T+5m)
+
+Stagger 30s apart to reduce handshake storms:
+
+```bash
+for node in zhtp-g2 zhtp-g3 zhtp-g4 zhtp-g5; do
+  ssh $node 'sudo systemctl start zhtp'
+  sleep 30
+done
+```
+
+Watch for:
+- `Caught up` / catch-up sync completing
+- `5/5` validators in consensus (no `PARTITION`)
+- No `Insufficient token balance` during initial sync
+
+---
+
+## Phase 6 — Verification (T+30m)
+
+| Check | Command / signal |
+|-------|------------------|
+| All services active | `systemctl is-active zhtp` on each node |
+| Heights aligned | API tip or logs within 1 block |
+| g4 caught up | g4 logs show commit at peer height, not stuck at 74009 |
+| Replay gate (optional) | Re-export fixture at h=74010 post-reset; manual gate green |
+
+---
+
+## Phase 7 — Post-reset seeding (GENESIS-6 follow-up)
+
+After shrunk genesis is live:
+
+1. **CBE / BUBL** — founding `TokenCreation` + contract deploy txs in blocks 1..k (not genesis rows)
+2. **Wallets** — `WalletRegistration` / UBI / coinbase in early blocks ([#2733](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2733))
+3. **Domains** — `./scripts/replay-domains.sh` if domain snapshot exists
+4. **Sites** — redeploy per ops checklist
+
+---
+
+## Rollback
+
+If reset fails (consensus partition, replay errors, mass crash-loop):
+
+1. Stop all validators
+2. Restore `sled.pre-genesis3.*` backup on each node
+3. Redeploy **previous** known-good binary
+4. Start g1, then followers
+5. File incident on [#2727](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2727) with height + error line
+
+**Peer sled transplant** (g1 → g4 relay) is a valid recovery if a single node fails catch-up — do not wipe that node's sled again until pagination fix is confirmed on deployed binary.
+
+---
+
+## genesis.toml changes (GENESIS-3 scope)
+
+On reset commit:
+
+- Remove bulk `[[allocations.sov_balances]]` from active `genesis.toml`
+- Set `[sov] initial_supply = 0`
+- Archive migrated allocations to `archive/genesis-v1-pre-cutover.toml` (forensic only)
+- Retire `[cbe_curve]` / block-0 CBE seed when GENESIS-6 lands
+
+---
+
+## Related docs
+
+- [`docs/arch/genesis-bootstrap-surface.md`](../arch/genesis-bootstrap-surface.md) — genesis vs on-chain boundary
+- [`scripts/validate-genesis-replay-gate.sh`](../../scripts/validate-genesis-replay-gate.sh) — CI replay gate
+- [`scripts/reset-testnet.sh`](../../scripts/reset-testnet.sh) — legacy EPIC-001 script (update node list before use)

--- a/docs/protocol/genesis-3-testnet-reset.md
+++ b/docs/protocol/genesis-3-testnet-reset.md
@@ -48,13 +48,15 @@ halt_lead_time:              T-30 minutes (stop accepting user txs / announce ma
 
 ## Validator inventory
 
-| Host | IP | sudo | Role |
-|------|-----|------|------|
-| zhtp-g1 | 77.42.37.161 | no | bootstrap leader |
-| zhtp-g2 | 77.42.74.80 | no | validator |
-| zhtp-g3 | 51.75.62.133 | no | validator |
-| zhtp-g4 | 148.113.140.176 | yes | validator |
-| zhtp-g5 | 178.105.9.247 | yes | validator |
+| Host (SSH alias) | sudo | Role |
+|------------------|------|------|
+| zhtp-g1 | no | bootstrap leader |
+| zhtp-g2 | no | validator |
+| zhtp-g3 | no | validator |
+| zhtp-g4 | yes | validator |
+| zhtp-g5 | yes | validator |
+
+IP inventory lives in private ops config (not in-repo).
 
 Data path (all nodes): `/opt/zhtp/.zhtp/data/testnet/sled`
 

--- a/docs/protocol/genesis-3-testnet-reset.md
+++ b/docs/protocol/genesis-3-testnet-reset.md
@@ -22,7 +22,7 @@ Do **not** reset until every item is checked:
 - [ ] **GENESIS-1 merged** — `project_chain_bootstrap_to_store()` at h=0 ([#2741](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/pull/2741))
 - [ ] **GENESIS-2 CI green** — `./scripts/validate-genesis-replay-gate.sh`
 - [ ] **Pagination sync fix deployed** — `ChainSync::import_blocks` uses canonical runtime on page 2+ (fixes g4 @ h=74010 wipe failure)
-- [ ] **Manual g4 fixture green** — export from live sled, replay to checkpoint:
+- [ ] **Pre-reset g4 fixture documents divergence class** — manual gate is **expected red** on pre-reset chain (replay cannot reproduce h=73982 write-path history). Re-run after reset; gate must be **green** on post-reset chain before declaring success:
   ```bash
   cargo run --release -p tools --bin export_replay_fixture -- \
     <source-sled> /tmp/g4-fixture --to-height 74010
@@ -40,7 +40,7 @@ Do **not** reset until every item is checked:
 ## Reset datetime
 
 ```
-GENESIS-3 reset_time (UTC):  2026-07-02T12:00:00Z   (Wednesday — adjust if needed)
+GENESIS-3 reset_time (UTC):  TBD — fill in before announcing (placeholder was 2026-07-02T12:00:00Z)
 halt_lead_time:              T-30 minutes (stop accepting user txs / announce maintenance)
 ```
 
@@ -84,9 +84,19 @@ Run **simultaneously** on all validators:
 
 ```bash
 for node in zhtp-g1 zhtp-g2 zhtp-g3 zhtp-g4 zhtp-g5; do
-  ssh $node 'sudo systemctl stop zhtp' &
+  ssh $node 'sudo systemctl stop zhtp --wait-timeout 120' &
 done
 wait
+```
+
+If a node does not reach `inactive` within 120s (wedged FSM, locked sled), force-kill and verify:
+
+```bash
+for node in zhtp-g1 zhtp-g2 zhtp-g3 zhtp-g4 zhtp-g5; do
+  ssh $node 'sudo systemctl is-active zhtp 2>/dev/null || echo stopped'
+done
+# If still active after 120s:
+# ssh $node 'sudo systemctl kill -s SIGKILL zhtp && sleep 5 && sudo systemctl is-active zhtp || echo killed'
 ```
 
 Verify all stopped:
@@ -118,11 +128,21 @@ rsync -az target/release/zhtp zhtp-g1:/opt/zhtp/zhtp
 
 ## Phase 3 — Wipe sled (T+0)
 
-**All validators together** — empty sled triggers peer catch-up from block 0:
+**All validators together** — empty sled triggers peer catch-up from block 0.
+
+Wipe canonical sled **and** legacy sidecar state under the testnet data dir:
 
 ```bash
+DATA=/opt/zhtp/.zhtp/data/testnet
 for node in zhtp-g1 zhtp-g2 zhtp-g3 zhtp-g4 zhtp-g5; do
-  ssh $node 'sudo rm -rf /opt/zhtp/.zhtp/data/testnet/sled && sudo mkdir -p /opt/zhtp/.zhtp/data/testnet/sled'
+  ssh $node "sudo rm -rf \
+    $DATA/sled \
+    $DATA/blockchain.dat \
+    $DATA/rewards.sled \
+    $DATA/rewards.dat \
+    $DATA/notifications.sled \
+    $DATA/storage \
+    && sudo mkdir -p $DATA/sled"
 done
 ```
 
@@ -138,7 +158,7 @@ sleep 30
 ssh zhtp-g1 'sudo journalctl -u zhtp -n 30 --no-pager | grep -iE "genesis|height|Loaded blockchain"'
 ```
 
-Confirm g1 loads genesis and begins producing blocks.
+Confirm g1 loads genesis and **creates block proposals**. g1 alone cannot **commit** blocks — BFT needs 4/5 quorum. Expect **no committed blocks** until followers join (Phase 5). Proposals waiting for votes is normal; do not panic on "height stuck at 0" for the first few minutes.
 
 ---
 
@@ -153,10 +173,14 @@ for node in zhtp-g2 zhtp-g3 zhtp-g4 zhtp-g5; do
 done
 ```
 
+**Catch-up duration:** canonical import replays every block through the full runtime (~10–30 blocks/sec on real testnet history, not the ~225/s synthetic estimate). A follower importing ~177k blocks from genesis may need **1–3 hours** — plan maintenance accordingly.
+
 Watch for:
 - `Caught up` / catch-up sync completing
-- `5/5` validators in consensus (no `PARTITION`)
+- `5/5` validators in consensus (no sustained `PARTITION`)
 - No `Insufficient token balance` during initial sync
+
+**Partition noise:** ignore `PARTITION SUSPECTED` in the first **60 seconds** after start on any node — handshake window false positives are common during healthy startups.
 
 ---
 
@@ -166,8 +190,10 @@ Watch for:
 |-------|------------------|
 | All services active | `systemctl is-active zhtp` on each node |
 | Heights aligned | API tip or logs within 1 block |
-| g4 caught up | g4 logs show commit at peer height, not stuck at 74009 |
-| Replay gate (optional) | Re-export fixture at h=74010 post-reset; manual gate green |
+| g4 caught up | g4 committing at chain tip within 3 blocks of other validators |
+| Replay gate (optional) | Re-export fixture at new tip post-reset; manual gate green |
+
+Allow extra time (up to T+3h) if followers are still catching up from genesis.
 
 ---
 

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -6,7 +6,8 @@
 //! # Design Principles
 //!
 //! 1. **Genesis bootstrap (h=0)** - Block 0 via executor, blocks 1+ via canonical runtime
-//! 2. **Continuation (h≥1)** - Always canonical `Blockchain` runtime (matches live validators)
+//! 2. **Continuation (h≥1)** - Always canonical `Blockchain` runtime (matches live validators).
+//!    `ChainSync` validates `previous_hash` before each import (trusted-replay executor skips it).
 //! 3. **No direct state writes** - Import never writes directly to store
 //! 4. **Atomic failure** - If any block fails, stop immediately; state reflects last committed block
 //! 5. **Deterministic** - Same blocks always produce same state
@@ -32,9 +33,7 @@
 pub mod replay_fixture;
 pub mod snapshot;
 
-pub use replay_fixture::{
-    ReplayBlocksFixture, G4_CHECKPOINT_HEIGHT_FLOOR, REPLAY_BLOCKS_FIXTURE_VERSION,
-};
+pub use replay_fixture::{ReplayBlocksFixture, REPLAY_BLOCKS_FIXTURE_VERSION};
 pub use snapshot::{SnapshotError, SnapshotId, SnapshotInfo, SnapshotManager, SnapshotResult};
 
 use std::sync::Arc;
@@ -260,11 +259,10 @@ impl ChainSync {
     /// `finish_block_processing` hooks (domain fees, identity, wallet, …) match
     /// the incremental live-validator path.
     ///
-    /// Correctness over speed: canonical import is slower than executor-only (~225
-    /// blocks/sec observed) but required because live validators built state via
-    /// `process_and_commit_block`, not raw `BlockExecutor::apply_block` alone.
-    /// A 177k-block fresh sync is on the order of tens of minutes — acceptable for
-    /// wipe-and-recover, not the steady-state hot path.
+    /// Correctness over speed: canonical import is slower than executor-only.
+    /// Synthetic SOV-only chains: ~100–225 blocks/sec. Real testnet blocks with
+    /// mixed tx types: ~10–30 blocks/sec (empirical). A 177k-block wipe-and-catch-up
+    /// is roughly 90 min–3 h per follower — acceptable for recovery, not steady-state.
     fn import_blocks_from_genesis_bootstrap<F>(
         &self,
         blocks: Vec<Block>,
@@ -358,6 +356,7 @@ impl ChainSync {
 
                 for block in prefix {
                     let height = block.header.height;
+                    Self::validate_block_previous_hash(&*self.store, &block)?;
                     executor
                         .apply_block(&block)
                         .map_err(|e| SyncError::BlockApplyFailed { height, error: e })?;
@@ -415,6 +414,45 @@ impl ChainSync {
         })
     }
 
+    /// Enforce `previous_hash` chain continuity before trusted-replay import.
+    ///
+    /// `BlockExecutor::from_config_trusted_replay` sets `skip_prev_hash_validation=true`;
+    /// `Blockchain::add_block_from_network` uses that executor, so ChainSync must check.
+    fn validate_block_previous_hash(
+        store: &dyn BlockchainStore,
+        block: &Block,
+    ) -> SyncResult<()> {
+        let height = block.header.height;
+        if height == 0 {
+            return Ok(());
+        }
+
+        use lib_types::primitives::BlockHash;
+
+        let expected_hash = store
+            .get_block_hash_by_height(height - 1)?
+            .ok_or_else(|| SyncError::BlockApplyFailed {
+                height,
+                error: BlockApplyError::ValidationFailed(format!(
+                    "Previous block at height {} not found",
+                    height - 1
+                )),
+            })?;
+
+        let actual_hash = BlockHash::new(block.header.previous_hash);
+        if expected_hash != actual_hash {
+            return Err(SyncError::BlockApplyFailed {
+                height,
+                error: BlockApplyError::InvalidPreviousHash {
+                    expected: expected_hash,
+                    actual: actual_hash,
+                },
+            });
+        }
+
+        Ok(())
+    }
+
     fn run_canonical_import(&self, blocks: Vec<Block>) -> SyncResult<CanonicalImportResult> {
         if tokio::runtime::Handle::try_current().is_ok() {
             let store = Arc::clone(&self.store);
@@ -457,6 +495,7 @@ fn run_canonical_import_inner(
         let mut heights = Vec::with_capacity(blocks.len());
         for block in blocks {
             let height = block.header.height;
+            ChainSync::validate_block_previous_hash(&*store, &block)?;
             blockchain
                 .add_block_from_network(block)
                 .await

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -5,9 +5,8 @@
 //!
 //! # Design Principles
 //!
-//! 1. **Import uses executor by default** - Standard imports go through `BlockExecutor::apply_block`
-//! 2. **Canonical fallback for Contract/DAO txs** - Imports containing `Contract*`/`Dao*`
-//!    transactions replay via canonical `Blockchain` runtime path
+//! 1. **Genesis bootstrap (h=0)** - Block 0 via executor, blocks 1+ via canonical runtime
+//! 2. **Continuation (h≥1)** - Always canonical `Blockchain` runtime (matches live validators)
 //! 3. **No direct state writes** - Import never writes directly to store
 //! 4. **Atomic failure** - If any block fails, stop immediately; state reflects last committed block
 //! 5. **Deterministic** - Same blocks always produce same state
@@ -247,66 +246,13 @@ impl ChainSync {
             return self.import_blocks_from_genesis_bootstrap(blocks, on_progress);
         }
 
-        if Self::requires_canonical_runtime_import(&blocks) {
-            return self.import_blocks_via_canonical_runtime(blocks, Some(&mut on_progress));
-        }
-
-        let executor = BlockExecutor::from_config_trusted_replay(
-            Arc::clone(&self.store),
-            self.executor_config.clone(),
-        );
-
-        // Track last committed block hash for chain continuity validation.
-        // The executor uses trusted replay (skip_prev_hash_validation=true),
-        // so ChainSync must enforce previous_hash continuity itself.
-        let mut prev_block_hash: Option<[u8; 32]> = if expected_start > 0 {
-            self.store
-                .get_block_hash_by_height(expected_start - 1)?
-                .map(|bh| *bh.as_bytes())
-        } else {
-            None
-        };
-
-        let mut imported_count = 0;
-        let mut last_height = None;
-
-        for block in blocks {
-            let height = block.header.height;
-
-            // Validate previous_hash chain continuity (non-genesis blocks)
-            if height > 0 {
-                if let Some(expected_prev) = prev_block_hash {
-                    if block.header.previous_hash != expected_prev {
-                        use lib_types::primitives::BlockHash;
-                        return Err(SyncError::BlockApplyFailed {
-                            height,
-                            error: BlockApplyError::InvalidPreviousHash {
-                                expected: BlockHash::new(expected_prev),
-                                actual: BlockHash::new(block.header.previous_hash),
-                            },
-                        });
-                    }
-                }
-            }
-
-            // Apply block through executor
-            // This handles: prechecks, begin_block, apply txs, append_block, commit_block
-            // On error: automatic rollback, state unchanged from before begin_block
-            executor
-                .apply_block(&block)
-                .map_err(|e| SyncError::BlockApplyFailed { height, error: e })?;
-
-            prev_block_hash = Some(block.header.block_hash.as_array());
-
-            imported_count += 1;
-            last_height = Some(height);
-            on_progress(height, imported_count);
-        }
-
-        Ok(ImportResult {
-            blocks_imported: imported_count,
-            final_height: last_height,
-        })
+        // Blocks 1+ must replay through canonical `Blockchain` runtime to match
+        // live-validator `process_and_commit_block` / `finish_block_processing`.
+        // Executor-only `apply_block` skips finish_block hooks and breaks wallet
+        // projection parity (g4 @ h=74010). Paginated initial sync (50 blocks/page
+        // in `try_initial_sync_from_peer`) lands here on page 2+ — unconditional
+        // canonical import is required for wipe-and-replay correctness.
+        self.import_blocks_via_canonical_runtime(blocks, Some(&mut on_progress))
     }
 
     /// Fresh bootstrap from genesis: executor applies block 0 (seeds genesis SOV to

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -33,7 +33,9 @@
 pub mod replay_fixture;
 pub mod snapshot;
 
-pub use replay_fixture::{ReplayBlocksFixture, REPLAY_BLOCKS_FIXTURE_VERSION};
+pub use replay_fixture::{
+    ReplayBlocksFixture, MAX_REPLAY_FIXTURE_BYTES, REPLAY_BLOCKS_FIXTURE_VERSION,
+};
 pub use snapshot::{SnapshotError, SnapshotId, SnapshotInfo, SnapshotManager, SnapshotResult};
 
 use std::sync::Arc;
@@ -310,12 +312,6 @@ impl ChainSync {
             blocks_imported: 1 + canonical.blocks_imported,
             final_height: canonical.final_height,
         })
-    }
-
-    /// Contract/DAO/domain variants currently execute through canonical `Blockchain` flow,
-    /// not `BlockExecutor`'s phase-2 transaction applicator.
-    fn requires_canonical_runtime_import(blocks: &[Block]) -> bool {
-        blocks.iter().any(Self::block_needs_canonical_runtime)
     }
 
     fn import_blocks_via_canonical_runtime(
@@ -826,7 +822,7 @@ mod tests {
     }
 
     #[test]
-    fn test_requires_canonical_runtime_import_detection() {
+    fn test_block_needs_canonical_runtime_detection() {
         let normal_block = create_block_at_height(0, Hash::default());
         let canonical_header = create_block_at_height(1, normal_block.header.block_hash).header;
         let canonical_block = Block::new(
@@ -834,13 +830,8 @@ mod tests {
             vec![create_test_tx(TransactionType::ContractExecution)],
         );
 
-        assert!(!ChainSync::requires_canonical_runtime_import(&[
-            normal_block.clone()
-        ]));
-        assert!(ChainSync::requires_canonical_runtime_import(&[
-            normal_block,
-            canonical_block
-        ]));
+        assert!(!ChainSync::block_needs_canonical_runtime(&normal_block));
+        assert!(ChainSync::block_needs_canonical_runtime(&canonical_block));
     }
 
     #[test]

--- a/lib-blockchain/src/sync/replay_fixture.rs
+++ b/lib-blockchain/src/sync/replay_fixture.rs
@@ -9,6 +9,9 @@ use crate::block::Block;
 /// Fixture format version — bump when `ReplayBlocksFixture` layout changes.
 pub const REPLAY_BLOCKS_FIXTURE_VERSION: u32 = 1;
 
+/// Maximum fixture file size (512 MiB) — guards against OOM on malformed/truncated input.
+pub const MAX_REPLAY_FIXTURE_BYTES: usize = 512 * 1024 * 1024;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReplayBlocksFixture {
     pub version: u32,
@@ -21,17 +24,35 @@ impl ReplayBlocksFixture {
         bincode::serialize(self)
     }
 
-    pub fn decode(data: &[u8]) -> Result<Self, bincode::Error> {
-        bincode::deserialize(data)
+    /// Decode and validate version + size bound. Prefer this over raw `bincode::deserialize`.
+    pub fn decode_validated(data: &[u8]) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            data.len() <= MAX_REPLAY_FIXTURE_BYTES,
+            "fixture too large ({} bytes, max {})",
+            data.len(),
+            MAX_REPLAY_FIXTURE_BYTES
+        );
+        let fixture: Self = bincode::deserialize(data)
+            .map_err(|e| anyhow::anyhow!("replay fixture decode failed: {e}"))?;
+        anyhow::ensure!(
+            fixture.version == REPLAY_BLOCKS_FIXTURE_VERSION,
+            "unsupported fixture version {} (expected {})",
+            fixture.version,
+            REPLAY_BLOCKS_FIXTURE_VERSION
+        );
+        Ok(fixture)
     }
 
     pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let meta = std::fs::metadata(path)?;
+        anyhow::ensure!(
+            meta.len() as usize <= MAX_REPLAY_FIXTURE_BYTES,
+            "fixture file too large ({} bytes, max {})",
+            meta.len(),
+            MAX_REPLAY_FIXTURE_BYTES
+        );
         let data = std::fs::read(path)?;
-        Self::decode(&data).map_err(|e| {
-            anyhow::anyhow!(
-                "replay fixture decode failed (version mismatch or corrupt file): {e}"
-            )
-        })
+        Self::decode_validated(&data)
     }
 
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {

--- a/lib-blockchain/src/sync/replay_fixture.rs
+++ b/lib-blockchain/src/sync/replay_fixture.rs
@@ -9,9 +9,6 @@ use crate::block::Block;
 /// Fixture format version — bump when `ReplayBlocksFixture` layout changes.
 pub const REPLAY_BLOCKS_FIXTURE_VERSION: u32 = 1;
 
-/// g4 wipe-and-replay first wedged here (Insufficient SOV @ payroll). Floor for manual gates.
-pub const G4_CHECKPOINT_HEIGHT_FLOOR: u64 = 74_010;
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReplayBlocksFixture {
     pub version: u32,

--- a/lib-blockchain/tests/common/replay_gate.rs
+++ b/lib-blockchain/tests/common/replay_gate.rs
@@ -297,16 +297,15 @@ pub fn within_tolerance(expected: u128, actual: u128, tolerance: u128) -> bool {
 
 /// Load a versioned replay fixture (`blocks.v1.bin`) or legacy raw `Vec<Block>` bincode.
 pub fn load_blocks_fixture(path: &Path) -> anyhow::Result<Vec<lib_blockchain::block::Block>> {
-    let data = std::fs::read(path)?;
-    if let Ok(fixture) = ReplayBlocksFixture::decode(&data) {
-        anyhow::ensure!(
-            fixture.version == lib_blockchain::sync::REPLAY_BLOCKS_FIXTURE_VERSION,
-            "unsupported fixture version {} (expected {})",
-            fixture.version,
-            lib_blockchain::sync::REPLAY_BLOCKS_FIXTURE_VERSION
-        );
+    if let Ok(fixture) = ReplayBlocksFixture::load(path) {
         return Ok(fixture.blocks);
     }
+    let data = std::fs::read(path)?;
+    anyhow::ensure!(
+        data.len() <= lib_blockchain::sync::MAX_REPLAY_FIXTURE_BYTES,
+        "fixture file too large ({} bytes)",
+        data.len()
+    );
     // Legacy: unversioned Vec<Block> — may break across bincode layout changes.
     bincode::deserialize(&data)
         .map_err(|e| anyhow::anyhow!("block fixture decode failed (try re-exporting v1): {e}"))

--- a/lib-blockchain/tests/common/replay_gate.rs
+++ b/lib-blockchain/tests/common/replay_gate.rs
@@ -11,7 +11,10 @@ use lib_blockchain::contracts::utils::{generate_custom_token_id, generate_lib_to
 use lib_blockchain::genesis::GenesisConfig;
 use lib_blockchain::protocol::ProtocolParams;
 use lib_blockchain::storage::{Address, BlockchainStore, TokenId};
-use lib_blockchain::sync::{G4_CHECKPOINT_HEIGHT_FLOOR, ReplayBlocksFixture};
+use lib_blockchain::sync::ReplayBlocksFixture;
+
+/// Pre-GENESIS-3 testnet incident height (g4 wedged @ h=74_010). Meaningless after reset.
+pub const G4_CHECKPOINT_HEIGHT_FLOOR: u64 = 74_010;
 use lib_blockchain::Blockchain;
 use serde::{Deserialize, Serialize};
 

--- a/lib-blockchain/tests/g4_replay_acceptance_tests.rs
+++ b/lib-blockchain/tests/g4_replay_acceptance_tests.rs
@@ -29,7 +29,7 @@
 //!
 //! ## Manual g4 fixture
 //! ```bash
-//! cargo run -p tools --bin export_replay_fixture -- /opt/zhtp/data/testnet/sled /tmp/g4 --to-height 74010
+//! cargo run -p tools --bin export_replay_fixture -- <sled-path> /tmp/g4 --to-height 74010
 //! G4_REPLAY_BLOCKS_PATH=/tmp/g4/blocks.v1.bin G4_REPLAY_SNAPSHOT_PATH=/tmp/g4/checkpoint.json \
 //!   cargo test -p lib-blockchain --test g4_replay_acceptance_tests \
 //!   test_g4_checkpoint_replay_acceptance -- --ignored --nocapture

--- a/lib-blockchain/tests/g4_replay_acceptance_tests.rs
+++ b/lib-blockchain/tests/g4_replay_acceptance_tests.rs
@@ -116,13 +116,19 @@ fn create_dao_token_transfer_tx(
 }
 
 fn build_sov_activity_chain() -> Vec<lib_blockchain::block::Block> {
+    build_sov_activity_chain_to_height(6)
+}
+
+/// Longer chain so paginated import (50 blocks/page, as in `try_initial_sync_from_peer`)
+/// spans multiple pages and exercises the continuation import path.
+fn build_sov_activity_chain_to_height(last_height: u64) -> Vec<lib_blockchain::block::Block> {
     let wallets = first_n_genesis_sov_wallets(3);
     let genesis = genesis_block();
     let mut blocks = vec![genesis.clone()];
     let mut prev = genesis.header.block_hash;
     let mut sender_nonce = [0u64; 3];
 
-    for height in 1..=6 {
+    for height in 1..=last_height {
         let from_idx = (height as usize - 1) % wallets.len();
         let to_idx = height as usize % wallets.len();
         let nonce = sender_nonce[from_idx];
@@ -133,6 +139,16 @@ fn build_sov_activity_chain() -> Vec<lib_blockchain::block::Block> {
         prev = block.header.block_hash;
     }
     blocks
+}
+
+/// Mirrors production `BLOCKS_PER_PAGE` in `zhtp::runtime::try_initial_sync_from_peer`.
+const INITIAL_SYNC_PAGE_SIZE: usize = 50;
+
+fn import_blocks_paginated(sync: &ChainSync, blocks: Vec<lib_blockchain::block::Block>) {
+    for chunk in blocks.chunks(INITIAL_SYNC_PAGE_SIZE) {
+        sync.import_blocks(chunk.to_vec())
+            .expect("paginated import must not hit Insufficient token balance");
+    }
 }
 
 fn build_dao_token_activity_chain() -> (Vec<lib_blockchain::block::Block>, DaoTokenExpectation) {
@@ -217,6 +233,48 @@ fn run_wipe_replay_parity(
 fn test_sov_native_wipe_replay_parity() {
     let sample = first_n_genesis_sov_wallets(3);
     run_wipe_replay_parity(build_sov_activity_chain(), 6, &sample, &[]);
+}
+
+/// Paginated fresh sync must match single-shot wipe-and-replay (g4 page-2+ bug class).
+#[test]
+fn test_paginated_fresh_sync_replay_parity() {
+    const CHECKPOINT: u64 = 60;
+    let sample = first_n_genesis_sov_wallets(3);
+    let blocks = build_sov_activity_chain_to_height(CHECKPOINT);
+
+    let live_dir = TempDir::new().expect("live tempdir");
+    let live_store = open_fresh_store(&live_dir);
+    let live_sync = ChainSync::new(Arc::clone(&live_store));
+    live_sync
+        .import_blocks(blocks.clone())
+        .expect("live single-shot import");
+
+    let reference = ReplayCheckpointSnapshot::from_store_at_height(
+        &*live_store,
+        CHECKPOINT,
+        &sample,
+        &[],
+    );
+
+    let replay_dir = TempDir::new().expect("replay tempdir");
+    let replay_store = open_fresh_store(&replay_dir);
+    let replay_sync = ChainSync::new(Arc::clone(&replay_store));
+    import_blocks_paginated(&replay_sync, blocks);
+
+    assert_eq!(
+        replay_store.latest_height().expect("paginated replay height"),
+        CHECKPOINT
+    );
+
+    let replayed = ReplayCheckpointSnapshot::from_store_at_height(
+        &*replay_store,
+        CHECKPOINT,
+        &sample,
+        &[],
+    );
+    compare_snapshots("paginated-fresh-sync", &reference, &replayed).expect(
+        "paginated import must match single-shot live reference",
+    );
 }
 
 /// DAO `TokenCreation` + custom-token transfer replay parity (BUBL class — g4-adjacent).
@@ -333,4 +391,28 @@ fn test_g4_checkpoint_replay_acceptance() {
     reference
         .assert_matches_store(&*replay_store, "g4-checkpoint")
         .expect("g4 checkpoint balance parity");
+}
+
+/// Manual g4 gate via paginated import (production `try_initial_sync_from_peer` path).
+#[test]
+#[ignore = "manual g4 paginated fixture — same env vars as test_g4_checkpoint_replay_acceptance"]
+fn test_g4_checkpoint_paginated_replay_acceptance() {
+    let blocks_path = std::env::var("G4_REPLAY_BLOCKS_PATH")
+        .expect("G4_REPLAY_BLOCKS_PATH must point to blocks.v1.bin fixture");
+    let snapshot_path = std::env::var("G4_REPLAY_SNAPSHOT_PATH")
+        .expect("G4_REPLAY_SNAPSHOT_PATH must point to checkpoint.json");
+
+    let reference =
+        ReplayCheckpointSnapshot::load_json(snapshot_path.as_ref()).expect("load snapshot");
+    let blocks = load_blocks_fixture(blocks_path.as_ref()).expect("load block fixture");
+
+    let replay_dir = TempDir::new().expect("replay tempdir");
+    let replay_store = open_fresh_store(&replay_dir);
+    let replay_sync = ChainSync::new(Arc::clone(&replay_store));
+
+    import_blocks_paginated(&replay_sync, blocks);
+
+    reference
+        .assert_matches_store(&*replay_store, "g4-checkpoint-paginated")
+        .expect("paginated g4 checkpoint balance parity");
 }

--- a/lib-blockchain/tests/g4_replay_acceptance_tests.rs
+++ b/lib-blockchain/tests/g4_replay_acceptance_tests.rs
@@ -1,5 +1,19 @@
 //! GENESIS-2 (#2730): replay acceptance gates.
 //!
+//! ## Test map
+//!
+//! | Test | Guards |
+//! |------|--------|
+//! | `test_sov_native_wipe_replay_parity` | SOV genesis bootstrap + transfer wipe-replay (#2725/#2741) |
+//! | `test_dao_token_creation_wipe_replay_parity` | `TokenCreation` + custom-token transfer (BUBL class) |
+//! | `test_paginated_fresh_sync_replay_parity` | Page-2+ paginated sync regression (canonical import on continuation) |
+//! | `test_g4_wallet74010_sequence_isolated_replay` | h=74010 forensics — **expected replay failure** until GENESIS-3 |
+//! | `test_g4_wallet74010_sequence_tx_version_eight` | Rules out tx-version-8 as divergence cause |
+//! | `test_genesis_bootstrap_checkpoint_balances` | Block-0 SOV shell + CBE treasury seed |
+//! | `test_g4_checkpoint_replay_acceptance` | Manual ≥74k fixture — full-chain empirical gate (ignored) |
+//! | `test_g4_checkpoint_paginated_replay_acceptance` | Manual ≥74k fixture via paginated import (ignored) |
+//! | `test_canonical_import_throughput_benchmark_10k` | `#[ignore]` ops floor — blocks/sec on 10k synthetic chain |
+//!
 //! ## CI scope (honest)
 //! - `test_sov_native_wipe_replay_parity` — SOV genesis bootstrap + SOV transfers (#2725/#2741 fix class)
 //! - `test_dao_token_creation_wipe_replay_parity` — `TokenCreation` + custom-token transfer (BUBL class)
@@ -27,7 +41,7 @@ use lib_blockchain::contracts::bonding_curve::canonical::GENESIS_TREASURY_ALLOCA
 use lib_blockchain::contracts::utils::generate_lib_token_id;
 use lib_blockchain::genesis::GenesisConfig;
 use lib_blockchain::storage::{Address, TokenId};
-use lib_blockchain::sync::G4_CHECKPOINT_HEIGHT_FLOOR;
+
 use lib_blockchain::transaction::{
     token_creation::TokenCreationPayloadV1, TokenTransferData, Transaction, TransactionPayload,
     WalletTransactionData,
@@ -44,6 +58,7 @@ use common::crypto_fixtures::{dummy_public_key, dummy_signature};
 use common::replay_gate::{
     bubl_like_token_id, cbe_treasury_address, compare_snapshots, first_n_genesis_sov_wallets,
     load_blocks_fixture, open_fresh_store, DaoTokenExpectation, ReplayCheckpointSnapshot,
+    G4_CHECKPOINT_HEIGHT_FLOOR,
 };
 
 use lib_blockchain::sync::ChainSync;
@@ -275,6 +290,13 @@ fn run_wipe_replay_parity(
 
 /// Isolated repro of g4 wallet `0e2962d5…` activity through the failing h=74010 tx.
 /// Pins current executor semantics without replaying 74k prefix blocks.
+///
+/// **This test PASSES because replay diverges from live chain history at h=74010.**
+/// The `import_blocks(vec![h4]).expect_err(...)` failure **is** the acceptance criterion
+/// until GENESIS-3 reset ([#2731](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2731)).
+/// Do **not** "fix" this to make h4 succeed unless the reset is complete **or** you are
+/// intentionally reintroducing the pre-#2641 write-path bug that double-credited the
+/// h=73982 self-transfer on live validators.
 #[test]
 fn test_g4_wallet74010_sequence_isolated_replay() {
     const ATOMS: u128 = 1_000_000_000_000_000_000;
@@ -404,6 +426,36 @@ fn test_g4_wallet74010_sequence_tx_version_eight() {
 fn test_sov_native_wipe_replay_parity() {
     let sample = first_n_genesis_sov_wallets(3);
     run_wipe_replay_parity(build_sov_activity_chain(), 6, &sample, &[]);
+}
+
+/// Floor estimate for ops: canonical-import throughput on a synthetic 10k SOV chain.
+///
+/// Run manually before estimating wipe-and-catch-up wall-clock:
+/// `cargo test -p lib-blockchain --test g4_replay_acceptance_tests \
+///   test_canonical_import_throughput_benchmark_10k -- --ignored --nocapture`
+#[test]
+#[ignore = "benchmark — run manually for canonical import throughput floor estimate"]
+fn test_canonical_import_throughput_benchmark_10k() {
+    const HEIGHT: u64 = 10_000;
+    let blocks = build_sov_activity_chain_to_height(HEIGHT);
+
+    let dir = TempDir::new().expect("tempdir");
+    let store = open_fresh_store(&dir);
+    let sync = ChainSync::new(Arc::clone(&store));
+
+    let start = std::time::Instant::now();
+    sync.import_blocks(blocks).expect("10k canonical import");
+    let elapsed = start.elapsed();
+    let secs = elapsed.as_secs_f64();
+    let blocks_per_sec = HEIGHT as f64 / secs;
+
+    eprintln!(
+        "canonical import throughput: {HEIGHT} blocks in {secs:.1}s ({blocks_per_sec:.1} blocks/sec)"
+    );
+    eprintln!(
+        "ops estimate: 177k blocks at {blocks_per_sec:.0}/s ≈ {:.0} min",
+        177_000.0 / blocks_per_sec / 60.0
+    );
 }
 
 /// Paginated fresh sync must match single-shot wipe-and-replay (g4 page-2+ bug class).

--- a/lib-blockchain/tests/g4_replay_acceptance_tests.rs
+++ b/lib-blockchain/tests/g4_replay_acceptance_tests.rs
@@ -7,6 +7,12 @@
 //! These do **not** replace the manual g4 fixture at ≥74k — they regression-test replay mechanics
 //! that g4's failure class depends on. Empirical g4 parity requires `test_g4_checkpoint_replay_acceptance`.
 //!
+//! **Forensics @ h=74010 (wallet `0e2962d5…`):** current executor replay ends at **4100 SOV**
+//! before the canonical **4150 SOV** self-transfer (`test_g4_wallet74010_sequence_isolated_replay`).
+//! Live g1 applied that tx (sled nonce=4 at tip). The 50 SOV gap matches the h=73982 self-transfer
+//! amount — pre-reset testnet state was built under older write paths; wipe-and-replay with today's
+//! sled-canonical executor cannot re-derive it. **GENESIS-3 reset** is the clean gate, not a 74k replay patch.
+//!
 //! ## Manual g4 fixture
 //! ```bash
 //! cargo run -p tools --bin export_replay_fixture -- /opt/zhtp/data/testnet/sled /tmp/g4 --to-height 74010
@@ -24,7 +30,9 @@ use lib_blockchain::storage::{Address, TokenId};
 use lib_blockchain::sync::G4_CHECKPOINT_HEIGHT_FLOOR;
 use lib_blockchain::transaction::{
     token_creation::TokenCreationPayloadV1, TokenTransferData, Transaction, TransactionPayload,
+    WalletTransactionData,
 };
+use lib_blockchain::types::Hash;
 use lib_blockchain::transaction::DEFAULT_TOKEN_CREATION_FEE;
 use lib_blockchain::types::TransactionType;
 use lib_blockchain::Blockchain;
@@ -32,7 +40,7 @@ use tempfile::TempDir;
 
 mod common;
 use common::block_builders::{block_at_height_with_txs, genesis_block};
-use common::crypto_fixtures::dummy_signature;
+use common::crypto_fixtures::{dummy_public_key, dummy_signature};
 use common::replay_gate::{
     bubl_like_token_id, cbe_treasury_address, compare_snapshots, first_n_genesis_sov_wallets,
     load_blocks_fixture, open_fresh_store, DaoTokenExpectation, ReplayCheckpointSnapshot,
@@ -40,9 +48,46 @@ use common::replay_gate::{
 
 use lib_blockchain::sync::ChainSync;
 
-fn create_sov_transfer_tx(from: [u8; 32], to: [u8; 32], amount: u128, nonce: u64) -> Transaction {
+fn create_wallet_registration_tx(wallet_id: [u8; 32], initial_balance: u128) -> Transaction {
+    let owner = dummy_public_key();
     Transaction {
-        version: 1,
+        version: 8,
+        chain_id: 0x03,
+        transaction_type: TransactionType::WalletRegistration,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: dummy_signature(),
+        memo: vec![],
+        payload: TransactionPayload::Wallet(WalletTransactionData {
+            wallet_id: Hash::new(wallet_id),
+            owner_identity_id: None,
+            alias: None,
+            wallet_name: "g4-repro".to_string(),
+            wallet_type: "Primary".to_string(),
+            public_key: owner.dilithium_pk.to_vec(),
+            capabilities: 0,
+            created_at: 0,
+            registration_fee: 0,
+            initial_balance,
+            seed_commitment: Hash::zero(),
+        }),
+    }
+}
+
+fn create_sov_transfer_tx(from: [u8; 32], to: [u8; 32], amount: u128, nonce: u64) -> Transaction {
+    create_sov_transfer_tx_version(from, to, amount, nonce, 8u32)
+}
+
+fn create_sov_transfer_tx_version(
+    from: [u8; 32],
+    to: [u8; 32],
+    amount: u128,
+    nonce: u64,
+    version: u32,
+) -> Transaction {
+    Transaction {
+        version,
         chain_id: 0x03,
         transaction_type: TransactionType::TokenTransfer,
         inputs: vec![],
@@ -226,6 +271,132 @@ fn run_wipe_replay_parity(
     compare_snapshots("wipe-and-replay", &reference, &replayed).expect(
         "replay checkpoint must match live reference — see token_id/address/have/need above",
     );
+}
+
+/// Isolated repro of g4 wallet `0e2962d5…` activity through the failing h=74010 tx.
+/// Pins current executor semantics without replaying 74k prefix blocks.
+#[test]
+fn test_g4_wallet74010_sequence_isolated_replay() {
+    const ATOMS: u128 = 1_000_000_000_000_000_000;
+    let wallet: [u8; 32] =
+        hex::decode("0e2962d527220810ffe8c78ae3290fdf37b25f9bbba1c9a69eac612193db78ab")
+            .expect("wallet hex")
+            .try_into()
+            .expect("wallet len");
+    let recipient: [u8; 32] =
+        hex::decode("7beb2195d122ffa72b4cb124125c30eb540a19a36b69a143ff2b25c2bd32f3b7")
+            .expect("recipient hex")
+            .try_into()
+            .expect("recipient len");
+
+    let genesis = genesis_block();
+    let mut prev = genesis.header.block_hash;
+    let h1 = block_at_height_with_txs(
+        1,
+        prev,
+        vec![create_wallet_registration_tx(wallet, 5000 * ATOMS)],
+    );
+    prev = h1.header.block_hash;
+    let h2 = block_at_height_with_txs(
+        2,
+        prev,
+        vec![create_sov_transfer_tx(wallet, wallet, 50 * ATOMS, 0)],
+    );
+    prev = h2.header.block_hash;
+    let h3 = block_at_height_with_txs(
+        3,
+        prev,
+        vec![create_sov_transfer_tx(wallet, recipient, 900 * ATOMS, 1)],
+    );
+    prev = h3.header.block_hash;
+    let h4 = block_at_height_with_txs(
+        4,
+        prev,
+        vec![create_sov_transfer_tx(wallet, wallet, 4150 * ATOMS, 2)],
+    );
+
+    let dir = TempDir::new().expect("tempdir");
+    let store = open_fresh_store(&dir);
+    let sync = ChainSync::new(Arc::clone(&store));
+
+    sync.import_blocks(vec![genesis, h1, h2, h3])
+        .expect("import through outbound transfer");
+
+    let sov = TokenId::new(generate_lib_token_id());
+    let bal = store
+        .get_token_balance(&sov, &Address::new(wallet))
+        .expect("read balance");
+    assert_eq!(
+        bal, 4100 * ATOMS,
+        "after 5000 mint, zero-net 50 self-transfer, 900 outbound: have {bal}"
+    );
+    let nonce = store
+        .get_token_nonce(&sov, &Address::new(wallet))
+        .expect("read nonce");
+    assert_eq!(nonce, 2, "outbound transfer must advance nonce to 2 before final leg");
+
+    let err = sync
+        .import_blocks(vec![h4])
+        .expect_err("4150 self-transfer must fail — 50 SOV short of g4 canonical block");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("Insufficient token balance") || msg.contains("InsufficientBalance"),
+        "expected balance error, got: {msg}"
+    );
+}
+
+/// Fixture uses tx version 8 — confirm version is not the replay/live divergence.
+#[test]
+fn test_g4_wallet74010_sequence_tx_version_eight() {
+    const ATOMS: u128 = 1_000_000_000_000_000_000;
+    let wallet: [u8; 32] =
+        hex::decode("0e2962d527220810ffe8c78ae3290fdf37b25f9bbba1c9a69eac612193db78ab")
+            .expect("wallet hex")
+            .try_into()
+            .expect("wallet len");
+    let recipient: [u8; 32] =
+        hex::decode("7beb2195d122ffa72b4cb124125c30eb540a19a36b69a143ff2b25c2bd32f3b7")
+            .expect("recipient hex")
+            .try_into()
+            .expect("recipient len");
+
+    let genesis = genesis_block();
+    let mut prev = genesis.header.block_hash;
+    let h1 = block_at_height_with_txs(
+        1,
+        prev,
+        vec![create_wallet_registration_tx(wallet, 5000 * ATOMS)],
+    );
+    prev = h1.header.block_hash;
+    let h2 = block_at_height_with_txs(
+        2,
+        prev,
+        vec![create_sov_transfer_tx_version(wallet, wallet, 50 * ATOMS, 0, 8u32)],
+    );
+    prev = h2.header.block_hash;
+    let h3 = block_at_height_with_txs(
+        3,
+        prev,
+        vec![create_sov_transfer_tx_version(wallet, recipient, 900 * ATOMS, 1, 8u32)],
+    );
+    prev = h3.header.block_hash;
+    let h4 = block_at_height_with_txs(
+        4,
+        prev,
+        vec![create_sov_transfer_tx_version(wallet, wallet, 4150 * ATOMS, 2, 8u32)],
+    );
+
+    let dir = TempDir::new().expect("tempdir");
+    let store = open_fresh_store(&dir);
+    let sync = ChainSync::new(Arc::clone(&store));
+    sync.import_blocks(vec![genesis, h1, h2, h3])
+        .expect("import through outbound transfer");
+    let sov = TokenId::new(generate_lib_token_id());
+    let bal = store
+        .get_token_balance(&sov, &Address::new(wallet))
+        .expect("balance");
+    assert_eq!(bal, 4100 * ATOMS);
+    assert!(sync.import_blocks(vec![h4]).is_err());
 }
 
 /// SOV-native genesis bootstrap + SOV transfer replay parity (#2725 / #2741 fix class).

--- a/scripts/validate-genesis-replay-gate.sh
+++ b/scripts/validate-genesis-replay-gate.sh
@@ -29,6 +29,11 @@ run_gate \
     test_sov_native_wipe_replay_parity -- --nocapture
 
 run_gate \
+  "Paginated fresh sync replay parity (page-2+ canonical import)" \
+  cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \
+    test_paginated_fresh_sync_replay_parity -- --nocapture
+
+run_gate \
   "DAO TokenCreation + custom-token wipe-and-replay parity" \
   cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \
     test_dao_token_creation_wipe_replay_parity -- --nocapture
@@ -41,7 +46,8 @@ run_gate \
 echo ""
 echo "[genesis-replay-gate] All GENESIS-2 CI gates passed"
 echo "[genesis-replay-gate] Manual g4 fixture (testnet maintainer, pre-deploy):"
-echo "  cargo run -p tools --bin export_replay_fixture -- <sled-path> <out-dir> --to-height 74010"
+echo "  cargo run --release -p tools --bin export_replay_fixture -- <sled-path> <out-dir> --to-height 74010"
 echo "  G4_REPLAY_BLOCKS_PATH=<out>/blocks.v1.bin G4_REPLAY_SNAPSHOT_PATH=<out>/checkpoint.json \\"
-echo "    cargo test --locked -p lib-blockchain --test g4_replay_acceptance_tests \\"
+echo "    cargo test --release -p lib-blockchain --test g4_replay_acceptance_tests \\"
 echo "      test_g4_checkpoint_replay_acceptance -- --ignored --nocapture"
+echo "  Optional paginated path (production mirror; 3–6h at 74k): test_g4_checkpoint_paginated_replay_acceptance"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -40,6 +40,7 @@ serde = { version = "1.0", features = ["derive"] }
 blake3 = "1"
 serde_json = "1"
 dirs = "5"
+tempfile = "3"
 
 [[bin]]
 name = "regen_cbe_key"
@@ -48,3 +49,7 @@ path = "regen_cbe_key.rs"
 [[bin]]
 name = "export_replay_fixture"
 path = "export_replay_fixture.rs"
+
+[[bin]]
+name = "replay_divergence"
+path = "replay_divergence.rs"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -34,6 +34,7 @@ lib-blockchain = { path = "../lib-blockchain" }
 lib-types = { path = "../lib-types" }
 hex = "0.4"
 anyhow = "1"
+clap = { version = "4.0", features = ["derive"] }
 sled = "0.34"
 bincode = "1.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/tools/replay_divergence.rs
+++ b/tools/replay_divergence.rs
@@ -1,0 +1,314 @@
+//! Hunt replay vs live-sled balance divergence for GENESIS-2 forensics.
+//!
+//! Usage:
+//!   replay_divergence inspect-block <blocks.v1.bin> <height>
+//!   replay_divergence find-divergence <live-sled> <blocks.v1.bin> <wallet-hex> [max-height]
+
+use anyhow::{Context, Result};
+use lib_blockchain::contracts::utils::generate_lib_token_id;
+use lib_blockchain::storage::{Address, BlockchainStore, SledStore, TokenId};
+use lib_blockchain::sync::{ChainSync, ReplayBlocksFixture};
+use lib_blockchain::transaction::TransactionPayload;
+use lib_blockchain::types::TransactionType;
+use std::path::Path;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+fn load_fixture(path: &Path) -> Result<Vec<lib_blockchain::block::Block>> {
+    let data = std::fs::read(path)?;
+    if let Ok(fixture) = ReplayBlocksFixture::decode(&data) {
+        return Ok(fixture.blocks);
+    }
+    bincode::deserialize(&data).context("decode blocks fixture")
+}
+
+fn sov_token() -> TokenId {
+    TokenId::new(generate_lib_token_id())
+}
+
+fn balance_at(store: &dyn BlockchainStore, wallet: &[u8; 32]) -> Result<u128> {
+    Ok(store
+        .get_token_balance(&sov_token(), &Address::new(*wallet))
+        .unwrap_or(0))
+}
+
+fn replay_to_height(blocks: &[lib_blockchain::block::Block], height: u64) -> Result<Arc<dyn BlockchainStore>> {
+    let slice: Vec<_> = blocks
+        .iter()
+        .filter(|b| b.header.height <= height)
+        .cloned()
+        .collect();
+    anyhow::ensure!(!slice.is_empty(), "no blocks up to height {height}");
+    anyhow::ensure!(
+        slice.last().map(|b| b.header.height) == Some(height),
+        "fixture missing block at height {height}"
+    );
+    let dir = TempDir::new()?;
+    let store: Arc<dyn BlockchainStore> = Arc::new(SledStore::open(dir.path())?);
+    let sync = ChainSync::new(Arc::clone(&store));
+    sync.import_blocks(slice).context("replay import")?;
+    Ok(store)
+}
+
+fn inspect_block(path: &Path, height: u64) -> Result<()> {
+    let blocks = load_fixture(path)?;
+    let block = blocks
+        .iter()
+        .find(|b| b.header.height == height)
+        .with_context(|| format!("block {height} not in fixture"))?;
+
+    println!("Block {height}: tx_count={}", block.transactions.len());
+    println!("SOV token_id={}", hex::encode(generate_lib_token_id()));
+
+    for (i, tx) in block.transactions.iter().enumerate() {
+        println!("\n--- tx[{i}] type={:?} fee={} v={}", tx.transaction_type, tx.fee, tx.version);
+        match &tx.transaction_type {
+            TransactionType::TokenTransfer => {
+                if let TransactionPayload::TokenTransfer(data) = &tx.payload {
+                    println!(
+                        "  TokenTransfer: token={} from={} to={} amount={} nonce={}",
+                        hex::encode(data.token_id),
+                        hex::encode(data.from),
+                        hex::encode(data.to),
+                        data.amount,
+                        data.nonce
+                    );
+                } else {
+                    println!("  TokenTransfer payload missing TokenTransferData");
+                }
+            }
+            TransactionType::WalletRegistration | TransactionType::WalletUpdate => {
+                if let Some(wd) = tx.wallet_data() {
+                    println!(
+                        "  {:?}: wallet_id={} initial_balance={} type={}",
+                        tx.transaction_type,
+                        hex::encode(wd.wallet_id.as_array()),
+                        wd.initial_balance,
+                        wd.wallet_type
+                    );
+                } else {
+                    println!("  {:?} (no wallet_data)", tx.transaction_type);
+                }
+            }
+            other => println!("  (other type: {other:?})"),
+        }
+        println!("  signer key_id={}", hex::encode(tx.signature.public_key.key_id));
+    }
+    Ok(())
+}
+
+fn scan_wallet_transfers(
+    blocks_path: &Path,
+    wallet_hex: &str,
+    from_height: u64,
+    to_height: u64,
+) -> Result<()> {
+    let wallet_bytes = hex::decode(wallet_hex).context("wallet hex")?;
+    anyhow::ensure!(wallet_bytes.len() == 32, "wallet must be 32 bytes");
+    let mut wallet = [0u8; 32];
+    wallet.copy_from_slice(&wallet_bytes);
+
+    let blocks = load_fixture(blocks_path)?;
+    println!(
+        "TokenTransfer activity for {} in [{from_height}, {to_height}]",
+        wallet_hex
+    );
+    for block in blocks.iter().filter(|b| {
+        b.header.height >= from_height && b.header.height <= to_height
+    }) {
+        for (i, tx) in block.transactions.iter().enumerate() {
+            if tx.transaction_type != TransactionType::TokenTransfer {
+                continue;
+            }
+            let TransactionPayload::TokenTransfer(data) = &tx.payload else {
+                continue;
+            };
+            if data.from != wallet && data.to != wallet {
+                continue;
+            }
+            let dir = if data.from == wallet { "debit" } else { "credit" };
+            println!(
+                "  h={} tx[{i}] {dir} amount={} nonce={} counterparty={}",
+                block.header.height,
+                data.amount,
+                data.nonce,
+                hex::encode(if data.from == wallet { data.to } else { data.from })
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Single-pass incremental replay; sample balances at milestones.
+fn incremental_milestones(
+    blocks_path: &Path,
+    wallet_hex: &str,
+    max_height: u64,
+) -> Result<()> {
+    let wallet_bytes = hex::decode(wallet_hex).context("wallet hex")?;
+    anyhow::ensure!(wallet_bytes.len() == 32, "wallet must be 32 bytes");
+    let mut wallet = [0u8; 32];
+    wallet.copy_from_slice(&wallet_bytes);
+
+    let blocks = load_fixture(blocks_path)?;
+    let milestones: Vec<u64> = [
+        0, 1, 50, 1000, 10000, 50000, 70000, 73000, 73800, 73900, 73950, 73980, 73990, 74000,
+        74005, 74008, 74009, 74010,
+    ]
+    .into_iter()
+    .filter(|h| *h <= max_height)
+    .collect();
+
+    let dir = TempDir::new()?;
+    let store: Arc<dyn BlockchainStore> = Arc::new(SledStore::open(dir.path())?);
+    let sync = ChainSync::new(Arc::clone(&store));
+
+    let mut cursor = 0usize;
+    let mut next_milestone = 0usize;
+
+    while cursor < blocks.len() && next_milestone < milestones.len() {
+        let target = milestones[next_milestone];
+        let end = blocks
+            .iter()
+            .position(|b| b.header.height > target)
+            .unwrap_or(blocks.len());
+        if end > cursor {
+            let chunk: Vec<_> = blocks[cursor..end].to_vec();
+            sync.import_blocks(chunk).context("incremental import")?;
+            cursor = end;
+        }
+        let bal = balance_at(store.as_ref(), &wallet)?;
+        eprintln!("replay height={target:>6} balance={bal}");
+        next_milestone += 1;
+    }
+
+    // Live sled tip balance (includes blocks > max_height — informational only).
+    Ok(())
+}
+
+fn find_wallet_in_chain(blocks_path: &Path, wallet_hex: &str) -> Result<()> {
+    let wallet_bytes = hex::decode(wallet_hex).context("wallet hex")?;
+    anyhow::ensure!(wallet_bytes.len() == 32, "wallet must be 32 bytes");
+    let mut wallet = [0u8; 32];
+    wallet.copy_from_slice(&wallet_bytes);
+
+    let blocks = load_fixture(blocks_path)?;
+    println!("Scanning for wallet {wallet_hex} in all block txs");
+    for block in &blocks {
+        for (i, tx) in block.transactions.iter().enumerate() {
+            let mut hit = false;
+            if let TransactionPayload::TokenTransfer(d) = &tx.payload {
+                if d.from == wallet || d.to == wallet {
+                    hit = true;
+                    println!(
+                        "  h={} tx[{i}] TokenTransfer amount={} nonce={} from={} to={}",
+                        block.header.height,
+                        d.amount,
+                        d.nonce,
+                        hex::encode(d.from),
+                        hex::encode(d.to)
+                    );
+                }
+            }
+            if let Some(wd) = tx.wallet_data() {
+                if wd.wallet_id.as_array() == wallet {
+                    hit = true;
+                    println!(
+                        "  h={} tx[{i}] {:?} initial_balance={} type={}",
+                        block.header.height,
+                        tx.transaction_type,
+                        wd.initial_balance,
+                        wd.wallet_type
+                    );
+                }
+            }
+            if !hit {
+                if tx.signature.public_key.key_id == wallet {
+                    println!(
+                        "  h={} tx[{i}] {:?} signer_key_id=wallet",
+                        block.header.height, tx.transaction_type
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1).collect::<Vec<_>>();
+    let cmd = args
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "help".to_string());
+
+    match cmd.as_str() {
+        "inspect-block" => {
+            let path = Path::new(args.get(1).context("blocks path")?);
+            let height: u64 = args.get(2).context("height")?.parse()?;
+            inspect_block(path, height)?;
+        }
+        "scan-wallet" => {
+            let blocks = Path::new(args.get(1).context("blocks path")?);
+            let wallet = args.get(2).context("wallet hex")?;
+            let from_h: u64 = args.get(3).map(|s| s.parse()).transpose()?.unwrap_or(73_900);
+            let to_h: u64 = args.get(4).map(|s| s.parse()).transpose()?.unwrap_or(74_010);
+            scan_wallet_transfers(blocks, wallet, from_h, to_h)?;
+        }
+        "find-wallet" => {
+            let blocks = Path::new(args.get(1).context("blocks path")?);
+            let wallet = args.get(2).context("wallet hex")?;
+            find_wallet_in_chain(blocks, wallet)?;
+        }
+        "milestones" => {
+            let blocks = Path::new(args.get(1).context("blocks path")?);
+            let wallet = args.get(2).context("wallet hex")?;
+            let max_h: u64 = args
+                .get(3)
+                .map(|s| s.parse())
+                .transpose()?
+                .unwrap_or(74_010);
+            incremental_milestones(blocks, wallet, max_h)?;
+        }
+        "balance-at" => {
+            let blocks = Path::new(args.get(1).context("blocks path")?);
+            let wallet = args.get(2).context("wallet hex")?;
+            let height: u64 = args.get(3).context("height")?.parse()?;
+            let wallet_bytes = hex::decode(wallet).context("wallet hex")?;
+            anyhow::ensure!(wallet_bytes.len() == 32, "wallet must be 32 bytes");
+            let mut w = [0u8; 32];
+            w.copy_from_slice(&wallet_bytes);
+            let store = replay_to_height(&load_fixture(blocks)?, height)?;
+            let bal = balance_at(store.as_ref(), &w)?;
+            println!("replay height={height} balance={bal}");
+        }
+        "live-balance" => {
+            let sled = Path::new(args.get(1).context("sled path")?);
+            let wallet = args.get(2).context("wallet hex")?;
+            let wallet_bytes = hex::decode(wallet).context("wallet hex")?;
+            anyhow::ensure!(wallet_bytes.len() == 32, "wallet must be 32 bytes");
+            let mut w = [0u8; 32];
+            w.copy_from_slice(&wallet_bytes);
+            let store = SledStore::open(sled)?;
+            let h = store.latest_height().unwrap_or(0);
+            let bal = balance_at(&store, &w)?;
+            let token = sov_token();
+            let nonce = store
+                .get_token_nonce(&token, &Address::new(w))
+                .unwrap_or(0);
+            println!("live sled height={h} balance={bal} nonce={nonce}");
+        }
+        _ => {
+            eprintln!(
+                "Usage:\n  \
+                 replay_divergence inspect-block <blocks.v1.bin> <height>\n  \
+                 replay_divergence scan-wallet <blocks.v1.bin> <wallet-hex> [from-h] [to-h]\n  \
+                 replay_divergence find-wallet <blocks.v1.bin> <wallet-hex>\n  \
+                 replay_divergence milestones <blocks.v1.bin> <wallet-hex> [max-height]\n  \
+                 replay_divergence balance-at <blocks.v1.bin> <wallet-hex> <height>\n  \
+                 replay_divergence live-balance <sled-path> <wallet-hex>"
+            );
+        }
+    }
+    Ok(())
+}

--- a/tools/replay_divergence.rs
+++ b/tools/replay_divergence.rs
@@ -1,10 +1,7 @@
 //! Hunt replay vs live-sled balance divergence for GENESIS-2 forensics.
-//!
-//! Usage:
-//!   replay_divergence inspect-block <blocks.v1.bin> <height>
-//!   replay_divergence find-divergence <live-sled> <blocks.v1.bin> <wallet-hex> [max-height]
 
 use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
 use lib_blockchain::contracts::utils::generate_lib_token_id;
 use lib_blockchain::storage::{Address, BlockchainStore, SledStore, TokenId};
 use lib_blockchain::sync::{ChainSync, ReplayBlocksFixture};
@@ -235,61 +232,110 @@ fn find_wallet_in_chain(blocks_path: &Path, wallet_hex: &str) -> Result<()> {
     Ok(())
 }
 
-fn main() -> Result<()> {
-    let mut args = std::env::args().skip(1).collect::<Vec<_>>();
-    let cmd = args
-        .first()
-        .cloned()
-        .unwrap_or_else(|| "help".to_string());
+#[derive(Parser)]
+#[command(
+    name = "replay_divergence",
+    about = "Hunt replay vs live-sled balance divergence for GENESIS-2 forensics",
+    version
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
 
-    match cmd.as_str() {
-        "inspect-block" => {
-            let path = Path::new(args.get(1).context("blocks path")?);
-            let height: u64 = args.get(2).context("height")?.parse()?;
-            inspect_block(path, height)?;
+#[derive(Subcommand)]
+enum Commands {
+    /// Print txs in a fixture block at a given height.
+    InspectBlock {
+        /// Path to blocks.v1.bin (or raw bincode fixture).
+        blocks: std::path::PathBuf,
+        /// Block height to inspect.
+        height: u64,
+    },
+    /// List TokenTransfer debits/credits for a wallet in a height range.
+    ScanWallet {
+        blocks: std::path::PathBuf,
+        /// 32-byte wallet id as hex.
+        wallet: String,
+        /// Start height (default 73900).
+        #[arg(long, default_value_t = 73_900)]
+        from_height: u64,
+        /// End height (default 74010).
+        #[arg(long, default_value_t = 74_010)]
+        to_height: u64,
+    },
+    /// Scan all fixture blocks for wallet-related txs.
+    FindWallet {
+        blocks: std::path::PathBuf,
+        wallet: String,
+    },
+    /// Incremental replay with balance samples at milestone heights.
+    Milestones {
+        blocks: std::path::PathBuf,
+        wallet: String,
+        /// Last height to replay (default 74010).
+        #[arg(long, default_value_t = 74_010)]
+        max_height: u64,
+    },
+    /// Replay fixture to height and print wallet SOV balance.
+    BalanceAt {
+        blocks: std::path::PathBuf,
+        wallet: String,
+        height: u64,
+    },
+    /// Read wallet SOV balance + nonce from a live sled store.
+    LiveBalance {
+        sled: std::path::PathBuf,
+        wallet: String,
+    },
+}
+
+fn parse_wallet_hex(wallet: &str) -> Result<[u8; 32]> {
+    let wallet_bytes = hex::decode(wallet).context("wallet hex")?;
+    anyhow::ensure!(wallet_bytes.len() == 32, "wallet must be 32 bytes");
+    let mut w = [0u8; 32];
+    w.copy_from_slice(&wallet_bytes);
+    Ok(w)
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::InspectBlock { blocks, height } => {
+            inspect_block(&blocks, height)?;
         }
-        "scan-wallet" => {
-            let blocks = Path::new(args.get(1).context("blocks path")?);
-            let wallet = args.get(2).context("wallet hex")?;
-            let from_h: u64 = args.get(3).map(|s| s.parse()).transpose()?.unwrap_or(73_900);
-            let to_h: u64 = args.get(4).map(|s| s.parse()).transpose()?.unwrap_or(74_010);
-            scan_wallet_transfers(blocks, wallet, from_h, to_h)?;
+        Commands::ScanWallet {
+            blocks,
+            wallet,
+            from_height,
+            to_height,
+        } => {
+            scan_wallet_transfers(&blocks, &wallet, from_height, to_height)?;
         }
-        "find-wallet" => {
-            let blocks = Path::new(args.get(1).context("blocks path")?);
-            let wallet = args.get(2).context("wallet hex")?;
-            find_wallet_in_chain(blocks, wallet)?;
+        Commands::FindWallet { blocks, wallet } => {
+            find_wallet_in_chain(&blocks, &wallet)?;
         }
-        "milestones" => {
-            let blocks = Path::new(args.get(1).context("blocks path")?);
-            let wallet = args.get(2).context("wallet hex")?;
-            let max_h: u64 = args
-                .get(3)
-                .map(|s| s.parse())
-                .transpose()?
-                .unwrap_or(74_010);
-            incremental_milestones(blocks, wallet, max_h)?;
+        Commands::Milestones {
+            blocks,
+            wallet,
+            max_height,
+        } => {
+            incremental_milestones(&blocks, &wallet, max_height)?;
         }
-        "balance-at" => {
-            let blocks = Path::new(args.get(1).context("blocks path")?);
-            let wallet = args.get(2).context("wallet hex")?;
-            let height: u64 = args.get(3).context("height")?.parse()?;
-            let wallet_bytes = hex::decode(wallet).context("wallet hex")?;
-            anyhow::ensure!(wallet_bytes.len() == 32, "wallet must be 32 bytes");
-            let mut w = [0u8; 32];
-            w.copy_from_slice(&wallet_bytes);
-            let store = replay_to_height(&load_fixture(blocks)?, height)?;
+        Commands::BalanceAt {
+            blocks,
+            wallet,
+            height,
+        } => {
+            let w = parse_wallet_hex(&wallet)?;
+            let store = replay_to_height(&load_fixture(&blocks)?, height)?;
             let bal = balance_at(store.as_ref(), &w)?;
             println!("replay height={height} balance={bal}");
         }
-        "live-balance" => {
-            let sled = Path::new(args.get(1).context("sled path")?);
-            let wallet = args.get(2).context("wallet hex")?;
-            let wallet_bytes = hex::decode(wallet).context("wallet hex")?;
-            anyhow::ensure!(wallet_bytes.len() == 32, "wallet must be 32 bytes");
-            let mut w = [0u8; 32];
-            w.copy_from_slice(&wallet_bytes);
-            let store = SledStore::open(sled)?;
+        Commands::LiveBalance { sled, wallet } => {
+            let w = parse_wallet_hex(&wallet)?;
+            let store = SledStore::open(&sled)?;
             let h = store.latest_height().unwrap_or(0);
             let bal = balance_at(&store, &w)?;
             let token = sov_token();
@@ -297,17 +343,6 @@ fn main() -> Result<()> {
                 .get_token_nonce(&token, &Address::new(w))
                 .unwrap_or(0);
             println!("live sled height={h} balance={bal} nonce={nonce}");
-        }
-        _ => {
-            eprintln!(
-                "Usage:\n  \
-                 replay_divergence inspect-block <blocks.v1.bin> <height>\n  \
-                 replay_divergence scan-wallet <blocks.v1.bin> <wallet-hex> [from-h] [to-h]\n  \
-                 replay_divergence find-wallet <blocks.v1.bin> <wallet-hex>\n  \
-                 replay_divergence milestones <blocks.v1.bin> <wallet-hex> [max-height]\n  \
-                 replay_divergence balance-at <blocks.v1.bin> <wallet-hex> <height>\n  \
-                 replay_divergence live-balance <sled-path> <wallet-hex>"
-            );
         }
     }
     Ok(())

--- a/tools/replay_divergence.rs
+++ b/tools/replay_divergence.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use lib_blockchain::contracts::utils::generate_lib_token_id;
 use lib_blockchain::storage::{Address, BlockchainStore, SledStore, TokenId};
-use lib_blockchain::sync::{ChainSync, ReplayBlocksFixture};
+use lib_blockchain::sync::{ChainSync, ReplayBlocksFixture, MAX_REPLAY_FIXTURE_BYTES};
 use lib_blockchain::transaction::TransactionPayload;
 use lib_blockchain::types::TransactionType;
 use std::path::Path;
@@ -12,11 +12,16 @@ use std::sync::Arc;
 use tempfile::TempDir;
 
 fn load_fixture(path: &Path) -> Result<Vec<lib_blockchain::block::Block>> {
-    let data = std::fs::read(path)?;
-    if let Ok(fixture) = ReplayBlocksFixture::decode(&data) {
+    if let Ok(fixture) = ReplayBlocksFixture::load(path) {
         return Ok(fixture.blocks);
     }
-    bincode::deserialize(&data).context("decode blocks fixture")
+    let data = std::fs::read(path)?;
+    anyhow::ensure!(
+        data.len() <= MAX_REPLAY_FIXTURE_BYTES,
+        "fixture file too large ({} bytes)",
+        data.len()
+    );
+    bincode::deserialize(&data).context("decode legacy blocks fixture (try re-exporting v1)")
 }
 
 fn sov_token() -> TokenId {
@@ -29,7 +34,11 @@ fn balance_at(store: &dyn BlockchainStore, wallet: &[u8; 32]) -> Result<u128> {
         .unwrap_or(0))
 }
 
-fn replay_to_height(blocks: &[lib_blockchain::block::Block], height: u64) -> Result<Arc<dyn BlockchainStore>> {
+fn replay_balance_at(
+    blocks: &[lib_blockchain::block::Block],
+    height: u64,
+    wallet: &[u8; 32],
+) -> Result<u128> {
     let slice: Vec<_> = blocks
         .iter()
         .filter(|b| b.header.height <= height)
@@ -40,11 +49,12 @@ fn replay_to_height(blocks: &[lib_blockchain::block::Block], height: u64) -> Res
         slice.last().map(|b| b.header.height) == Some(height),
         "fixture missing block at height {height}"
     );
+    // Keep TempDir alive for the lifetime of the sled store.
     let dir = TempDir::new()?;
     let store: Arc<dyn BlockchainStore> = Arc::new(SledStore::open(dir.path())?);
     let sync = ChainSync::new(Arc::clone(&store));
     sync.import_blocks(slice).context("replay import")?;
-    Ok(store)
+    balance_at(store.as_ref(), wallet)
 }
 
 fn inspect_block(path: &Path, height: u64) -> Result<()> {
@@ -329,8 +339,7 @@ fn main() -> Result<()> {
             height,
         } => {
             let w = parse_wallet_hex(&wallet)?;
-            let store = replay_to_height(&load_fixture(&blocks)?, height)?;
-            let bal = balance_at(store.as_ref(), &w)?;
+            let bal = replay_balance_at(&load_fixture(&blocks)?, height, &w)?;
             println!("replay height={height} balance={bal}");
         }
         Commands::LiveBalance { sled, wallet } => {

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -319,7 +319,7 @@ async fn try_initial_sync_from_peer(
             tip.height
         );
 
-        // Paginated import: 200 blocks per request, same as consensus catch-up.
+        // Paginated import: 50 blocks per request (ChainSync uses canonical runtime on page 2+).
         let sync = ChainSync::new(store.clone() as std::sync::Arc<dyn BlockchainStore>);
         let mut cursor = local_height;
         let mut next_start = first_start; // may be 0 (empty store) or local_height+1


### PR DESCRIPTION
## Summary

Fixes the g4 page-2+ sync bug where `ChainSync::import_blocks` used executor-only import for `expected_start > 0`, skipping `finish_block_processing` hooks and breaking wallet/SOV projection parity.

Also adds forensics tooling and fast isolated CI tests documenting why the **manual g4 gate @ h=74010 still fails on pre-reset testnet** — that is a separate historical-state issue, not pagination.

Rebased onto `development` (drops squash-merged #2742 content). Review feedback addressed in `3e3f1fdf`.

## Changes

### Pagination fix (`lib-blockchain/src/sync/mod.rs`)
- Route **all** post-genesis sync pages through `import_blocks_via_canonical_runtime` (same as live `process_and_commit_block`)
- Removes executor-only path that caused g4 wipe-and-replay to diverge at h=74010 on page 2+
- **`previous_hash` continuity:** trusted-replay executor skips prev-hash validation; `ChainSync::validate_block_previous_hash` now enforces it before both executor-prefix and canonical-runtime import. `test_progress_import_rejects_broken_continuity` covers this.
- Adds `test_paginated_fresh_sync_replay_parity` (60 blocks, 50/page)

### Performance (ops-relevant)
| Chain type | Throughput (empirical) |
|------------|------------------------|
| Synthetic SOV-only | ~100–225 blocks/sec |
| Real testnet (mixed tx types) | ~10–30 blocks/sec |
| 177k-block wipe-and-catch-up | **~90 min–3 h per follower** |

Run floor estimate: `cargo test -p lib-blockchain --test g4_replay_acceptance_tests test_canonical_import_throughput_benchmark_10k -- --ignored --nocapture`

### Forensics (`tools/replay_divergence.rs`)
- CLI with **clap `--help`**: `inspect-block`, `find-wallet`, `scan-wallet`, `balance-at`, `live-balance`, `milestones`
- Used to trace wallet `0e2962d5…` — 50 SOV short at h=74010 tx[1]

### Isolated repro tests
- `test_g4_wallet74010_sequence_isolated_replay` — ~2s, no 74k replay; **failure at h4 is the acceptance criterion until GENESIS-3**
- Confirms current executor: 5000 mint → zero-net 50 self-transfer → −900 outbound → **4100 SOV** before failing 4150 self-transfer
- Live g1 **did** commit that tx (sled nonce=4 at tip); pre-reset state was built under older write paths (#2637 / pre-#2641)
- Module doc includes per-test purpose table

### Reset runbook (`docs/protocol/genesis-3-testnet-reset.md`)
- Phase 1: `--wait-timeout 120` + kill -9 fallback
- Phase 3: full wipe list (sled, blockchain.dat, rewards.*, notifications.sled, storage/)
- Phase 4: g1 proposes but cannot commit without 4/5 quorum
- Phase 5: catch-up 1–3h; ignore PARTITION SUSPECTED first 60s
- Phase 6: g4 at tip within 3 blocks (not "stuck at 74009")
- Prereqs: pre-reset fixture red-by-design; reset datetime TBD

### API surface
- `G4_CHECKPOINT_HEIGHT_FLOOR` moved to test-only `common/replay_gate.rs` (no longer public crate API)

## Test plan

- [x] `cargo test -p lib-blockchain --test g4_replay_acceptance_tests test_paginated_fresh_sync_replay_parity`
- [x] `cargo test -p lib-blockchain --test g4_replay_acceptance_tests test_g4_wallet74010`
- [x] `cargo test -p lib-blockchain --lib test_progress_import_rejects_broken_continuity`
- [x] `scripts/validate-genesis-replay-gate.sh` (CI-scope gates)
- [ ] Manual g4 fixture @ 74010 — **expected red on pre-reset chain**; green after GENESIS-3 reset

## Gate status

| Gate | Pre-reset testnet | Post-GENESIS-3 |
|------|-------------------|----------------|
| Paginated fresh sync | Fixed by this PR | Fixed |
| Single-shot replay @ 74010 | Red (historical state) | Re-test after reset |
| g4 wipe empty sled | Do not wipe until reset | Safe after deploy + reset |

Closes #2730 (pagination); manual acceptance blocked on GENESIS-3 (#2731) for pre-reset fixture.