### PR TITLE
fix(crypto): bind signing to caller key, KyberSlash patch, domain sig validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,7 +3440,7 @@ dependencies = [
  "lib-network",
  "lib-protocols",
  "opaque-ke",
- "pqc_kyber",
+ "pqc_kyber_edit",
  "pqcrypto-kyber",
  "pqcrypto-traits",
  "quinn",
@@ -3575,7 +3575,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "hkdf",
- "pqc_kyber",
+ "pqc_kyber_edit",
  "rand 0.8.5",
  "serde",
  "sha3",
@@ -3735,7 +3735,7 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "parking_lot 0.12.5",
- "pqc_kyber",
+ "pqc_kyber_edit",
  "quick-xml 0.31.0",
  "quinn",
  "rand 0.8.5",
@@ -5123,10 +5123,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pqc_kyber"
-version = "0.7.1"
+name = "pqc_kyber_edit"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b23e1823e8a78ad67990c5cb843d5eba75ab3b8a44d041f3814fde89463dc6f"
+checksum = "90af5ab02bb265c976d2f0de25fa35a70dec379fee21d509a8bbd9a606054bc0"
 dependencies = [
  "rand_core 0.6.4",
 ]

--- a/docs/protocol/crypto-signing-cutover.md
+++ b/docs/protocol/crypto-signing-cutover.md
@@ -1,0 +1,170 @@
+# Crypto Signing Cutover Runbook
+
+**Status:** Draft — promote to **Approved** after validator ops review.
+**Owner:** Protocol + operations.
+**Audience:** Validator operators deploying PR #2745 signing fixes.
+
+PR #2745 corrects broken transaction and identity signing paths and patches
+the KyberSlash advisory (`RUSTSEC-2023-0079`). This is a **coordinated
+binary deploy**, not a chain restart. Signing semantics change at the moment
+validators run the new build.
+
+## What changes
+
+| Area | Before | After |
+|------|--------|-------|
+| `sign_transaction` | Generated a fresh random keypair per call | Signs with the caller's `PrivateKey` via `KeyPair::from_private_key` |
+| `IdentityManager::sign_with_identity` | Returned a Blake3 hash as "signature" | Real Dilithium5 signature with domain prefix `ZHTP-identity-sig-v1\0` |
+| Domain updates (`lib-network`) | Structural hex-length check only | Dilithium5 verify when `owner_dilithium_pk` is stored on the record |
+| Kyber KEM | `pqc_kyber` (vulnerable) | `pqc_kyber_edit` community fork |
+
+## Why coordinated deploy is required
+
+1. **Transaction signatures** — Any code path that called the old
+   `sign_transaction` produced signatures from random keys. After deploy,
+   signatures bind to the caller keystore. Mempool txs built with the old
+   binary may fail verification on new nodes (and vice versa).
+
+2. **Identity attestations** — New attestations use real Dilithium5 bytes
+   with domain separation. Verifiers must run the new `verify_identity_attestation`
+   helper (or equivalent) to validate them.
+
+3. **Domain updates** — Records registered after this deploy store
+   `owner_dilithium_pk`. Updates to those domains require a valid Dilithium5
+   signature over:
+
+   ```
+   domain|expected_previous_manifest_cid|new_manifest_cid|timestamp
+   ```
+
+   Legacy records without `owner_dilithium_pk` still accept structural-only
+   validation during the grace window documented below.
+
+## Pre-deploy checklist
+
+- [ ] PR #2745 merged to `development` and release binaries built from tip.
+- [ ] `cargo test -p lib-crypto from_private_key` passes.
+- [ ] `cargo test -p lib-blockchain --lib sign_transaction_binds` passes.
+- [ ] `cargo test -p lib-network --lib test_domain_update_persists` passes.
+- [ ] `cargo test -p lib-identity --lib sign_with_identity_roundtrips` passes.
+- [ ] Validator keystores confirmed: Dilithium sk/pk pairs match (no corrupted
+      `PrivateKey` structs with mismatched halves).
+- [ ] Operators notified ≥24h before cutover window.
+
+## Cutover window
+
+```
+Deploy branch:  development @ <merge-sha>
+Validators:     g1, g2, g3 (testnet)
+Grace end:      T+7 days after deploy (structural-only domain updates disabled)
+```
+
+Record the actual merge SHA and datetime here when scheduled:
+
+```
+merge_sha:     <pending>
+cutover_utc:   <pending>
+```
+
+## Deploy sequence
+
+Run on **all validators** in the same maintenance window (rolling is OK
+if mempool is paused first).
+
+### 1. Pause mempool ingress
+
+```bash
+# On each validator — stop accepting new txs during binary swap
+zhtp-cli admin mempool-pause
+```
+
+### 2. Drain in-flight work
+
+Wait until each node's mempool is empty or quiescent:
+
+```bash
+zhtp-cli admin mempool-status
+```
+
+Reject or drop txs signed with pre-cutover semantics if they remain after
+5 minutes (they will not verify on new binaries).
+
+### 3. Build and install
+
+```bash
+git fetch origin
+git checkout development
+git pull
+cargo build --release --features validator
+# Install binary per node playbook (systemd unit restart)
+sudo systemctl restart zhtp-validator
+```
+
+### 4. Verify health
+
+```bash
+zhtp-cli node status
+zhtp-cli consensus peers
+```
+
+Confirm all three validators report the same `development` tip hash.
+
+### 5. Resume mempool
+
+```bash
+zhtp-cli admin mempool-resume
+```
+
+### 6. Smoke-test signing paths
+
+```bash
+# Transaction signing — must verify on-chain
+zhtp-cli wallet transfer --dry-run ...
+
+# Domain update — must produce 9190-char hex signature
+zhtp-cli domain update --domain <test>.zhtp ...
+
+# Identity attestation roundtrip (API)
+curl -X POST /api/v1/identity/sign ...
+```
+
+## Domain registry migration
+
+New registrations automatically persist `owner_dilithium_pk` from the
+owner's `ZhtpIdentity.public_key`.
+
+**Legacy records** (registered before cutover, `owner_dilithium_pk` all
+zeros):
+
+- Updates continue to work with structural signature validation only.
+- Operators SHOULD re-register or run `DomainRegistry::migrate_domains`
+  after an owner-initiated update that includes a valid signature, so the
+  pubkey is captured on the next registration path.
+
+**After grace window (T+7 days):** plan follow-up issue to reject domain
+updates on records without `owner_dilithium_pk`.
+
+## Rollback
+
+If cutover fails:
+
+1. Pause mempool on all validators.
+2. Reinstall previous binary (record pre-cutover SHA before deploy).
+3. Flush mempool (`zhtp-cli admin mempool-flush`).
+4. Resume with old binary.
+
+Do **not** roll back only one validator — mixed signing semantics across
+the quorum will cause validation divergence.
+
+## Follow-up work (tracked as GitHub issues)
+
+- Enforce `owner_dilithium_pk` on all domain updates (disable structural-only grace).
+- Add `ZHTP-domain-update-v1\0` domain prefix to domain signing (breaking; coordinate with clients).
+- On-chain `OnChainDomainRecord` owner pubkey for validator-side domain tx verify.
+- Kyber fork audit / upstream tracking for `pqc_kyber_edit`.
+
+## References
+
+- PR #2745: `fix/crypto-signing-kyber-domain`
+- RUSTSEC-2023-0079 (KyberSlash)
+- Client domain update wire format: `lib-client/src/token_tx.rs::build_domain_update_request`

--- a/lib-blockchain/src/transaction/signing.rs
+++ b/lib-blockchain/src/transaction/signing.rs
@@ -36,15 +36,12 @@ pub fn sign_transaction(
     // Create signing hash (without existing signature)
     let signing_hash = crate::transaction::hashing::hash_for_signature(transaction);
 
-    // Create a keypair from the provided private key for signing
-    // TODO: In a proper implementation, would construct keypair from the provided private_key
-    // For now, we use the private_key validation but generate a new keypair
-    if private_key.dilithium_sk.is_empty() {
+    if private_key.dilithium_sk.iter().all(|&x| x == 0) {
         return Err(SigningError::InvalidPrivateKey);
     }
 
-    let keypair =
-        lib_crypto::KeyPair::generate().map_err(|e| SigningError::CryptoError(e.to_string()))?;
+    let keypair = lib_crypto::KeyPair::from_private_key(private_key)
+        .map_err(|e| SigningError::CryptoError(e.to_string()))?;
 
     // Sign the hash using the keypair and transaction context
     let signature = keypair

--- a/lib-blockchain/src/transaction/signing.rs
+++ b/lib-blockchain/src/transaction/signing.rs
@@ -288,3 +288,53 @@ pub mod utils {
         base_cost + zk_cost + identity_cost
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+    use crate::transaction::core::Transaction;
+    use lib_crypto::KeyPair;
+
+    fn empty_signature() -> Signature {
+        Signature {
+            signature: Vec::new(),
+            public_key: PublicKey::new([0u8; 2592]),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 0,
+        }
+    }
+
+    #[test]
+    fn sign_transaction_binds_to_caller_private_key() {
+        let signer = KeyPair::generate().expect("signer keypair");
+        let other = KeyPair::generate().expect("other keypair");
+
+        let mut tx = Transaction::new(vec![], vec![], 0, empty_signature(), vec![]);
+
+        sign_transaction(&mut tx, &signer.private_key).expect("sign with caller key");
+
+        assert!(
+            verify_transaction_signature(&tx, &signer.public_key).expect("verify signer"),
+            "signature must verify against caller public key"
+        );
+        assert!(
+            !verify_transaction_signature(&tx, &other.public_key).expect("verify other"),
+            "signature must not verify against a different public key"
+        );
+    }
+
+    #[test]
+    fn sign_transaction_rejects_zero_private_key() {
+        let mut tx = Transaction::new(vec![], vec![], 0, empty_signature(), vec![]);
+        let zero_key = PrivateKey {
+            dilithium_sk: [0u8; 4896],
+            dilithium_pk: [0u8; 2592],
+            kyber_sk: [0u8; 3168],
+            master_seed: [0u8; 64],
+        };
+
+        let err = sign_transaction(&mut tx, &zero_key).unwrap_err();
+        assert!(matches!(err, SigningError::InvalidPrivateKey));
+    }
+}

--- a/lib-client/Cargo.toml
+++ b/lib-client/Cargo.toml
@@ -81,7 +81,7 @@ jni = "0.21"
 # WASM: Pure Rust PQC implementations
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 crystals-dilithium = "1.0"
-pqc_kyber = { version = "0.7", features = ["kyber1024"] }
+pqc_kyber_edit = { version = "0.7", features = ["kyber1024"] }
 
 # WASM (optional, for web)
 wasm-bindgen = { version = "0.2", optional = true }

--- a/lib-client/Cargo.toml
+++ b/lib-client/Cargo.toml
@@ -81,6 +81,7 @@ jni = "0.21"
 # WASM: Pure Rust PQC implementations
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 crystals-dilithium = "1.0"
+# SECURITY: RUSTSEC-2023-0079 (KyberSlash) — patched fork until upstream ships fix
 pqc_kyber_edit = { version = "0.7", features = ["kyber1024"] }
 
 # WASM (optional, for web)

--- a/lib-client/src/crypto.rs
+++ b/lib-client/src/crypto.rs
@@ -147,7 +147,7 @@ mod wasm_crypto {
     use crystals_dilithium::dilithium5::{
         Keypair as DilithiumKeypair, PublicKey, SecretKey, SIGNBYTES,
     };
-    use pqc_kyber::*;
+    use pqc_kyber_edit::*;
 
     /// Dilithium5 post-quantum digital signatures (pure Rust implementation)
     /// Uses crystals-dilithium crate for WASM compatibility

--- a/lib-crypto/Cargo.toml
+++ b/lib-crypto/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/SOVEREIGN-NETWORK/ZHTPDEV"
 [dependencies]
 # Post-quantum cryptography (NIST standardized CRYSTALS)
 crystals-dilithium = "1.0"
-pqc_kyber = { version = "0.7", features = ["kyber1024"] }
+# RUSTSEC-2023-0079 (KyberSlash): pqc_kyber_edit contains the patched Kyber implementation
+pqc_kyber_edit = { version = "0.7", features = ["kyber1024"] }
 
 # Classical cryptography for compatibility (but identities use pure PQC)
 ed25519-dalek = { version = "2.0", features = ["rand_core"] }

--- a/lib-crypto/Cargo.toml
+++ b/lib-crypto/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/SOVEREIGN-NETWORK/ZHTPDEV"
 [dependencies]
 # Post-quantum cryptography (NIST standardized CRYSTALS)
 crystals-dilithium = "1.0"
-# RUSTSEC-2023-0079 (KyberSlash): pqc_kyber_edit contains the patched Kyber implementation
+# SECURITY: RUSTSEC-2023-0079 (KyberSlash) — pqc_kyber_edit until upstream/FIPS-203 fixed crate
+# TODO(#2745-followup): migrate to maintained upstream once KyberSlash patch is released
 pqc_kyber_edit = { version = "0.7", features = ["kyber1024"] }
 
 # Classical cryptography for compatibility (but identities use pure PQC)

--- a/lib-crypto/src/keypair/generation.rs
+++ b/lib-crypto/src/keypair/generation.rs
@@ -46,13 +46,26 @@ mod key_rotation_policy_tests {
     fn test_key_rotation_policy_constant() {
         assert_eq!(KEY_ROTATION_POLICY, "no_rotation");
     }
+
+    #[test]
+    fn from_private_key_signs_with_stored_material() -> Result<()> {
+        let keypair = KeyPair::generate()?;
+        let derived = KeyPair::from_private_key(&keypair.private_key)?;
+        let message = b"caller-key-bind-test";
+        let signature = derived.sign(message)?;
+        assert!(derived.public_key.verify(message, &signature)?);
+
+        let other = KeyPair::generate()?;
+        assert!(!other.public_key.verify(message, &signature)?);
+        Ok(())
+    }
 }
 
 use crate::types::{PrivateKey, PublicKey};
 use anyhow::Result;
 use blake3::Hasher as Blake3Hasher;
 use crystals_dilithium::dilithium5::Keypair as DilithiumKeypair;
-use pqc_kyber;
+use pqc_kyber_edit as pqc_kyber;
 use rand::rngs::OsRng;
 use rand::RngCore;
 
@@ -120,6 +133,53 @@ impl KeyPair {
         keypair.validate()?;
 
         Ok(keypair)
+    }
+
+    /// Build a signing keypair from stored Dilithium private key material.
+    ///
+    /// Used when the caller already holds a `PrivateKey` (keystore, identity store)
+    /// and must sign with that key — not a freshly generated one.
+    pub fn from_private_key(private_key: &PrivateKey) -> Result<Self> {
+        if private_key.dilithium_sk.iter().all(|&x| x == 0) {
+            return Err(anyhow::anyhow!("Invalid Dilithium private key: all zeros"));
+        }
+
+        let dilithium_pk = private_key.dilithium_pk;
+        let key_id = crate::hash_blake3(&dilithium_pk);
+
+        Ok(Self {
+            private_key: private_key.clone(),
+            public_key: PublicKey {
+                dilithium_pk,
+                kyber_pk: [0u8; 1568],
+                key_id,
+            },
+        })
+    }
+
+    /// Build a signing keypair from raw Dilithium key byte slices (identity store layout).
+    pub fn from_dilithium_bytes(secret_key: &[u8], public_key: &[u8]) -> Result<Self> {
+        if secret_key.is_empty() || secret_key.iter().all(|&x| x == 0) {
+            return Err(anyhow::anyhow!("Invalid Dilithium secret key"));
+        }
+        if public_key.is_empty() {
+            return Err(anyhow::anyhow!("Invalid Dilithium public key"));
+        }
+
+        let mut dilithium_sk = [0u8; 4896];
+        let sk_len = secret_key.len().min(4896);
+        dilithium_sk[..sk_len].copy_from_slice(&secret_key[..sk_len]);
+
+        let mut dilithium_pk = [0u8; 2592];
+        let pk_len = public_key.len().min(2592);
+        dilithium_pk[..pk_len].copy_from_slice(&public_key[..pk_len]);
+
+        Self::from_private_key(&PrivateKey {
+            dilithium_sk,
+            dilithium_pk,
+            kyber_sk: [0u8; 3168],
+            master_seed: [0u8; 64],
+        })
     }
 
     /// Validate that the keypair is properly formed and secure

--- a/lib-crypto/src/keypair/generation.rs
+++ b/lib-crypto/src/keypair/generation.rs
@@ -59,6 +59,24 @@ mod key_rotation_policy_tests {
         assert!(!other.public_key.verify(message, &signature)?);
         Ok(())
     }
+
+    #[test]
+    fn from_private_key_rejects_sk_pk_mismatch() -> Result<()> {
+        let keypair = KeyPair::generate()?;
+        let mut corrupted = keypair.private_key.clone();
+        corrupted.dilithium_pk[0] ^= 0xFF;
+        assert!(KeyPair::from_private_key(&corrupted).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn from_private_key_key_id_matches_public_key_new() -> Result<()> {
+        let keypair = KeyPair::generate()?;
+        let derived = KeyPair::from_private_key(&keypair.private_key)?;
+        let expected = PublicKey::new(keypair.private_key.dilithium_pk);
+        assert_eq!(derived.public_key.key_id, expected.key_id);
+        Ok(())
+    }
 }
 
 use crate::types::{PrivateKey, PublicKey};
@@ -145,15 +163,21 @@ impl KeyPair {
         }
 
         let dilithium_pk = private_key.dilithium_pk;
-        let key_id = crate::hash_blake3(&dilithium_pk);
+        let sk_matches_pk = crate::post_quantum::dilithium::dilithium5_sk_matches_pk(
+            &private_key.dilithium_sk,
+            &dilithium_pk,
+        )?;
+        if !sk_matches_pk {
+            return Err(anyhow::anyhow!(
+                "Dilithium secret key does not match stored public key"
+            ));
+        }
 
+        // key_id matches PublicKey::new (blake3 of dilithium_pk only). Full KeyPair::generate
+        // uses blake3(dilithium_pk || kyber_pk); callers needing that form must supply kyber_pk.
         Ok(Self {
             private_key: private_key.clone(),
-            public_key: PublicKey {
-                dilithium_pk,
-                kyber_pk: [0u8; 1568],
-                key_id,
-            },
+            public_key: PublicKey::new(dilithium_pk),
         })
     }
 

--- a/lib-crypto/src/keypair/operations.rs
+++ b/lib-crypto/src/keypair/operations.rs
@@ -11,7 +11,7 @@ use crystals_dilithium::dilithium5::{
     PublicKey as CrystalsPublicKey, SecretKey as CrystalsSecretKey, SIGNBYTES,
 };
 use hkdf::Hkdf;
-use pqc_kyber;
+use pqc_kyber_edit as pqc_kyber;
 use sha3::Sha3_256;
 // Ed25519 imports removed - pure post-quantum only
 use super::KeyPair;

--- a/lib-crypto/src/post_quantum/dilithium.rs
+++ b/lib-crypto/src/post_quantum/dilithium.rs
@@ -82,6 +82,13 @@ pub fn dilithium5_verify(message: &[u8], signature: &[u8], public_key: &[u8]) ->
     Ok(pk.verify(message, &sig_arr))
 }
 
+/// Verify that a Dilithium5 secret key matches the given public key.
+pub fn dilithium5_sk_matches_pk(secret_key: &[u8], public_key: &[u8]) -> Result<bool> {
+    const BIND_CHALLENGE: &[u8] = b"ZHTP-Dilithium-SK-PK-Bind-v1";
+    let signature = dilithium5_sign(BIND_CHALLENGE, secret_key)?;
+    dilithium5_verify(BIND_CHALLENGE, &signature, public_key)
+}
+
 /// Alias for dilithium5_verify (crystals-dilithium is now the only implementation).
 pub fn dilithium5_verify_crystals(
     message: &[u8],

--- a/lib-crypto/src/post_quantum/kyber.rs
+++ b/lib-crypto/src/post_quantum/kyber.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use hkdf::Hkdf;
-use pqc_kyber;
+use pqc_kyber_edit as pqc_kyber;
 use rand::rngs::OsRng;
 use sha3::Sha3_256;
 

--- a/lib-crypto/src/types/keys.rs
+++ b/lib-crypto/src/types/keys.rs
@@ -332,7 +332,7 @@ impl PrivateKey {
 // ============================================================================
 
 #[cfg(test)]
-mod tests {
+mod timing_resistance_tests {
     use super::*;
 
     #[test]

--- a/lib-identity/src/identity/manager.rs
+++ b/lib-identity/src/identity/manager.rs
@@ -1019,42 +1019,20 @@ impl IdentityManager {
 
         let message_to_sign = [data, identity_id.0.as_slice(), &timestamp.to_le_bytes()].concat();
 
-        // Generate quantum-resistant signature using CRYSTALS-Dilithium approach
-        // Derive seed from private key (removed hardcoded zero-seed per identity architecture)
-        let derived_seed = lib_crypto::hash_blake3(private_data.private_key());
-        let signature_seed = lib_crypto::hash_blake3(
-            &[
-                private_data.private_key(),
-                &derived_seed.to_vec(),
-                &message_to_sign,
-            ]
-            .concat(),
-        );
+        let keypair = lib_crypto::KeyPair::from_dilithium_bytes(
+            private_data.private_key(),
+            private_data.public_key(),
+        )
+        .map_err(|e| anyhow!("Failed to load identity signing key: {}", e))?;
 
-        // Create the signature using proper post-quantum methods
-        let signature_bytes =
-            lib_crypto::hash_blake3(&[signature_seed.as_slice(), &message_to_sign].concat());
-
-        // FIXME: This function creates fake signatures using hashing instead of real Dilithium signing.
-        // It needs to be rewritten to use the actual Dilithium private key for signing.
-        // For now, we create properly-sized zero arrays to satisfy type requirements.
-        
-        // Create key ID from identity
-        let mut key_id = [0u8; 32];
-        key_id.copy_from_slice(&identity_id.0);
-
-        // FIXME: These should be real Dilithium5 keys from the identity's keypair
-        let dilithium_pk = [0u8; 2592];
-        let kyber_pk = [0u8; 1568];
+        let signature = keypair
+            .sign(&message_to_sign)
+            .map_err(|e| anyhow!("Dilithium5 signing failed: {}", e))?;
 
         Ok(PostQuantumSignature {
-            signature: signature_bytes.to_vec(),
-            public_key: lib_crypto::PublicKey {
-                dilithium_pk,
-                kyber_pk,
-                key_id,
-            },
-            algorithm: lib_crypto::SignatureAlgorithm::DEFAULT, // Updated to match consensus
+            signature: signature.signature,
+            public_key: signature.public_key,
+            algorithm: lib_crypto::SignatureAlgorithm::DEFAULT,
             timestamp,
         })
     }

--- a/lib-identity/src/identity/manager.rs
+++ b/lib-identity/src/identity/manager.rs
@@ -444,6 +444,20 @@ impl IdentityManager {
         self.identities.insert(identity_id, identity);
     }
 
+    /// Test helper: seed private signing material for `sign_with_identity` tests.
+    #[cfg(test)]
+    pub fn seed_test_private_data(
+        &mut self,
+        identity_id: &IdentityId,
+        private_key: Vec<u8>,
+        public_key: Vec<u8>,
+    ) {
+        self.private_data.insert(
+            identity_id.clone(),
+            PrivateIdentityData::new(private_key, public_key, vec![]),
+        );
+    }
+
     /// Register an externally-created identity (client-side key generation)
     ///
     /// This method registers an identity where the keys were generated on the client
@@ -1045,6 +1059,35 @@ impl IdentityManager {
         })
     }
 
+    /// Verify an attestation produced by [`Self::sign_with_identity`].
+    pub fn verify_identity_attestation(
+        &self,
+        identity_id: &IdentityId,
+        data: &[u8],
+        attestation: &PostQuantumSignature,
+    ) -> Result<bool> {
+        let identity = self
+            .identities
+            .get(identity_id)
+            .ok_or_else(|| anyhow!("Identity not found"))?;
+
+        const IDENTITY_SIGN_DOMAIN: &[u8] = b"ZHTP-identity-sig-v1\0";
+        let message = [
+            IDENTITY_SIGN_DOMAIN,
+            data,
+            identity_id.0.as_slice(),
+            &attestation.timestamp.to_le_bytes(),
+        ]
+        .concat();
+
+        lib_crypto::verify_signature(
+            &message,
+            &attestation.signature,
+            &identity.public_key.dilithium_pk,
+        )
+        .map_err(|e| anyhow!("Identity attestation verification failed: {}", e))
+    }
+
     /// Import an identity from 20-word recovery phrase (enables password functionality)
     pub async fn import_identity_from_phrase(
         &mut self,
@@ -1433,6 +1476,54 @@ impl IdentityManager {
 impl Default for IdentityManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod identity_signing_tests {
+    use super::*;
+
+    fn seeded_identity(seed: [u8; 64]) -> ZhtpIdentity {
+        ZhtpIdentity::new_unified(
+            IdentityType::Human,
+            Some(30),
+            Some("US".to_string()),
+            "laptop",
+            Some(seed),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn sign_with_identity_roundtrips_through_verify_helper() {
+        let mut manager = IdentityManager::new();
+        let identity = seeded_identity([0x44u8; 64]);
+        let identity_id = identity.id.clone();
+        let private_key = identity
+            .private_key
+            .as_ref()
+            .expect("seeded identity must include private key")
+            .dilithium_sk
+            .to_vec();
+        let public_key = identity.public_key.dilithium_pk.to_vec();
+        manager.add_identity(identity);
+        manager.seed_test_private_data(&identity_id, private_key, public_key);
+
+        let payload = b"attestation payload for integration test";
+        let attestation = manager
+            .sign_with_identity(&identity_id, payload)
+            .await
+            .expect("sign");
+
+        let ok = manager
+            .verify_identity_attestation(&identity_id, payload, &attestation)
+            .expect("verify");
+        assert!(ok);
+
+        let tampered = manager
+            .verify_identity_attestation(&identity_id, b"tampered", &attestation)
+            .expect("verify tampered");
+        assert!(!tampered);
     }
 }
 

--- a/lib-identity/src/identity/manager.rs
+++ b/lib-identity/src/identity/manager.rs
@@ -1017,7 +1017,15 @@ impl IdentityManager {
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs();
 
-        let message_to_sign = [data, identity_id.0.as_slice(), &timestamp.to_le_bytes()].concat();
+        // Domain-separated from transaction signing hashes (see sign_transaction).
+        const IDENTITY_SIGN_DOMAIN: &[u8] = b"ZHTP-identity-sig-v1\0";
+        let message_to_sign = [
+            IDENTITY_SIGN_DOMAIN,
+            data,
+            identity_id.0.as_slice(),
+            &timestamp.to_le_bytes(),
+        ]
+        .concat();
 
         let keypair = lib_crypto::KeyPair::from_dilithium_bytes(
             private_data.private_key(),

--- a/lib-identity/src/identity/manager_tests.rs
+++ b/lib-identity/src/identity/manager_tests.rs
@@ -302,8 +302,7 @@ mod tests {
             .await.expect("Failed to sign with identity");
         
         assert!(!signature.signature.is_empty());
-        assert!(!signature.public_key.dilithium_pk.is_empty());
-        assert!(!signature.public_key.kyber_pk.is_empty());
+        assert!(!signature.public_key.dilithium_pk.iter().all(|&b| b == 0));
         assert_eq!(signature.algorithm, lib_crypto::SignatureAlgorithm::DEFAULT);
         assert!(signature.timestamp > 0);
     }

--- a/lib-network/Cargo.toml
+++ b/lib-network/Cargo.toml
@@ -73,6 +73,7 @@ sled = "0.34"
 x25519-dalek = "2.0"
 
 # Post-quantum cryptography (Kyber for forward secrecy)
+# SECURITY: RUSTSEC-2023-0079 (KyberSlash) — patched fork until upstream ships fix
 pqc_kyber_edit = { version = "0.7", features = ["kyber1024"] }
 
 # System calls (for Bluetooth Classic on macOS/Linux)

--- a/lib-network/Cargo.toml
+++ b/lib-network/Cargo.toml
@@ -73,7 +73,7 @@ sled = "0.34"
 x25519-dalek = "2.0"
 
 # Post-quantum cryptography (Kyber for forward secrecy)
-pqc_kyber = { version = "0.7", features = ["kyber1024"] }
+pqc_kyber_edit = { version = "0.7", features = ["kyber1024"] }
 
 # System calls (for Bluetooth Classic on macOS/Linux)
 libc = "0.2"

--- a/lib-network/src/web4/domain_registry.rs
+++ b/lib-network/src/web4/domain_registry.rs
@@ -1270,9 +1270,9 @@ impl DomainRegistry {
                 "Domain update requires a valid signature from the domain owner".to_string(),
             );
         }
-        if signature.len() < Self::DILITHIUM5_HEX_SIGNATURE_LEN {
+        if signature.len() != Self::DILITHIUM5_HEX_SIGNATURE_LEN {
             return Some(format!(
-                "Invalid signature length: {} chars (expected at least {} for Dilithium5)",
+                "Invalid signature length: {} chars (expected exactly {} for Dilithium5)",
                 signature.len(),
                 Self::DILITHIUM5_HEX_SIGNATURE_LEN
             ));

--- a/lib-network/src/web4/domain_registry.rs
+++ b/lib-network/src/web4/domain_registry.rs
@@ -1260,6 +1260,29 @@ impl DomainRegistry {
         })
     }
 
+    /// Hex-encoded Dilithium5 detached signatures are 4595 bytes → 9190 hex chars.
+    const DILITHIUM5_HEX_SIGNATURE_LEN: usize = 9190;
+
+    /// Reject missing or malformed owner signatures before mutating domain state.
+    fn validate_domain_owner_signature(signature: &str) -> Option<String> {
+        if signature.is_empty() {
+            return Some(
+                "Domain update requires a valid signature from the domain owner".to_string(),
+            );
+        }
+        if signature.len() < Self::DILITHIUM5_HEX_SIGNATURE_LEN {
+            return Some(format!(
+                "Invalid signature length: {} chars (expected at least {} for Dilithium5)",
+                signature.len(),
+                Self::DILITHIUM5_HEX_SIGNATURE_LEN
+            ));
+        }
+        if !signature.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Some("Invalid signature: must be hex-encoded Dilithium5 bytes".to_string());
+        }
+        None
+    }
+
     /// Update domain with new manifest (atomic compare-and-swap)
     pub async fn update_domain(
         &self,
@@ -1316,8 +1339,19 @@ impl DomainRegistry {
             });
         }
 
-        // TODO: Verify signature matches domain owner
-        // For now, we trust the caller has verified authorization
+        if let Some(error) = Self::validate_domain_owner_signature(&update_request.signature) {
+            return Ok(DomainUpdateResponse {
+                success: false,
+                new_version: 0,
+                new_manifest_cid: String::new(),
+                previous_manifest_cid: String::new(),
+                updated_at: 0,
+                error: Some(error),
+            });
+        }
+
+        // TODO: Cryptographic verify signature over (domain, new_cid, expected_prev, timestamp)
+        // against record.owner's registered Dilithium public key.
 
         let previous_manifest_cid = record.current_web4_manifest_cid.clone();
         let new_version = record.version + 1;
@@ -1567,7 +1601,7 @@ impl DomainRegistry {
             domain: domain.to_string(),
             new_manifest_cid: target_cid,
             expected_previous_manifest_cid: current_cid,
-            signature: String::new(), // TODO: Require signature
+            signature: String::new(), // Caller must supply owner signature (validated in update_domain)
             timestamp: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)?
                 .as_secs(),
@@ -1641,6 +1675,10 @@ mod tests {
     use lib_identity::{IdentityType, ZhtpIdentity};
     use std::sync::RwLock as StdRwLock;
     use tempfile::TempDir;
+
+    fn test_dilithium_hex_signature() -> String {
+        "ab".repeat(DomainRegistry::DILITHIUM5_HEX_SIGNATURE_LEN / 2)
+    }
 
     /// Test storage implementation that actually persists data in memory
     #[derive(Clone, Default)]
@@ -1832,12 +1870,17 @@ mod tests {
         let owner = create_test_identity();
         let domain_name = "updatetest.zhtp";
         let initial_manifest_cid: String;
-        let updated_manifest_cid = "bafknewmanifest123456".to_string();
+        let updated_manifest_cid: String;
 
         // Create registry, register domain, then update it
         {
             let storage = create_test_storage_with_persistence(persist_path.clone()).await;
             let registry = DomainRegistry::new(storage).await.unwrap();
+
+            updated_manifest_cid = registry
+                .store_content_by_cid(br#"{"files":[]}"#.to_vec())
+                .await
+                .unwrap();
 
             // Register domain
             let registration_proof = ZeroKnowledgeProof::new(
@@ -1887,7 +1930,7 @@ mod tests {
                 domain: domain_name.to_string(),
                 new_manifest_cid: updated_manifest_cid.clone(),
                 expected_previous_manifest_cid: initial_manifest_cid.clone(),
-                signature: String::new(),
+                signature: test_dilithium_hex_signature(),
                 timestamp: std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap()

--- a/lib-network/src/web4/domain_registry.rs
+++ b/lib-network/src/web4/domain_registry.rs
@@ -14,6 +14,9 @@ use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
 use super::content_publisher::ContentPublisher;
+use super::domain_signing::{
+    has_owner_signing_key, validate_domain_owner_signature_hex, verify_domain_update_signature,
+};
 use super::types::*;
 use crate::dht::ZkDHTIntegration;
 use crate::storage_stub::UnifiedStorage;
@@ -528,6 +531,7 @@ impl DomainRegistry {
             DomainRecord {
                 domain: request.domain.clone(),
                 owner: existing.owner.clone(),
+                owner_dilithium_pk: request.owner.public_key.dilithium_pk.to_vec(),
                 current_web4_manifest_cid: web4_manifest_cid,
                 version,
                 registered_at: existing.registered_at,
@@ -543,6 +547,7 @@ impl DomainRegistry {
             DomainRecord {
                 domain: request.domain.clone(),
                 owner: request.owner.id.clone(),
+                owner_dilithium_pk: request.owner.public_key.dilithium_pk.to_vec(),
                 current_web4_manifest_cid: web4_manifest_cid,
                 version,
                 registered_at: current_time,
@@ -760,6 +765,7 @@ impl DomainRegistry {
 
             let mut updated_record = record.clone();
             updated_record.owner = to_owner.id.clone();
+            updated_record.owner_dilithium_pk = to_owner.public_key.dilithium_pk.to_vec();
             updated_record.transfer_history.push(transfer_record);
             updated_record.ownership_proof = new_ownership_proof;
 
@@ -1260,29 +1266,6 @@ impl DomainRegistry {
         })
     }
 
-    /// Hex-encoded Dilithium5 detached signatures are 4595 bytes → 9190 hex chars.
-    const DILITHIUM5_HEX_SIGNATURE_LEN: usize = 9190;
-
-    /// Reject missing or malformed owner signatures before mutating domain state.
-    fn validate_domain_owner_signature(signature: &str) -> Option<String> {
-        if signature.is_empty() {
-            return Some(
-                "Domain update requires a valid signature from the domain owner".to_string(),
-            );
-        }
-        if signature.len() != Self::DILITHIUM5_HEX_SIGNATURE_LEN {
-            return Some(format!(
-                "Invalid signature length: {} chars (expected exactly {} for Dilithium5)",
-                signature.len(),
-                Self::DILITHIUM5_HEX_SIGNATURE_LEN
-            ));
-        }
-        if !signature.chars().all(|c| c.is_ascii_hexdigit()) {
-            return Some("Invalid signature: must be hex-encoded Dilithium5 bytes".to_string());
-        }
-        None
-    }
-
     /// Update domain with new manifest (atomic compare-and-swap)
     pub async fn update_domain(
         &self,
@@ -1339,7 +1322,7 @@ impl DomainRegistry {
             });
         }
 
-        if let Some(error) = Self::validate_domain_owner_signature(&update_request.signature) {
+        if let Some(error) = validate_domain_owner_signature_hex(&update_request.signature) {
             return Ok(DomainUpdateResponse {
                 success: false,
                 new_version: 0,
@@ -1350,8 +1333,47 @@ impl DomainRegistry {
             });
         }
 
-        // TODO: Cryptographic verify signature over (domain, new_cid, expected_prev, timestamp)
-        // against record.owner's registered Dilithium public key.
+        if has_owner_signing_key(&record.owner_dilithium_pk) {
+            match verify_domain_update_signature(
+                &record.owner_dilithium_pk,
+                &update_request.domain,
+                &update_request.expected_previous_manifest_cid,
+                &update_request.new_manifest_cid,
+                update_request.timestamp,
+                &update_request.signature,
+            ) {
+                Ok(true) => {}
+                Ok(false) => {
+                    return Ok(DomainUpdateResponse {
+                        success: false,
+                        new_version: record.version,
+                        new_manifest_cid: record.current_web4_manifest_cid.clone(),
+                        previous_manifest_cid: record.current_web4_manifest_cid.clone(),
+                        updated_at: record.updated_at,
+                        error: Some(
+                            "Invalid domain update signature: does not match registered owner key"
+                                .to_string(),
+                        ),
+                    });
+                }
+                Err(e) => {
+                    return Ok(DomainUpdateResponse {
+                        success: false,
+                        new_version: 0,
+                        new_manifest_cid: String::new(),
+                        previous_manifest_cid: String::new(),
+                        updated_at: 0,
+                        error: Some(e.to_string()),
+                    });
+                }
+            }
+        } else {
+            warn!(
+                "Domain {} update accepted with structural signature only — \
+                 owner_dilithium_pk missing (legacy record); re-register to enable crypto verify",
+                update_request.domain
+            );
+        }
 
         let previous_manifest_cid = record.current_web4_manifest_cid.clone();
         let new_version = record.version + 1;
@@ -1676,8 +1698,30 @@ mod tests {
     use std::sync::RwLock as StdRwLock;
     use tempfile::TempDir;
 
-    fn test_dilithium_hex_signature() -> String {
-        "ab".repeat(DomainRegistry::DILITHIUM5_HEX_SIGNATURE_LEN / 2)
+    fn sign_domain_update(
+        owner: &ZhtpIdentity,
+        domain: &str,
+        expected_previous_manifest_cid: &str,
+        new_manifest_cid: &str,
+        timestamp: u64,
+    ) -> String {
+        use crate::web4::domain_signing::domain_update_signing_message;
+        use lib_crypto::{KeyPair, sign_message};
+
+        let private_key = owner
+            .private_key
+            .as_ref()
+            .expect("test identity must include private key");
+        let keypair =
+            KeyPair::from_private_key(private_key).expect("reconstruct owner signing keypair");
+        let message = domain_update_signing_message(
+            domain,
+            expected_previous_manifest_cid,
+            new_manifest_cid,
+            timestamp,
+        );
+        let sig = sign_message(&keypair, &message).expect("sign domain update");
+        hex::encode(&sig.signature)
     }
 
     /// Test storage implementation that actually persists data in memory
@@ -1925,16 +1969,25 @@ mod tests {
                 .current_web4_manifest_cid
                 .clone();
 
+            let timestamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            let signature = sign_domain_update(
+                &owner,
+                domain_name,
+                &initial_manifest_cid,
+                &updated_manifest_cid,
+                timestamp,
+            );
+
             // Update domain
             let update_request = DomainUpdateRequest {
                 domain: domain_name.to_string(),
                 new_manifest_cid: updated_manifest_cid.clone(),
                 expected_previous_manifest_cid: initial_manifest_cid.clone(),
-                signature: test_dilithium_hex_signature(),
-                timestamp: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
+                signature,
+                timestamp,
             };
 
             let update_response = registry.update_domain(update_request).await.unwrap();

--- a/lib-network/src/web4/domain_signing.rs
+++ b/lib-network/src/web4/domain_signing.rs
@@ -1,0 +1,128 @@
+//! Canonical domain-update signing and Dilithium5 verification.
+//!
+//! Wire format matches zhtp-cli and lib-client:
+//!   `domain|expected_previous_manifest_cid|new_manifest_cid|timestamp`
+
+use anyhow::{anyhow, Result};
+use lib_crypto::verify_signature;
+
+/// Hex-encoded Dilithium5 detached signatures are 4595 bytes → 9190 hex chars.
+pub const DILITHIUM5_HEX_SIGNATURE_LEN: usize = 9190;
+
+/// Returns true when a stored owner public key is present (full Dilithium5 size, non-zero).
+pub fn has_owner_signing_key(owner_dilithium_pk: &[u8]) -> bool {
+    owner_dilithium_pk.len() == 2592 && !owner_dilithium_pk.iter().all(|&x| x == 0)
+}
+
+fn owner_pk_array(owner_dilithium_pk: &[u8]) -> Result<[u8; 2592]> {
+    if owner_dilithium_pk.len() != 2592 {
+        return Err(anyhow!("owner_dilithium_pk must be exactly 2592 bytes"));
+    }
+    let mut arr = [0u8; 2592];
+    arr.copy_from_slice(owner_dilithium_pk);
+    Ok(arr)
+}
+
+/// Build the canonical domain-update signing message.
+pub fn domain_update_signing_message(
+    domain: &str,
+    expected_previous_manifest_cid: &str,
+    new_manifest_cid: &str,
+    timestamp: u64,
+) -> Vec<u8> {
+    format!(
+        "{}|{}|{}|{}",
+        domain, expected_previous_manifest_cid, new_manifest_cid, timestamp
+    )
+    .into_bytes()
+}
+
+/// Reject missing or malformed owner signatures before mutating domain state.
+pub fn validate_domain_owner_signature_hex(signature: &str) -> Option<String> {
+    if signature.is_empty() {
+        return Some(
+            "Domain update requires a valid signature from the domain owner".to_string(),
+        );
+    }
+    if signature.len() != DILITHIUM5_HEX_SIGNATURE_LEN {
+        return Some(format!(
+            "Invalid signature length: {} chars (expected exactly {} for Dilithium5)",
+            signature.len(),
+            DILITHIUM5_HEX_SIGNATURE_LEN
+        ));
+    }
+    if !signature.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Some("Invalid signature: must be hex-encoded Dilithium5 bytes".to_string());
+    }
+    None
+}
+
+/// Verify a domain update signature against the stored owner Dilithium5 public key.
+pub fn verify_domain_update_signature(
+    owner_dilithium_pk: &[u8],
+    domain: &str,
+    expected_previous_manifest_cid: &str,
+    new_manifest_cid: &str,
+    timestamp: u64,
+    signature_hex: &str,
+) -> Result<bool> {
+    if let Some(error) = validate_domain_owner_signature_hex(signature_hex) {
+        return Err(anyhow!(error));
+    }
+
+    let owner_pk = owner_pk_array(owner_dilithium_pk)?;
+
+    let message = domain_update_signing_message(
+        domain,
+        expected_previous_manifest_cid,
+        new_manifest_cid,
+        timestamp,
+    );
+
+    let signature_bytes = hex::decode(signature_hex)
+        .map_err(|e| anyhow!("Invalid signature hex: {}", e))?;
+
+    verify_signature(&message, &signature_bytes, owner_pk.as_slice())
+        .map_err(|e| anyhow!("Domain update signature verification failed: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lib_crypto::{generate_keypair, sign_message};
+
+    #[test]
+    fn domain_update_roundtrip_sign_and_verify() {
+        let keypair = generate_keypair().expect("keypair");
+        let domain = "app.zhtp";
+        let prev = "bafkabc123";
+        let new_cid = "bafkdef456";
+        let timestamp = 1_700_000_000u64;
+
+        let message = domain_update_signing_message(domain, prev, new_cid, timestamp);
+        let sig = sign_message(&keypair, &message).expect("sign");
+        let sig_hex = hex::encode(&sig.signature);
+
+        let ok = verify_domain_update_signature(
+            keypair.public_key.dilithium_pk.as_slice(),
+            domain,
+            prev,
+            new_cid,
+            timestamp,
+            &sig_hex,
+        )
+        .expect("verify");
+        assert!(ok);
+
+        let bad = verify_domain_update_signature(
+            keypair.public_key.dilithium_pk.as_slice(),
+            domain,
+            prev,
+            "bafkwrong",
+            timestamp,
+            &sig_hex,
+        )
+        .expect("verify runs");
+        assert!(!bad);
+    }
+}

--- a/lib-network/src/web4/mod.rs
+++ b/lib-network/src/web4/mod.rs
@@ -23,6 +23,7 @@ pub mod client;
 pub mod content_publisher;
 pub mod content_service;
 pub mod domain_registry;
+pub mod domain_signing;
 pub mod name_resolver;
 pub mod types;
 
@@ -31,6 +32,10 @@ pub use client::Web4Client;
 pub use content_publisher::*;
 pub use content_service::*;
 pub use domain_registry::*;
+pub use domain_signing::{
+    domain_update_signing_message, has_owner_signing_key, verify_domain_update_signature,
+    validate_domain_owner_signature_hex, DILITHIUM5_HEX_SIGNATURE_LEN,
+};
 pub use name_resolver::NameResolver;
 #[cfg(feature = "quic")]
 pub use trust::{

--- a/lib-network/src/web4/types.rs
+++ b/lib-network/src/web4/types.rs
@@ -52,6 +52,10 @@ pub struct DomainRecord {
     /// Owner's identity
     #[serde(default)]
     pub owner: IdentityId,
+    /// Owner Dilithium5 public key (2592 bytes) for domain-update verification.
+    /// Empty for legacy records migrated before this field existed.
+    #[serde(default)]
+    pub owner_dilithium_pk: Vec<u8>,
     /// CANONICAL: Current Web4Manifest CID (runtime truth for resolution)
     /// This is the authoritative pointer used by all domain resolution logic
     /// MIGRATION: serde alias allows loading old records with "current_manifest_cid"


### PR DESCRIPTION
## Summary

Fixes critical security bugs identified during fork review — implemented natively on `development`, not cherry-picked from the external fork.

### P0 — Transaction signing
`sign_transaction` previously called `KeyPair::generate()` and signed with a **fresh random key**, ignoring the caller's `PrivateKey`. Now constructs the keypair from the provided material via `KeyPair::from_private_key`, with sk/pk binding enforced.

### P1 — Identity signing
`IdentityManager::sign_with_identity` replaced Blake3 hash "signatures" with real Dilithium5 signing using `KeyPair::from_dilithium_bytes`, domain-separated with `ZHTP-identity-sig-v1\0`. Added `verify_identity_attestation` helper + roundtrip test.

### P1 — Kyber timing attack (RUSTSEC-2023-0079)
Migrates `pqc_kyber` → `pqc_kyber_edit` across `lib-crypto`, `lib-client`, and `lib-network`.

### P2 — Domain update cryptographic verify
- New `lib-network/src/web4/domain_signing.rs` — canonical message `domain|expected_prev|new_cid|timestamp` (matches zhtp-cli + lib-client)
- `DomainRecord.owner_dilithium_pk` persisted at registration/transfer
- `update_domain` verifies Dilithium5 when pubkey is present; legacy records (empty pubkey) accept structural validation during grace window
- Exact 9190-char hex length enforced

## Deploy / ops
**Coordinated validator deploy required** — signing semantics change at binary swap.

See runbook: [`docs/protocol/crypto-signing-cutover.md`](docs/protocol/crypto-signing-cutover.md)

## Also included
- `KeyPair::from_private_key` / `from_dilithium_bytes` helpers in `lib-crypto`
- sk/pk mismatch rejection tests
- `sign_transaction_binds_to_caller_private_key` integration test in `lib-blockchain`
- Fix duplicate `#[cfg(test)] mod tests` in `lib-crypto/src/types/keys.rs`
- Fix `test_domain_update_persists` to use real Dilithium signatures + manifest content before CAS update

## Test plan
- [x] `cargo test -p lib-crypto from_private_key`
- [x] `cargo test -p lib-blockchain --lib sign_transaction`
- [x] `cargo test -p lib-network --lib domain_update`
- [x] `cargo test -p lib-identity --lib sign_with_identity_roundtrips`
- [x] `cargo check -p lib-crypto -p lib-blockchain -p lib-identity -p lib-network`

## Follow-up issues
- #2747 — Enforce `owner_dilithium_pk` on all domain updates (end structural-only grace)
- #2746 — Add `ZHTP-domain-update-v1\0` domain prefix to domain signing
- #2748 — On-chain owner pubkey for validator-side `DomainUpdate` tx verify