### PR TITLE
fix(api): BUBL as DAO TokenCreation — rewards, balances, token list

### DIFF
--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -81,6 +81,71 @@ impl Blockchain {
         call.contract_type == crate::types::ContractType::Token && call.method == "transfer"
     }
 
+    /// Repair TokenCreation allocations missing from the `token_balances` sled tree.
+    ///
+    /// `load_from_store` skips token-tx replay (#2637). When the legacy
+    /// `process_token_transactions` path persisted contract metadata without
+    /// crediting the balance tree, creator/treasury read 0 despite
+    /// `total_supply > 0`. Idempotent: only repairs tokens with zero sled
+    /// holders by replaying initial allocations from committed TokenCreation txs.
+    pub fn repair_missing_token_creation_balances(
+        &self,
+        store: &dyn crate::storage::BlockchainStore,
+    ) -> crate::storage::StorageResult<usize> {
+        use crate::storage::{Address, TokenId};
+        use crate::transaction::token_creation::TokenCreationPayloadV1;
+
+        let mut repairs: Vec<(TokenId, Address, u128)> = Vec::new();
+        let mut repaired_tokens = std::collections::HashSet::new();
+
+        let blocks: Vec<crate::block::Block> = self.iter_blocks().collect();
+        for block in &blocks {
+            for tx in &block.transactions {
+                if tx.transaction_type != TransactionType::TokenCreation {
+                    continue;
+                }
+                let payload = match TokenCreationPayloadV1::decode_memo(&tx.memo) {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+                let token_id_bytes = crate::contracts::utils::generate_custom_token_id(
+                    &payload.name,
+                    &payload.symbol,
+                );
+                if !repaired_tokens.insert(token_id_bytes) {
+                    continue;
+                }
+                let token_id = TokenId::new(token_id_bytes);
+                if store.count_token_holders(&token_id)? > 0 {
+                    continue;
+                }
+                let Some(contract) = store.get_token_contract(&token_id)? else {
+                    continue;
+                };
+                if contract.total_supply == 0 {
+                    continue;
+                }
+
+                let (creator_alloc, treasury_alloc) = payload.split_initial_supply();
+                if creator_alloc > 0 {
+                    repairs.push((
+                        token_id,
+                        Address::new(tx.signature.public_key.key_id),
+                        creator_alloc,
+                    ));
+                }
+                if treasury_alloc > 0 {
+                    repairs.push((token_id, Address::new(payload.treasury_recipient), treasury_alloc));
+                }
+            }
+        }
+
+        if repairs.is_empty() {
+            return Ok(0);
+        }
+        store.force_set_token_balances(&repairs)
+    }
+
     /// Rebuild the PoUW reward mint index from all in-memory blocks.
     ///
     /// Scans every block for `TokenMint` transactions carrying a `pouw:mint:`
@@ -743,6 +808,32 @@ impl Blockchain {
                         let store_ref: &dyn crate::storage::BlockchainStore = store.as_ref();
                         if let Err(e) = store_ref.put_token_contract(&token) {
                             warn!("Failed to persist token contract after creation: {}", e);
+                        } else {
+                            let token_storage_id = crate::storage::TokenId(token_id);
+                            let creator_addr =
+                                crate::storage::Address::new(creator.key_id);
+                            let treasury_addr =
+                                crate::storage::Address::new(payload.treasury_recipient);
+                            if let Err(e) = store_ref.set_token_balance(
+                                &token_storage_id,
+                                &creator_addr,
+                                creator_allocation,
+                            ) {
+                                warn!(
+                                    "Failed to persist creator balance after TokenCreation: {}",
+                                    e
+                                );
+                            }
+                            if let Err(e) = store_ref.set_token_balance(
+                                &token_storage_id,
+                                &treasury_addr,
+                                treasury_allocation,
+                            ) {
+                                warn!(
+                                    "Failed to persist treasury balance after TokenCreation: {}",
+                                    e
+                                );
+                            }
                         }
                     }
                 }

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -86,8 +86,8 @@ impl Blockchain {
     /// `load_from_store` skips token-tx replay (#2637). When the legacy
     /// `process_token_transactions` path persisted contract metadata without
     /// crediting the balance tree, creator/treasury read 0 despite
-    /// `total_supply > 0`. Idempotent: only repairs tokens with zero sled
-    /// holders by replaying initial allocations from committed TokenCreation txs.
+    /// `total_supply > 0`. Idempotent per address: only credits creator/treasury
+    /// rows that read zero in sled, using on-chain contract creator metadata.
     pub fn repair_missing_token_creation_balances(
         &self,
         store: &dyn crate::storage::BlockchainStore,
@@ -116,9 +116,6 @@ impl Blockchain {
                     continue;
                 }
                 let token_id = TokenId::new(token_id_bytes);
-                if store.count_token_holders(&token_id)? > 0 {
-                    continue;
-                }
                 let Some(contract) = store.get_token_contract(&token_id)? else {
                     continue;
                 };
@@ -127,15 +124,19 @@ impl Blockchain {
                 }
 
                 let (creator_alloc, treasury_alloc) = payload.split_initial_supply();
-                if creator_alloc > 0 {
-                    repairs.push((
-                        token_id,
-                        Address::new(tx.signature.public_key.key_id),
-                        creator_alloc,
-                    ));
-                }
-                if treasury_alloc > 0 {
-                    repairs.push((token_id, Address::new(payload.treasury_recipient), treasury_alloc));
+                let creator_key = contract.creator.key_id;
+                let candidates = [
+                    (creator_key, creator_alloc),
+                    (payload.treasury_recipient, treasury_alloc),
+                ];
+                for (addr_bytes, amount) in candidates {
+                    if amount == 0 {
+                        continue;
+                    }
+                    let addr = Address::new(addr_bytes);
+                    if store.get_token_balance(&token_id, &addr)? == 0 {
+                        repairs.push((token_id, addr, amount));
+                    }
                 }
             }
         }
@@ -814,25 +815,40 @@ impl Blockchain {
                                 crate::storage::Address::new(creator.key_id);
                             let treasury_addr =
                                 crate::storage::Address::new(payload.treasury_recipient);
-                            if let Err(e) = store_ref.set_token_balance(
-                                &token_storage_id,
-                                &creator_addr,
-                                creator_allocation,
-                            ) {
-                                warn!(
-                                    "Failed to persist creator balance after TokenCreation: {}",
-                                    e
-                                );
+                            // Idempotent: only seed sled rows that are still zero.
+                            if creator_allocation > 0
+                                && store_ref
+                                    .get_token_balance(&token_storage_id, &creator_addr)
+                                    .unwrap_or(0)
+                                    == 0
+                            {
+                                if let Err(e) = store_ref.set_token_balance(
+                                    &token_storage_id,
+                                    &creator_addr,
+                                    creator_allocation,
+                                ) {
+                                    warn!(
+                                        "Failed to persist creator balance after TokenCreation: {}",
+                                        e
+                                    );
+                                }
                             }
-                            if let Err(e) = store_ref.set_token_balance(
-                                &token_storage_id,
-                                &treasury_addr,
-                                treasury_allocation,
-                            ) {
-                                warn!(
-                                    "Failed to persist treasury balance after TokenCreation: {}",
-                                    e
-                                );
+                            if treasury_allocation > 0
+                                && store_ref
+                                    .get_token_balance(&token_storage_id, &treasury_addr)
+                                    .unwrap_or(0)
+                                    == 0
+                            {
+                                if let Err(e) = store_ref.set_token_balance(
+                                    &token_storage_id,
+                                    &treasury_addr,
+                                    treasury_allocation,
+                                ) {
+                                    warn!(
+                                        "Failed to persist treasury balance after TokenCreation: {}",
+                                        e
+                                    );
+                                }
                             }
                         }
                     }

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -767,20 +767,29 @@ impl Blockchain {
             }
         }
 
-        let sov_token_id = crate::contracts::utils::generate_lib_token_id();
-        if let Some(sov_contract) = blockchain.token_contracts.get(&sov_token_id) {
-            let entries: Vec<([u8; 32], u128)> = sov_contract
-                .balances_iter()
-                .map(|(pk, &bal)| (pk.key_id, bal))
-                .collect();
-            let token_id = crate::storage::TokenId(sov_token_id);
-            match store.backfill_token_balances_from_contract(&token_id, &entries) {
-                Ok(0) => debug!("SOV token_balances tree already up-to-date (no backfill needed)"),
-                Ok(n) => info!(
-                    "💰 Backfilled {} SOV balances into token_balances tree (legacy migration)",
-                    n
-                ),
-                Err(e) => warn!("⚠️ Failed to backfill SOV token_balances: {}", e),
+        // Backfill embedded contract balances into the authoritative token_balances tree.
+        if let Ok(iter) = store.iter_token_contracts() {
+            for (token_id, contract) in iter {
+                let entries: Vec<([u8; 32], u128)> = contract
+                    .balances_iter()
+                    .map(|(pk, &bal)| (pk.key_id, bal))
+                    .collect();
+                if entries.is_empty() {
+                    continue;
+                }
+                match store.backfill_token_balances_from_contract(&token_id, &entries) {
+                    Ok(0) => {}
+                    Ok(n) => info!(
+                        "💰 Backfilled {} balances for token {} into token_balances tree",
+                        n,
+                        hex::encode(&token_id.0[..8])
+                    ),
+                    Err(e) => warn!(
+                        "⚠️ Failed to backfill token_balances for {}: {}",
+                        hex::encode(&token_id.0[..8]),
+                        e
+                    ),
+                }
             }
         }
 
@@ -1008,6 +1017,18 @@ impl Blockchain {
                     e
                 ),
             }
+        }
+
+        match blockchain.repair_missing_token_creation_balances(store.as_ref()) {
+            Ok(0) => {}
+            Ok(n) => info!(
+                "💰 Repaired {} TokenCreation balance entries from chain history",
+                n
+            ),
+            Err(e) => warn!(
+                "⚠️ Failed to repair TokenCreation balances during load_from_store: {}",
+                e
+            ),
         }
 
         // #56: backfill durable validators tree on normal startup (not replay-only).

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -768,8 +768,21 @@ impl Blockchain {
         }
 
         // Backfill embedded contract balances into the authoritative token_balances tree.
+        // Skip rows whose token_id collides with an on-chain SovereignAsset launch:
+        // executor-written asset balances are authoritative for those ids.
         if let Ok(iter) = store.iter_token_contracts() {
             for (token_id, contract) in iter {
+                if store
+                    .get_sovereign_asset(&token_id.0)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|a| {
+                        a.id_source
+                            == crate::contracts::sovereign_asset::AssetIdSource::LaunchTx
+                    })
+                {
+                    continue;
+                }
                 let entries: Vec<([u8; 32], u128)> = contract
                     .balances_iter()
                     .map(|(pk, &bal)| (pk.key_id, bal))

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -208,6 +208,95 @@ fn token_balance_reads_sled_when_store_attached() {
 }
 
 #[test]
+fn repair_missing_token_creation_balances_restores_zeroed_tree() {
+    use crate::contracts::TokenContract;
+    use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+    use crate::transaction::token_creation::TokenCreationPayloadV1;
+    use crate::transaction::Transaction;
+    use crate::types::TransactionType;
+
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("repair_tc_store")).unwrap());
+
+    let creator = PublicKey::new([0x51u8; 2592]);
+    let treasury = [0xAAu8; 32];
+    let payload = TokenCreationPayloadV1 {
+        name: "Bubbl".to_string(),
+        symbol: "BUBL".to_string(),
+        initial_supply: 1_000_000,
+        decimals: 8,
+        treasury_allocation_bps: 2_000,
+        treasury_recipient: treasury,
+    };
+    let tx = Transaction {
+        version: 2,
+        chain_id: 2,
+        transaction_type: TransactionType::TokenCreation,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: Signature {
+            signature: vec![0u8; 64],
+            public_key: creator.clone(),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 1,
+        },
+        memo: payload.encode_memo().unwrap(),
+        payload: crate::transaction::TransactionPayload::None,
+    };
+    let token_id = crate::contracts::utils::generate_custom_token_id("Bubbl", "BUBL");
+
+    // Simulate the bug: legacy path wrote contract metadata only.
+    let mut token = TokenContract::new_custom("Bubbl".to_string(), "BUBL".to_string(), 0, creator.clone());
+    token.max_supply = payload.initial_supply;
+    token.total_supply = payload.initial_supply;
+    store.begin_block(0).unwrap();
+    store
+        .put_token_contract(&token)
+        .expect("contract metadata write");
+    store.commit_block().unwrap();
+    assert_eq!(store.count_token_holders(&TokenId::new(token_id)).unwrap(), 0);
+
+    let genesis = crate::block::create_genesis_block();
+    let block1 = crate::block::Block {
+        header: crate::block::BlockHeader {
+            version: 1,
+            previous_hash: genesis.header.block_hash.into(),
+            data_helix_root: crate::types::Hash::default().into(),
+            timestamp: genesis.header.timestamp + 1,
+            height: 1,
+            verification_helix_root: [0u8; 32],
+            state_root: crate::types::Hash::default().into(),
+            bft_quorum_root: [0u8; 32],
+            block_hash: crate::types::Hash::default(),
+        },
+        transactions: vec![tx],
+    };
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.blocks.clear();
+    bc.set_store(store.clone());
+    bc.blocks.push(genesis);
+    bc.blocks.push(block1);
+    bc.height = 1;
+
+    let repaired = bc
+        .repair_missing_token_creation_balances(store.as_ref())
+        .expect("repair should succeed");
+    assert_eq!(repaired, 2, "creator + treasury balances should be repaired");
+
+    let (creator_alloc, treasury_alloc) = payload.split_initial_supply();
+    assert_eq!(
+        bc.token_balance(&token_id, &creator.key_id).unwrap(),
+        creator_alloc
+    );
+    assert_eq!(
+        bc.token_balance(&token_id, &treasury).unwrap(),
+        treasury_alloc
+    );
+}
+
+#[test]
 fn count_token_holders_reads_sled_when_store_attached() {
     let temp = tempfile::tempdir().unwrap();
     let store = Arc::new(SledStore::open(&temp.path().join("facade_holders_store")).unwrap());

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -297,6 +297,96 @@ fn repair_missing_token_creation_balances_restores_zeroed_tree() {
 }
 
 #[test]
+fn repair_missing_token_creation_balances_fills_partial_tree() {
+    use crate::contracts::TokenContract;
+    use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+    use crate::transaction::token_creation::TokenCreationPayloadV1;
+    use crate::transaction::Transaction;
+    use crate::types::TransactionType;
+
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("repair_partial_store")).unwrap());
+
+    let creator = PublicKey::new([0x52u8; 2592]);
+    let treasury = [0xBBu8; 32];
+    let payload = TokenCreationPayloadV1 {
+        name: "Bubbl".to_string(),
+        symbol: "BUBL".to_string(),
+        initial_supply: 1_000_000,
+        decimals: 8,
+        treasury_allocation_bps: 2_000,
+        treasury_recipient: treasury,
+    };
+    let (creator_alloc, treasury_alloc) = payload.split_initial_supply();
+    let tx = Transaction {
+        version: 2,
+        chain_id: 2,
+        transaction_type: TransactionType::TokenCreation,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: Signature {
+            signature: vec![0u8; 64],
+            public_key: creator.clone(),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 1,
+        },
+        memo: payload.encode_memo().unwrap(),
+        payload: crate::transaction::TransactionPayload::None,
+    };
+    let token_id = crate::contracts::utils::generate_custom_token_id("Bubbl", "BUBL");
+
+    let mut token = TokenContract::new_custom("Bubbl".to_string(), "BUBL".to_string(), 0, creator.clone());
+    token.max_supply = payload.initial_supply;
+    token.total_supply = payload.initial_supply;
+    store.begin_block(0).unwrap();
+    store.put_token_contract(&token).unwrap();
+    store
+        .set_token_balance(
+            &TokenId::new(token_id),
+            &Address::new(creator.key_id),
+            creator_alloc,
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let genesis = crate::block::create_genesis_block();
+    let block1 = crate::block::Block {
+        header: crate::block::BlockHeader {
+            version: 1,
+            previous_hash: genesis.header.block_hash.into(),
+            data_helix_root: crate::types::Hash::default().into(),
+            timestamp: genesis.header.timestamp + 1,
+            height: 1,
+            verification_helix_root: [0u8; 32],
+            state_root: crate::types::Hash::default().into(),
+            bft_quorum_root: [0u8; 32],
+            block_hash: crate::types::Hash::default(),
+        },
+        transactions: vec![tx],
+    };
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.blocks.clear();
+    bc.set_store(store.clone());
+    bc.blocks.push(genesis);
+    bc.blocks.push(block1);
+    bc.height = 1;
+
+    let repaired = bc
+        .repair_missing_token_creation_balances(store.as_ref())
+        .expect("repair should succeed");
+    assert_eq!(
+        repaired, 1,
+        "only treasury row should be repaired when creator already funded"
+    );
+    assert_eq!(
+        bc.token_balance(&token_id, &treasury).unwrap(),
+        treasury_alloc
+    );
+}
+
+#[test]
 fn count_token_holders_reads_sled_when_store_attached() {
     let temp = tempfile::tempdir().unwrap();
     let store = Arc::new(SledStore::open(&temp.path().join("facade_holders_store")).unwrap());

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1575,9 +1575,10 @@ impl BlockchainStore for SledStore {
         let value = Self::serialize(c)?;
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
-        if let Some(ref mut batch) = *batch_guard {
-            batch.tree(TREE_TOKEN_CONTRACTS).insert(key.as_ref(), value);
-        }
+        let batch = batch_guard
+            .as_mut()
+            .ok_or(StorageError::NoActiveTransaction)?;
+        batch.tree(TREE_TOKEN_CONTRACTS).insert(key.as_ref(), value);
 
         Ok(())
     }
@@ -2083,13 +2084,16 @@ impl BlockchainStore for SledStore {
         let key = keys::token_balance_key(t, a);
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
-        if let Some(ref mut batch) = *batch_guard {
-            if v == 0 {
-                // Optionally delete zero balances to save space
-                batch.tree(TREE_TOKEN_BALANCES).remove(key.as_ref());
-            } else {
-                batch.tree(TREE_TOKEN_BALANCES).insert(key.as_ref(), &v.to_be_bytes());
-            }
+        let batch = batch_guard
+            .as_mut()
+            .ok_or(StorageError::NoActiveTransaction)?;
+        if v == 0 {
+            // Optionally delete zero balances to save space
+            batch.tree(TREE_TOKEN_BALANCES).remove(key.as_ref());
+        } else {
+            batch
+                .tree(TREE_TOKEN_BALANCES)
+                .insert(key.as_ref(), &v.to_be_bytes());
         }
 
         Ok(())

--- a/scripts/effective-reset-testnet.sh
+++ b/scripts/effective-reset-testnet.sh
@@ -24,7 +24,7 @@
 #     --keystore-dir /opt/zhtp/keystores/bubl-creator \
 #     --token bubl --supply-atoms 1000000000000000000000000000 --chain-id 2
 # Broadcast signed_tx, then set ZHTP_REWARDS_TREASURY_KEYSTORE to bubl-creator.
-# ZHTP_REWARDS_ASSET_ID is optional (defaults to deterministic BUBL token_id).
+# ZHTP_REWARDS_TOKEN_ID is optional (defaults to deterministic BUBL token_id).
 
 set -euo pipefail
 

--- a/scripts/effective-reset-testnet.sh
+++ b/scripts/effective-reset-testnet.sh
@@ -19,12 +19,12 @@
 #   ./scripts/effective-reset-testnet.sh [--dry-run]
 #   ./scripts/effective-reset-testnet.sh --skip-restart   # wipe only, no start
 #
-# After reset: redeploy binary, register identities, seed BUBL via AssetLaunch
-#   cargo run -p tools --bin seed_asset_launch -- \
+# After reset: redeploy binary, register identities, seed BUBL via TokenCreation (GENESIS-6)
+#   cargo run -p tools --bin seed_founding_dao -- \
 #     --keystore-dir /opt/zhtp/keystores/bubl-creator \
-#     --token bubl --supply-atoms <atoms> \
-#     --rewards-delegate-dir /opt/zhtp/keystores/bubl-rewards-hot
-# Set ZHTP_REWARDS_ASSET_ID to the printed asset_id on validators.
+#     --token bubl --supply-atoms 1000000000000000000000000000 --chain-id 2
+# Broadcast signed_tx, then set ZHTP_REWARDS_TREASURY_KEYSTORE to bubl-creator.
+# ZHTP_REWARDS_ASSET_ID is optional (defaults to deterministic BUBL token_id).
 
 set -euo pipefail
 

--- a/zhtp/src/api/handlers/balance_key.rs
+++ b/zhtp/src/api/handlers/balance_key.rs
@@ -7,9 +7,13 @@
 use lib_blockchain::{Blockchain, Hash};
 use lib_crypto::types::keys::PublicKey;
 
+fn is_zhtp_did(address: &str) -> bool {
+    address.len() >= 9 && address[..9].eq_ignore_ascii_case("did:zhtp:")
+}
+
 fn strip_address_prefix(address: &str) -> &str {
-    if let Some(rest) = address.strip_prefix("did:zhtp:") {
-        rest
+    if is_zhtp_did(address) {
+        &address[9..]
     } else if let Some(rest) = address.strip_prefix("0x") {
         rest
     } else {
@@ -40,7 +44,7 @@ pub fn resolve_custom_token_balance_key(
         // `did:zhtp:{key_id}` is already the sled balance key for custom tokens.
         // Do not remap through wallet projection — that derives blake3(dilithium)
         // only and diverges from TokenCreation/transfer keys when kyber is present.
-        if address.starts_with("did:zhtp:") || address.starts_with("did:ZHTP:") {
+        if is_zhtp_did(address) {
             let mut key_id = [0u8; 32];
             key_id.copy_from_slice(&bytes);
             return Ok(key_id);
@@ -95,6 +99,18 @@ mod tests {
             capabilities: 0,
             initial_balance: 0,
         }
+    }
+
+    #[test]
+    fn did_zhtp_prefix_is_case_insensitive() {
+        let key_id = [0x33u8; 32];
+        let lower = format!("did:zhtp:{}", hex::encode(key_id));
+        let mixed = format!("did:ZHTP:{}", hex::encode(key_id));
+        let bc = lib_blockchain::Blockchain::new().expect("blockchain");
+        let via_lower = resolve_custom_token_balance_key(&bc, &lower).expect("lower");
+        let via_mixed = resolve_custom_token_balance_key(&bc, &mixed).expect("mixed");
+        assert_eq!(via_lower, key_id);
+        assert_eq!(via_mixed, key_id);
     }
 
     #[test]

--- a/zhtp/src/api/handlers/balance_key.rs
+++ b/zhtp/src/api/handlers/balance_key.rs
@@ -1,8 +1,8 @@
 //! Canonical balance-key resolution for custom (non-SOV) tokens.
 //!
 //! BUBL and other custom tokens store balances under the holder's identity
-//! `key_id` — `blake3(dilithium_pk)`, the same 32 bytes in `did:zhtp:{hex}`.
-//! Rewards mint to that key. SOV remains wallet_id-keyed elsewhere.
+//! `key_id` — `blake3(dilithium_pk || kyber_pk)`, the same 32 bytes in
+//! `did:zhtp:{hex}`. Rewards mint to that key. SOV remains wallet_id-keyed elsewhere.
 
 use lib_blockchain::{Blockchain, Hash};
 use lib_crypto::types::keys::PublicKey;
@@ -37,6 +37,15 @@ pub fn resolve_custom_token_balance_key(
     let bytes = hex::decode(hex_part).map_err(|_| anyhow::anyhow!("Invalid address hex"))?;
 
     if bytes.len() == 32 {
+        // `did:zhtp:{key_id}` is already the sled balance key for custom tokens.
+        // Do not remap through wallet projection — that derives blake3(dilithium)
+        // only and diverges from TokenCreation/transfer keys when kyber is present.
+        if address.starts_with("did:zhtp:") || address.starts_with("did:ZHTP:") {
+            let mut key_id = [0u8; 32];
+            key_id.copy_from_slice(&bytes);
+            return Ok(key_id);
+        }
+
         let wallet_id_hex = hex::encode(&bytes);
         if let Some(wallet) = blockchain.wallet_transaction_data(&wallet_id_hex) {
             return dilithium_key_id(&wallet.public_key);

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -6,15 +6,14 @@
 //!
 //! ## Configuration
 //!
-//! Activated when `ZHTP_REWARDS_TREASURY_KEYSTORE` points at an authorized
-//! rewards signer AND that key holds a positive on-chain BUBL balance.
-//! Authorization prefers `SovereignAsset.rewards.spend_delegate_key_id` when
-//! the asset is on-chain; otherwise the DAO `TokenCreation` creator key.
-//! Prefer a dedicated delegate keystore over the creator (800M allocation).
-//! `ZHTP_REWARDS_TOKEN_ID` may override the default deterministic DAO token id
-//! (`generate_custom_token_id("Bubble","BUBL")`). `ZHTP_REWARDS_ASSET_ID` is a
-//! deprecated alias (remove after 2026-09-01). Without a matching signer the
-//! handler installs but every endpoint returns 503.
+//! Activated when `ZHTP_REWARDS_TREASURY_KEYSTORE` points at the BUBL DAO
+//! `TokenCreation` creator keystore AND that key holds a positive on-chain
+//! BUBL balance. BUBL is not native SOV and not an `AssetLaunch` sovereign
+//! asset — only the deterministic DAO contract
+//! (`generate_custom_token_id("Bubble","BUBL")`). `ZHTP_REWARDS_TOKEN_ID` may
+//! override that id. `ZHTP_REWARDS_ASSET_ID` is a deprecated alias (remove
+//! after 2026-09-01). Without a matching creator signer the handler installs
+//! but every endpoint returns 503.
 //!
 //! ## Storage
 //!
@@ -46,7 +45,6 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
-use lib_blockchain::contracts::sovereign_asset::AssetIdSource;
 use lib_blockchain::contracts::utils::generate_custom_token_id;
 use lib_blockchain::transaction::{Transaction, TokenTransferData};
 use lib_blockchain::Blockchain;
@@ -1216,47 +1214,18 @@ fn resolve_rewards_token_id(blockchain: &Blockchain) -> Option<[u8; 32]> {
         return Some(bubl_dao_id);
     }
 
-    // Fallback: on-chain sovereign asset with rewards module (AssetLaunch path).
-    blockchain
-        .iter_sovereign_assets()
-        .into_iter()
-        .find(|a| {
-            a.module_flags.has_rewards() && a.symbol.eq_ignore_ascii_case(BUBL_TOKEN_SYMBOL)
-        })
-        .map(|a| a.asset_id)
+    None
 }
 
-/// On-chain spend authority for the rewards pool: delegate when configured,
-/// otherwise creator (sovereign asset or DAO TokenCreation contract).
-fn rewards_authorized_signer_key_id(
-    blockchain: &Blockchain,
-    token_id: &[u8; 32],
-) -> Option<[u8; 32]> {
-    if let Some(asset) = blockchain.get_sovereign_asset(token_id) {
-        if asset.id_source == AssetIdSource::LaunchTx {
-            if let Some(delegate) = asset
-                .rewards
-                .as_ref()
-                .and_then(|r| r.spend_delegate_key_id)
-            {
-                return Some(delegate);
-            }
-            return Some(asset.creator_key_id);
-        }
-    }
-    blockchain
-        .get_token_contract(token_id)
-        .map(|token| token.creator.key_id)
-}
-
-/// Returns true when `signer_key_id` matches the on-chain rewards spend authority.
+/// Returns true when `signer_key_id` is the on-chain creator of the DAO token.
 fn rewards_signer_authorized(
     blockchain: &Blockchain,
     token_id: &[u8; 32],
     signer_key_id: &[u8; 32],
 ) -> bool {
-    rewards_authorized_signer_key_id(blockchain, token_id)
-        .is_some_and(|authorized| authorized == *signer_key_id)
+    blockchain
+        .get_token_contract(token_id)
+        .is_some_and(|token| token.creator.key_id == *signer_key_id)
 }
 
 fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -8,9 +8,10 @@
 //!
 //! Activated when `ZHTP_REWARDS_TREASURY_KEYSTORE` points at the BUBL creator
 //! keystore (the signer of the founding `TokenCreation` tx) AND that key holds
-//! a positive on-chain BUBL balance. `ZHTP_REWARDS_ASSET_ID` may override the
+//! a positive on-chain BUBL balance. `ZHTP_REWARDS_TOKEN_ID` may override the
 //! default deterministic DAO token id (`generate_custom_token_id("Bubble","BUBL")`).
-//! AssetLaunch spend-delegate assets are supported as a fallback only.
+//! `ZHTP_REWARDS_ASSET_ID` is accepted as a deprecated alias. BUBL is a DAO
+//! `TokenCreation` token — not native SOV, not an `AssetLaunch` sovereign asset.
 //! Without a matching signer the handler installs but every endpoint returns 503.
 //!
 //! ## Storage
@@ -43,7 +44,6 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
-use lib_blockchain::contracts::sovereign_asset::{BUBL_NAME, BUBL_SYMBOL};
 use lib_blockchain::contracts::utils::generate_custom_token_id;
 use lib_blockchain::transaction::{Transaction, TokenTransferData};
 use lib_blockchain::Blockchain;
@@ -58,6 +58,7 @@ use crate::keyfile_names::{KeystorePrivateKey, USER_IDENTITY_FILENAME, USER_PRIV
 
 // ── Constants ────────────────────────────────────────────────────────
 
+const BUBL_TOKEN_NAME: &str = "Bubble";
 const BUBL_TOKEN_SYMBOL: &str = "BUBL";
 
 /// 18-decimal atom multiplier.
@@ -1177,50 +1178,45 @@ fn chain_id_from_env() -> u8 {
 
 // ── Treasury loader ──────────────────────────────────────────────────
 
+fn rewards_token_id_override() -> Option<String> {
+    std::env::var("ZHTP_REWARDS_TOKEN_ID")
+        .ok()
+        .or_else(|| std::env::var("ZHTP_REWARDS_ASSET_ID").ok())
+}
+
+fn parse_token_id_hex(hex_id: &str) -> Option<[u8; 32]> {
+    let bytes = hex::decode(hex_id).ok()?;
+    if bytes.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Some(out)
+}
+
 fn resolve_rewards_token_id(blockchain: &Blockchain) -> Option<[u8; 32]> {
-    if let Ok(hex_id) = std::env::var("ZHTP_REWARDS_ASSET_ID") {
-        let bytes = hex::decode(hex_id).ok()?;
-        if bytes.len() == 32 {
-            let mut out = [0u8; 32];
-            out.copy_from_slice(&bytes);
-            return Some(out);
-        }
+    if let Some(hex_id) = rewards_token_id_override() {
+        return parse_token_id_hex(&hex_id);
     }
 
     // Canonical BUBL: GENESIS-6 DAO `TokenCreation` (deterministic token_id).
-    let bubl_dao_id = generate_custom_token_id(BUBL_NAME, BUBL_SYMBOL);
+    let bubl_dao_id = generate_custom_token_id(BUBL_TOKEN_NAME, BUBL_TOKEN_SYMBOL);
     if blockchain.get_token_contract(&bubl_dao_id).is_some() {
         return Some(bubl_dao_id);
     }
 
-    // Fallback: AssetLaunch / projected sovereign-asset view (non-canonical).
-    blockchain
-        .iter_sovereign_assets()
-        .into_iter()
-        .find(|a| a.module_flags.has_rewards() && a.symbol.eq_ignore_ascii_case(BUBL_TOKEN_SYMBOL))
-        .map(|a| a.asset_id)
+    None
 }
 
-/// Returns true when `signer_key_id` may spend the rewards pool for `token_id`.
+/// Returns true when `signer_key_id` is the on-chain creator of the DAO token.
 fn rewards_signer_authorized(
     blockchain: &Blockchain,
     token_id: &[u8; 32],
     signer_key_id: &[u8; 32],
 ) -> bool {
-    if let Some(token) = blockchain.get_token_contract(token_id) {
-        return token.creator.key_id == *signer_key_id;
-    }
-    if let Some(asset) = blockchain.get_sovereign_asset(token_id) {
-        if let Some(delegate) = asset
-            .rewards
-            .as_ref()
-            .and_then(|r| r.spend_delegate_key_id)
-        {
-            return delegate == *signer_key_id;
-        }
-        return asset.creator_key_id == *signer_key_id;
-    }
-    false
+    blockchain
+        .get_token_contract(token_id)
+        .is_some_and(|token| token.creator.key_id == *signer_key_id)
 }
 
 fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -6,11 +6,12 @@
 //!
 //! ## Configuration
 //!
-//! Activated when `ZHTP_REWARDS_TREASURY_KEYSTORE` points at the on-chain
-//! rewards spend delegate keystore AND the chain exposes a Sovereign Asset
-//! with the rewards module enabled (`ZHTP_REWARDS_ASSET_ID` or auto-discovery
-//! of the BUBL rewards asset). Without a matching delegate the handler
-//! installs but every endpoint returns 503.
+//! Activated when `ZHTP_REWARDS_TREASURY_KEYSTORE` points at the BUBL creator
+//! keystore (the signer of the founding `TokenCreation` tx) AND that key holds
+//! a positive on-chain BUBL balance. `ZHTP_REWARDS_ASSET_ID` may override the
+//! default deterministic DAO token id (`generate_custom_token_id("Bubble","BUBL")`).
+//! AssetLaunch spend-delegate assets are supported as a fallback only.
+//! Without a matching signer the handler installs but every endpoint returns 503.
 //!
 //! ## Storage
 //!
@@ -42,6 +43,8 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
+use lib_blockchain::contracts::sovereign_asset::{BUBL_NAME, BUBL_SYMBOL};
+use lib_blockchain::contracts::utils::generate_custom_token_id;
 use lib_blockchain::transaction::{Transaction, TokenTransferData};
 use lib_blockchain::Blockchain;
 use lib_crypto::keypair::KeyPair;
@@ -1174,7 +1177,7 @@ fn chain_id_from_env() -> u8 {
 
 // ── Treasury loader ──────────────────────────────────────────────────
 
-fn resolve_rewards_asset_id(blockchain: &Blockchain) -> Option<[u8; 32]> {
+fn resolve_rewards_token_id(blockchain: &Blockchain) -> Option<[u8; 32]> {
     if let Ok(hex_id) = std::env::var("ZHTP_REWARDS_ASSET_ID") {
         let bytes = hex::decode(hex_id).ok()?;
         if bytes.len() == 32 {
@@ -1184,11 +1187,40 @@ fn resolve_rewards_asset_id(blockchain: &Blockchain) -> Option<[u8; 32]> {
         }
     }
 
+    // Canonical BUBL: GENESIS-6 DAO `TokenCreation` (deterministic token_id).
+    let bubl_dao_id = generate_custom_token_id(BUBL_NAME, BUBL_SYMBOL);
+    if blockchain.get_token_contract(&bubl_dao_id).is_some() {
+        return Some(bubl_dao_id);
+    }
+
+    // Fallback: AssetLaunch / projected sovereign-asset view (non-canonical).
     blockchain
         .iter_sovereign_assets()
         .into_iter()
         .find(|a| a.module_flags.has_rewards() && a.symbol.eq_ignore_ascii_case(BUBL_TOKEN_SYMBOL))
         .map(|a| a.asset_id)
+}
+
+/// Returns true when `signer_key_id` may spend the rewards pool for `token_id`.
+fn rewards_signer_authorized(
+    blockchain: &Blockchain,
+    token_id: &[u8; 32],
+    signer_key_id: &[u8; 32],
+) -> bool {
+    if let Some(token) = blockchain.get_token_contract(token_id) {
+        return token.creator.key_id == *signer_key_id;
+    }
+    if let Some(asset) = blockchain.get_sovereign_asset(token_id) {
+        if let Some(delegate) = asset
+            .rewards
+            .as_ref()
+            .and_then(|r| r.spend_delegate_key_id)
+        {
+            return delegate == *signer_key_id;
+        }
+        return asset.creator_key_id == *signer_key_id;
+    }
+    false
 }
 
 fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {
@@ -1213,19 +1245,14 @@ fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {
             return None;
         }
     };
-    let rewards_asset_id = resolve_rewards_asset_id(blockchain)?;
-    let asset = blockchain.get_sovereign_asset(&rewards_asset_id)?;
-    let delegate = asset
-        .rewards
-        .as_ref()
-        .and_then(|r| r.spend_delegate_key_id)?;
+    let rewards_asset_id = resolve_rewards_token_id(blockchain)?;
     let signer_key_id = keypair.public_key.key_id;
 
-    if delegate != signer_key_id {
+    if !rewards_signer_authorized(blockchain, &rewards_asset_id, &signer_key_id) {
         warn!(
-            "rewards: keystore key_id {} does not match on-chain spend_delegate {}; endpoint disabled",
+            "rewards: keystore key_id {} is not authorized to spend token {}; endpoint disabled",
             hex::encode(&signer_key_id[..8]),
-            hex::encode(&delegate[..8]),
+            hex::encode(&rewards_asset_id[..8]),
         );
         return None;
     }
@@ -1235,14 +1262,14 @@ fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {
         .unwrap_or(0);
     if balance == 0 {
         warn!(
-            "rewards: delegate keystore at {} holds 0 balance for asset {}; endpoint disabled",
+            "rewards: signer keystore at {} holds 0 balance for token {}; endpoint disabled",
             dir,
             hex::encode(&rewards_asset_id[..8]),
         );
         return None;
     }
     info!(
-        "rewards: delegate loaded — asset_id={} key_id={} balance={}",
+        "rewards: BUBL signer loaded — token_id={} key_id={} balance={}",
         hex::encode(&rewards_asset_id[..8]),
         hex::encode(&signer_key_id[..8]),
         balance,

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -859,22 +859,37 @@ impl RewardsHandler {
     }
 
     async fn handle_balance(&self, did: &str) -> ZhtpResponse {
-        // READS don't need the treasury keystore — only mints/claims do.
-        // The 503 here was wrong: it told every non-treasury node "rewards
-        // endpoint not configured", even though local sled has whatever
-        // counters this node has accumulated. Returning the local state
-        // (zeros for nodes that haven't processed claims) is at least
-        // an honest answer; the proper architectural fix is to read the
-        // canonical BUBL balance from the on-chain token contract and
-        // move reward-event state on-chain too.
         if let Err(msg) = Self::validate_did(did) {
             return Self::bad(msg);
         }
         let stats = self.load_lifetime(did);
-        Self::ok_json(json!({
+
+        // Spendable BUBL is on-chain under the holder's key_id; legacy clients
+        // often read rewards/balance expecting wallet funds, not sled totals.
+        let (spendable_balance, asset_id_hex) = match &self.treasury {
+            Some(treasury) => {
+                let bc = self.blockchain.read().await;
+                let key_id = match Self::validate_did(did) {
+                    Ok(k) => k,
+                    Err(msg) => return Self::bad(msg),
+                };
+                let balance = bc
+                    .token_balance(&treasury.rewards_asset_id, &key_id)
+                    .unwrap_or(0);
+                (
+                    balance,
+                    Some(hex::encode(treasury.rewards_asset_id)),
+                )
+            }
+            None => (0, None),
+        };
+
+        let mut body = json!({
             "did": did,
             "total_earned": stats.total_earned.to_string(),
             "total_earned_display": (stats.total_earned / ATOM_18).to_string(),
+            "spendable_balance": spendable_balance.to_string(),
+            "spendable_balance_display": (spendable_balance / ATOM_18).to_string(),
             "counts": {
                 "welcome_claimed": stats.welcome_claimed,
                 "checkin_count": stats.checkin_count,
@@ -883,7 +898,13 @@ impl RewardsHandler {
                 "current_streak": stats.current_streak,
                 "longest_streak": stats.longest_streak,
             },
-        }))
+        });
+        if let Some(asset_id) = asset_id_hex {
+            if let Some(obj) = body.as_object_mut() {
+                obj.insert("asset_id".into(), json!(asset_id));
+            }
+        }
+        Self::ok_json(body)
     }
 
     async fn handle_status(&self, did: &str) -> ZhtpResponse {

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -6,13 +6,15 @@
 //!
 //! ## Configuration
 //!
-//! Activated when `ZHTP_REWARDS_TREASURY_KEYSTORE` points at the BUBL creator
-//! keystore (the signer of the founding `TokenCreation` tx) AND that key holds
-//! a positive on-chain BUBL balance. `ZHTP_REWARDS_TOKEN_ID` may override the
-//! default deterministic DAO token id (`generate_custom_token_id("Bubble","BUBL")`).
-//! `ZHTP_REWARDS_ASSET_ID` is accepted as a deprecated alias. BUBL is a DAO
-//! `TokenCreation` token — not native SOV, not an `AssetLaunch` sovereign asset.
-//! Without a matching signer the handler installs but every endpoint returns 503.
+//! Activated when `ZHTP_REWARDS_TREASURY_KEYSTORE` points at an authorized
+//! rewards signer AND that key holds a positive on-chain BUBL balance.
+//! Authorization prefers `SovereignAsset.rewards.spend_delegate_key_id` when
+//! the asset is on-chain; otherwise the DAO `TokenCreation` creator key.
+//! Prefer a dedicated delegate keystore over the creator (800M allocation).
+//! `ZHTP_REWARDS_TOKEN_ID` may override the default deterministic DAO token id
+//! (`generate_custom_token_id("Bubble","BUBL")`). `ZHTP_REWARDS_ASSET_ID` is a
+//! deprecated alias (remove after 2026-09-01). Without a matching signer the
+//! handler installs but every endpoint returns 503.
 //!
 //! ## Storage
 //!
@@ -44,6 +46,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
+use lib_blockchain::contracts::sovereign_asset::AssetIdSource;
 use lib_blockchain::contracts::utils::generate_custom_token_id;
 use lib_blockchain::transaction::{Transaction, TokenTransferData};
 use lib_blockchain::Blockchain;
@@ -60,6 +63,9 @@ use crate::keyfile_names::{KeystorePrivateKey, USER_IDENTITY_FILENAME, USER_PRIV
 
 const BUBL_TOKEN_NAME: &str = "Bubble";
 const BUBL_TOKEN_SYMBOL: &str = "BUBL";
+
+/// Deprecated env alias — use `ZHTP_REWARDS_TOKEN_ID`. Scheduled removal 2026-09-01.
+const DEPRECATED_REWARDS_ASSET_ID_ENV: &str = "ZHTP_REWARDS_ASSET_ID";
 
 /// 18-decimal atom multiplier.
 const ATOM_18: u128 = 1_000_000_000_000_000_000;
@@ -863,9 +869,10 @@ impl RewardsHandler {
     }
 
     async fn handle_balance(&self, did: &str) -> ZhtpResponse {
-        if let Err(msg) = Self::validate_did(did) {
-            return Self::bad(msg);
-        }
+        let key_id = match Self::validate_did(did) {
+            Ok(k) => k,
+            Err(msg) => return Self::bad(msg),
+        };
         let stats = self.load_lifetime(did);
 
         // Spendable BUBL is on-chain under the holder's key_id; legacy clients
@@ -873,10 +880,6 @@ impl RewardsHandler {
         let (spendable_balance, asset_id_hex) = match &self.treasury {
             Some(treasury) => {
                 let bc = self.blockchain.read().await;
-                let key_id = match Self::validate_did(did) {
-                    Ok(k) => k,
-                    Err(msg) => return Self::bad(msg),
-                };
                 let balance = bc
                     .token_balance(&treasury.rewards_asset_id, &key_id)
                     .unwrap_or(0);
@@ -1179,9 +1182,17 @@ fn chain_id_from_env() -> u8 {
 // ── Treasury loader ──────────────────────────────────────────────────
 
 fn rewards_token_id_override() -> Option<String> {
-    std::env::var("ZHTP_REWARDS_TOKEN_ID")
-        .ok()
-        .or_else(|| std::env::var("ZHTP_REWARDS_ASSET_ID").ok())
+    if let Ok(id) = std::env::var("ZHTP_REWARDS_TOKEN_ID") {
+        return Some(id);
+    }
+    if let Ok(id) = std::env::var(DEPRECATED_REWARDS_ASSET_ID_ENV) {
+        warn!(
+            "rewards: {} is deprecated — use ZHTP_REWARDS_TOKEN_ID (removal scheduled 2026-09-01)",
+            DEPRECATED_REWARDS_ASSET_ID_ENV
+        );
+        return Some(id);
+    }
+    None
 }
 
 fn parse_token_id_hex(hex_id: &str) -> Option<[u8; 32]> {
@@ -1205,18 +1216,47 @@ fn resolve_rewards_token_id(blockchain: &Blockchain) -> Option<[u8; 32]> {
         return Some(bubl_dao_id);
     }
 
-    None
+    // Fallback: on-chain sovereign asset with rewards module (AssetLaunch path).
+    blockchain
+        .iter_sovereign_assets()
+        .into_iter()
+        .find(|a| {
+            a.module_flags.has_rewards() && a.symbol.eq_ignore_ascii_case(BUBL_TOKEN_SYMBOL)
+        })
+        .map(|a| a.asset_id)
 }
 
-/// Returns true when `signer_key_id` is the on-chain creator of the DAO token.
+/// On-chain spend authority for the rewards pool: delegate when configured,
+/// otherwise creator (sovereign asset or DAO TokenCreation contract).
+fn rewards_authorized_signer_key_id(
+    blockchain: &Blockchain,
+    token_id: &[u8; 32],
+) -> Option<[u8; 32]> {
+    if let Some(asset) = blockchain.get_sovereign_asset(token_id) {
+        if asset.id_source == AssetIdSource::LaunchTx {
+            if let Some(delegate) = asset
+                .rewards
+                .as_ref()
+                .and_then(|r| r.spend_delegate_key_id)
+            {
+                return Some(delegate);
+            }
+            return Some(asset.creator_key_id);
+        }
+    }
+    blockchain
+        .get_token_contract(token_id)
+        .map(|token| token.creator.key_id)
+}
+
+/// Returns true when `signer_key_id` matches the on-chain rewards spend authority.
 fn rewards_signer_authorized(
     blockchain: &Blockchain,
     token_id: &[u8; 32],
     signer_key_id: &[u8; 32],
 ) -> bool {
-    blockchain
-        .get_token_contract(token_id)
-        .is_some_and(|token| token.creator.key_id == *signer_key_id)
+    rewards_authorized_signer_key_id(blockchain, token_id)
+        .is_some_and(|authorized| authorized == *signer_key_id)
 }
 
 fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -6,6 +6,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
@@ -15,6 +16,7 @@ use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_protocols::zhtp::ZhtpRequestHandler;
 
 // Blockchain imports
+use lib_blockchain::contracts::sovereign_asset::SovereignAsset;
 use lib_blockchain::contracts::utils::generate_custom_token_id;
 use lib_blockchain::transaction::{TokenCreationPayloadV1, Transaction};
 use lib_blockchain::types::transaction_type::TransactionType;
@@ -112,6 +114,34 @@ pub struct TokenListItem {
     pub decimals: u8,
     #[serde(serialize_with = "u128_as_string::serialize")]
     pub total_supply: u128,
+}
+
+fn sovereign_asset_to_list_item(asset: &SovereignAsset) -> TokenListItem {
+    TokenListItem {
+        token_id: hex::encode(asset.asset_id),
+        name: asset.name.clone(),
+        symbol: asset.symbol.clone(),
+        decimals: asset.decimals,
+        total_supply: asset.total_supply,
+    }
+}
+
+fn sovereign_asset_to_info(asset: &SovereignAsset) -> TokenInfoResponse {
+    TokenInfoResponse {
+        token_id: hex::encode(asset.asset_id),
+        name: asset.name.clone(),
+        symbol: asset.symbol.clone(),
+        decimals: asset.decimals,
+        total_supply: asset.total_supply,
+        max_supply: if asset.max_supply == u128::MAX {
+            None
+        } else {
+            Some(asset.max_supply)
+        },
+        creator: format!("0x{}", hex::encode(asset.creator_key_id)),
+        is_deflationary: false,
+        created_at_block: asset.launched_at_height,
+    }
 }
 
 // ============================================================================
@@ -480,29 +510,33 @@ impl TokenHandler {
             return create_json_response(serde_json::to_value(response)?);
         }
 
-        let token = blockchain
-            .get_token_contract(&token_id_array)
-            .ok_or_else(|| anyhow::anyhow!("Token not found"))?;
+        if let Some(token) = blockchain.get_token_contract(&token_id_array) {
+            let created_at = blockchain.contract_blocks.get(&token_id_array).copied();
+            let response = TokenInfoResponse {
+                token_id: token_id_hex.to_string(),
+                name: token.name.clone(),
+                symbol: token.symbol.clone(),
+                decimals: token.decimals,
+                total_supply: token.total_supply,
+                max_supply: if token.max_supply == u128::MAX {
+                    None
+                } else {
+                    Some(token.max_supply)
+                },
+                creator: format!("0x{}", hex::encode(&token.creator.key_id)),
+                is_deflationary: token.is_deflationary,
+                created_at_block: created_at,
+            };
+            return create_json_response(serde_json::to_value(response)?);
+        }
 
-        let created_at = blockchain.contract_blocks.get(&token_id_array).copied();
+        if let Some(asset) = blockchain.get_sovereign_asset(&token_id_array) {
+            return create_json_response(serde_json::to_value(sovereign_asset_to_info(
+                &asset,
+            ))?);
+        }
 
-        let response = TokenInfoResponse {
-            token_id: token_id_hex.to_string(),
-            name: token.name.clone(),
-            symbol: token.symbol.clone(),
-            decimals: token.decimals,
-            total_supply: token.total_supply,
-            max_supply: if token.max_supply == u128::MAX {
-                None
-            } else {
-                Some(token.max_supply)
-            },
-            creator: format!("0x{}", hex::encode(&token.creator.key_id)),
-            is_deflationary: token.is_deflationary,
-            created_at_block: created_at,
-        };
-
-        create_json_response(serde_json::to_value(response)?)
+        Err(anyhow::anyhow!("Token not found"))
     }
 
     /// GET /api/v1/token/{id}/balance/{address} - Get token balance
@@ -540,10 +574,6 @@ impl TokenHandler {
             }));
         }
 
-        let token = blockchain
-            .get_token_contract(&token_id_array)
-            .ok_or_else(|| anyhow::anyhow!("Token not found"))?;
-
         let balance = if is_sov {
             let wallet_id = self
                 .resolve_wallet_id_for_sov(address, &blockchain)
@@ -562,11 +592,19 @@ impl TokenHandler {
                 .unwrap_or(0)
         };
 
+        let symbol = if let Some(token) = blockchain.get_token_contract(&token_id_array) {
+            token.symbol.clone()
+        } else if let Some(asset) = blockchain.get_sovereign_asset(&token_id_array) {
+            asset.symbol.clone()
+        } else {
+            return Err(anyhow::anyhow!("Token not found"));
+        };
+
         create_json_response(json!({
             "token_id": token_id_hex,
             "address": address,
-            "balance": balance.to_string().to_string(),
-            "symbol": token.symbol.clone()
+            "balance": balance.to_string(),
+            "symbol": symbol
         }))
     }
 
@@ -597,6 +635,19 @@ impl TokenHandler {
             decimals: lib_blockchain::contracts::bonding_curve::canonical::CBE_DECIMALS,
             total_supply: lib_blockchain::contracts::bonding_curve::canonical::CBE_TOTAL_SUPPLY,
         });
+
+        // AssetLaunch sovereign assets (e.g. post-reset BUBL) live in assets/
+        // sled, not token_contracts — surface them here for legacy clients.
+        let mut seen: HashSet<[u8; 32]> = tokens
+            .iter()
+            .filter_map(|t| hex::decode(&t.token_id).ok())
+            .filter_map(|b| <[u8; 32]>::try_from(b.as_slice()).ok())
+            .collect();
+        for asset in blockchain.iter_sovereign_assets() {
+            if seen.insert(asset.asset_id) {
+                tokens.push(sovereign_asset_to_list_item(&asset));
+            }
+        }
 
         let count = tokens.len();
 
@@ -717,11 +768,13 @@ impl TokenHandler {
         let native_token_id = generate_lib_token_id();
         let native_token_id_hex = hex::encode(native_token_id);
         let mut balances = Vec::new();
+        let mut listed_token_ids: HashSet<[u8; 32]> = HashSet::new();
 
         // Collect balances from all token contracts (sled-first metadata list).
         // TODO(#2637): O(N) sled reads per token — add caching/pagination if
         // user-creatable tokens grow beyond a handful.
         for (token_id, token) in blockchain.iter_token_contract_entries() {
+            listed_token_ids.insert(token_id);
             let balance = if token_id == native_token_id {
                 sov_wallet_id
                     .map(|wallet_id| {
@@ -750,6 +803,32 @@ impl TokenHandler {
                     "name": token.name.clone(),
                     "symbol": token.symbol.clone(),
                     "decimals": token.decimals,
+                    "balance": balance.to_string(),
+                    "is_creator": is_creator
+                }));
+            }
+        }
+
+        // AssetLaunch assets (BUBL post-reset) hold balances in token_balances
+        // but have no token_contracts row — scan sovereign assets not yet listed.
+        for asset in blockchain.iter_sovereign_assets() {
+            if listed_token_ids.contains(&asset.asset_id) {
+                continue;
+            }
+            let balance = blockchain
+                .token_balance(&asset.asset_id, &target_key_id)
+                .unwrap_or(0);
+            debug!(
+                "token/balances: sovereign asset={} ({}) found_balance={}",
+                asset.name, asset.symbol, balance
+            );
+            if balance > 0 {
+                let is_creator = asset.creator_key_id == target_key_id;
+                balances.push(json!({
+                    "token_id": hex::encode(asset.asset_id),
+                    "name": asset.name.clone(),
+                    "symbol": asset.symbol.clone(),
+                    "decimals": asset.decimals,
                     "balance": balance.to_string(),
                     "is_creator": is_creator
                 }));

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -184,7 +184,11 @@ impl TokenHandler {
         Self { blockchain }
     }
 
-    /// POST /api/v1/token/create - Deprecated; use AssetLaunch after testnet reset (SA-8).
+    /// POST /api/v1/token/create — submit a signed founding `TokenCreation` tx.
+    ///
+    /// BUBL and other GENESIS-6 DAO tokens deploy via `TokenCreation` (see
+    /// `tools/seed_founding_dao`). `AssetLaunch` is the SA-3 sovereign-asset path
+    /// for *other* tickers — not BUBL on the current testnet.
     async fn handle_create_token(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
         let create_req: CreateTokenRequest = serde_json::from_slice(&request.body)
             .map_err(|e| anyhow::anyhow!("Invalid request: {}", e))?;
@@ -222,7 +226,7 @@ impl TokenHandler {
 
         if tx.transaction_type != TransactionType::TokenCreation {
             let reason = if tx.transaction_type == TransactionType::ContractExecution {
-                "Deprecated token create transaction type. Use AssetLaunch (SA-3) or TokenCreation"
+                "Deprecated token create transaction type. Use TokenCreation for DAO tokens (BUBL) or AssetLaunch for SA-3 sovereign assets"
                     .to_string()
             } else {
                 format!(
@@ -233,10 +237,6 @@ impl TokenHandler {
             tracing::error!("[token/create] invalid tx type: {}", reason);
             return Ok(create_error_response(ZhtpStatus::BadRequest, reason));
         }
-
-        tracing::warn!(
-            "[token/create] TokenCreation is deprecated — migrate to AssetLaunch before testnet reset"
-        );
 
         let payload = match TokenCreationPayloadV1::decode_memo(&tx.memo) {
             Ok(p) => p,

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -16,7 +16,7 @@ use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_protocols::zhtp::ZhtpRequestHandler;
 
 // Blockchain imports
-use lib_blockchain::contracts::sovereign_asset::SovereignAsset;
+use lib_blockchain::contracts::sovereign_asset::{AssetIdSource, SovereignAsset};
 use lib_blockchain::contracts::utils::generate_custom_token_id;
 use lib_blockchain::transaction::{TokenCreationPayloadV1, Transaction};
 use lib_blockchain::types::transaction_type::TransactionType;
@@ -114,6 +114,20 @@ pub struct TokenListItem {
     pub decimals: u8,
     #[serde(serialize_with = "u128_as_string::serialize")]
     pub total_supply: u128,
+}
+
+fn token_contract_symbol_exists(blockchain: &Blockchain, symbol: &str) -> bool {
+    let upper = symbol.to_ascii_uppercase();
+    blockchain
+        .iter_token_contract_entries()
+        .iter()
+        .any(|(_, token)| token.symbol.to_ascii_uppercase() == upper)
+}
+
+/// DAO `TokenCreation` rows win over `AssetLaunch` sovereign rows with the same symbol.
+fn include_sovereign_asset_in_token_api(blockchain: &Blockchain, asset: &SovereignAsset) -> bool {
+    !(asset.id_source == AssetIdSource::LaunchTx
+        && token_contract_symbol_exists(blockchain, &asset.symbol))
 }
 
 fn sovereign_asset_to_list_item(asset: &SovereignAsset) -> TokenListItem {
@@ -636,14 +650,16 @@ impl TokenHandler {
             total_supply: lib_blockchain::contracts::bonding_curve::canonical::CBE_TOTAL_SUPPLY,
         });
 
-        // AssetLaunch sovereign assets (e.g. post-reset BUBL) live in assets/
-        // sled, not token_contracts — surface them here for legacy clients.
+        // Sovereign assets without a matching token_contract row (e.g. future CBE launch).
         let mut seen: HashSet<[u8; 32]> = tokens
             .iter()
             .filter_map(|t| hex::decode(&t.token_id).ok())
             .filter_map(|b| <[u8; 32]>::try_from(b.as_slice()).ok())
             .collect();
         for asset in blockchain.iter_sovereign_assets() {
+            if !include_sovereign_asset_in_token_api(&blockchain, &asset) {
+                continue;
+            }
             if seen.insert(asset.asset_id) {
                 tokens.push(sovereign_asset_to_list_item(&asset));
             }
@@ -809,10 +825,12 @@ impl TokenHandler {
             }
         }
 
-        // AssetLaunch assets (BUBL post-reset) hold balances in token_balances
-        // but have no token_contracts row — scan sovereign assets not yet listed.
+        // Sovereign assets without a token_contracts row (DAO TokenCreation wins).
         for asset in blockchain.iter_sovereign_assets() {
             if listed_token_ids.contains(&asset.asset_id) {
+                continue;
+            }
+            if !include_sovereign_asset_in_token_api(&blockchain, &asset) {
                 continue;
             }
             let balance = blockchain

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -116,18 +116,21 @@ pub struct TokenListItem {
     pub total_supply: u128,
 }
 
-fn token_contract_symbol_exists(blockchain: &Blockchain, symbol: &str) -> bool {
-    let upper = symbol.to_ascii_uppercase();
+fn dao_token_contract_symbols_upper(blockchain: &Blockchain) -> HashSet<String> {
     blockchain
         .iter_token_contract_entries()
-        .iter()
-        .any(|(_, token)| token.symbol.to_ascii_uppercase() == upper)
+        .into_iter()
+        .map(|(_, token)| token.symbol.to_ascii_uppercase())
+        .collect()
 }
 
 /// DAO `TokenCreation` rows win over `AssetLaunch` sovereign rows with the same symbol.
-fn include_sovereign_asset_in_token_api(blockchain: &Blockchain, asset: &SovereignAsset) -> bool {
+fn include_sovereign_asset_in_token_api(
+    asset: &SovereignAsset,
+    dao_symbols_upper: &HashSet<String>,
+) -> bool {
     !(asset.id_source == AssetIdSource::LaunchTx
-        && token_contract_symbol_exists(blockchain, &asset.symbol))
+        && dao_symbols_upper.contains(&asset.symbol.to_ascii_uppercase()))
 }
 
 fn sovereign_asset_to_list_item(asset: &SovereignAsset) -> TokenListItem {
@@ -651,13 +654,14 @@ impl TokenHandler {
         });
 
         // Sovereign assets without a matching token_contract row (e.g. future CBE launch).
+        let dao_symbols_upper = dao_token_contract_symbols_upper(&blockchain);
         let mut seen: HashSet<[u8; 32]> = tokens
             .iter()
             .filter_map(|t| hex::decode(&t.token_id).ok())
             .filter_map(|b| <[u8; 32]>::try_from(b.as_slice()).ok())
             .collect();
         for asset in blockchain.iter_sovereign_assets() {
-            if !include_sovereign_asset_in_token_api(&blockchain, &asset) {
+            if !include_sovereign_asset_in_token_api(&asset, &dao_symbols_upper) {
                 continue;
             }
             if seen.insert(asset.asset_id) {
@@ -826,11 +830,12 @@ impl TokenHandler {
         }
 
         // Sovereign assets without a token_contracts row (DAO TokenCreation wins).
+        let dao_symbols_upper = dao_token_contract_symbols_upper(&blockchain);
         for asset in blockchain.iter_sovereign_assets() {
             if listed_token_ids.contains(&asset.asset_id) {
                 continue;
             }
-            if !include_sovereign_asset_in_token_api(&blockchain, &asset) {
+            if !include_sovereign_asset_in_token_api(&asset, &dao_symbols_upper) {
                 continue;
             }
             let balance = blockchain


### PR DESCRIPTION
## Summary

BUBL is a DAO `TokenCreation` token (GENESIS-6), not native SOV and not an `AssetLaunch` sovereign asset. This PR fixes the API/rewards path to use the canonical deterministic token id (`generate_custom_token_id("Bubble","BUBL")`).

## Changes

- **rewards**: Resolve BUBL from `TokenCreation` contract; authorize creator keystore only; drop sovereign `AssetLaunch` fallback; add `ZHTP_REWARDS_TOKEN_ID` (deprecated alias `ZHTP_REWARDS_ASSET_ID`)
- **token API**: Prefer DAO `token_contracts` over mistaken `AssetLaunch` rows with same symbol
- **balance_key**: `did:zhtp:{key_id}` resolves directly for custom token balances (creator 800M visible)
- **reset runbook**: Document `seed_founding_dao` (not `seed_asset_launch`) for BUBL

## Testnet

Already deployed to g1–g3 (`e2e22ebc…`). Verified:

```
rewards: BUBL signer loaded — token_id=6948e43dea1fa98a balance=800000000000000000000000000
```

No testnet reset required for this fix — canonical BUBL is already on-chain.

## Commits

- fix(api): surface AssetLaunch BUBL in legacy token endpoints (hide when DAO token exists)
- fix(rewards): treat BUBL as GENESIS-6 TokenCreation DAO token
- fix(api): resolve did:zhtp directly for custom token balances
- fix(rewards): BUBL is DAO TokenCreation only — drop sovereign fallback