### PR TITLE
security(audit-4): gate add_system_transaction injection paths

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2463,11 +2463,75 @@ impl Blockchain {
     /// the bypass itself is load-bearing (see #2647 Patterns A and B). This
     /// path does NOT run `lib_mempool::admit()` nor `verify_transaction`;
     /// each caller is responsible for the trust it implicitly grants.
+    /// Validate a system-originated transaction before it enters the pending pool.
+    ///
+    /// System injectors bypass signature verification at admission time; this gate
+    /// enforces minimum structural trust per originator class.
+    fn validate_system_injection(
+        originator: &'static str,
+        tx: &Transaction,
+    ) -> anyhow::Result<()> {
+        use crate::types::transaction_type::TransactionType;
+
+        let empty_sig = tx.signature.signature.is_empty();
+
+        if tx.transaction_type == TransactionType::TokenMint && empty_sig {
+            let allowed_originator =
+                matches!(originator, "pouw_mint" | "pouw_reward");
+            let memo_ok = tx.memo.starts_with(b"pouw:mint:");
+            if !allowed_originator || !memo_ok {
+                return Err(anyhow::anyhow!(
+                    "rejecting unsigned TokenMint from originator '{}': \
+                     only pouw_mint/pouw_reward with pouw:mint: memo are permitted",
+                    originator
+                ));
+            }
+        }
+
+        if tx.transaction_type == TransactionType::WalletRegistration {
+            if let Some(wallet_data) = tx.wallet_data() {
+                if wallet_data.initial_balance > 0 && !Self::is_treasury_system_originator(originator)
+                {
+                    return Err(anyhow::anyhow!(
+                        "rejecting WalletRegistration with initial_balance={} from originator '{}': \
+                         treasury originator required for funded wallet bootstrap",
+                        wallet_data.initial_balance,
+                        originator
+                    ));
+                }
+            }
+        }
+
+        if empty_sig
+            && matches!(
+                originator,
+                "web4_domain_register" | "web4_domain_update"
+            )
+        {
+            return Err(anyhow::anyhow!(
+                "rejecting unsigned domain system tx from originator '{}'",
+                originator
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn is_treasury_system_originator(originator: &str) -> bool {
+        originator.contains("treasury")
+            || matches!(
+                originator,
+                "admin_sov_mint" | "genesis_bootstrap" | "genesis_wallet" | "migration_wallet"
+            )
+    }
+
     pub fn add_system_transaction(
         &mut self,
         transaction: Transaction,
         originator: &'static str,
     ) -> Result<()> {
+        Self::validate_system_injection(originator, &transaction)?;
+
         tracing::info!(
             originator = originator,
             tx_hash = %hex::encode(&transaction.hash().as_bytes()[..8]),

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -42,6 +42,8 @@ mod validators;
 mod gateways;
 mod wallets;
 mod utxo;
+mod system_originator;
+pub use system_originator::SystemOriginator;
 
 pub use persistence::PersistenceStats;
 pub use utxo::SpendableOutputView;
@@ -2468,29 +2470,42 @@ impl Blockchain {
     /// System injectors bypass signature verification at admission time; this gate
     /// enforces minimum structural trust per originator class.
     fn validate_system_injection(
-        originator: &'static str,
+        originator: SystemOriginator,
         tx: &Transaction,
     ) -> anyhow::Result<()> {
         use crate::types::transaction_type::TransactionType;
 
         let empty_sig = tx.signature.signature.is_empty();
+        let label = originator.as_str();
 
         if tx.transaction_type == TransactionType::TokenMint {
-            if matches!(originator, "pouw_mint" | "pouw_reward") {
-                if !empty_sig {
+            match originator {
+                SystemOriginator::PouwMint | SystemOriginator::PouwReward => {
+                    if !empty_sig {
+                        return Err(anyhow::anyhow!(
+                            "rejecting signed PoUW TokenMint from originator '{}'",
+                            label
+                        ));
+                    }
+                    Self::validate_pouw_mint_memo(tx)?;
+                }
+                o if o.is_treasury() => {}
+                SystemOriginator::Other(unknown) => {
+                    tracing::warn!(
+                        originator = unknown,
+                        "rejecting TokenMint from untyped Other originator"
+                    );
                     return Err(anyhow::anyhow!(
-                        "rejecting signed PoUW TokenMint from originator '{}'",
+                        "rejecting TokenMint from untrusted originator '{}'",
+                        unknown
+                    ));
+                }
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "rejecting TokenMint from untrusted originator '{:?}'",
                         originator
                     ));
                 }
-                Self::validate_pouw_mint_memo(tx)?;
-            } else if Self::is_treasury_system_originator(originator) {
-                // Treasury bootstrap paths may inject unsigned mints until admin handler removal.
-            } else {
-                return Err(anyhow::anyhow!(
-                    "rejecting TokenMint from untrusted originator '{}'",
-                    originator
-                ));
             }
         }
 
@@ -2498,10 +2513,9 @@ impl Blockchain {
             let wallet_data = tx
                 .wallet_data()
                 .ok_or_else(|| anyhow::anyhow!("WalletRegistration missing wallet_data"))?;
-            if wallet_data.initial_balance > 0 && !Self::is_treasury_system_originator(originator)
-            {
+            if wallet_data.initial_balance > 0 && !originator.is_treasury() {
                 return Err(anyhow::anyhow!(
-                    "rejecting WalletRegistration with initial_balance={} from originator '{}': \
+                    "rejecting WalletRegistration with initial_balance={} from originator '{:?}': \
                      treasury originator required for funded wallet bootstrap",
                     wallet_data.initial_balance,
                     originator
@@ -2512,11 +2526,11 @@ impl Blockchain {
         if empty_sig
             && matches!(
                 originator,
-                "web4_domain_register" | "web4_domain_update"
+                SystemOriginator::Web4DomainRegister | SystemOriginator::Web4DomainUpdate
             )
         {
             return Err(anyhow::anyhow!(
-                "rejecting unsigned domain system tx from originator '{}'",
+                "rejecting unsigned domain system tx from originator '{:?}'",
                 originator
             ));
         }
@@ -2570,33 +2584,22 @@ impl Blockchain {
         Ok(())
     }
 
-    fn is_treasury_system_originator(originator: &str) -> bool {
-        matches!(
-            originator,
-            "admin_sov_mint"
-                | "genesis_bootstrap"
-                | "genesis_wallet"
-                | "migration_wallet"
-                | "treasury_kernel"
-                | "treasury_allocation"
-        )
-    }
-
     pub fn add_system_transaction(
         &mut self,
         transaction: Transaction,
-        originator: &'static str,
+        originator: SystemOriginator,
     ) -> Result<()> {
         Self::validate_system_injection(originator, &transaction)?;
 
+        let label = originator.as_str();
         tracing::info!(
-            originator = originator,
+            originator = label,
             tx_hash = %hex::encode(&transaction.hash().as_bytes()[..8]),
             "system tx (bypass admission + verify)",
         );
         *self
             .system_tx_originators
-            .entry(originator)
+            .entry(label)
             .or_insert(0) += 1;
 
         // Keep `mempool_state` paired with the pending pool. We bypass
@@ -2621,7 +2624,7 @@ impl Blockchain {
         if let Some(store) = &self.store {
             if let Err(e) = store.put_pending_transaction(&transaction) {
                 tracing::warn!(
-                    originator = originator,
+                    originator = label,
                     "system tx persistence failed: {}",
                     e
                 );
@@ -6736,7 +6739,7 @@ impl Blockchain {
 
         let mint_tx = Transaction::new_token_mint(mint_data, signature, memo);
         let tx_hash = mint_tx.hash();
-        self.add_system_transaction(mint_tx, "pouw_mint")?;
+        self.add_system_transaction(mint_tx, SystemOriginator::PouwMint)?;
         Ok(tx_hash)
     }
 }

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2475,30 +2475,37 @@ impl Blockchain {
 
         let empty_sig = tx.signature.signature.is_empty();
 
-        if tx.transaction_type == TransactionType::TokenMint && empty_sig {
-            let allowed_originator =
-                matches!(originator, "pouw_mint" | "pouw_reward");
-            let memo_ok = tx.memo.starts_with(b"pouw:mint:");
-            if !allowed_originator || !memo_ok {
+        if tx.transaction_type == TransactionType::TokenMint {
+            if matches!(originator, "pouw_mint" | "pouw_reward") {
+                if !empty_sig {
+                    return Err(anyhow::anyhow!(
+                        "rejecting signed PoUW TokenMint from originator '{}'",
+                        originator
+                    ));
+                }
+                Self::validate_pouw_mint_memo(tx)?;
+            } else if Self::is_treasury_system_originator(originator) {
+                // Treasury bootstrap paths may inject unsigned mints until admin handler removal.
+            } else {
                 return Err(anyhow::anyhow!(
-                    "rejecting unsigned TokenMint from originator '{}': \
-                     only pouw_mint/pouw_reward with pouw:mint: memo are permitted",
+                    "rejecting TokenMint from untrusted originator '{}'",
                     originator
                 ));
             }
         }
 
         if tx.transaction_type == TransactionType::WalletRegistration {
-            if let Some(wallet_data) = tx.wallet_data() {
-                if wallet_data.initial_balance > 0 && !Self::is_treasury_system_originator(originator)
-                {
-                    return Err(anyhow::anyhow!(
-                        "rejecting WalletRegistration with initial_balance={} from originator '{}': \
-                         treasury originator required for funded wallet bootstrap",
-                        wallet_data.initial_balance,
-                        originator
-                    ));
-                }
+            let wallet_data = tx
+                .wallet_data()
+                .ok_or_else(|| anyhow::anyhow!("WalletRegistration missing wallet_data"))?;
+            if wallet_data.initial_balance > 0 && !Self::is_treasury_system_originator(originator)
+            {
+                return Err(anyhow::anyhow!(
+                    "rejecting WalletRegistration with initial_balance={} from originator '{}': \
+                     treasury originator required for funded wallet bootstrap",
+                    wallet_data.initial_balance,
+                    originator
+                ));
             }
         }
 
@@ -2517,12 +2524,62 @@ impl Blockchain {
         Ok(())
     }
 
+    fn validate_pouw_mint_memo(tx: &Transaction) -> anyhow::Result<()> {
+        let mint_data = tx
+            .token_mint_data()
+            .ok_or_else(|| anyhow::anyhow!("PoUW TokenMint missing mint data"))?;
+        let memo_str = std::str::from_utf8(&tx.memo)
+            .map_err(|_| anyhow::anyhow!("PoUW TokenMint memo is not valid UTF-8"))?;
+        let rest = memo_str
+            .strip_prefix("pouw:mint:")
+            .ok_or_else(|| anyhow::anyhow!("PoUW TokenMint memo missing pouw:mint: prefix"))?;
+        let mut parts = rest.splitn(2, ':');
+        let recipient_hex = parts
+            .next()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("PoUW TokenMint memo missing recipient"))?;
+        let amount_str = parts
+            .next()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("PoUW TokenMint memo missing amount"))?;
+
+        let decoded = hex::decode(recipient_hex)
+            .map_err(|_| anyhow::anyhow!("PoUW TokenMint memo recipient is not valid hex"))?;
+        if decoded.len() != 32 {
+            return Err(anyhow::anyhow!(
+                "PoUW TokenMint memo recipient must decode to 32 bytes"
+            ));
+        }
+        let mut recipient = [0u8; 32];
+        recipient.copy_from_slice(&decoded);
+        if recipient != mint_data.to {
+            return Err(anyhow::anyhow!(
+                "PoUW TokenMint memo recipient does not match mint_data.to"
+            ));
+        }
+
+        let amount: u128 = amount_str
+            .parse()
+            .map_err(|_| anyhow::anyhow!("PoUW TokenMint memo amount is not a valid integer"))?;
+        if amount != mint_data.amount {
+            return Err(anyhow::anyhow!(
+                "PoUW TokenMint memo amount does not match mint_data.amount"
+            ));
+        }
+
+        Ok(())
+    }
+
     fn is_treasury_system_originator(originator: &str) -> bool {
-        originator.contains("treasury")
-            || matches!(
-                originator,
-                "admin_sov_mint" | "genesis_bootstrap" | "genesis_wallet" | "migration_wallet"
-            )
+        matches!(
+            originator,
+            "admin_sov_mint"
+                | "genesis_bootstrap"
+                | "genesis_wallet"
+                | "migration_wallet"
+                | "treasury_kernel"
+                | "treasury_allocation"
+        )
     }
 
     pub fn add_system_transaction(

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2479,6 +2479,12 @@ impl Blockchain {
         let label = originator.as_str();
 
         if tx.transaction_type == TransactionType::TokenMint {
+            if tx.token_mint_data().is_none() {
+                return Err(anyhow::anyhow!(
+                    "rejecting TokenMint from originator '{:?}' with missing mint payload",
+                    originator
+                ));
+            }
             match originator {
                 SystemOriginator::PouwMint | SystemOriginator::PouwReward => {
                     if !empty_sig {

--- a/lib-blockchain/src/blockchain/identity.rs
+++ b/lib-blockchain/src/blockchain/identity.rs
@@ -1137,7 +1137,10 @@ impl Blockchain {
             b"Auto-registration for wallet identity".to_vec(),
         );
 
-        self.add_system_transaction(registration_tx.clone(), "auto_identity_registration")?;
+        self.add_system_transaction(
+            registration_tx.clone(),
+            super::SystemOriginator::AutoIdentityRegistration,
+        )?;
         self.identity_registry
             .insert(identity_did.clone(), identity_data.clone());
         self.identity_blocks.insert(identity_did, self.height + 1);

--- a/lib-blockchain/src/blockchain/system_originator.rs
+++ b/lib-blockchain/src/blockchain/system_originator.rs
@@ -1,0 +1,107 @@
+//! Typed system-transaction originators (audit follow-up: compile-time exhaustiveness).
+
+/// Subsystem identity for `add_system_transaction` injectors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SystemOriginator {
+    PouwMint,
+    PouwReward,
+    AdminSovMint,
+    GenesisBootstrap,
+    GenesisWallet,
+    MigrationWallet,
+    TreasuryKernel,
+    TreasuryAllocation,
+    TreasuryWalletBootstrap,
+    AutoWalletRegistration,
+    AutoIdentityRegistration,
+    IdentityProvisioning,
+    KyberKeyUpdate,
+    CredentialClaim,
+    CredentialRegister,
+    CredentialPasswordUpdate,
+    OpaqueCredentialRegister,
+    SeedRecoveryIdentity,
+    RecoveryFallbackWallet,
+    Web4DomainRegister,
+    Web4DomainUpdate,
+    IpcExternal,
+    DurabilityTest,
+    TestOriginator,
+    Other(&'static str),
+}
+
+impl SystemOriginator {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PouwMint => "pouw_mint",
+            Self::PouwReward => "pouw_reward",
+            Self::AdminSovMint => "admin_sov_mint",
+            Self::GenesisBootstrap => "genesis_bootstrap",
+            Self::GenesisWallet => "genesis_wallet",
+            Self::MigrationWallet => "migration_wallet",
+            Self::TreasuryKernel => "treasury_kernel",
+            Self::TreasuryAllocation => "treasury_allocation",
+            Self::TreasuryWalletBootstrap => "treasury_wallet_bootstrap",
+            Self::AutoWalletRegistration => "auto_wallet_registration",
+            Self::AutoIdentityRegistration => "auto_identity_registration",
+            Self::IdentityProvisioning => "identity_provisioning",
+            Self::KyberKeyUpdate => "kyber_key_update",
+            Self::CredentialClaim => "credential_claim",
+            Self::CredentialRegister => "credential_register",
+            Self::CredentialPasswordUpdate => "credential_password_update",
+            Self::OpaqueCredentialRegister => "opaque_credential_register",
+            Self::SeedRecoveryIdentity => "seed_recovery_identity",
+            Self::RecoveryFallbackWallet => "recovery_fallback_wallet",
+            Self::Web4DomainRegister => "web4_domain_register",
+            Self::Web4DomainUpdate => "web4_domain_update",
+            Self::IpcExternal => "ipc_external",
+            Self::DurabilityTest => "durability_test",
+            Self::TestOriginator => "test_originator",
+            Self::Other(label) => label,
+        }
+    }
+
+    pub fn is_treasury(self) -> bool {
+        matches!(
+            self,
+            Self::AdminSovMint
+                | Self::GenesisBootstrap
+                | Self::GenesisWallet
+                | Self::MigrationWallet
+                | Self::TreasuryKernel
+                | Self::TreasuryAllocation
+                | Self::TreasuryWalletBootstrap
+        )
+    }
+
+    /// Parse a legacy string label into a typed originator (unknown → [`Self::Other`]).
+    pub fn from_label(label: &'static str) -> Self {
+        match label {
+            "pouw_mint" => Self::PouwMint,
+            "pouw_reward" => Self::PouwReward,
+            "admin_sov_mint" => Self::AdminSovMint,
+            "genesis_bootstrap" => Self::GenesisBootstrap,
+            "genesis_wallet" => Self::GenesisWallet,
+            "migration_wallet" => Self::MigrationWallet,
+            "treasury_kernel" => Self::TreasuryKernel,
+            "treasury_allocation" => Self::TreasuryAllocation,
+            "treasury_wallet_bootstrap" => Self::TreasuryWalletBootstrap,
+            "auto_wallet_registration" => Self::AutoWalletRegistration,
+            "auto_identity_registration" => Self::AutoIdentityRegistration,
+            "identity_provisioning" => Self::IdentityProvisioning,
+            "kyber_key_update" => Self::KyberKeyUpdate,
+            "credential_claim" => Self::CredentialClaim,
+            "credential_register" => Self::CredentialRegister,
+            "credential_password_update" => Self::CredentialPasswordUpdate,
+            "opaque_credential_register" => Self::OpaqueCredentialRegister,
+            "seed_recovery_identity" => Self::SeedRecoveryIdentity,
+            "recovery_fallback_wallet" => Self::RecoveryFallbackWallet,
+            "web4_domain_register" => Self::Web4DomainRegister,
+            "web4_domain_update" => Self::Web4DomainUpdate,
+            "ipc_external" => Self::IpcExternal,
+            "durability_test" => Self::DurabilityTest,
+            "test_originator" => Self::TestOriginator,
+            other => Self::Other(other),
+        }
+    }
+}

--- a/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
@@ -143,7 +143,7 @@ fn system_injection_rejects_unsigned_token_mint_from_unknown_originator() {
 }
 
 #[test]
-fn system_injection_allows_pouw_mint_with_pouw_memo_prefix() {
+fn system_injection_allows_pouw_mint_with_matching_memo() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     let recipient = [9u8; 32];
     let amount = 500u128;

--- a/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
@@ -130,17 +130,17 @@ fn system_injection_rejects_unsigned_token_mint_from_unknown_originator() {
     }, b"not-a-pouw-mint".to_vec());
 
     let err = bc
-        .add_system_transaction(tx, "admin_sov_mint")
+        .add_system_transaction(tx, "evil_originator")
         .expect_err("unsigned mint must be rejected");
     assert!(
-        err.to_string().contains("rejecting unsigned TokenMint"),
+        err.to_string().contains("untrusted originator"),
         "unexpected error: {}",
         err
     );
 }
 
 #[test]
-fn system_injection_allows_pouw_mint_with_matching_memo() {
+fn system_injection_allows_pouw_mint_with_pouw_memo_prefix() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     let recipient = [9u8; 32];
     let amount = 500u128;
@@ -159,6 +159,96 @@ fn system_injection_allows_pouw_mint_with_matching_memo() {
 
     bc.add_system_transaction(tx, "pouw_mint").expect("pouw mint allowed");
     assert_eq!(bc.pending_transactions.len(), 1);
+}
+
+#[test]
+fn system_injection_rejects_pouw_mint_with_mismatched_recipient() {
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    let recipient = [9u8; 32];
+    let amount = 500u128;
+    let mint_data = crate::transaction::TokenMintData {
+        token_id: crate::contracts::utils::generate_lib_token_id(),
+        to: [8u8; 32],
+        amount,
+    };
+    let memo = format!("pouw:mint:{}:{}", hex::encode(recipient), amount).into_bytes();
+    let tx = Transaction::new_token_mint(mint_data, Signature {
+        signature: Vec::new(),
+        public_key: PublicKey::new([0u8; 2592]),
+        algorithm: SignatureAlgorithm::Dilithium5,
+        timestamp: 0,
+    }, memo);
+
+    let err = bc
+        .add_system_transaction(tx, "pouw_mint")
+        .expect_err("mismatched recipient must be rejected");
+    assert!(err.to_string().contains("recipient does not match"));
+}
+
+#[test]
+fn system_injection_rejects_token_mint_from_ipc_external() {
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    let mint_data = crate::transaction::TokenMintData {
+        token_id: crate::contracts::utils::generate_lib_token_id(),
+        to: [7u8; 32],
+        amount: 100,
+    };
+    let tx = Transaction::new_token_mint(mint_data, Signature {
+        signature: vec![1u8; 64],
+        public_key: PublicKey::new([0u8; 2592]),
+        algorithm: SignatureAlgorithm::Dilithium5,
+        timestamp: 0,
+    }, b"signed-but-untrusted".to_vec());
+
+    let err = bc
+        .add_system_transaction(tx, "ipc_external")
+        .expect_err("ipc TokenMint must be rejected");
+    assert!(err.to_string().contains("untrusted originator"));
+}
+
+#[test]
+fn system_injection_rejects_wallet_registration_without_wallet_data() {
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    let tx = make_tx(TransactionType::WalletRegistration);
+
+    let err = bc
+        .add_system_transaction(tx, "auto_wallet_registration")
+        .expect_err("wallet registration without payload must be rejected");
+    assert!(err.to_string().contains("missing wallet_data"));
+}
+
+#[test]
+fn system_injection_rejects_funded_wallet_registration_from_non_treasury() {
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    let wallet_data = crate::transaction::WalletTransactionData {
+        wallet_id: crate::types::Hash::new([0x11; 32]),
+        wallet_type: "Primary".to_string(),
+        wallet_name: "test".to_string(),
+        alias: None,
+        public_key: vec![0x22; 32],
+        owner_identity_id: None,
+        seed_commitment: crate::types::Hash::new([0x33; 32]),
+        created_at: 0,
+        registration_fee: 0,
+        capabilities: 0,
+        initial_balance: 1_000,
+    };
+    let tx = Transaction::new_wallet_registration(
+        wallet_data,
+        vec![],
+        Signature {
+            signature: vec![0u8; 64],
+            public_key: PublicKey::new([1u8; 2592]),
+            algorithm: SignatureAlgorithm::Dilithium5,
+            timestamp: 0,
+        },
+        vec![],
+    );
+
+    let err = bc
+        .add_system_transaction(tx, "auto_wallet_registration")
+        .expect_err("funded wallet registration must be rejected");
+    assert!(err.to_string().contains("initial_balance=1000"));
 }
 
 #[test]

--- a/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
@@ -115,6 +115,53 @@ fn pending_tx_survives_store_reattach() {
 }
 
 #[test]
+fn system_injection_rejects_unsigned_token_mint_from_unknown_originator() {
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    let mint_data = crate::transaction::TokenMintData {
+        token_id: crate::contracts::utils::generate_lib_token_id(),
+        to: [7u8; 32],
+        amount: 100,
+    };
+    let tx = Transaction::new_token_mint(mint_data, Signature {
+        signature: Vec::new(),
+        public_key: PublicKey::new([0u8; 2592]),
+        algorithm: SignatureAlgorithm::Dilithium5,
+        timestamp: 0,
+    }, b"not-a-pouw-mint".to_vec());
+
+    let err = bc
+        .add_system_transaction(tx, "admin_sov_mint")
+        .expect_err("unsigned mint must be rejected");
+    assert!(
+        err.to_string().contains("rejecting unsigned TokenMint"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
+fn system_injection_allows_pouw_mint_with_matching_memo() {
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    let recipient = [9u8; 32];
+    let amount = 500u128;
+    let mint_data = crate::transaction::TokenMintData {
+        token_id: crate::contracts::utils::generate_lib_token_id(),
+        to: recipient,
+        amount,
+    };
+    let memo = format!("pouw:mint:{}:{}", hex::encode(recipient), amount).into_bytes();
+    let tx = Transaction::new_token_mint(mint_data, Signature {
+        signature: Vec::new(),
+        public_key: PublicKey::new([0u8; 2592]),
+        algorithm: SignatureAlgorithm::Dilithium5,
+        timestamp: 0,
+    }, memo);
+
+    bc.add_system_transaction(tx, "pouw_mint").expect("pouw mint allowed");
+    assert_eq!(bc.pending_transactions.len(), 1);
+}
+
+#[test]
 fn audit_only_config_admits_zero_fee_transactions() {
     // The S2 default (`audit_only`) must not reject the existing zero-fee
     // traffic (coinbase, system mints) at the admission gate; BlockExecutor

--- a/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
@@ -56,11 +56,14 @@ fn admit_gate_rejects_when_tx_count_cap_exceeded() {
 fn system_tx_originator_counter_increments_per_call() {
     let mut bc = Blockchain::new().expect("blockchain construct");
 
-    bc.add_system_transaction(make_tx(TransactionType::Coinbase), "test_originator")
+    bc.add_system_transaction(make_tx(TransactionType::Coinbase), crate::blockchain::SystemOriginator::TestOriginator)
         .expect("system tx accept");
-    bc.add_system_transaction(make_tx(TransactionType::Coinbase), "test_originator")
+    bc.add_system_transaction(make_tx(TransactionType::Coinbase), crate::blockchain::SystemOriginator::TestOriginator)
         .expect("system tx accept");
-    bc.add_system_transaction(make_tx(TransactionType::Coinbase), "other_originator")
+    bc.add_system_transaction(
+        make_tx(TransactionType::Coinbase),
+        crate::blockchain::SystemOriginator::Other("other_originator"),
+    )
         .expect("system tx accept");
 
     assert_eq!(
@@ -86,7 +89,7 @@ fn pending_tx_survives_store_reattach() {
 
     let tx = make_tx(TransactionType::Coinbase);
     let tx_hash = tx.hash();
-    bc1.add_system_transaction(tx, "durability_test")
+    bc1.add_system_transaction(tx, crate::blockchain::SystemOriginator::DurabilityTest)
         .expect("system tx accept");
     assert_eq!(bc1.pending_transactions.len(), 1);
 
@@ -130,7 +133,7 @@ fn system_injection_rejects_unsigned_token_mint_from_unknown_originator() {
     }, b"not-a-pouw-mint".to_vec());
 
     let err = bc
-        .add_system_transaction(tx, "evil_originator")
+        .add_system_transaction(tx, crate::blockchain::SystemOriginator::Other("evil_originator"))
         .expect_err("unsigned mint must be rejected");
     assert!(
         err.to_string().contains("untrusted originator"),
@@ -157,7 +160,8 @@ fn system_injection_allows_pouw_mint_with_pouw_memo_prefix() {
         timestamp: 0,
     }, memo);
 
-    bc.add_system_transaction(tx, "pouw_mint").expect("pouw mint allowed");
+    bc.add_system_transaction(tx, crate::blockchain::SystemOriginator::PouwMint)
+        .expect("pouw mint allowed");
     assert_eq!(bc.pending_transactions.len(), 1);
 }
 
@@ -180,7 +184,7 @@ fn system_injection_rejects_pouw_mint_with_mismatched_recipient() {
     }, memo);
 
     let err = bc
-        .add_system_transaction(tx, "pouw_mint")
+        .add_system_transaction(tx, crate::blockchain::SystemOriginator::PouwMint)
         .expect_err("mismatched recipient must be rejected");
     assert!(err.to_string().contains("recipient does not match"));
 }
@@ -201,7 +205,7 @@ fn system_injection_rejects_token_mint_from_ipc_external() {
     }, b"signed-but-untrusted".to_vec());
 
     let err = bc
-        .add_system_transaction(tx, "ipc_external")
+        .add_system_transaction(tx, crate::blockchain::SystemOriginator::IpcExternal)
         .expect_err("ipc TokenMint must be rejected");
     assert!(err.to_string().contains("untrusted originator"));
 }
@@ -212,7 +216,7 @@ fn system_injection_rejects_wallet_registration_without_wallet_data() {
     let tx = make_tx(TransactionType::WalletRegistration);
 
     let err = bc
-        .add_system_transaction(tx, "auto_wallet_registration")
+        .add_system_transaction(tx, crate::blockchain::SystemOriginator::AutoWalletRegistration)
         .expect_err("wallet registration without payload must be rejected");
     assert!(err.to_string().contains("missing wallet_data"));
 }
@@ -246,7 +250,7 @@ fn system_injection_rejects_funded_wallet_registration_from_non_treasury() {
     );
 
     let err = bc
-        .add_system_transaction(tx, "auto_wallet_registration")
+        .add_system_transaction(tx, crate::blockchain::SystemOriginator::AutoWalletRegistration)
         .expect_err("funded wallet registration must be rejected");
     assert!(err.to_string().contains("initial_balance=1000"));
 }

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -761,7 +761,10 @@ impl Blockchain {
             format!("Wallet registration for {}", wallet_data.wallet_name).into_bytes(),
         );
 
-        self.add_system_transaction(registration_tx.clone(), "auto_wallet_registration")?;
+        self.add_system_transaction(
+            registration_tx.clone(),
+            super::SystemOriginator::AutoWalletRegistration,
+        )?;
         self.wallet_registry
             .insert(wallet_id_str.clone(), wallet_data.clone());
         self.wallet_blocks

--- a/lib-blockchain/src/ipc/server.rs
+++ b/lib-blockchain/src/ipc/server.rs
@@ -223,7 +223,7 @@ async fn dispatch_request(
             match crate::query::BlockchainMutate::submit_system_transaction(
                 &mut *bc,
                 tx.clone(),
-                "ipc_external",
+                crate::blockchain::SystemOriginator::IpcExternal,
             ) {
                 Ok(()) => IpcResponse::Ok,
                 Err(e) => IpcResponse::Error(e.to_string()),

--- a/lib-blockchain/src/lib.rs
+++ b/lib-blockchain/src/lib.rs
@@ -101,7 +101,7 @@ pub use block::{
 // Blockchain module
 pub use blockchain::{
     Blockchain, BlockchainBroadcastMessage, BlockchainImport, ConsensusCheckpoint,
-    EconomicsTransaction, PouwMintRecord, ValidatorInfo, GatewayInfo,
+    EconomicsTransaction, PouwMintRecord, SystemOriginator, ValidatorInfo, GatewayInfo,
     ADMISSION_SOURCE_BOOTSTRAP_GENESIS,
 };
 pub use query::{BlockchainQuery, BlockchainMutate};

--- a/lib-blockchain/src/query.rs
+++ b/lib-blockchain/src/query.rs
@@ -148,6 +148,6 @@ pub trait BlockchainMutate {
     fn submit_system_transaction(
         &mut self,
         tx: Transaction,
-        originator: &'static str,
+        originator: crate::blockchain::SystemOriginator,
     ) -> anyhow::Result<()>;
 }

--- a/lib-blockchain/src/query_impl.rs
+++ b/lib-blockchain/src/query_impl.rs
@@ -174,7 +174,7 @@ impl crate::query::BlockchainMutate for Blockchain {
     fn submit_system_transaction(
         &mut self,
         tx: Transaction,
-        originator: &'static str,
+        originator: crate::blockchain::SystemOriginator,
     ) -> anyhow::Result<()> {
         self.add_system_transaction(tx, originator)
     }

--- a/zhtp/src/api/handlers/credentials/mod.rs
+++ b/zhtp/src/api/handlers/credentials/mod.rs
@@ -216,7 +216,7 @@ impl CredentialsHandler {
         {
             let mut blockchain = self.blockchain.write().await;
             blockchain
-                .add_system_transaction(tx, "credential_register")
+                .add_system_transaction(tx, lib_blockchain::SystemOriginator::CredentialRegister)
                 .map_err(|e| anyhow::anyhow!("Failed to submit credential tx: {}", e))?;
 
             // Cache warmup so signin works before block commit
@@ -364,7 +364,7 @@ impl CredentialsHandler {
         {
             let mut blockchain = self.blockchain.write().await;
             blockchain
-                .add_system_transaction(tx, "credential_password_update")
+                .add_system_transaction(tx, lib_blockchain::SystemOriginator::CredentialPasswordUpdate)
                 .map_err(|e| anyhow::anyhow!("Failed to submit password update tx: {}", e))?;
 
             let height = blockchain.query_height();

--- a/zhtp/src/api/handlers/credentials/opaque.rs
+++ b/zhtp/src/api/handlers/credentials/opaque.rs
@@ -485,7 +485,7 @@ impl OpaqueHandlers {
         };
         {
             let mut bc = self.blockchain.write().await;
-            if let Err(e) = bc.add_system_transaction(tx, "opaque_credential_register") {
+            if let Err(e) = bc.add_system_transaction(tx, lib_blockchain::SystemOriginator::OpaqueCredentialRegister) {
                 return Ok(json_err(
                     ZhtpStatus::InternalServerError,
                     &format!("failed to submit RegisterCredential tx: {}", e),

--- a/zhtp/src/api/handlers/identity/backup_recovery.rs
+++ b/zhtp/src/api/handlers/identity/backup_recovery.rs
@@ -573,7 +573,7 @@ async fn auto_create_identity_from_seed(
                     },
                     b"seed-recovery-auto-register".to_vec(),
                 );
-                if let Err(e) = blockchain.add_system_transaction(reg_tx, "seed_recovery_identity") {
+                if let Err(e) = blockchain.add_system_transaction(reg_tx, lib_blockchain::SystemOriginator::SeedRecoveryIdentity) {
                     tracing::warn!("Recovery: failed to queue identity registration tx: {}", e);
                 } else {
                     // Identity will be added to registry when the block containing
@@ -713,7 +713,7 @@ async fn migrate_wallets_for_identity(
 
         // add_system_transaction bypasses signature validation (correct for a
         // server-originated system tx where we hold no user private key).
-        match blockchain.add_system_transaction(reg_tx, "migration_wallet") {
+        match blockchain.add_system_transaction(reg_tx, lib_blockchain::SystemOriginator::MigrationWallet) {
             Ok(_) => tracing::info!(
                 "Migration: queued WalletRegistration for {} ({} SOV)",
                 &wallet_id_hex[..16.min(wallet_id_hex.len())],
@@ -784,7 +784,7 @@ async fn create_fallback_wallet(
         return;
     };
 
-    match blockchain.add_system_transaction(reg_tx, "recovery_fallback_wallet") {
+    match blockchain.add_system_transaction(reg_tx, lib_blockchain::SystemOriginator::RecoveryFallbackWallet) {
         Ok(_) => {
             blockchain.insert_wallet_shadow(wallet_id_hex.clone(), wallet_data);
             tracing::info!(

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1683,7 +1683,7 @@ impl IdentityHandler {
                 },
                 format!("kyber-key-update:{}", &req.did[..20.min(req.did.len())]).into_bytes(),
             );
-            if let Err(e) = blockchain.add_system_transaction(update_tx, "kyber_key_update") {
+            if let Err(e) = blockchain.add_system_transaction(update_tx, lib_blockchain::SystemOriginator::KyberKeyUpdate) {
                 tracing::warn!("Failed to submit Kyber key update tx: {}", e);
             }
         }
@@ -1826,7 +1826,7 @@ impl IdentityHandler {
 
         {
             let mut blockchain = blockchain_arc.write().await;
-            if let Err(e) = blockchain.add_system_transaction(tx, "credential_claim") {
+            if let Err(e) = blockchain.add_system_transaction(tx, lib_blockchain::SystemOriginator::CredentialClaim) {
                 return Ok(ZhtpResponse::error(
                     ZhtpStatus::InternalServerError,
                     format!("Failed to submit claim tx: {}", e),

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -1677,7 +1677,7 @@ impl WalletHandler {
                     },
                     format!("Provisioned identity {}", &did[..40.min(did.len())]).into_bytes(),
                 );
-                if let Err(e) = blockchain.add_system_transaction(identity_tx, "identity_provisioning") {
+                if let Err(e) = blockchain.add_system_transaction(identity_tx, lib_blockchain::SystemOriginator::IdentityProvisioning) {
                     tracing::warn!("Failed to submit identity tx: {}", e);
                 }
                 // Cache warmup: identity must be visible immediately for QUIC handshake
@@ -1748,5 +1748,4 @@ impl WalletHandler {
             }
         }
     }
-
 }

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -786,7 +786,7 @@ impl Web4Handler {
                 payload: lib_blockchain::transaction::TransactionPayload::None,
             };
             let mut blockchain = self.blockchain.write().await;
-            if let Err(e) = blockchain.add_system_transaction(domain_tx, "web4_domain_register") {
+            if let Err(e) = blockchain.add_system_transaction(domain_tx, lib_blockchain::SystemOriginator::Web4DomainRegister) {
                 warn!("Failed to submit domain {} tx: {}", if is_update { "update" } else { "registration" }, e);
             }
         }
@@ -1111,7 +1111,7 @@ impl Web4Handler {
                 payload: lib_blockchain::transaction::TransactionPayload::None,
             };
             let mut blockchain = self.blockchain.write().await;
-            if let Err(e) = blockchain.add_system_transaction(domain_tx, "web4_domain_update") {
+            if let Err(e) = blockchain.add_system_transaction(domain_tx, lib_blockchain::SystemOriginator::Web4DomainUpdate) {
                 warn!("Failed to submit domain {} tx: {}", if is_update { "update" } else { "registration" }, e);
             }
         }

--- a/zhtp/src/rewards/reward_minter.rs
+++ b/zhtp/src/rewards/reward_minter.rs
@@ -10,6 +10,7 @@ use tracing::info;
 
 use lib_blockchain::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
 use lib_blockchain::transaction::{TokenMintData, Transaction};
+use lib_blockchain::SystemOriginator;
 
 use super::budget_tracker::RewardSource;
 
@@ -64,7 +65,7 @@ impl RewardMinter {
         // Write lock only for mempool insertion
         {
             let mut bc = self.blockchain.write().await;
-            bc.add_system_transaction(mint_tx, "pouw_reward")?;
+            bc.add_system_transaction(mint_tx, SystemOriginator::PouwReward)?;
         }
 
         info!(


### PR DESCRIPTION
## Audit finding
- **CRITICAL #4** — `add_system_transaction()` bypasses mempool + `verify_transaction()`

## Changes
- `validate_system_injection` rejects unsigned mints except pouw paths
- Block funded `WalletRegistration` from non-treasury originators
- Reject unsigned domain system txs from web4 handlers
- Tests: `system_injection_*` in `mempool_admit_tests`

Independent of the validation.rs stack; can merge in parallel with #01.

Replaces monolithic #2749 (split per finding).