### PR TITLE
fix(api): unify BUBL balance key resolution across token/assets APIs

### DIFF
--- a/zhtp/src/api/handlers/assets/mod.rs
+++ b/zhtp/src/api/handlers/assets/mod.rs
@@ -230,7 +230,8 @@ impl AssetsHandler {
             anyhow::bail!("Balance lookup for launch_tx asset_id not implemented until SA-3");
         }
 
-        let key_id = resolve_key_id(address)?;
+        let key_id =
+            crate::api::handlers::balance_key::resolve_custom_token_balance_key(&bc, address)?;
         let balance = bc
             .token_balance(&asset_id, &key_id)
             .map_err(|e| anyhow::anyhow!("balance lookup failed: {}", e))?;
@@ -260,24 +261,6 @@ fn parse_asset_id(hex_str: &str) -> Result<[u8; 32]> {
     let mut out = [0u8; 32];
     out.copy_from_slice(&bytes);
     Ok(out)
-}
-
-fn resolve_key_id(address: &str) -> Result<[u8; 32]> {
-    let key_bytes = if address.starts_with("did:zhtp:") {
-        let hex_part = address.strip_prefix("did:zhtp:").unwrap_or(address);
-        hex::decode(hex_part).map_err(|_| anyhow::anyhow!("Invalid DID format"))?
-    } else if address.starts_with("0x") {
-        hex::decode(&address[2..]).map_err(|_| anyhow::anyhow!("Invalid hex address"))?
-    } else {
-        hex::decode(address).map_err(|_| anyhow::anyhow!("Invalid identity format"))?
-    };
-
-    if key_bytes.len() != 32 {
-        anyhow::bail!("Address must be 32-byte key_id hex");
-    }
-    let mut key_id = [0u8; 32];
-    key_id.copy_from_slice(&key_bytes);
-    Ok(key_id)
 }
 
 #[async_trait::async_trait]

--- a/zhtp/src/api/handlers/balance_key.rs
+++ b/zhtp/src/api/handlers/balance_key.rs
@@ -1,0 +1,110 @@
+//! Canonical balance-key resolution for custom (non-SOV) tokens.
+//!
+//! BUBL and other custom tokens store balances under the holder's identity
+//! `key_id` — `blake3(dilithium_pk)`, the same 32 bytes in `did:zhtp:{hex}`.
+//! Rewards mint to that key. SOV remains wallet_id-keyed elsewhere.
+
+use lib_blockchain::{Blockchain, Hash};
+use lib_crypto::types::keys::PublicKey;
+
+fn strip_address_prefix(address: &str) -> &str {
+    if let Some(rest) = address.strip_prefix("did:zhtp:") {
+        rest
+    } else if let Some(rest) = address.strip_prefix("0x") {
+        rest
+    } else {
+        address
+    }
+}
+
+fn dilithium_key_id(public_key_bytes: &[u8]) -> anyhow::Result<[u8; 32]> {
+    let pk: [u8; 2592] = public_key_bytes
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("public_key must be 2592 bytes"))?;
+    Ok(PublicKey::new(pk).key_id)
+}
+
+/// Resolve the sled `token_balances` key for a custom token holder.
+///
+/// Accepts `did:zhtp:{key_id}`, wallet_id hex, identity_id hex, or 2592-byte
+/// dilithium public key hex. Wallet and identity identifiers map to the owner's
+/// dilithium-derived `key_id`, not the raw wallet_id bytes.
+pub fn resolve_custom_token_balance_key(
+    blockchain: &Blockchain,
+    address: &str,
+) -> anyhow::Result<[u8; 32]> {
+    let hex_part = strip_address_prefix(address);
+    let bytes = hex::decode(hex_part).map_err(|_| anyhow::anyhow!("Invalid address hex"))?;
+
+    if bytes.len() == 32 {
+        let wallet_id_hex = hex::encode(&bytes);
+        if let Some(wallet) = blockchain.wallet_transaction_data(&wallet_id_hex) {
+            return dilithium_key_id(&wallet.public_key);
+        }
+
+        let identity_hash = Hash::from_slice(&bytes);
+        if let Some((_, wallet)) = blockchain
+            .wallet_registry_snapshot()
+            .into_iter()
+            .find(|(_, w)| w.owner_identity_id.as_ref() == Some(&identity_hash))
+        {
+            return dilithium_key_id(&wallet.public_key);
+        }
+
+        let mut key_id = [0u8; 32];
+        key_id.copy_from_slice(&bytes);
+        return Ok(key_id);
+    }
+
+    if bytes.len() == 2592 {
+        return dilithium_key_id(&bytes);
+    }
+
+    anyhow::bail!(
+        "Address must be did:zhtp, 32-byte wallet/key_id hex, or 2592-byte dilithium public key"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lib_blockchain::transaction::WalletTransactionData;
+
+    fn test_wallet_data(wallet_id: [u8; 32], owner: [u8; 32]) -> WalletTransactionData {
+        let mut dilithium_pk = [0u8; 2592];
+        dilithium_pk[0] = 0xAB;
+        WalletTransactionData {
+            wallet_id: Hash::from_slice(&wallet_id),
+            wallet_type: "Primary".to_string(),
+            wallet_name: "Primary".to_string(),
+            alias: None,
+            public_key: dilithium_pk.to_vec(),
+            owner_identity_id: Some(Hash::from_slice(&owner)),
+            seed_commitment: Hash::default(),
+            created_at: 0,
+            registration_fee: 0,
+            capabilities: 0,
+            initial_balance: 0,
+        }
+    }
+
+    #[test]
+    fn wallet_id_resolves_to_dilithium_key_id_not_raw_wallet_bytes() {
+        let mut bc = lib_blockchain::Blockchain::new().expect("blockchain");
+        let wallet_id = [0x11u8; 32];
+        let owner_id = [0x22u8; 32];
+        let wallet_hex = hex::encode(wallet_id);
+        bc.register_wallet(test_wallet_data(wallet_id, owner_id))
+            .expect("register wallet");
+
+        let via_wallet = resolve_custom_token_balance_key(&bc, &wallet_hex).expect("wallet");
+        let via_did = resolve_custom_token_balance_key(
+            &bc,
+            &format!("did:zhtp:{}", hex::encode(via_wallet)),
+        )
+        .expect("did");
+
+        assert_ne!(via_wallet, wallet_id, "must not use raw wallet_id bytes");
+        assert_eq!(via_wallet, via_did, "wallet_id and DID must agree");
+    }
+}

--- a/zhtp/src/api/handlers/mod.rs
+++ b/zhtp/src/api/handlers/mod.rs
@@ -3,6 +3,7 @@
 //! Clean, minimal handler modules for ZHTP API
 
 pub mod assets;
+pub mod balance_key;
 pub mod bearer_auth;
 pub mod blockchain;
 pub mod bonding_curve;

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -525,9 +525,13 @@ impl TokenHandler {
                 .token_balance(&token_id_array, &wallet_id)
                 .unwrap_or(0)
         } else {
-            let pubkey = self.identity_to_pubkey(address)?;
+            let balance_key =
+                crate::api::handlers::balance_key::resolve_custom_token_balance_key(
+                    &blockchain,
+                    address,
+                )?;
             blockchain
-                .token_balance(&token_id_array, &pubkey.key_id)
+                .token_balance(&token_id_array, &balance_key)
                 .unwrap_or(0)
         };
 
@@ -669,15 +673,11 @@ impl TokenHandler {
         use lib_blockchain::contracts::utils::generate_lib_token_id;
 
         let blockchain = self.blockchain.read().await;
-        let target_key_id = if let Some(wallet) = blockchain.wallet_transaction_data(address) {
-            let wallet_pk = PublicKey::new(
-                wallet.public_key.as_slice().try_into().unwrap_or([0u8; 2592])
-            );
-            wallet_pk.key_id
-        } else {
-            let pubkey = self.identity_to_pubkey(address)?;
-            pubkey.key_id
-        };
+        let target_key_id =
+            crate::api::handlers::balance_key::resolve_custom_token_balance_key(
+                &blockchain,
+                address,
+            )?;
         let sov_wallet_id = self.resolve_wallet_id_for_sov(address, &blockchain);
 
         debug!(


### PR DESCRIPTION
## Problem

Wallet UI showed inconsistent BUBL balances (422 vs 110 vs 112) because different endpoints resolved the holder address differently:

- `token/{id}/balance/{wallet_id}` treated raw wallet_id bytes as the sled key
- `token/balances/{wallet_id}` used dilithium-derived `key_id`
- `assets/.../balances/{did}` used DID key_id (correct — matches rewards mint target)
- `rewards/balance/{did}` returns lifetime `total_earned` (not spendable balance)

## Fix

Add `balance_key::resolve_custom_token_balance_key()` — wallet_id, identity_id, and `did:zhtp:` all map to `blake3(dilithium_pk)` before `token_balance()` lookup.

Wired into:
- `GET /api/v1/token/{id}/balance/{address}`
- `GET /api/v1/token/balances/{address}`
- `GET /api/v1/assets/{id}/balances/{address}`

SOV remains wallet_id-keyed (unchanged). Rewards balance endpoint unchanged (lifetime stats).

## Deploy

Merge → `cargo build -p zhtp --release` → `scripts/deploy-validators.sh target/release/zhtp`