### PR TITLE
Windows build error fix.

### DIFF
--- a/lib-blockchain/src/ipc/client.rs
+++ b/lib-blockchain/src/ipc/client.rs
@@ -1,11 +1,11 @@
-//! IPC client — connects to the blockchain engine via Unix domain socket.
+//! IPC client — connects to the blockchain engine via Unix domain socket
+//! (Unix) or TCP loopback (Windows).
 //!
 //! Provides owned-type query methods equivalent to `BlockchainQuery`.
 //! Can be used as a drop-in replacement for `Arc<RwLock<Blockchain>>` reads.
 
 use std::path::{Path, PathBuf};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixStream;
 use tokio::sync::Mutex;
 use tracing::warn;
 
@@ -18,12 +18,23 @@ use crate::transaction::{
 use crate::types::Hash;
 use super::protocol::*;
 
+// ── Platform-specific IPC types ──────────────────────────────────────
+#[cfg(unix)]
+use tokio::net::UnixStream;
+#[cfg(unix)]
+type IpcStream = UnixStream;
+
+#[cfg(windows)]
+use tokio::net::TcpStream;
+#[cfg(windows)]
+type IpcStream = TcpStream;
+
 /// IPC client that connects to the blockchain engine.
 ///
 /// Thread-safe: wraps the stream in a Mutex so multiple tasks can share it.
 /// For higher throughput, consider a connection pool.
 pub struct IpcClient {
-    stream: Mutex<Option<UnixStream>>,
+    stream: Mutex<Option<IpcStream>>,
     socket_path: PathBuf,
 }
 
@@ -37,8 +48,25 @@ impl IpcClient {
     }
 
     /// Connect to the blockchain engine. Reconnects if already connected.
+    ///
+    /// On Unix: connects to the Unix domain socket at `socket_path`.
+    /// On Windows: reads the TCP port from `socket_path` and connects to
+    /// 127.0.0.1:{port}.
     pub async fn connect(&self) -> anyhow::Result<()> {
+        #[cfg(unix)]
         let stream = UnixStream::connect(&self.socket_path).await?;
+
+        #[cfg(windows)]
+        let stream = {
+            let port_str = std::fs::read_to_string(&self.socket_path)
+                .map_err(|e| anyhow::anyhow!("Failed to read IPC port file '{}': {}", self.socket_path.display(), e))?;
+            let port: u16 = port_str
+                .trim()
+                .parse()
+                .map_err(|e| anyhow::anyhow!("Invalid IPC port in '{}': {}", self.socket_path.display(), e))?;
+            TcpStream::connect(format!("127.0.0.1:{}", port)).await?
+        };
+
         *self.stream.lock().await = Some(stream);
         Ok(())
     }

--- a/lib-blockchain/src/ipc/server.rs
+++ b/lib-blockchain/src/ipc/server.rs
@@ -1,10 +1,9 @@
-//! IPC server — listens on a Unix domain socket and dispatches queries
-//! to the blockchain engine.
+//! IPC server — listens on a Unix domain socket (Unix) or TCP loopback
+//! (Windows) and dispatches queries to the blockchain engine.
 
 use std::path::Path;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixListener;
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
@@ -12,7 +11,26 @@ use crate::blockchain::Blockchain;
 use crate::query::BlockchainQuery;
 use super::protocol::*;
 
-/// Start the IPC server on the given Unix socket path.
+// ── Platform-specific IPC types ──────────────────────────────────────
+#[cfg(unix)]
+use tokio::net::{UnixListener, UnixStream};
+#[cfg(unix)]
+type IpcListener = UnixListener;
+#[cfg(unix)]
+type IpcStream = UnixStream;
+
+#[cfg(windows)]
+use tokio::net::{TcpListener, TcpStream};
+#[cfg(windows)]
+type IpcListener = TcpListener;
+#[cfg(windows)]
+type IpcStream = TcpStream;
+
+/// Start the IPC server on the given socket path.
+///
+/// On Unix: binds to a Unix domain socket at `socket_path`.
+/// On Windows: binds to TCP 127.0.0.1:0 and writes the assigned port
+/// number to `socket_path` so clients can discover it.
 ///
 /// Spawns a background task that accepts connections and dispatches
 /// requests to the blockchain. Each connection is handled concurrently.
@@ -20,11 +38,28 @@ pub async fn start_ipc_server(
     socket_path: &Path,
     blockchain: Arc<RwLock<Blockchain>>,
 ) -> std::io::Result<()> {
-    // Remove stale socket file if it exists
+    // Remove stale socket / port file if it exists
     let _ = std::fs::remove_file(socket_path);
 
-    let listener = UnixListener::bind(socket_path)?;
-    info!("IPC server listening on {}", socket_path.display());
+    #[cfg(unix)]
+    let listener = {
+        let l = UnixListener::bind(socket_path)?;
+        info!("IPC server listening on {}", socket_path.display());
+        l
+    };
+
+    #[cfg(windows)]
+    let listener = {
+        let l = TcpListener::bind("127.0.0.1:0").await?;
+        let port = l.local_addr()?.port();
+        std::fs::write(socket_path, port.to_string())?;
+        info!(
+            "IPC server listening on 127.0.0.1:{} (port written to {})",
+            port,
+            socket_path.display()
+        );
+        l
+    };
 
     tokio::spawn(async move {
         loop {
@@ -45,7 +80,7 @@ pub async fn start_ipc_server(
 }
 
 async fn handle_connection(
-    mut stream: tokio::net::UnixStream,
+    mut stream: IpcStream,
     blockchain: Arc<RwLock<Blockchain>>,
 ) {
     loop {

--- a/lib-network/src/protocols/bluetooth/discovery.rs
+++ b/lib-network/src/protocols/bluetooth/discovery.rs
@@ -8,6 +8,7 @@ use tracing::{info, warn};
 use super::device;
 use super::device::{BleDevice, MeshPeer};
 use super::BluetoothMeshProtocol;
+use crate::constants::BLE_MESH_SERVICE_UUID;
 
 use sha2::{Digest, Sha256};
 

--- a/lib-network/src/protocols/wifi_direct.rs
+++ b/lib-network/src/protocols/wifi_direct.rs
@@ -8,7 +8,7 @@ use lib_crypto::symmetric::chacha20::encrypt_data;
 use mdns_sd::{ServiceDaemon, ServiceInfo};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1031,8 +1031,16 @@ impl NetworkHandler {
         // Spawn shutdown in background so the response gets sent first
         tokio::spawn(async {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            info!("Node shutdown: sending SIGTERM to self");
-            unsafe { libc::kill(libc::getpid(), libc::SIGTERM); }
+            #[cfg(unix)]
+            {
+                info!("Node shutdown: sending SIGTERM to self");
+                unsafe { libc::kill(libc::getpid(), libc::SIGTERM); }
+            }
+            #[cfg(windows)]
+            {
+                info!("Node shutdown: terminating process");
+                std::process::exit(0);
+            }
         });
         Ok(ZhtpResponse::json(&response, None)?)
     }


### PR DESCRIPTION
## Stack

```
development
  └── #2796 Windows build (this PR)  ← merge first
        └── #2797 Windows linker stack reserve
```

Independent of #2920 (identity registration).

## Summary

Fixed Unix-specific assumptions that blocked the Windows build:

1. **IPC** — Windows TCP loopback + port file instead of Unix domain sockets
2. **Network imports** — `BLE_MESH_SERVICE_UUID` / `Mutex` for bluetooth + wifi_direct
3. **Shutdown** — portable path instead of Unix-only `libc::kill`/`SIGTERM`

## Linked issues

- #578 / #577 Windows Bluetooth build errors
- #2915 Windows IPC transport
- #2918 BLE/wifi_direct imports
- Stack child: #2797 / #2916

## Test plan

- [ ] cargo check on Windows for lib-blockchain, lib-network, zhtp
- [ ] Unix path unchanged

## Risk and reversibility

Minimal. `#[cfg]` guards preserve Unix behaviour.