### PR TITLE
security(audit-6): require signatures for privileged system transactions

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -533,6 +533,9 @@ pub struct Blockchain {
     /// is load-bearing (Pattern A/B in #2647) and won't disappear in S2.
     #[serde(skip)]
     pub system_tx_originators: HashMap<&'static str, u64>,
+    /// Nesting depth while `apply_genesis_state` is running (audit follow-up: genesis mint gate).
+    #[serde(skip, default)]
+    pub(crate) genesis_apply_depth: u32,
 }
 
 /// Validator information stored on-chain.
@@ -2588,6 +2591,19 @@ impl Blockchain {
         }
 
         Ok(())
+    }
+
+    /// True while genesis state is being applied (stronger than height/heuristic checks).
+    pub fn is_applying_genesis_state(&self) -> bool {
+        self.genesis_apply_depth > 0
+    }
+
+    pub(crate) fn begin_genesis_apply(&mut self) {
+        self.genesis_apply_depth = self.genesis_apply_depth.saturating_add(1);
+    }
+
+    pub(crate) fn end_genesis_apply(&mut self) {
+        self.genesis_apply_depth = self.genesis_apply_depth.saturating_sub(1);
     }
 
     pub fn add_system_transaction(

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -108,6 +108,7 @@ impl Blockchain {
             mempool_config: lib_mempool::MempoolConfig::audit_only(),
             mempool_state: lib_mempool::MempoolState::default(),
             system_tx_originators: HashMap::new(),
+            genesis_apply_depth: 0,
         }
     }
 

--- a/lib-blockchain/src/blockchain/persistence.rs
+++ b/lib-blockchain/src/blockchain/persistence.rs
@@ -294,6 +294,7 @@ impl BlockchainV1 {
             mempool_config: lib_mempool::MempoolConfig::audit_only(),
             mempool_state: lib_mempool::MempoolState::default(),
             system_tx_originators: HashMap::new(),
+            genesis_apply_depth: 0,
         }
     }
 }
@@ -645,6 +646,7 @@ impl BlockchainStorageV3 {
             mempool_config: lib_mempool::MempoolConfig::audit_only(),
             mempool_state: lib_mempool::MempoolState::default(),
             system_tx_originators: HashMap::new(),
+            genesis_apply_depth: 0,
         }
     }
 }

--- a/lib-blockchain/src/blockchain/system_originator.rs
+++ b/lib-blockchain/src/blockchain/system_originator.rs
@@ -104,4 +104,8 @@ impl SystemOriginator {
             other => Self::Other(other),
         }
     }
+
+    pub fn allows_unsigned_domain_tx(self) -> bool {
+        false
+    }
 }

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -735,6 +735,18 @@ impl Blockchain {
             .collect()
     }
 
+    /// Register a wallet via the trusted system-injection path.
+    ///
+    /// **Trusted callers** (in-process only — not mempool-admitted):
+    /// - `zhtp` citizenship / identity handlers (`identity/mod.rs`)
+    /// - `zhtp` runtime wallet bootstrap (`runtime/mod.rs`, `runtime/components/identity.rs`)
+    /// - `zhtp` mesh identity API (`server/mesh/identity_api.rs`)
+    /// - `zhtp` wallet provisioning handler (`api/handlers/wallet/mod.rs`)
+    /// - Genesis allocation replay (`blockchain/contracts.rs`)
+    ///
+    /// Welcome-bonus SOV (`initial_balance > 0`) is only minted in-memory during
+    /// `apply_genesis_state`. At `height > 0`, callers must set `initial_balance = 0`
+    /// and submit a separate treasury-signed [`TransactionType::TokenMint`].
     pub fn register_wallet(
         &mut self,
         wallet_data: crate::transaction::WalletTransactionData,
@@ -777,6 +789,14 @@ impl Blockchain {
             .insert(wallet_id_str.clone(), self.height + 1);
 
         if wallet_data.initial_balance > 0 {
+            if !self.is_applying_genesis_state() {
+                return Err(anyhow::anyhow!(
+                    "register_wallet initial_balance={} rejected at height {}: \
+                     submit a treasury-signed TokenMint instead of in-memory mint",
+                    wallet_data.initial_balance,
+                    self.height
+                ));
+            }
             let sov_token_id = crate::contracts::utils::generate_lib_token_id();
             self.ensure_sov_token_contract();
             let mut wallet_id_bytes_arr = [0u8; 32];
@@ -786,14 +806,14 @@ impl Blockchain {
                 if token.balance_of(&recipient_pk) == 0 {
                     if let Err(e) = token.mint(&recipient_pk, wallet_data.initial_balance as u128) {
                         warn!(
-                            "register_wallet: failed to mint {} SOV for {}: {}",
+                            "register_wallet: genesis bootstrap mint failed {} SOV for {}: {}",
                             wallet_data.initial_balance,
                             &wallet_id_str[..16.min(wallet_id_str.len())],
                             e
                         );
                     } else {
                         info!(
-                            "💰 register_wallet: minted {} SOV for wallet {} (in-memory)",
+                            "💰 register_wallet: genesis bootstrap minted {} SOV for wallet {}",
                             wallet_data.initial_balance,
                             &wallet_id_str[..16.min(wallet_id_str.len())]
                         );

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -875,6 +875,13 @@ impl GenesisConfig {
     /// the identity/wallet registries are empty because genesis state is populated via
     /// direct inserts in build_block0(), not via transactions.
     pub fn apply_genesis_state(&self, bc: &mut crate::Blockchain) -> Result<()> {
+        bc.begin_genesis_apply();
+        let result = self.apply_genesis_state_inner(bc);
+        bc.end_genesis_apply();
+        result
+    }
+
+    fn apply_genesis_state_inner(&self, bc: &mut crate::Blockchain) -> Result<()> {
         // Load the OPAQUE server setup if `[opaque]` is present.
         // Missing section is allowed in v1 — networks without lobby auth
         // simply have `bc.opaque_server_setup = None` and the OPAQUE

--- a/lib-blockchain/src/transaction/mint_authorization.rs
+++ b/lib-blockchain/src/transaction/mint_authorization.rs
@@ -28,9 +28,7 @@ pub fn is_treasury_authorized_signer(blockchain: &Blockchain, signer: &PublicKey
 }
 
 fn is_genesis_unsigned_mint_exception(blockchain: &Blockchain, transaction: &Transaction) -> bool {
-    blockchain.height == 0
-        && blockchain.latest_block().is_none()
-        && transaction.signature.signature.is_empty()
+    blockchain.is_applying_genesis_state() && transaction.signature.signature.is_empty()
 }
 
 fn validate_ubi_distribution_memo(
@@ -234,13 +232,13 @@ mod tests {
     #[test]
     fn sov_mint_allows_genesis_unsigned_exception() {
         let mut blockchain = Blockchain::default();
-        blockchain.blocks.clear();
-        blockchain.height = 0;
+        blockchain.begin_genesis_apply();
         let sov_id = crate::contracts::utils::generate_lib_token_id();
         let signer = test_public_key(30);
 
         let result = validate_token_mint_authorization(&blockchain, &mint_tx(&signer, sov_id, "", true));
         assert!(result.is_ok());
+        blockchain.end_genesis_apply();
     }
 
     #[test]
@@ -321,9 +319,8 @@ mod tests {
     }
 
     #[test]
-    fn genesis_exception_does_not_fire_when_blocks_present() {
-        let mut blockchain = Blockchain::default();
-        blockchain.height = 0;
+    fn genesis_exception_does_not_fire_outside_apply_genesis_state() {
+        let blockchain = Blockchain::default();
         let sov_id = crate::contracts::utils::generate_lib_token_id();
         let signer = test_public_key(44);
 

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -16,6 +16,7 @@ pub mod hashing;
 pub mod mint_authorization;
 pub mod oracle_governance;
 pub mod signing;
+pub mod system_tx_signature;
 pub mod threshold_approval;
 pub mod token_creation;
 pub mod validation;

--- a/lib-blockchain/src/transaction/system_tx_signature.rs
+++ b/lib-blockchain/src/transaction/system_tx_signature.rs
@@ -1,0 +1,145 @@
+//! System-transaction signature policy (audit follow-up: exhaustive TransactionType map).
+//!
+//! Every [`TransactionType`] variant must be explicitly classified so new variants
+//! cannot silently bypass signature requirements.
+
+use crate::transaction::core::Transaction;
+use crate::types::transaction_type::TransactionType;
+
+/// How a system transaction's tx-level signature is treated at validation time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemTxSignaturePolicy {
+    /// Privileged state mutation — valid Dilithium signature required.
+    Required,
+    /// Threshold-approval payload is authoritative; tx-level signature optional.
+    ThresholdApproval,
+    /// Protocol/bootstrap emission (coinbase, system UBI push, audit sessions).
+    Bootstrap,
+}
+
+/// Explicit policy for every transaction type. Compiler forces updates when variants are added.
+pub fn system_tx_signature_policy(ty: TransactionType) -> SystemTxSignaturePolicy {
+    match ty {
+        TransactionType::Transfer
+        | TransactionType::TokenTransfer
+        | TransactionType::IdentityRegistration
+        | TransactionType::IdentityUpdate
+        | TransactionType::IdentityRevocation
+        | TransactionType::ContractDeployment
+        | TransactionType::ContractExecution
+        | TransactionType::ContentUpload
+        | TransactionType::WalletRegistration
+        | TransactionType::WalletUpdate
+        | TransactionType::ValidatorRegistration
+        | TransactionType::ValidatorUpdate
+        | TransactionType::ValidatorUnregister
+        | TransactionType::DaoProposal
+        | TransactionType::DaoVote
+        | TransactionType::DaoExecution
+        | TransactionType::DifficultyUpdate
+        | TransactionType::UBIClaim
+        | TransactionType::ProfitDeclaration
+        | TransactionType::GovernanceConfigUpdate
+        | TransactionType::TokenMint
+        | TransactionType::TokenCreation
+        | TransactionType::TokenSwap
+        | TransactionType::CreatePool
+        | TransactionType::AddLiquidity
+        | TransactionType::RemoveLiquidity
+        | TransactionType::BondingCurveDeploy
+        | TransactionType::BondingCurveBuy
+        | TransactionType::BondingCurveSell
+        | TransactionType::BondingCurveGraduate
+        | TransactionType::UpdateOracleCommittee
+        | TransactionType::UpdateOracleConfig
+        | TransactionType::OracleAttestation
+        | TransactionType::CancelOracleUpdate
+        | TransactionType::InitEntityRegistry
+        | TransactionType::InitCbeToken
+        | TransactionType::CreateEmploymentContract
+        | TransactionType::ProcessPayroll
+        | TransactionType::DaoStake
+        | TransactionType::DaoUnstake
+        | TransactionType::DomainRegistration
+        | TransactionType::DomainUpdate
+        | TransactionType::GatewayRegistration
+        | TransactionType::GatewayUpdate
+        | TransactionType::GatewayUnregister
+        | TransactionType::NftCreateCollection
+        | TransactionType::NftMint
+        | TransactionType::NftTransfer
+        | TransactionType::NftBurn
+        | TransactionType::RegisterObserver
+        | TransactionType::UpdateObserverMetadata
+        | TransactionType::SuspendObserver
+        | TransactionType::RevokeObserver
+        | TransactionType::ReauthorizeObserver
+        | TransactionType::RegisterCredential
+        | TransactionType::UpdateCredentialPassword => SystemTxSignaturePolicy::Required,
+
+        TransactionType::RecordOnRampTrade | TransactionType::TreasuryAllocation => {
+            SystemTxSignaturePolicy::ThresholdApproval
+        }
+
+        TransactionType::Coinbase
+        | TransactionType::UbiDistribution
+        | TransactionType::SessionCreation
+        | TransactionType::SessionTermination => SystemTxSignaturePolicy::Bootstrap,
+    }
+}
+
+/// Returns true when a system transaction must carry a valid tx-level signature.
+pub fn requires_system_tx_signature(transaction: &Transaction) -> bool {
+    system_tx_signature_policy(transaction.transaction_type) == SystemTxSignaturePolicy::Required
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transfer_always_requires_signature_even_when_empty() {
+        let tx = Transaction {
+            version: 8,
+            chain_id: 0x03,
+            transaction_type: TransactionType::Transfer,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: Default::default(),
+            memo: vec![],
+            payload: crate::transaction::TransactionPayload::None,
+        };
+        assert!(requires_system_tx_signature(&tx));
+    }
+
+    #[test]
+    fn threshold_types_do_not_require_tx_signature() {
+        for ty in [
+            TransactionType::RecordOnRampTrade,
+            TransactionType::TreasuryAllocation,
+        ] {
+            assert_eq!(
+                system_tx_signature_policy(ty),
+                SystemTxSignaturePolicy::ThresholdApproval
+            );
+        }
+    }
+
+    #[test]
+    fn privileged_registration_types_require_signature() {
+        for ty in [
+            TransactionType::WalletRegistration,
+            TransactionType::ValidatorRegistration,
+            TransactionType::GatewayRegistration,
+            TransactionType::NftMint,
+            TransactionType::OracleAttestation,
+            TransactionType::DaoStake,
+        ] {
+            assert_eq!(
+                system_tx_signature_policy(ty),
+                SystemTxSignaturePolicy::Required
+            );
+        }
+    }
+}

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -145,6 +145,23 @@ impl std::error::Error for ValidationError {}
 pub type ValidationResult = Result<(), ValidationError>;
 
 /// Transaction validator with state context
+
+/// Returns true when a system transaction must still carry a valid signature.
+fn requires_system_tx_signature(transaction: &Transaction) -> bool {
+    matches!(
+        transaction.transaction_type,
+        TransactionType::WalletRegistration
+            | TransactionType::IdentityRegistration
+            | TransactionType::DomainRegistration
+            | TransactionType::DomainUpdate
+            | TransactionType::TokenMint
+            | TransactionType::InitEntityRegistry
+            | TransactionType::TokenCreation
+            | TransactionType::WalletUpdate
+    ) || (transaction.transaction_type == TransactionType::Transfer
+        && (!transaction.outputs.is_empty() || transaction.fee > 0))
+}
+
 pub struct TransactionValidator {
     // Note: In implementation, this would contain references to
     // blockchain state, UTXO set, nullifier set, etc.
@@ -592,14 +609,8 @@ impl TransactionValidator {
         //   mempool intake and poisoning block proposals on other validators.
         // - RecordOnRampTrade and TreasuryAllocation use threshold approvals; the
         //   transaction-level signature may be empty/dummy on these types.
-        let require_signature = !is_system_transaction
-            || matches!(
-                transaction.transaction_type,
-                TransactionType::WalletUpdate
-                    | TransactionType::TokenMint
-                    | TransactionType::TokenCreation
-                    | TransactionType::InitEntityRegistry
-            );
+        let require_signature =
+            !is_system_transaction || requires_system_tx_signature(transaction);
         let has_nonempty_sig = !transaction.signature.signature.is_empty();
         // Skip tx-level sig validation for threshold-approval-only types
         let is_threshold_only = matches!(
@@ -890,14 +901,8 @@ impl TransactionValidator {
         //   This prevents malformed signatures (wrong size, invalid bytes) from passing
         //   mempool intake and poisoning block proposals on other validators.
         // - RecordOnRampTrade and TreasuryAllocation use threshold approvals.
-        let require_signature = !is_system_transaction
-            || matches!(
-                transaction.transaction_type,
-                TransactionType::WalletUpdate
-                    | TransactionType::TokenMint
-                    | TransactionType::TokenCreation
-                    | TransactionType::InitEntityRegistry
-            );
+        let require_signature =
+            !is_system_transaction || requires_system_tx_signature(transaction);
         let has_nonempty_sig = !transaction.signature.signature.is_empty();
         let is_threshold_only_sflag = matches!(
             transaction.transaction_type,
@@ -2348,11 +2353,8 @@ impl<'a> StatefulTransactionValidator<'a> {
         // Signature validation (always required except for system transactions)
         // TokenMint and InitEntityRegistry are system for fee purposes but MUST still be signed.
         // RecordOnRampTrade and TreasuryAllocation use threshold approvals — skip tx-level sig.
-        let mut skip_signature = is_system_transaction
-            && !matches!(
-                transaction.transaction_type,
-                TransactionType::TokenMint | TransactionType::InitEntityRegistry
-            );
+        let mut skip_signature =
+            is_system_transaction && !requires_system_tx_signature(transaction);
         // Always skip tx-level signature for threshold-approval-only types
         if is_threshold_type {
             skip_signature = true;

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -9,6 +9,7 @@ use crate::transaction::core::{
     IdentityTransactionData, Transaction, TransactionInput, TransactionOutput,
 };
 use crate::transaction::mint_authorization::validate_token_mint_authorization;
+use crate::transaction::system_tx_signature::requires_system_tx_signature;
 use crate::transaction::token_creation::TokenCreationPayloadV1;
 use crate::transaction::{
     decode_bonding_curve_buy, decode_bonding_curve_sell, BONDING_CURVE_TX_PAYLOAD_LEN,
@@ -145,22 +146,6 @@ impl std::error::Error for ValidationError {}
 pub type ValidationResult = Result<(), ValidationError>;
 
 /// Transaction validator with state context
-
-/// Returns true when a system transaction must still carry a valid signature.
-fn requires_system_tx_signature(transaction: &Transaction) -> bool {
-    matches!(
-        transaction.transaction_type,
-        TransactionType::WalletRegistration
-            | TransactionType::IdentityRegistration
-            | TransactionType::DomainRegistration
-            | TransactionType::DomainUpdate
-            | TransactionType::TokenMint
-            | TransactionType::InitEntityRegistry
-            | TransactionType::TokenCreation
-            | TransactionType::WalletUpdate
-    ) || (transaction.transaction_type == TransactionType::Transfer
-        && (!transaction.outputs.is_empty() || transaction.fee > 0))
-}
 
 pub struct TransactionValidator {
     // Note: In implementation, this would contain references to
@@ -2361,11 +2346,10 @@ impl<'a> StatefulTransactionValidator<'a> {
         }
         if transaction.transaction_type == TransactionType::TokenMint {
             if let Some(blockchain) = self.blockchain {
-                if blockchain.height == 0
-                    && blockchain.latest_block().is_none() // #2636: facade form of blocks.is_empty()
+                if blockchain.is_applying_genesis_state()
                     && transaction.signature.signature.is_empty()
                 {
-                    skip_signature = true; // Allow genesis TokenMint without signature
+                    skip_signature = true; // Allow genesis TokenMint only during apply_genesis_state
                 }
             }
         }
@@ -3008,14 +2992,9 @@ impl<'a> StatefulTransactionValidator<'a> {
     fn validate_sender_identity_exists(&self, transaction: &Transaction) -> ValidationResult {
         tracing::debug!("[BREADCRUMB] validate_sender_identity_exists ENTER");
 
-        // If we don't have blockchain access, skip this check (backward compatibility)
-        let blockchain = match self.blockchain {
-            Some(blockchain) => blockchain,
-            None => {
-                tracing::warn!("SECURITY WARNING: Identity verification skipped - no blockchain state available");
-                return Ok(());
-            }
-        };
+        let blockchain = self
+            .blockchain
+            .ok_or(ValidationError::InvalidTransaction)?;
 
         // Extract the public key from the transaction signature
         let sender_public_key = transaction.signature.public_key.as_bytes();


### PR DESCRIPTION
CRITICAL stack PR. **HIGH #6** — system transactions skip signature verification.

Expands `requires_system_tx_signature` to wallet/domain/identity registration types; system transfers with outputs/fees also require valid signatures.

Depends on #2752. Replaces monolithic #2749.