### PR TITLE
fix(windows): raise linker stack reserve to 16 MB for overflow error.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,15 @@
 # for all cargo-invoked processes. Harmless in production (larger stacks only).
 [env]
 RUST_MIN_STACK = "16777216"
+
+# Windows: the main thread created by #[tokio::main] inherits the OS-default
+# 1 MB stack, which is too small for the deeply-nested startup futures in
+# RuntimeOrchestrator::start_node().  Raising the linker stack reserve to 16 MB
+# prevents "thread 'main' has overflowed its stack" crashes on stock Windows.
+# This is a linker-level setting and does NOT affect runtime memory usage
+# (only the reserved address space, not committed pages).
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=/STACK:16777216"]
+
+[target.x86_64-pc-windows-gnu]
+rustflags = ["-C", "link-arg=-Wl,--stack,16777216"]


### PR DESCRIPTION
## Stack

```
development
  └── #2796 Windows build (IPC / BLE / Mutex)  ← base
        └── #2797 Windows linker stack reserve (this PR)
```

Independent of #2920 (identity registration).

## Summary

Raise the Windows linker stack reserve from 1 MB to 16 MB to prevent the thread `main` has overflowed its stack crash on `zhtp.exe`. The `#[tokio::main]` entry point runs on the OS main thread (default 1 MB stack on Windows MSVC). Deeply nested startup futures in `RuntimeOrchestrator::start_node()` exceed 1 MB after LTO.

## Linked issues

- #2916 Windows: raise linker stack reserve
- Related stack base: #2796 / #2915 / #2918

## Test plan

- [ ] Manual verification on Windows 11: cargo build + run without stack overflow
- [ ] dumpbin stack reserve → 16 MB
- [ ] Linux/macOS builds unaffected

## Risk and reversibility

Low. Windows-only linker flags in `.cargo/config.toml`.