### PR TITLE
security(audit-8): identity citizenship uses caller key + signing_hash

### DIFF
--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -284,28 +284,33 @@ impl IdentityHandler {
             tracing::info!(" Creating blockchain transactions for identity and wallets");
             let did_string = format!("did:zhtp:{}", citizenship_result.identity_id);
 
-            // Create proper ownership proof by signing the DID with identity data
-            let ownership_proof_data = format!("{}:{}", did_string, citizenship_result.identity_id);
-            let ownership_proof = ownership_proof_data.as_bytes().to_vec();
+            // Use the citizen's actual key material from identity manager (not a throwaway keypair).
+            let citizen_identity = identity_manager
+                .get_identity(&citizenship_result.identity_id)
+                .ok_or_else(|| anyhow::anyhow!("Citizen identity missing after onboarding"))?;
+            let citizen_private_key = citizen_identity
+                .private_key
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Citizen private key missing after onboarding"))?;
+            let keypair = lib_crypto::KeyPair {
+                public_key: citizen_identity.public_key.clone(),
+                private_key: citizen_private_key,
+            };
+            let public_key_bytes = citizen_identity.public_key.dilithium_pk.to_vec();
+            let ownership_proof = citizen_identity.ownership_proof.proof_data.clone();
 
             let identity_transaction_data = IdentityTransactionData::new(
                 did_string.clone(),
-                citizenship_result.identity_id.to_string(),
-                citizenship_result.primary_wallet_id.as_bytes().to_vec(), // public key
-                ownership_proof,                                          // proper ownership proof
+                req_data.display_name.clone(),
+                public_key_bytes,
+                ownership_proof,
                 "human".to_string(),
                 Hash::default(), // DID document hash
                 0,               // registration fee - system transactions are fee-free
                 0,               // DAO fee - system transactions are fee-free
             );
 
-            // Create proper cryptographic signature for blockchain transaction
-            // The signature must be over the transaction hash, not arbitrary data
-            use lib_crypto::{generate_keypair, sign_message};
-
-            // Generate a temporary keypair (in production, use citizen's actual keypair)
-            let keypair = generate_keypair()
-                .map_err(|e| anyhow::anyhow!("Failed to generate keypair: {}", e))?;
+            use lib_crypto::sign_message;
 
             // ========================================================================
             // CRITICAL FIX: Create welcome bonus UTXO output (5,000 SOV)
@@ -344,37 +349,33 @@ impl IdentityHandler {
 
             let outputs = vec![welcome_bonus_output];
 
-            // Create transaction WITHOUT signature first to get the hash for signing
+            // Build unsigned skeleton, then sign with signing_hash() (canonical validator path).
             let temp_transaction = Transaction::new_identity_registration(
                 identity_transaction_data.clone(),
-                outputs.clone(), // Include welcome bonus output
+                outputs.clone(),
                 Signature {
-                    signature: Vec::new(),                  // Empty signature for hash calculation
-                    public_key: PublicKey::new([0u8; 2592]), // Empty public key for hash calculation
+                    signature: Vec::new(),
+                    public_key: PublicKey::new(keypair.public_key.dilithium_pk),
                     algorithm: SignatureAlgorithm::DEFAULT,
                     timestamp: citizenship_result.dao_registration.registered_at,
                 },
-                Vec::new(), // Empty data for initial hash
+                Vec::new(),
             );
 
-            // Get the transaction hash that needs to be signed
-            let tx_hash = temp_transaction.hash();
-
-            // Sign the transaction hash with proper cryptographic signature
-            let crypto_signature = sign_message(&keypair, tx_hash.as_bytes())
+            let signing_hash = temp_transaction.signing_hash();
+            let crypto_signature = sign_message(&keypair, signing_hash.as_bytes())
                 .map_err(|e| anyhow::anyhow!("Failed to create signature: {}", e))?;
 
-            // Create the final blockchain transaction with proper signature
             let transaction = Transaction::new_identity_registration(
                 identity_transaction_data,
-                outputs, //  Include welcome bonus UTXO output
+                outputs,
                 Signature {
-                    signature: crypto_signature.signature, // cryptographic signature over tx hash
-                    public_key: PublicKey::new(keypair.public_key.dilithium_pk), // public key
-                    algorithm: SignatureAlgorithm::DEFAULT, // Post-quantum algorithm
+                    signature: crypto_signature.signature,
+                    public_key: PublicKey::new(keypair.public_key.dilithium_pk),
+                    algorithm: SignatureAlgorithm::DEFAULT,
                     timestamp: citizenship_result.dao_registration.registered_at,
                 },
-                Vec::new(), // No additional data needed
+                Vec::new(),
             );
 
             // Submit identity transaction to shared blockchain
@@ -414,7 +415,10 @@ impl IdentityHandler {
                 initial_balance: citizenship_result.welcome_bonus.bonus_amount, // Welcome bonus goes to primary
             };
 
-            if let Err(e) = self.submit_wallet_to_blockchain(primary_wallet_tx).await {
+            if let Err(e) = self
+                .submit_wallet_to_blockchain(primary_wallet_tx, &keypair)
+                .await
+            {
                 tracing::warn!("Failed to submit primary wallet to blockchain: {}", e);
             }
 
@@ -435,7 +439,10 @@ impl IdentityHandler {
                 initial_balance: 0,   // UBI payments come later
             };
 
-            if let Err(e) = self.submit_wallet_to_blockchain(ubi_wallet_tx).await {
+            if let Err(e) = self
+                .submit_wallet_to_blockchain(ubi_wallet_tx, &keypair)
+                .await
+            {
                 tracing::warn!("Failed to submit UBI wallet to blockchain: {}", e);
             }
 
@@ -456,7 +463,10 @@ impl IdentityHandler {
                 initial_balance: 0,   // Starts empty
             };
 
-            if let Err(e) = self.submit_wallet_to_blockchain(savings_wallet_tx).await {
+            if let Err(e) = self
+                .submit_wallet_to_blockchain(savings_wallet_tx, &keypair)
+                .await
+            {
                 tracing::warn!("Failed to submit savings wallet to blockchain: {}", e);
             }
 
@@ -651,13 +661,10 @@ impl IdentityHandler {
     async fn submit_wallet_to_blockchain(
         &self,
         wallet_data: lib_blockchain::transaction::WalletTransactionData,
+        keypair: &lib_crypto::KeyPair,
     ) -> Result<String> {
         use lib_blockchain::integration::{PublicKey, Signature, SignatureAlgorithm};
         use lib_blockchain::transaction::{Transaction, TransactionOutput};
-
-        // Generate keypair for wallet transaction signature
-        let keypair = lib_crypto::KeyPair::generate()
-            .map_err(|e| anyhow::anyhow!("Failed to generate keypair: {}", e))?;
 
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
@@ -714,12 +721,10 @@ impl IdentityHandler {
             Vec::new(), // Empty data
         );
 
-        // Get the transaction hash for signing
-        let tx_hash = temp_transaction.hash();
-
-        // Sign the transaction hash
+        // Sign with canonical signing_hash() (matches validator verification).
+        let signing_hash = temp_transaction.signing_hash();
         let crypto_signature = keypair
-            .sign(tx_hash.as_bytes())
+            .sign(signing_hash.as_bytes())
             .map_err(|e| anyhow::anyhow!("Failed to sign wallet transaction: {}", e))?;
 
         // Create final signed transaction

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -39,6 +39,31 @@ use lib_blockchain::{
 
 // Removed unused cryptographic imports
 
+/// Queue a treasury-signed SOV TokenMint for a welcome bonus (post wallet registration).
+async fn queue_welcome_bonus_token_mint(
+    blockchain: &mut lib_blockchain::Blockchain,
+    wallet_id: [u8; 32],
+    amount: u128,
+) {
+    let memo = format!("WELCOME_BONUS_V1:{}", hex::encode(wallet_id)).into_bytes();
+    match crate::runtime::token_utils::build_sov_mint_tx(&wallet_id, amount, memo).await {
+        Ok(mint_tx) => {
+            if let Err(e) =
+                blockchain.add_system_transaction(mint_tx, "treasury_wallet_bootstrap")
+            {
+                tracing::warn!("Failed to queue welcome bonus TokenMint: {}", e);
+            } else {
+                tracing::info!(
+                    "💰 Welcome bonus TokenMint queued ({} atoms → wallet {})",
+                    amount,
+                    hex::encode(&wallet_id[..8])
+                );
+            }
+        }
+        Err(e) => tracing::warn!("Failed to build welcome bonus TokenMint: {}", e),
+    }
+}
+
 /// Clean identity handler implementation
 pub struct IdentityHandler {
     identity_manager: Arc<RwLock<IdentityManager>>,
@@ -2182,18 +2207,16 @@ impl IdentityHandler {
             }
         };
 
-        // Wallet registrations are queued here; wallet_registry updates and the welcome-bonus
-        // mint happen when the WalletRegistration transactions are committed in a block.
+        // Wallet registrations are queued here; welcome-bonus SOV is credited via a
+        // separate treasury-signed TokenMint (not initial_balance on WalletRegistration).
+        let primary_wallet_id_arr = citizenship_result.primary_wallet_id.0;
         if let Ok(blockchain_arc) =
             crate::runtime::blockchain_provider::get_global_blockchain().await
         {
             let mut blockchain = blockchain_arc.write().await;
 
-            // Primary wallet gets welcome bonus
             let primary_wallet_data = lib_blockchain::transaction::WalletTransactionData {
-                wallet_id: lib_blockchain::Hash::from_slice(
-                    &citizenship_result.primary_wallet_id.0,
-                ),
+                wallet_id: lib_blockchain::Hash::from_slice(&primary_wallet_id_arr),
                 wallet_type: "Primary".to_string(),
                 wallet_name: "Primary Wallet".to_string(),
                 alias: Some("primary".to_string()),
@@ -2203,13 +2226,19 @@ impl IdentityHandler {
                 created_at,
                 registration_fee: 50,
                 capabilities: 0xFF,
-                initial_balance: welcome_bonus_amount, // 5,000 SOV welcome bonus (atomic units)
+                initial_balance: 0,
             };
             if let Err(e) = blockchain.register_wallet(primary_wallet_data) {
                 tracing::warn!("Failed to register primary wallet: {}", e);
             } else {
+                queue_welcome_bonus_token_mint(
+                    &mut blockchain,
+                    primary_wallet_id_arr,
+                    welcome_bonus_amount,
+                )
+                .await;
                 tracing::info!(
-                    "💰 Primary wallet queued with {} SOV welcome bonus pending block inclusion",
+                    "💰 Primary wallet queued; {} SOV welcome bonus mint pending block inclusion",
                     SOV_WELCOME_BONUS_SOV
                 );
             }

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -1632,7 +1632,7 @@ impl WalletHandler {
             created_at: now,
             registration_fee: 0,
             capabilities: if req.wallet_type == "Primary" { 0xFF } else { 0x01 },
-            initial_balance: welcome_bonus_amount,
+            initial_balance: 0,
         };
 
         // Register on blockchain — creates system transaction for block inclusion
@@ -1697,6 +1697,32 @@ impl WalletHandler {
 
             match blockchain.register_wallet(wallet_data) {
                 Ok(tx_hash) => {
+                    if req.welcome_bonus && welcome_bonus_amount > 0 {
+                        let memo = format!(
+                            "WELCOME_BONUS_V1:{}",
+                            hex::encode(wallet_id_arr)
+                        )
+                        .into_bytes();
+                        if let Ok(mint_tx) = crate::runtime::token_utils::build_sov_mint_tx(
+                            &wallet_id_arr,
+                            welcome_bonus_amount,
+                            memo,
+                        )
+                        .await
+                        {
+                            if let Err(e) = blockchain.add_system_transaction(
+                                mint_tx,
+                                "treasury_wallet_bootstrap",
+                            ) {
+                                tracing::warn!(
+                                    "Failed to queue welcome bonus TokenMint: {}",
+                                    e
+                                );
+                            }
+                        } else {
+                            tracing::warn!("Failed to build welcome bonus TokenMint");
+                        }
+                    }
                     tracing::info!(
                         "✅ Wallet provisioned: {} (type={}, owner={}, bonus={})",
                         &req.wallet_id[..16.min(req.wallet_id.len())],


### PR DESCRIPTION
**HIGH #8** — Identity citizenship flow uses `generate_keypair()` + `hash()` not user key + `signing_hash()`.

Replaces monolithic #2749.