### PR TITLE
fix: SystemOriginator for welcome bonus TokenMint

### DIFF
--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -49,7 +49,10 @@ async fn queue_welcome_bonus_token_mint(
     match crate::runtime::token_utils::build_sov_mint_tx(&wallet_id, amount, memo).await {
         Ok(mint_tx) => {
             if let Err(e) =
-                blockchain.add_system_transaction(mint_tx, "treasury_wallet_bootstrap")
+                blockchain.add_system_transaction(
+                    mint_tx,
+                    lib_blockchain::SystemOriginator::TreasuryWalletBootstrap,
+                )
             {
                 tracing::warn!("Failed to queue welcome bonus TokenMint: {}", e);
             } else {

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -1712,7 +1712,7 @@ impl WalletHandler {
                         {
                             if let Err(e) = blockchain.add_system_transaction(
                                 mint_tx,
-                                "treasury_wallet_bootstrap",
+                                lib_blockchain::SystemOriginator::TreasuryWalletBootstrap,
                             ) {
                                 tracing::warn!(
                                     "Failed to queue welcome bonus TokenMint: {}",


### PR DESCRIPTION
Fixes compile error after #2751 + #2754: treasury welcome-bonus mint uses TreasuryWalletBootstrap enum.