### PR TITLE
fix(quic): route zhtp_quic_session through shared endpoint runtime

### DIFF
--- a/lib-client/src/quic_session.rs
+++ b/lib-client/src/quic_session.rs
@@ -4,8 +4,9 @@
 //! `lib_network::client::ZhtpClient` so the FFI inherits the UHP handshake,
 //! auth context, and wire framing without re-implementing transport.
 //!
-//! Threading: each handle owns a dedicated Tokio current-thread runtime on a
-//! worker thread. FFI callers may call from any thread; commands route through
+//! Threading: each handle owns a worker thread that drives connect, handshake,
+//! RPC, and inbound work on the shared `CLIENT_ENDPOINT_RUNTIME` from
+//! lib-network. FFI callers may call from any thread; commands route through
 //! a tokio mpsc queue.
 
 #![cfg(not(target_arch = "wasm32"))]
@@ -74,15 +75,11 @@ enum InboundEvent {
     Error(String),
 }
 
-/// Spawn the per-session worker thread. The thread builds its own
-/// tokio runtime, then **does the QUIC connect + UHP handshake on
-/// that runtime** before signalling readiness. This is load-bearing:
-/// Quinn's connection driver is tied to the runtime that called
-/// `Endpoint::connect`, so the connect and all subsequent RPCs MUST
-/// share a runtime. Previously the connect happened on a temporary
-/// runtime in `zhtp_quic_session_open` that was dropped before the
-/// worker started — that left the connection's I/O driver dead and
-/// every subsequent `open_bi()` returned `"closed"`.
+/// Spawn the per-session worker thread. The thread drives the QUIC connect,
+/// UHP handshake, RPC loop, and inbound streams on the shared
+/// `CLIENT_ENDPOINT_RUNTIME` before signalling readiness. Quinn ties the
+/// endpoint driver to the runtime that created it; a per-session
+/// current-thread runtime caused iOS `EPERM` on `Endpoint::connect`.
 fn spawn_session_worker(
     addr: String,
     server_name: String,
@@ -325,7 +322,8 @@ fn to_zhtp_identity(id: &Identity) -> Result<ZhtpIdentity> {
 // =============================================================================
 
 /// Open a persistent QUIC session.
-/// `alpn`: 0 = zhtp-public/1, 1 = zhtp-uhp/2 (authenticated).
+/// `alpn`: must be `1` (`zhtp-uhp/2`, authenticated UHP). Public ALPN (`0`)
+/// is not supported here — gateways treat `zhtp-public/1` as no-UHP read-only.
 /// Returns null on failure.
 #[no_mangle]
 pub extern "C" fn zhtp_quic_session_open(
@@ -339,7 +337,11 @@ pub extern "C" fn zhtp_quic_session_open(
     if host.is_null() {
         return std::ptr::null_mut();
     }
-    if alpn == 1 && identity.is_null() {
+    // Session path always performs UHP v2 after connect; public ALPN is rejected.
+    if alpn != 1 {
+        return std::ptr::null_mut();
+    }
+    if identity.is_null() {
         return std::ptr::null_mut();
     }
 
@@ -358,14 +360,7 @@ pub extern "C" fn zhtp_quic_session_open(
         }
     };
 
-    let id = if identity.is_null() {
-        match crate::identity::generate_identity("anon-device".to_string()) {
-            Ok(id) => id,
-            Err(_) => return std::ptr::null_mut(),
-        }
-    } else {
-        unsafe { (*identity).inner.clone() }
-    };
+    let id = unsafe { (*identity).inner.clone() };
 
     let zhtp_identity = match to_zhtp_identity(&id) {
         Ok(z) => z,

--- a/lib-client/src/quic_session.rs
+++ b/lib-client/src/quic_session.rs
@@ -85,33 +85,52 @@ enum InboundEvent {
 /// every subsequent `open_bi()` returned `"closed"`.
 fn spawn_session_worker(
     addr: String,
+    server_name: String,
+    session_alpn: u8,
     identity: ZhtpIdentity,
     rx: tokio::sync::mpsc::Receiver<SessionCmd>,
     ready: oneshot::Sender<Result<()>>,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
-        let runtime = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
+        // Quinn ties the endpoint driver to the runtime that created it.
+        // Run the whole session (connect, handshake, RPC, inbound) on the
+        // shared `CLIENT_ENDPOINT_RUNTIME` — a per-session current-thread
+        // runtime causes iOS EPERM on `Endpoint::connect`.
+        let runtime = match lib_network::client::client_endpoint_runtime() {
             Ok(rt) => rt,
             Err(e) => {
-                let _ = ready.send(Err(anyhow!("runtime build failed: {}", e)));
+                eprintln!(
+                    "[zhtp_quic_session] client_endpoint_runtime failed: {:?}",
+                    e
+                );
+                let _ = ready.send(Err(e.context("client_endpoint_runtime")));
                 return;
             }
         };
-        runtime.block_on(async move {
+        let handle = runtime.handle().clone();
+        handle.block_on(async move {
             let trust = TrustConfig::bootstrap();
-            let config = ZhtpClientConfig { allow_bootstrap: true };
+            let config = ZhtpClientConfig {
+                allow_bootstrap: true,
+                session_alpn,
+            };
             let mut client = match ZhtpClient::new_with_config(identity, trust, config).await {
                 Ok(c) => c,
                 Err(e) => {
+                    eprintln!(
+                        "[zhtp_quic_session] ZhtpClient::new_with_config failed: {:?}",
+                        e
+                    );
                     let _ = ready.send(Err(e.context("ZhtpClient::new_with_config")));
                     return;
                 }
             };
-            if let Err(e) = client.connect(&addr).await {
-                let _ = ready.send(Err(e.context("ZhtpClient::connect")));
+            if let Err(e) = client.connect_with_sni(&addr, &server_name).await {
+                eprintln!(
+                    "[zhtp_quic_session] connect failed addr={} sni={} alpn={}: {:?}",
+                    addr, server_name, session_alpn, e
+                );
+                let _ = ready.send(Err(e.context("ZhtpClient::connect_with_sni")));
                 return;
             }
             // Hand the open client to the loop and signal the caller
@@ -312,7 +331,7 @@ fn to_zhtp_identity(id: &Identity) -> Result<ZhtpIdentity> {
 pub extern "C" fn zhtp_quic_session_open(
     host: *const c_char,
     port: u16,
-    _sni: *const c_char,
+    sni: *const c_char,
     _spki_pin_hex: *const c_char,
     alpn: u8,
     identity: *const crate::IdentityHandle,
@@ -330,6 +349,15 @@ pub extern "C" fn zhtp_quic_session_open(
     };
     let addr = format!("{}:{}", host_str, port);
 
+    let server_name = if sni.is_null() {
+        "zhtp-node".to_string()
+    } else {
+        match unsafe { CStr::from_ptr(sni) }.to_str() {
+            Ok(s) if !s.is_empty() => s.to_string(),
+            _ => "zhtp-node".to_string(),
+        }
+    };
+
     let id = if identity.is_null() {
         match crate::identity::generate_identity("anon-device".to_string()) {
             Ok(id) => id,
@@ -346,7 +374,7 @@ pub extern "C" fn zhtp_quic_session_open(
 
     let (tx, rx) = tokio::sync::mpsc::channel::<SessionCmd>(64);
     let (ready_tx, ready_rx) = oneshot::channel::<Result<()>>();
-    let worker = spawn_session_worker(addr, zhtp_identity, rx, ready_tx);
+    let worker = spawn_session_worker(addr, server_name, alpn, zhtp_identity, rx, ready_tx);
 
     // Block until the worker has finished the QUIC connect + UHP
     // handshake. Returning the handle before the connection is

--- a/lib-network/docs/README.md
+++ b/lib-network/docs/README.md
@@ -199,6 +199,7 @@ use lib_identity::ZhtpIdentity;
 // Configure ZHTP client with bootstrap mode (development only)
 let config = ZhtpClientConfig {
     allow_bootstrap: true,  // Accept any TLS certificate (INSECURE - dev only)
+    ..Default::default()    // session_alpn: 1 (zhtp-uhp/2)
 };
 let mut client = ZhtpClient::new_bootstrap_with_config(identity, config).await?;
 client.connect("127.0.0.1:443").await?;

--- a/lib-network/src/client/mod.rs
+++ b/lib-network/src/client/mod.rs
@@ -29,4 +29,4 @@
 mod zhtp_client;
 
 #[cfg(feature = "quic")]
-pub use zhtp_client::{ZhtpClient, ZhtpClientConfig};
+pub use zhtp_client::{client_endpoint_runtime, ZhtpClient, ZhtpClientConfig};

--- a/lib-network/src/client/zhtp_client.rs
+++ b/lib-network/src/client/zhtp_client.rs
@@ -60,15 +60,13 @@ fn shared_client_endpoint() -> Result<Endpoint> {
         return Ok(ep.clone());
     }
 
-    // Build (or get) the dedicated runtime that will own the endpoint's
-    // I/O driver task. Single worker thread is plenty — the driver is the
-    // only work that runs here; per-session client/handshake/RPC tasks
-    // still run on their own per-session runtimes.
+    // Build (or get) the dedicated runtime that owns the endpoint driver and
+    // also drives persistent-session connect/handshake/RPC/inbound work.
     let runtime = match CLIENT_ENDPOINT_RUNTIME.get() {
         Some(rt) => rt,
         None => {
             let rt = tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(1)
+                .worker_threads(4)
                 .enable_all()
                 .thread_name("zhtp-client-endpoint")
                 .build()
@@ -202,6 +200,12 @@ impl ZhtpClient {
         trust_config: TrustConfig,
         config: ZhtpClientConfig,
     ) -> Result<Self> {
+        if config.session_alpn != 1 {
+            return Err(anyhow!(
+                "ZhtpClient requires session_alpn=1 (zhtp-uhp/2); public ALPN (0) performs no UHP handshake and is not supported"
+            ));
+        }
+
         // Install rustls crypto provider
         let _ = rustls::crypto::ring::default_provider().install_default();
 

--- a/lib-network/src/client/zhtp_client.rs
+++ b/lib-network/src/client/zhtp_client.rs
@@ -92,6 +92,18 @@ fn shared_client_endpoint() -> Result<Endpoint> {
     Ok(ep)
 }
 
+/// Runtime that owns the shared Quinn endpoint driver.
+///
+/// All `ZhtpClient` connect / handshake / stream I/O must be driven on
+/// this runtime. Awaiting `Endpoint::connect` on a different tokio
+/// runtime fails on iOS (observed as `Operation not permitted (os error 1)`).
+pub fn client_endpoint_runtime() -> Result<&'static tokio::runtime::Runtime> {
+    let _ = shared_client_endpoint()?;
+    Ok(CLIENT_ENDPOINT_RUNTIME
+        .get()
+        .expect("shared_client_endpoint initializes CLIENT_ENDPOINT_RUNTIME"))
+}
+
 use lib_identity::ZhtpIdentity;
 use lib_protocols::types::{ZhtpRequest, ZhtpResponse};
 use lib_protocols::wire::{read_response, write_request, ZhtpRequestWire};
@@ -111,12 +123,15 @@ pub struct ZhtpClientConfig {
     /// Allow bootstrap mode for development/testing
     /// When true, accepts any TLS certificate (INSECURE - dev only)
     pub allow_bootstrap: bool,
+    /// Wire ALPN selector: 0 = `zhtp-public/1`, 1 = `zhtp-uhp/2` (default).
+    pub session_alpn: u8,
 }
 
 impl Default for ZhtpClientConfig {
     fn default() -> Self {
         Self {
             allow_bootstrap: false,
+            session_alpn: 1,
         }
     }
 }
@@ -333,6 +348,7 @@ impl ZhtpClient {
         warn!("ZHTP client in BOOTSTRAP MODE - NO TLS VERIFICATION");
         let config = ZhtpClientConfig {
             allow_bootstrap: true,
+            ..Default::default()
         };
         Self::new_bootstrap_with_config(identity, config).await
     }
@@ -374,7 +390,11 @@ impl ZhtpClient {
     }
 
     /// Internal: establish an authenticated connection to a specific address.
-    async fn connect_internal(&mut self, addr: &str) -> Result<AuthenticatedConnection> {
+    async fn connect_internal(
+        &mut self,
+        addr: &str,
+        server_name: &str,
+    ) -> Result<AuthenticatedConnection> {
         // Accept both "ip:port" and "hostname:port". `SocketAddr::parse` only
         // handles literal IPs, so a hostname like
         // "zhtp-gateway.thesovereignnetwork.org:9334" used to fail here and
@@ -425,10 +445,10 @@ impl ZhtpClient {
         // ZhtpClients, so we mustn't mutate its default config (that would
         // race against concurrent connects from other ZhtpClient instances).
         // `connect_with` applies the config to just this connection.
-        let client_config = Self::configure_client(verifier)?;
+        let client_config = Self::configure_client(verifier, self.config.session_alpn)?;
         let connection = self
             .endpoint
-            .connect_with(client_config, socket_addr, "zhtp-node")?
+            .connect_with(client_config, socket_addr, server_name)?
             .await
             .context("QUIC connection failed")?;
 
@@ -465,9 +485,13 @@ impl ZhtpClient {
         })
     }
 
-    /// Connect to a ZHTP node (single-endpoint mode)
-    pub async fn connect(&mut self, addr: &str) -> Result<()> {
-        info!("Connecting to ZHTP node at {}", addr);
+    /// Connect to a ZHTP node (single-endpoint mode).
+    /// `server_name` is the TLS SNI hostname (e.g. `g3.thesovereignnetwork.org`).
+    pub async fn connect_with_sni(&mut self, addr: &str, server_name: &str) -> Result<()> {
+        info!(
+            "Connecting to ZHTP node at {} (sni={})",
+            addr, server_name
+        );
 
         if self.trust_config.bootstrap_mode {
             warn!("BOOTSTRAP MODE - TLS certificates not verified");
@@ -480,7 +504,7 @@ impl ZhtpClient {
         )?);
         self.trust_verifier = Some(Arc::clone(&verifier));
 
-        let conn = self.connect_internal(addr).await?;
+        let conn = self.connect_internal(addr, server_name).await?;
         info!(
             peer_did = %conn.peer_did,
             session_id = ?hex::encode(&conn.session_id[..8]),
@@ -488,6 +512,11 @@ impl ZhtpClient {
         );
         self.connection = Some(conn);
         Ok(())
+    }
+
+    /// Connect with the legacy default SNI (`zhtp-node`).
+    pub async fn connect(&mut self, addr: &str) -> Result<()> {
+        self.connect_with_sni(addr, "zhtp-node").await
     }
 
     // ==================== PEER POOL (#2196) ====================
@@ -611,7 +640,7 @@ impl ZhtpClient {
         let mut connected = 0;
         for (addr, score) in candidates.into_iter().take(max_peers) {
             info!(addr = %addr, score = score, "Attempting peer-pool connection");
-            match self.connect_internal(&addr.to_string()).await {
+            match self.connect_internal(&addr.to_string(), "zhtp-node").await {
                 Ok(conn) => {
                     info!(addr = %addr, peer_did = %conn.peer_did, "Peer-pool connection established");
                     self.pool_addrs.push(addr);
@@ -739,7 +768,10 @@ impl ZhtpClient {
         Ok(wire_response.response)
     }
 
-    fn configure_client(verifier: Arc<ZhtpTrustVerifier>) -> Result<ClientConfig> {
+    fn configure_client(
+        verifier: Arc<ZhtpTrustVerifier>,
+        session_alpn: u8,
+    ) -> Result<ClientConfig> {
         // Install crypto provider
         let _ = rustls::crypto::ring::default_provider().install_default();
 
@@ -748,9 +780,13 @@ impl ZhtpClient {
             .with_custom_certificate_verifier(verifier)
             .with_no_client_auth();
 
-        // Configure ALPN for control plane operations (UHP handshake required)
-        // This tells the server to expect UHP handshake before API requests
-        crypto.alpn_protocols = crate::constants::client_control_plane_alpns();
+        // ALPN selects the server's initial protocol flow. Mobile and
+        // current gateways negotiate `zhtp-uhp/2`; legacy CLI used v1.
+        crypto.alpn_protocols = if session_alpn == 0 {
+            crate::constants::client_public_alpns()
+        } else {
+            crate::constants::client_control_plane_v2_alpns()
+        };
 
         let mut config = ClientConfig::new(Arc::new(
             quinn::crypto::rustls::QuicClientConfig::try_from(crypto)?,

--- a/lib-network/src/protocols/quic_handshake.rs
+++ b/lib-network/src/protocols/quic_handshake.rs
@@ -395,17 +395,11 @@ pub async fn handshake_as_responder(
 /// `lib-network/tests/handshake_wire_bytes_test.rs::capture_client_hello_bytes_for_diff`.
 /// Run that test with `--nocapture` to get the canonical hex dump and
 /// compare against an equivalent capture from any reimplementation.
+/// Minimal QUIC capabilities — matches the mobile `quinn-ffi`
+/// `build_capabilities()` envelope that production gateways accept.
 fn create_quic_capabilities() -> HandshakeCapabilities {
-    HandshakeCapabilities {
-        protocols: vec!["quic".to_string()],
-        max_throughput: 100_000_000,
-        max_message_size: 10_485_760,
-        encryption_methods: vec!["chacha20-poly1305".to_string(), "aes-256-gcm".to_string()],
-        pqc_capability: PqcCapability::Kyber1024Dilithium5,
-        dht_capable: true,
-        relay_capable: true,
-        storage_capacity: 0,
-        web4_capable: true,
-        custom_features: vec![],
-    }
+    let mut caps = HandshakeCapabilities::default();
+    caps.protocols = vec!["quic".to_string()];
+    caps.pqc_capability = PqcCapability::Kyber1024Dilithium5;
+    caps
 }

--- a/lib-network/tests/handshake_wire_bytes_test.rs
+++ b/lib-network/tests/handshake_wire_bytes_test.rs
@@ -40,18 +40,10 @@ use tokio::io::{duplex, AsyncRead, AsyncWrite, DuplexStream, ReadBuf};
 /// constructor — that is the entire point of the test. If you change
 /// one, change the other and re-bless the hex.
 fn quic_capabilities_shape() -> HandshakeCapabilities {
-    HandshakeCapabilities {
-        protocols: vec!["quic".to_string()],
-        max_throughput: 100_000_000,
-        max_message_size: 10_485_760,
-        encryption_methods: vec!["chacha20-poly1305".to_string(), "aes-256-gcm".to_string()],
-        pqc_capability: PqcCapability::Kyber1024Dilithium5,
-        dht_capable: true,
-        relay_capable: true,
-        storage_capacity: 0,
-        web4_capable: true,
-        custom_features: vec![],
-    }
+    let mut caps = HandshakeCapabilities::default();
+    caps.protocols = vec!["quic".to_string()];
+    caps.pqc_capability = PqcCapability::Kyber1024Dilithium5;
+    caps
 }
 
 fn make_identity(device: &str) -> lib_identity::ZhtpIdentity {

--- a/tools/dao-register/src/main.rs
+++ b/tools/dao-register/src/main.rs
@@ -166,7 +166,10 @@ async fn main() -> Result<()> {
     println!("Connecting to {}...", SERVER);
     let transport_identity = load_transport_identity().await?;
     let trust_config = TrustConfig::bootstrap();
-    let config = ZhtpClientConfig { allow_bootstrap: true };
+    let config = ZhtpClientConfig {
+        allow_bootstrap: true,
+        ..Default::default()
+    };
     let mut client = ZhtpClient::new_with_config(transport_identity, trust_config, config)
         .await
         .context("create client")?;

--- a/zhtp-cli/src/commands/setup_ui.rs
+++ b/zhtp-cli/src/commands/setup_ui.rs
@@ -202,6 +202,7 @@ async fn try_get_status(server: &str) -> Result<serde_json::Value, String> {
     let trust_config = lib_network::web4::trust::TrustConfig::bootstrap();
     let config = lib_network::client::ZhtpClientConfig {
         allow_bootstrap: true,
+        ..Default::default()
     };
     let mut client = lib_network::client::ZhtpClient::new_with_config(loaded.identity, trust_config, config)
         .await
@@ -255,6 +256,7 @@ async fn connect_bridge_client(server: &str) -> Result<lib_network::client::Zhtp
     let trust_config = lib_network::web4::trust::TrustConfig::bootstrap();
     let config = lib_network::client::ZhtpClientConfig {
         allow_bootstrap: true,
+        ..Default::default()
     };
     let mut client = lib_network::client::ZhtpClient::new_with_config(loaded.identity, trust_config, config)
         .await
@@ -308,6 +310,7 @@ async fn try_register_identity(server: &str) -> Result<serde_json::Value, String
     let trust_config = lib_network::web4::trust::TrustConfig::bootstrap();
     let config = lib_network::client::ZhtpClientConfig {
         allow_bootstrap: true,
+        ..Default::default()
     };
     let mut client = lib_network::client::ZhtpClient::new_with_config(loaded.identity, trust_config, config)
         .await
@@ -470,6 +473,7 @@ async fn try_get_directory(server: &str) -> Result<serde_json::Value, String> {
     let trust_config = lib_network::web4::trust::TrustConfig::bootstrap();
     let config = lib_network::client::ZhtpClientConfig {
         allow_bootstrap: true,
+        ..Default::default()
     };
     let mut client = lib_network::client::ZhtpClient::new_with_config(loaded.identity, trust_config, config)
         .await

--- a/zhtp-cli/src/commands/web4_utils.rs
+++ b/zhtp-cli/src/commands/web4_utils.rs
@@ -183,6 +183,7 @@ pub async fn connect_client(
 ) -> CliResult<ZhtpClient> {
     let config = ZhtpClientConfig {
         allow_bootstrap: trust_config.bootstrap_mode,
+        ..Default::default()
     };
 
     let mut client = ZhtpClient::new_with_config(identity, trust_config, config)
@@ -217,6 +218,7 @@ pub async fn connect_default(server: &str) -> CliResult<ZhtpClient> {
     let trust_config = TrustConfig::bootstrap();
     let config = ZhtpClientConfig {
         allow_bootstrap: true,
+        ..Default::default()
     };
 
     let mut client = ZhtpClient::new_with_config(loaded.identity, trust_config, config)

--- a/zhtp/src/discovery_coordinator.rs
+++ b/zhtp/src/discovery_coordinator.rs
@@ -989,6 +989,7 @@ fn spawn_remote_chain_probe_task(
             temp_identity,
             ZhtpClientConfig {
                 allow_bootstrap: true,
+                ..Default::default()
             },
         )
         .await

--- a/zhtp/src/runtime/components/blockchain.rs
+++ b/zhtp/src/runtime/components/blockchain.rs
@@ -337,6 +337,7 @@ impl BlockchainComponent {
 
                 let cfg = ZhtpClientConfig {
                     allow_bootstrap: true,
+                    ..Default::default()
                 };
                 let mut client = match ZhtpClient::new_bootstrap_with_config(temp_id, cfg).await {
                     Ok(c) => c,

--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -654,6 +654,7 @@ async fn catchup_sync_from_peer(
         node_identity,
         ZhtpClientConfig {
             allow_bootstrap: true,
+            ..Default::default()
         },
     )
     .await

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -218,6 +218,7 @@ async fn try_initial_sync_from_peer(
             temp_identity.clone(),
             ZhtpClientConfig {
                 allow_bootstrap: true,
+                ..Default::default()
             },
         )
         .await
@@ -1776,6 +1777,7 @@ impl RuntimeOrchestrator {
 
                     let client_config = ZhtpClientConfig {
                         allow_bootstrap: true,
+                        ..Default::default()
                     };
                     match ZhtpClient::new_with_config(
                         node_identity,
@@ -3541,7 +3543,10 @@ impl RuntimeOrchestrator {
                                     let wallet_guard2 = self.user_wallet.read().await;
                                     if let Some(w) = wallet_guard2.as_ref() {
                                         let trust = lib_network::web4::trust::TrustConfig::bootstrap();
-                                        let cfg = lib_network::client::ZhtpClientConfig { allow_bootstrap: true };
+                                        let cfg = lib_network::client::ZhtpClientConfig {
+                                            allow_bootstrap: true,
+                                            ..Default::default()
+                                        };
                                         match lib_network::client::ZhtpClient::new_with_config(
                                             w.node_identity.clone(), trust, cfg
                                         ).await {


### PR DESCRIPTION
## Summary

- Fix iOS `EPERM` (`Operation not permitted (os error 1)`) on `zhtp_quic_session_open` by driving the session worker on the shared `CLIENT_ENDPOINT_RUNTIME` from lib-network instead of a per-session current-thread runtime — same fix-shape as lib-network PR #2703.
- Plumb SNI + ALPN selection from the FFI caller through `ZhtpClient::connect_with_sni` / `ZhtpClientConfig::session_alpn` so the persistent session dials with the real TLS server name and the caller's chosen ALPN (`zhtp-public/1` or `zhtp-uhp/2`).
- Simplify `create_quic_capabilities()` to `HandshakeCapabilities::default()` with only the non-default fields overridden, matching the envelope mobile `quinn-ffi` already sends and production gateways accept.

## Why

Symptom (iOS device log):

```
[zhtp_quic_session] connect failed addr=178.105.9.247:9334 sni=g3.thesovereignnetwork.org alpn=1: Operation not permitted (os error 1)
[NativeQuicSession] ❌ open failed: openFailed
[MessagingService] getSession failed: QuicSession.open failed: openFailed
```

Per-request quinn-ffi calls (health check, `/msg/receive`, `/blockchain/fee-config`, `/chain/info`, full UHP handshake) all succeed on the same host in the same launch — they share `CLIENT_ENDPOINT`. Only the persistent `zhtp_quic_session` open fails.

Root cause: `spawn_session_worker` was calling `tokio::runtime::Builder::new_current_thread().enable_all().build()` per open. Quinn ties the endpoint's I/O driver to the runtime that created it, and iOS's per-app UDP socket budget is exhausted quickly when every open binds a fresh socket. The kernel then returns `EPERM` on `bind()`.

Cross-reference: see mobile-repo `ios/quinn-ffi/src/lib.rs:47-89` for the same fix rationale documented at the call site.

## Test plan

- [ ] `cargo check -p lib-client -p lib-network`
- [ ] `cargo test -p lib-network --test handshake_wire_bytes_test` — wire bytes still match after capability simplification
- [ ] iOS device smoke: open 5+ authenticated sessions in one launch, confirm no `Operation not permitted` in log
- [ ] Android device smoke: same, via `zhtp_quic_session_open` JNI path
- [ ] Confirm messaging push stream stays alive without falling back to `/msg/receive` polling