### PR TITLE
security(audit-7): reject stub ZK proof systems in production

### DIFF
--- a/lib-proofs/src/types/zk_proof.rs
+++ b/lib-proofs/src/types/zk_proof.rs
@@ -363,11 +363,11 @@ impl ZkProof {
                 "ZHTP-Optimized-StorageAccess" => backend.verify_storage_access(backend_proof),
                 "ZHTP-Optimized-Merkle" => backend.verify_merkle(backend_proof, [0u8; 32]),
                 "ZHTP-Optimized-Routing" | "ZHTP-Optimized-DataIntegrity" | "fake" => {
-                    #[cfg(feature = "fake-proofs")]
+                    #[cfg(any(test, feature = "fake-proofs"))]
                     {
                         Ok(true)
                     }
-                    #[cfg(not(feature = "fake-proofs"))]
+                    #[cfg(not(any(test, feature = "fake-proofs")))]
                     {
                         Ok(false)
                     }

--- a/lib-proofs/src/types/zk_proof.rs
+++ b/lib-proofs/src/types/zk_proof.rs
@@ -362,9 +362,16 @@ impl ZkProof {
                 "ZHTP-Optimized-Range" | "Bulletproofs" => backend.verify_range(backend_proof),
                 "ZHTP-Optimized-StorageAccess" => backend.verify_storage_access(backend_proof),
                 "ZHTP-Optimized-Merkle" => backend.verify_merkle(backend_proof, [0u8; 32]),
-                "ZHTP-Optimized-Routing" => Ok(true), // stub
-                "ZHTP-Optimized-DataIntegrity" => Ok(true), // stub
-                "fake" => Ok(true),
+                "ZHTP-Optimized-Routing" | "ZHTP-Optimized-DataIntegrity" | "fake" => {
+                    #[cfg(feature = "fake-proofs")]
+                    {
+                        Ok(true)
+                    }
+                    #[cfg(not(feature = "fake-proofs"))]
+                    {
+                        Ok(false)
+                    }
+                }
                 _ => Ok(false), // Unknown proof type
             }
         } else {


### PR DESCRIPTION
**HIGH #7** — ZK verifier accepts `fake` / stub proof systems as valid.

Rejects stub proof systems (fake/Routing/DataIntegrity) outside test builds.

Replaces monolithic #2749.