### PR TITLE
DAO D1: zhtp/rewards-policy/v1 JSON Schema

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -30,6 +30,7 @@ mod test_utils;
 #[cfg(test)]
 mod tests;
 mod credentials;
+mod rewards;
 mod dao;
 pub mod replay;
 mod contracts;

--- a/lib-blockchain/src/blockchain/credentials.rs
+++ b/lib-blockchain/src/blockchain/credentials.rs
@@ -2,6 +2,7 @@
 
 use crate::block::Block;
 use crate::blockchain::Blockchain;
+use crate::storage::table::TableAccess;
 use crate::transaction::credentials::{AuthMethod, UserCredential};
 use crate::types::transaction_type::TransactionType;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -18,6 +19,31 @@ pub fn lobby_auth_migrations_total() -> u64 {
 }
 
 impl Blockchain {
+    /// Case-insensitive username taken check — credential registry sled-first (#2639).
+    pub fn credential_username_taken(&self, username_lower: &str) -> bool {
+        if let Some(store) = self.get_store() {
+            match store.iter::<crate::projections::CredentialProjectionTable>() {
+                Ok(iter) => {
+                    for (_, record) in iter {
+                        if record.credential.username.to_lowercase() == username_lower {
+                            return true;
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "credential_username_taken: sled iter failed; failing closed"
+                    );
+                    return true;
+                }
+            }
+        }
+        self.credential_registry
+            .keys()
+            .any(|u| u.to_lowercase() == username_lower)
+    }
+
     /// Process RegisterCredential and UpdateCredentialPassword transactions in a block.
     pub fn process_credential_transactions(&mut self, block: &Block) {
         let block_height = block.height();

--- a/lib-blockchain/src/blockchain/rewards.rs
+++ b/lib-blockchain/src/blockchain/rewards.rs
@@ -1,6 +1,5 @@
 //! BUBL reward eligibility facades (sled-first reads).
 
-use crate::storage::table::TableAccess;
 use crate::transaction::reward_claim::{
     daily_claim_key, partner_claim_key, partner_count_key, RewardEventKind, RewardStreakRecord,
 };
@@ -94,30 +93,5 @@ impl crate::blockchain::Blockchain {
             }
         }
         RewardStreakRecord::default()
-    }
-
-    /// Case-insensitive username taken check — credential registry sled-first (#2639).
-    pub fn credential_username_taken(&self, username_lower: &str) -> bool {
-        if let Some(store) = self.get_store() {
-            match store.iter::<crate::projections::CredentialProjectionTable>() {
-                Ok(iter) => {
-                    for (_, record) in iter {
-                        if record.credential.username.to_lowercase() == username_lower {
-                            return true;
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "credential_username_taken: sled iter failed; failing closed"
-                    );
-                    return true;
-                }
-            }
-        }
-        self.credential_registry
-            .keys()
-            .any(|u| u.to_lowercase() == username_lower)
     }
 }

--- a/lib-blockchain/src/blockchain/rewards.rs
+++ b/lib-blockchain/src/blockchain/rewards.rs
@@ -1,0 +1,123 @@
+//! BUBL reward eligibility facades (sled-first reads).
+
+use crate::storage::table::TableAccess;
+use crate::transaction::reward_claim::{
+    daily_claim_key, partner_claim_key, partner_count_key, RewardEventKind, RewardStreakRecord,
+};
+
+impl crate::blockchain::Blockchain {
+    /// Whether this DID has already claimed the one-shot welcome reward on-chain.
+    pub fn bubl_reward_welcome_claimed(&self, did: &str) -> bool {
+        if let Some(store) = self.get_store() {
+            match store.get_bubl_reward_welcome(did) {
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "bubl_reward_welcome_claimed: sled read failed; failing closed"
+                    );
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Whether a daily reward event was already claimed for `did` on `date` (UTC).
+    pub fn bubl_reward_daily_claimed(
+        &self,
+        date: &str,
+        did: &str,
+        event: RewardEventKind,
+    ) -> bool {
+        let key = daily_claim_key(date, did, event);
+        if let Some(store) = self.get_store() {
+            match store.get_bubl_reward_daily(&key) {
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "bubl_reward_daily_claimed: sled read failed; failing closed"
+                    );
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn bubl_reward_partner_claimed(&self, week: &str, did: &str, peer_did: &str) -> bool {
+        let key = partner_claim_key(week, did, peer_did);
+        if let Some(store) = self.get_store() {
+            match store.get_bubl_reward_partner(&key) {
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "bubl_reward_partner_claimed: sled read failed; failing closed"
+                    );
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn bubl_reward_partners_this_week(&self, week: &str, did: &str) -> u32 {
+        let key = partner_count_key(week, did);
+        if let Some(store) = self.get_store() {
+            match store.get_bubl_reward_partner_count(&key) {
+                Ok(Some(c)) => return c,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "bubl_reward_partners_this_week: sled read failed"
+                    );
+                }
+            }
+        }
+        0
+    }
+
+    pub fn bubl_reward_streak(&self, did: &str) -> RewardStreakRecord {
+        if let Some(store) = self.get_store() {
+            match store.get_bubl_reward_streak(did) {
+                Ok(Some(s)) => return s,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, "bubl_reward_streak: sled read failed");
+                }
+            }
+        }
+        RewardStreakRecord::default()
+    }
+
+    /// Case-insensitive username taken check — credential registry sled-first (#2639).
+    pub fn credential_username_taken(&self, username_lower: &str) -> bool {
+        if let Some(store) = self.get_store() {
+            match store.iter::<crate::projections::CredentialProjectionTable>() {
+                Ok(iter) => {
+                    for (_, record) in iter {
+                        if record.credential.username.to_lowercase() == username_lower {
+                            return true;
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "credential_username_taken: sled iter failed; failing closed"
+                    );
+                    return true;
+                }
+            }
+        }
+        self.credential_registry
+            .keys()
+            .any(|u| u.to_lowercase() == username_lower)
+    }
+}

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -1058,6 +1058,7 @@ impl BlockExecutor {
             // Phase-2 types: fall through to structural validation below.
             TransactionType::Transfer => {}
             TransactionType::TokenTransfer => {}
+            TransactionType::RewardClaim => {}
             TransactionType::TokenMint => {}
             TransactionType::TokenCreation => {}
             TransactionType::AssetLaunch => {}
@@ -1207,6 +1208,29 @@ impl BlockExecutor {
                 if data.amount == 0 {
                     return Err(TxApplyError::InvalidType(
                         "Token transfer amount must be greater than 0".to_string(),
+                    ));
+                }
+            }
+            TransactionType::RewardClaim => {
+                if tx.reward_claim_data().is_none() {
+                    return Err(TxApplyError::InvalidType(
+                        "RewardClaim requires reward_claim_data field".to_string(),
+                    ));
+                }
+                let data = tx.reward_claim_data().unwrap();
+                if data.amount == 0 {
+                    return Err(TxApplyError::InvalidType(
+                        "RewardClaim amount must be greater than 0".to_string(),
+                    ));
+                }
+                if !tx.inputs.is_empty() || !tx.outputs.is_empty() {
+                    return Err(TxApplyError::InvalidType(
+                        "RewardClaim must not have UTXO inputs or outputs".to_string(),
+                    ));
+                }
+                if tx.fee != 0 {
+                    return Err(TxApplyError::InvalidType(
+                        "RewardClaim transaction fee must be 0".to_string(),
                     ));
                 }
             }
@@ -1452,6 +1476,7 @@ impl BlockExecutor {
         match tx.transaction_type {
             TransactionType::Coinbase => return Ok(()), // Creates value, no fee
             TransactionType::TokenTransfer => return Ok(()), // Phase 2: subsidized
+            TransactionType::RewardClaim => return Ok(()), // Phase 2: subsidized
             TransactionType::TokenMint => return Ok(()), // Phase 2: system mint
             TransactionType::TokenCreation => {
                 // Accept fee=0 (subsidized/system creation) or fee==token_creation_fee (standard).
@@ -1467,7 +1492,10 @@ impl BlockExecutor {
         }
         // System transactions (empty inputs, excluding typed token ops that must pay fees)
         // are fee-exempt. Mirrors TransactionValidator::validate_transaction() logic.
-        if tx.inputs.is_empty() && tx.transaction_type != TransactionType::TokenTransfer {
+        if tx.inputs.is_empty()
+            && tx.transaction_type != TransactionType::TokenTransfer
+            && tx.transaction_type != TransactionType::RewardClaim
+        {
             return Ok(());
         }
 
@@ -1539,6 +1567,26 @@ impl BlockExecutor {
                     return Err(TxApplyError::InvalidNonce {
                         expected: expected_nonce,
                         actual: transfer.nonce,
+                    });
+                }
+            }
+            TransactionType::RewardClaim => {
+                let claim = tx.reward_claim_data().ok_or_else(|| {
+                    TxApplyError::InvalidType("RewardClaim requires reward_claim_data".into())
+                })?;
+                let token = TokenId::new(claim.token_id);
+                let from = Address::new(claim.from);
+                let expected_nonce = view.get_token_nonce(&token, &from)?;
+                if claim.nonce < expected_nonce {
+                    return Err(TxApplyError::ReplayDropped {
+                        expected: expected_nonce,
+                        actual: claim.nonce,
+                    });
+                }
+                if claim.nonce != expected_nonce {
+                    return Err(TxApplyError::InvalidNonce {
+                        expected: expected_nonce,
+                        actual: claim.nonce,
                     });
                 }
             }
@@ -3287,6 +3335,24 @@ impl BlockExecutor {
                     to,
                     amount,
                 }))
+            }
+            TransactionType::RewardClaim => {
+                let data = tx.reward_claim_data().ok_or_else(|| {
+                    TxApplyError::InvalidType(
+                        "RewardClaim requires reward_claim_data field".to_string(),
+                    )
+                })?;
+                let fee_sink = *self.fee_model.protocol_params.fee_sink_address();
+                match crate::execution::reward_claim::apply_reward_claim(
+                    mutator,
+                    data,
+                    block_height,
+                    block_timestamp,
+                    &fee_sink,
+                )? {
+                    Some(outcome) => Ok(TxOutcome::TokenTransfer(outcome)),
+                    None => Ok(TxOutcome::LegacySystem),
+                }
             }
             TransactionType::TokenMint => {
                 let mint_data = tx.token_mint_data().ok_or_else(|| {

--- a/lib-blockchain/src/execution/mod.rs
+++ b/lib-blockchain/src/execution/mod.rs
@@ -38,6 +38,7 @@
 
 pub mod errors;
 pub mod executor;
+pub mod reward_claim;
 pub mod sovereign_asset;
 pub mod state_view;
 pub mod tx_apply;

--- a/lib-blockchain/src/execution/reward_claim.rs
+++ b/lib-blockchain/src/execution/reward_claim.rs
@@ -1,0 +1,226 @@
+//! On-chain BUBL reward claim application (eligibility + token transfer).
+
+use tracing::warn;
+
+use crate::execution::errors::{TxApplyError, TxApplyResult};
+use crate::execution::executor::TokenTransferOutcome;
+use crate::execution::tx_apply::{self, StateMutator};
+use crate::storage::{Address, TokenId};
+use crate::transaction::reward_claim::{
+    daily_claim_key, expected_amount_for_event, iso_week_from_ts, key_id_from_did,
+    partner_claim_key, partner_count_key, utc_date_from_ts, utc_day_ordinal_from_ts,
+    RewardClaimData, RewardEventKind, WEEKLY_PARTNER_CAP,
+};
+/// Apply a `RewardClaim` inside the executor block window.
+///
+/// Returns `Ok(None)` when the claim is ineligible (tx is a no-op, block continues).
+/// Returns `Ok(Some(outcome))` on success.
+pub fn apply_reward_claim(
+    mutator: &StateMutator<'_>,
+    data: &RewardClaimData,
+    block_height: u64,
+    block_timestamp: u64,
+    fee_sink: &Address,
+) -> TxApplyResult<Option<TokenTransferOutcome>> {
+    if data.amount == 0 {
+        warn!("RewardClaim rejected at height {}: zero amount", block_height);
+        return Ok(None);
+    }
+
+    if key_id_from_did(&data.owner_did) != Some(data.recipient_key_id) {
+        warn!(
+            "RewardClaim rejected at height {}: recipient_key_id does not match owner_did",
+            block_height
+        );
+        return Ok(None);
+    }
+
+    let did_hash = crate::types::hash::blake3_hash(data.owner_did.as_bytes());
+    let did_hash_arr = did_hash.as_array();
+    if mutator.get_identity(&did_hash_arr)?.is_none() {
+        warn!(
+            "RewardClaim rejected at height {}: DID {} not registered",
+            block_height,
+            &data.owner_did[..20.min(data.owner_did.len())]
+        );
+        return Ok(None);
+    }
+
+    let token = TokenId::new(data.token_id);
+
+    let contract = match mutator.get_token_contract(&token)? {
+        Some(c) => c,
+        None => {
+            warn!(
+                "RewardClaim rejected at height {}: token contract not found",
+                block_height
+            );
+            return Ok(None);
+        }
+    };
+
+    if contract.creator.key_id != data.from {
+        warn!(
+            "RewardClaim rejected at height {}: signer is not token creator",
+            block_height
+        );
+        return Ok(None);
+    }
+
+    let date = utc_date_from_ts(block_timestamp);
+    let week = iso_week_from_ts(block_timestamp);
+    let today_ord = utc_day_ordinal_from_ts(block_timestamp);
+
+    let mut streak_day = 1u32;
+    if data.event == RewardEventKind::DailyCheckin {
+        let streak = mutator
+            .get_bubl_reward_streak(&data.owner_did)?
+            .unwrap_or_default();
+        streak_day = if streak.last_day == today_ord - 1 {
+            streak.current_streak.saturating_add(1)
+        } else {
+            1
+        };
+    }
+
+    let expected = expected_amount_for_event(data.event, streak_day);
+    if data.amount != expected {
+        warn!(
+            "RewardClaim rejected at height {}: amount {} != expected {} for {:?}",
+            block_height, data.amount, expected, data.event
+        );
+        return Ok(None);
+    }
+
+    match data.event {
+        RewardEventKind::Welcome => {
+            if mutator.get_bubl_reward_welcome(&data.owner_did)?.is_some() {
+                warn!(
+                    "RewardClaim rejected at height {}: welcome already claimed for {}",
+                    block_height,
+                    &data.owner_did[..20.min(data.owner_did.len())]
+                );
+                return Ok(None);
+            }
+        }
+        RewardEventKind::DailyCheckin | RewardEventKind::ActiveSession => {
+            let key = daily_claim_key(&date, &data.owner_did, data.event);
+            if mutator.get_bubl_reward_daily(&key)?.is_some() {
+                warn!(
+                    "RewardClaim rejected at height {}: daily claim already recorded ({})",
+                    block_height, key
+                );
+                return Ok(None);
+            }
+        }
+        RewardEventKind::NewPartner => {
+            let peer = match data.peer_did.as_deref() {
+                Some(p) if !p.is_empty() && p != data.owner_did => p,
+                _ => {
+                    warn!(
+                        "RewardClaim rejected at height {}: invalid peer_did",
+                        block_height
+                    );
+                    return Ok(None);
+                }
+            };
+            if key_id_from_did(peer).is_none() {
+                warn!(
+                    "RewardClaim rejected at height {}: peer_did format invalid",
+                    block_height
+                );
+                return Ok(None);
+            }
+            let slot_key = partner_claim_key(&week, &data.owner_did, peer);
+            if mutator.get_bubl_reward_partner(&slot_key)?.is_some() {
+                warn!(
+                    "RewardClaim rejected at height {}: partner already counted ({})",
+                    block_height, slot_key
+                );
+                return Ok(None);
+            }
+            let count_key = partner_count_key(&week, &data.owner_did);
+            let count = mutator.get_bubl_reward_partner_count(&count_key)?.unwrap_or(0);
+            if count >= WEEKLY_PARTNER_CAP {
+                warn!(
+                    "RewardClaim rejected at height {}: weekly partner cap reached",
+                    block_height
+                );
+                return Ok(None);
+            }
+        }
+    }
+
+    let from = Address::new(data.from);
+    let to = Address::new(data.recipient_key_id);
+    let expected_nonce = mutator.get_token_nonce(&token, &from)?;
+    if data.nonce < expected_nonce {
+        warn!(
+            "RewardClaim dropped at height {}: nonce replay (expected {})",
+            block_height, expected_nonce
+        );
+        return Ok(None);
+    }
+    if data.nonce > expected_nonce {
+        return Err(TxApplyError::InvalidType(format!(
+            "RewardClaim nonce gap: expected {}, got {}",
+            expected_nonce, data.nonce
+        )));
+    }
+
+    let cbe_token_id_arr = crate::Blockchain::derive_cbe_token_id_pub();
+    let fee_bps = if data.token_id == cbe_token_id_arr {
+        0u16
+    } else {
+        crate::contracts::tokens::constants::SOV_FEE_RATE_BPS
+    };
+
+    tx_apply::apply_token_transfer(
+        mutator,
+        &token,
+        &from,
+        &to,
+        data.amount,
+        fee_bps,
+        fee_sink,
+    )?;
+    mutator.increment_token_nonce(&token, &from)?;
+
+    match data.event {
+        RewardEventKind::Welcome => {
+            mutator.put_bubl_reward_welcome(&data.owner_did, block_height)?;
+        }
+        RewardEventKind::DailyCheckin => {
+            let key = daily_claim_key(&date, &data.owner_did, data.event);
+            mutator.put_bubl_reward_daily(&key, block_height)?;
+            let mut streak = mutator
+                .get_bubl_reward_streak(&data.owner_did)?
+                .unwrap_or_default();
+            streak.last_day = today_ord;
+            streak.current_streak = streak_day;
+            if streak_day > streak.longest_streak {
+                streak.longest_streak = streak_day;
+            }
+            mutator.put_bubl_reward_streak(&data.owner_did, &streak)?;
+        }
+        RewardEventKind::ActiveSession => {
+            let key = daily_claim_key(&date, &data.owner_did, data.event);
+            mutator.put_bubl_reward_daily(&key, block_height)?;
+        }
+        RewardEventKind::NewPartner => {
+            let peer = data.peer_did.as_deref().expect("validated above");
+            let slot_key = partner_claim_key(&week, &data.owner_did, peer);
+            mutator.put_bubl_reward_partner(&slot_key, block_height)?;
+            let count_key = partner_count_key(&week, &data.owner_did);
+            let count = mutator.get_bubl_reward_partner_count(&count_key)?.unwrap_or(0);
+            mutator.put_bubl_reward_partner_count(&count_key, count.saturating_add(1))?;
+        }
+    }
+
+    Ok(Some(TokenTransferOutcome {
+        token,
+        from,
+        to,
+        amount: data.amount,
+    }))
+}

--- a/lib-blockchain/src/execution/reward_claim.rs
+++ b/lib-blockchain/src/execution/reward_claim.rs
@@ -1,20 +1,24 @@
-//! On-chain BUBL reward claim application (eligibility + token transfer).
-
-use tracing::warn;
+//! On-chain BUBL reward claim application (policy-backed eligibility + token transfer).
 
 use crate::execution::errors::{TxApplyError, TxApplyResult};
 use crate::execution::executor::TokenTransferOutcome;
 use crate::execution::tx_apply::{self, StateMutator};
+use crate::rewards_policy::{expected_amount_for_trigger, legacy_bubl_policy, weekly_partner_cap};
 use crate::storage::{Address, TokenId};
 use crate::transaction::reward_claim::{
-    daily_claim_key, expected_amount_for_event, iso_week_from_ts, key_id_from_did,
-    partner_claim_key, partner_count_key, utc_date_from_ts, utc_day_ordinal_from_ts,
-    RewardClaimData, RewardEventKind, WEEKLY_PARTNER_CAP,
+    bubl_token_id, canonical_owner_did, daily_claim_key, iso_week_from_ts, key_id_from_did,
+    partner_claim_key, partner_count_key, reward_event_to_policy_event, utc_date_from_ts,
+    utc_day_ordinal_from_ts, RewardClaimData, RewardEventKind,
 };
+
+fn reject_claim(reason: impl Into<String>) -> TxApplyResult<Option<TokenTransferOutcome>> {
+    Err(TxApplyError::InvalidType(reason.into()))
+}
+
 /// Apply a `RewardClaim` inside the executor block window.
 ///
-/// Returns `Ok(None)` when the claim is ineligible (tx is a no-op, block continues).
-/// Returns `Ok(Some(outcome))` on success.
+/// Ineligible or invalid claims return `Err` so the tx is not committed as a
+/// silent no-op (review #2832 P1).
 pub fn apply_reward_claim(
     mutator: &StateMutator<'_>,
     data: &RewardClaimData,
@@ -22,51 +26,42 @@ pub fn apply_reward_claim(
     block_timestamp: u64,
     fee_sink: &Address,
 ) -> TxApplyResult<Option<TokenTransferOutcome>> {
+    if data.token_id != bubl_token_id() {
+        return reject_claim("RewardClaim is only valid for the canonical BUBL token_id");
+    }
+
     if data.amount == 0 {
-        warn!("RewardClaim rejected at height {}: zero amount", block_height);
-        return Ok(None);
+        return reject_claim("RewardClaim amount must be greater than 0");
     }
 
-    if key_id_from_did(&data.owner_did) != Some(data.recipient_key_id) {
-        warn!(
-            "RewardClaim rejected at height {}: recipient_key_id does not match owner_did",
-            block_height
-        );
-        return Ok(None);
+    let owner_did = canonical_owner_did(&data.owner_did)
+        .ok_or_else(|| TxApplyError::InvalidType("invalid owner_did".into()))?;
+
+    if key_id_from_did(&owner_did) != Some(data.recipient_key_id) {
+        return reject_claim("recipient_key_id does not match owner_did");
     }
 
-    let did_hash = crate::types::hash::blake3_hash(data.owner_did.as_bytes());
+    let did_hash = crate::types::hash::blake3_hash(owner_did.as_bytes());
     let did_hash_arr = did_hash.as_array();
     if mutator.get_identity(&did_hash_arr)?.is_none() {
-        warn!(
-            "RewardClaim rejected at height {}: DID {} not registered",
-            block_height,
-            &data.owner_did[..20.min(data.owner_did.len())]
-        );
-        return Ok(None);
+        return reject_claim(format!(
+            "DID {} not registered",
+            &owner_did[..20.min(owner_did.len())]
+        ));
     }
 
     let token = TokenId::new(data.token_id);
 
     let contract = match mutator.get_token_contract(&token)? {
         Some(c) => c,
-        None => {
-            warn!(
-                "RewardClaim rejected at height {}: token contract not found",
-                block_height
-            );
-            return Ok(None);
-        }
+        None => return reject_claim("token contract not found"),
     };
 
     if contract.creator.key_id != data.from {
-        warn!(
-            "RewardClaim rejected at height {}: signer is not token creator",
-            block_height
-        );
-        return Ok(None);
+        return reject_claim("signer is not token creator");
     }
 
+    let policy = legacy_bubl_policy();
     let date = utc_date_from_ts(block_timestamp);
     let week = iso_week_from_ts(block_timestamp);
     let today_ord = utc_day_ordinal_from_ts(block_timestamp);
@@ -74,7 +69,7 @@ pub fn apply_reward_claim(
     let mut streak_day = 1u32;
     if data.event == RewardEventKind::DailyCheckin {
         let streak = mutator
-            .get_bubl_reward_streak(&data.owner_did)?
+            .get_bubl_reward_streak(&owner_did)?
             .unwrap_or_default();
         streak_day = if streak.last_day == today_ord - 1 {
             streak.current_streak.saturating_add(1)
@@ -83,70 +78,43 @@ pub fn apply_reward_claim(
         };
     }
 
-    let expected = expected_amount_for_event(data.event, streak_day);
+    let policy_event = reward_event_to_policy_event(data.event);
+    let expected = expected_amount_for_trigger(&policy, policy_event, streak_day)
+        .ok_or_else(|| TxApplyError::InvalidType("no enabled policy trigger for event".into()))?;
     if data.amount != expected {
-        warn!(
-            "RewardClaim rejected at height {}: amount {} != expected {} for {:?}",
-            block_height, data.amount, expected, data.event
-        );
-        return Ok(None);
+        return reject_claim(format!(
+            "amount {} != expected {} for {:?}",
+            data.amount, expected, data.event
+        ));
     }
+
+    let partner_cap = weekly_partner_cap(&policy);
 
     match data.event {
         RewardEventKind::Welcome => {
-            if mutator.get_bubl_reward_welcome(&data.owner_did)?.is_some() {
-                warn!(
-                    "RewardClaim rejected at height {}: welcome already claimed for {}",
-                    block_height,
-                    &data.owner_did[..20.min(data.owner_did.len())]
-                );
-                return Ok(None);
+            if mutator.get_bubl_reward_welcome(&owner_did)?.is_some() {
+                return reject_claim("welcome already claimed");
             }
         }
         RewardEventKind::DailyCheckin | RewardEventKind::ActiveSession => {
-            let key = daily_claim_key(&date, &data.owner_did, data.event);
+            let key = daily_claim_key(&date, &owner_did, data.event);
             if mutator.get_bubl_reward_daily(&key)?.is_some() {
-                warn!(
-                    "RewardClaim rejected at height {}: daily claim already recorded ({})",
-                    block_height, key
-                );
-                return Ok(None);
+                return reject_claim(format!("daily claim already recorded ({key})"));
             }
         }
         RewardEventKind::NewPartner => {
-            let peer = match data.peer_did.as_deref() {
-                Some(p) if !p.is_empty() && p != data.owner_did => p,
-                _ => {
-                    warn!(
-                        "RewardClaim rejected at height {}: invalid peer_did",
-                        block_height
-                    );
-                    return Ok(None);
-                }
+            let peer = match data.peer_did.as_deref().and_then(canonical_owner_did) {
+                Some(p) if p != owner_did => p,
+                _ => return reject_claim("invalid peer_did"),
             };
-            if key_id_from_did(peer).is_none() {
-                warn!(
-                    "RewardClaim rejected at height {}: peer_did format invalid",
-                    block_height
-                );
-                return Ok(None);
-            }
-            let slot_key = partner_claim_key(&week, &data.owner_did, peer);
+            let slot_key = partner_claim_key(&week, &owner_did, &peer);
             if mutator.get_bubl_reward_partner(&slot_key)?.is_some() {
-                warn!(
-                    "RewardClaim rejected at height {}: partner already counted ({})",
-                    block_height, slot_key
-                );
-                return Ok(None);
+                return reject_claim(format!("partner already counted ({slot_key})"));
             }
-            let count_key = partner_count_key(&week, &data.owner_did);
+            let count_key = partner_count_key(&week, &owner_did);
             let count = mutator.get_bubl_reward_partner_count(&count_key)?.unwrap_or(0);
-            if count >= WEEKLY_PARTNER_CAP {
-                warn!(
-                    "RewardClaim rejected at height {}: weekly partner cap reached",
-                    block_height
-                );
-                return Ok(None);
+            if partner_cap == 0 || count >= partner_cap {
+                return reject_claim("weekly partner cap reached");
             }
         }
     }
@@ -155,17 +123,13 @@ pub fn apply_reward_claim(
     let to = Address::new(data.recipient_key_id);
     let expected_nonce = mutator.get_token_nonce(&token, &from)?;
     if data.nonce < expected_nonce {
-        warn!(
-            "RewardClaim dropped at height {}: nonce replay (expected {})",
-            block_height, expected_nonce
-        );
-        return Ok(None);
+        return reject_claim(format!("nonce replay (expected {expected_nonce})"));
     }
     if data.nonce > expected_nonce {
-        return Err(TxApplyError::InvalidType(format!(
-            "RewardClaim nonce gap: expected {}, got {}",
-            expected_nonce, data.nonce
-        )));
+        return reject_claim(format!(
+            "nonce gap: expected {expected_nonce}, got {}",
+            data.nonce
+        ));
     }
 
     let cbe_token_id_arr = crate::Blockchain::derive_cbe_token_id_pub();
@@ -188,30 +152,34 @@ pub fn apply_reward_claim(
 
     match data.event {
         RewardEventKind::Welcome => {
-            mutator.put_bubl_reward_welcome(&data.owner_did, block_height)?;
+            mutator.put_bubl_reward_welcome(&owner_did, block_height)?;
         }
         RewardEventKind::DailyCheckin => {
-            let key = daily_claim_key(&date, &data.owner_did, data.event);
+            let key = daily_claim_key(&date, &owner_did, data.event);
             mutator.put_bubl_reward_daily(&key, block_height)?;
             let mut streak = mutator
-                .get_bubl_reward_streak(&data.owner_did)?
+                .get_bubl_reward_streak(&owner_did)?
                 .unwrap_or_default();
             streak.last_day = today_ord;
             streak.current_streak = streak_day;
             if streak_day > streak.longest_streak {
                 streak.longest_streak = streak_day;
             }
-            mutator.put_bubl_reward_streak(&data.owner_did, &streak)?;
+            mutator.put_bubl_reward_streak(&owner_did, &streak)?;
         }
         RewardEventKind::ActiveSession => {
-            let key = daily_claim_key(&date, &data.owner_did, data.event);
+            let key = daily_claim_key(&date, &owner_did, data.event);
             mutator.put_bubl_reward_daily(&key, block_height)?;
         }
         RewardEventKind::NewPartner => {
-            let peer = data.peer_did.as_deref().expect("validated above");
-            let slot_key = partner_claim_key(&week, &data.owner_did, peer);
+            let peer = data
+                .peer_did
+                .as_deref()
+                .and_then(canonical_owner_did)
+                .expect("validated above");
+            let slot_key = partner_claim_key(&week, &owner_did, &peer);
             mutator.put_bubl_reward_partner(&slot_key, block_height)?;
-            let count_key = partner_count_key(&week, &data.owner_did);
+            let count_key = partner_count_key(&week, &owner_did);
             let count = mutator.get_bubl_reward_partner_count(&count_key)?.unwrap_or(0);
             mutator.put_bubl_reward_partner_count(&count_key, count.saturating_add(1))?;
         }
@@ -223,4 +191,154 @@ pub fn apply_reward_claim(
         to,
         amount: data.amount,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::errors::TxApplyError;
+    use crate::execution::tx_apply::StateMutator;
+    use crate::integration::crypto_integration::PublicKey;
+    use crate::storage::{
+        Address, AddressExt, BlockchainStore, IdentityConsensus, SledStore, TokenId,
+    };
+    use crate::transaction::reward_claim::{REWARD_WELCOME_ATOMS, bubl_token_id};
+    use std::sync::Arc;
+
+    fn fresh_store() -> Arc<SledStore> {
+        Arc::new(SledStore::open_temporary().unwrap())
+    }
+
+    fn test_public_key(key_id: [u8; 32]) -> PublicKey {
+        PublicKey {
+            dilithium_pk: [0u8; 2592],
+            kyber_pk: [0u8; 1568],
+            key_id,
+        }
+    }
+
+    fn seed_reward_claim_prereqs(store: &SledStore, creator: [u8; 32], owner_did: &str) {
+        let token_id = TokenId::new(bubl_token_id());
+        store
+            .force_set_token_balances(&[(
+                token_id,
+                Address::new(creator),
+                REWARD_WELCOME_ATOMS.saturating_mul(2),
+            )])
+            .unwrap();
+
+        store.begin_block(0).unwrap();
+        let mutator = StateMutator::new(store);
+        let did_hash = crate::types::hash::blake3_hash(owner_did.as_bytes()).as_array();
+        store
+            .put_identity(
+                &did_hash,
+                &IdentityConsensus {
+                    did_hash,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let token = crate::contracts::TokenContract::new_custom(
+            "Bubble".to_string(),
+            "BUBL".to_string(),
+            0,
+            test_public_key(creator),
+        );
+        mutator.put_token_contract(&token).unwrap();
+        store
+            .set_token_nonce(&token_id, &Address::new(creator), 0)
+            .unwrap();
+        store.commit_block().unwrap();
+    }
+
+    fn welcome_claim_data(creator: [u8; 32], owner_did: &str) -> RewardClaimData {
+        RewardClaimData {
+            event: RewardEventKind::Welcome,
+            owner_did: owner_did.to_string(),
+            recipient_key_id: creator,
+            token_id: bubl_token_id(),
+            from: creator,
+            amount: REWARD_WELCOME_ATOMS,
+            nonce: 0,
+            peer_did: None,
+        }
+    }
+
+    #[test]
+    fn rejects_non_bubl_token_id() {
+        let store = fresh_store();
+        let creator = [0xAAu8; 32];
+        let owner_did = format!("did:zhtp:{}", hex::encode(creator));
+        seed_reward_claim_prereqs(store.as_ref(), creator, &owner_did);
+
+        store.begin_block(1).unwrap();
+        let mutator = StateMutator::new(store.as_ref());
+        let mut data = welcome_claim_data(creator, &owner_did);
+        data.token_id = [0xFF; 32];
+
+        let err = apply_reward_claim(
+            &mutator,
+            &data,
+            1,
+            1_700_000_000,
+            &Address::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(err, TxApplyError::InvalidType(_)));
+        store.rollback_block().unwrap();
+    }
+
+    #[test]
+    fn rejects_welcome_when_already_claimed() {
+        let store = fresh_store();
+        let creator = [0xBBu8; 32];
+        let owner_did = format!("did:zhtp:{}", hex::encode(creator));
+        seed_reward_claim_prereqs(store.as_ref(), creator, &owner_did);
+
+        store.begin_block(1).unwrap();
+        let mutator = StateMutator::new(store.as_ref());
+        mutator.put_bubl_reward_welcome(&owner_did, 1).unwrap();
+
+        let data = welcome_claim_data(creator, &owner_did);
+        let err = apply_reward_claim(
+            &mutator,
+            &data,
+            1,
+            1_700_000_000,
+            &Address::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(err, TxApplyError::InvalidType(msg) if msg.contains("welcome already claimed")));
+        store.rollback_block().unwrap();
+    }
+
+    #[test]
+    fn rejects_unregistered_did() {
+        let store = fresh_store();
+        let creator = [0xCCu8; 32];
+        let owner_did = format!("did:zhtp:{}", hex::encode(creator));
+
+        store.begin_block(0).unwrap();
+        let mutator = StateMutator::new(store.as_ref());
+        let token = crate::contracts::TokenContract::new_custom(
+            "Bubble".to_string(),
+            "BUBL".to_string(),
+            0,
+            test_public_key(creator),
+        );
+        mutator.put_token_contract(&token).unwrap();
+
+        let data = welcome_claim_data(creator, &owner_did);
+        let err = apply_reward_claim(
+            &mutator,
+            &data,
+            1,
+            1_700_000_000,
+            &Address::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(err, TxApplyError::InvalidType(msg) if msg.contains("not registered")));
+        store.rollback_block().unwrap();
+    }
 }

--- a/lib-blockchain/src/execution/tx_apply.rs
+++ b/lib-blockchain/src/execution/tx_apply.rs
@@ -327,6 +327,58 @@ impl<'a> StateMutator<'a> {
         Ok(())
     }
 
+    pub fn get_bubl_reward_welcome(&self, did: &str) -> TxApplyResult<Option<u64>> {
+        Ok(self.store.get_bubl_reward_welcome(did)?)
+    }
+
+    pub fn put_bubl_reward_welcome(&self, did: &str, height: u64) -> TxApplyResult<()> {
+        self.store.put_bubl_reward_welcome(did, height)?;
+        Ok(())
+    }
+
+    pub fn get_bubl_reward_daily(&self, key: &str) -> TxApplyResult<Option<u64>> {
+        Ok(self.store.get_bubl_reward_daily(key)?)
+    }
+
+    pub fn put_bubl_reward_daily(&self, key: &str, height: u64) -> TxApplyResult<()> {
+        self.store.put_bubl_reward_daily(key, height)?;
+        Ok(())
+    }
+
+    pub fn get_bubl_reward_partner(&self, key: &str) -> TxApplyResult<Option<u64>> {
+        Ok(self.store.get_bubl_reward_partner(key)?)
+    }
+
+    pub fn put_bubl_reward_partner(&self, key: &str, height: u64) -> TxApplyResult<()> {
+        self.store.put_bubl_reward_partner(key, height)?;
+        Ok(())
+    }
+
+    pub fn get_bubl_reward_partner_count(&self, key: &str) -> TxApplyResult<Option<u32>> {
+        Ok(self.store.get_bubl_reward_partner_count(key)?)
+    }
+
+    pub fn put_bubl_reward_partner_count(&self, key: &str, count: u32) -> TxApplyResult<()> {
+        self.store.put_bubl_reward_partner_count(key, count)?;
+        Ok(())
+    }
+
+    pub fn get_bubl_reward_streak(
+        &self,
+        did: &str,
+    ) -> TxApplyResult<Option<crate::transaction::RewardStreakRecord>> {
+        Ok(self.store.get_bubl_reward_streak(did)?)
+    }
+
+    pub fn put_bubl_reward_streak(
+        &self,
+        did: &str,
+        streak: &crate::transaction::RewardStreakRecord,
+    ) -> TxApplyResult<()> {
+        self.store.put_bubl_reward_streak(did, streak)?;
+        Ok(())
+    }
+
     pub fn get_governance_module_state(
         &self,
         asset_id: &[u8; 32],

--- a/lib-blockchain/src/lib.rs
+++ b/lib-blockchain/src/lib.rs
@@ -34,6 +34,7 @@ pub mod oracle;
 pub mod pricing;
 pub mod projections;
 pub mod protocol;
+pub mod rewards_policy;
 pub mod receipts;
 pub mod resources;
 pub mod snapshot;

--- a/lib-blockchain/src/rewards_policy/mod.rs
+++ b/lib-blockchain/src/rewards_policy/mod.rs
@@ -1,0 +1,10 @@
+//! `zhtp/rewards-policy/v1` — DAO reward distribution policy document.
+//!
+//! Referenced on-chain via `RewardsModuleState.policy_hash` (BLAKE3 of canonical JSON).
+//! Schema: `schemas/zhtp/rewards-policy/v1.schema.json`
+
+mod types;
+mod validate;
+
+pub use types::*;
+pub use validate::{canonical_policy_bytes, policy_hash, validate_rewards_policy, RewardsPolicyError};

--- a/lib-blockchain/src/rewards_policy/mod.rs
+++ b/lib-blockchain/src/rewards_policy/mod.rs
@@ -7,4 +7,7 @@ mod types;
 mod validate;
 
 pub use types::*;
-pub use validate::{canonical_policy_bytes, policy_hash, validate_rewards_policy, RewardsPolicyError};
+pub use validate::{
+    canonical_policy_bytes, expected_amount_for_trigger, legacy_bubl_policy, policy_hash,
+    validate_rewards_policy, validate_rewards_policy_value, weekly_partner_cap, RewardsPolicyError,
+};

--- a/lib-blockchain/src/rewards_policy/types.rs
+++ b/lib-blockchain/src/rewards_policy/types.rs
@@ -1,0 +1,117 @@
+use serde::{Deserialize, Serialize};
+
+pub const REWARDS_POLICY_SCHEMA_V1: &str = "zhtp/rewards-policy/v1";
+
+/// Canonical event names — align with `RewardEventKind::from_str`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RewardsPolicyEvent {
+    Welcome,
+    DailyCheckin,
+    ActiveSession,
+    NewPartner,
+}
+
+impl RewardsPolicyEvent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Welcome => "welcome",
+            Self::DailyCheckin => "daily_checkin",
+            Self::ActiveSession => "active_session",
+            Self::NewPartner => "new_partner",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerKind {
+    OncePerDid,
+    OncePerUtcDay,
+    DistinctPeerPerIsoWeek,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreakBonus {
+    #[serde(with = "atoms_string")]
+    pub per_day_atoms: u128,
+    pub cap_days: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewardsTrigger {
+    pub id: String,
+    pub kind: TriggerKind,
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event: Option<RewardsPolicyEvent>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "optional_atoms_string")]
+    pub amount_atoms: Option<u128>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "optional_atoms_string")]
+    pub base_amount_atoms: Option<u128>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub streak_bonus: Option<StreakBonus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weekly_cap: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RewardsBudget {
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "optional_atoms_string")]
+    pub max_daily_outflow_atoms: Option<u128>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "optional_atoms_string")]
+    pub max_lifetime_per_did_atoms: Option<u128>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewardsPolicyV1 {
+    pub schema: String,
+    pub asset_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub triggers: Vec<RewardsTrigger>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget: Option<RewardsBudget>,
+}
+
+mod atoms_string {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &u128, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&value.to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<u128, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<u128>().map_err(serde::de::Error::custom)
+    }
+}
+
+mod optional_atoms_string {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &Option<u128>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serializer.serialize_some(&v.to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<u128>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt = Option::<String>::deserialize(deserializer)?;
+        opt.map(|s| s.parse::<u128>().map_err(serde::de::Error::custom))
+            .transpose()
+    }
+}

--- a/lib-blockchain/src/rewards_policy/validate.rs
+++ b/lib-blockchain/src/rewards_policy/validate.rs
@@ -1,0 +1,365 @@
+use super::types::{
+    RewardsPolicyEvent, RewardsPolicyV1, RewardsTrigger, TriggerKind, REWARDS_POLICY_SCHEMA_V1,
+};
+use crate::types::Hash;
+use std::collections::HashSet;
+
+const ATOM_18: u128 = 1_000_000_000_000_000_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RewardsPolicyError {
+    InvalidJson(String),
+    WrongSchema { expected: String, got: String },
+    InvalidAssetId(String),
+    EmptyTriggers,
+    TooManyTriggers,
+    DuplicateTriggerId(String),
+    DuplicateEvent(RewardsPolicyEvent),
+    TriggerDisabledNoop(String),
+    MissingField { trigger_id: String, field: &'static str },
+    InvalidAmount { trigger_id: String, reason: String },
+    InvalidWeeklyCap { trigger_id: String },
+    DescriptionTooLong,
+}
+
+impl std::fmt::Display for RewardsPolicyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidJson(e) => write!(f, "invalid JSON: {e}"),
+            Self::WrongSchema { expected, got } => {
+                write!(f, "schema must be '{expected}', got '{got}'")
+            }
+            Self::InvalidAssetId(s) => write!(f, "asset_id must be 64 hex chars: {s}"),
+            Self::EmptyTriggers => write!(f, "triggers must not be empty"),
+            Self::TooManyTriggers => write!(f, "triggers exceed max 32"),
+            Self::DuplicateTriggerId(id) => write!(f, "duplicate trigger id '{id}'"),
+            Self::DuplicateEvent(ev) => write!(f, "duplicate event '{}'", ev.as_str()),
+            Self::TriggerDisabledNoop(id) => write!(f, "trigger '{id}' disabled (ok)"),
+            Self::MissingField { trigger_id, field } => {
+                write!(f, "trigger '{trigger_id}' missing '{field}'")
+            }
+            Self::InvalidAmount { trigger_id, reason } => {
+                write!(f, "trigger '{trigger_id}' invalid amount: {reason}")
+            }
+            Self::InvalidWeeklyCap { trigger_id } => {
+                write!(f, "trigger '{trigger_id}' weekly_cap out of range")
+            }
+            Self::DescriptionTooLong => write!(f, "description exceeds 512 chars"),
+        }
+    }
+}
+
+impl std::error::Error for RewardsPolicyError {}
+
+/// Parse and semantically validate a rewards policy document.
+pub fn validate_rewards_policy(bytes: &[u8]) -> Result<RewardsPolicyV1, RewardsPolicyError> {
+    let policy: RewardsPolicyV1 = serde_json::from_slice(bytes)
+        .map_err(|e| RewardsPolicyError::InvalidJson(e.to_string()))?;
+    validate_rewards_policy_value(&policy)?;
+    Ok(policy)
+}
+
+pub fn validate_rewards_policy_value(policy: &RewardsPolicyV1) -> Result<(), RewardsPolicyError> {
+    if policy.schema != REWARDS_POLICY_SCHEMA_V1 {
+        return Err(RewardsPolicyError::WrongSchema {
+            expected: REWARDS_POLICY_SCHEMA_V1.to_string(),
+            got: policy.schema.clone(),
+        });
+    }
+    if policy.asset_id.len() != 64
+        || !policy.asset_id.chars().all(|c| c.is_ascii_hexdigit())
+    {
+        return Err(RewardsPolicyError::InvalidAssetId(policy.asset_id.clone()));
+    }
+    if let Some(desc) = &policy.description {
+        if desc.len() > 512 {
+            return Err(RewardsPolicyError::DescriptionTooLong);
+        }
+    }
+    if policy.triggers.is_empty() {
+        return Err(RewardsPolicyError::EmptyTriggers);
+    }
+    if policy.triggers.len() > 32 {
+        return Err(RewardsPolicyError::TooManyTriggers);
+    }
+
+    let mut ids = HashSet::new();
+    let mut events = HashSet::new();
+    let mut any_enabled = false;
+
+    for t in &policy.triggers {
+        if !ids.insert(t.id.clone()) {
+            return Err(RewardsPolicyError::DuplicateTriggerId(t.id.clone()));
+        }
+        if !t.enabled {
+            continue;
+        }
+        any_enabled = true;
+        validate_trigger(t)?;
+        if let Some(ev) = t.event {
+            if !events.insert(ev) {
+                return Err(RewardsPolicyError::DuplicateEvent(ev));
+            }
+        }
+    }
+
+    if !any_enabled {
+        return Err(RewardsPolicyError::EmptyTriggers);
+    }
+
+    Ok(())
+}
+
+fn validate_trigger(t: &RewardsTrigger) -> Result<(), RewardsPolicyError> {
+    let id = &t.id;
+    if !id
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_lowercase())
+        .unwrap_or(false)
+        || id.len() > 32
+        || !id.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return Err(RewardsPolicyError::InvalidAmount {
+            trigger_id: id.clone(),
+            reason: "id must match [a-z][a-z0-9_]{0,31}".to_string(),
+        });
+    }
+
+    let event = t.event.ok_or(RewardsPolicyError::MissingField {
+        trigger_id: id.clone(),
+        field: "event",
+    })?;
+
+    match t.kind {
+        TriggerKind::OncePerDid => {
+            let amount = t.amount_atoms.ok_or(RewardsPolicyError::MissingField {
+                trigger_id: id.clone(),
+                field: "amount_atoms",
+            })?;
+            require_positive(id, amount)?;
+            if event != RewardsPolicyEvent::Welcome {
+                // allowed but warn via validation — welcome is the expected pairing
+            }
+        }
+        TriggerKind::OncePerUtcDay => {
+            if let Some(amount) = t.amount_atoms {
+                require_positive(id, amount)?;
+            } else if let Some(base) = t.base_amount_atoms {
+                require_positive(id, base)?;
+                if let Some(sb) = &t.streak_bonus {
+                    require_positive(id, sb.per_day_atoms)?;
+                    if sb.cap_days > 365 {
+                        return Err(RewardsPolicyError::InvalidAmount {
+                            trigger_id: id.clone(),
+                            reason: "streak_bonus.cap_days > 365".to_string(),
+                        });
+                    }
+                }
+            } else {
+                return Err(RewardsPolicyError::MissingField {
+                    trigger_id: id.clone(),
+                    field: "amount_atoms or base_amount_atoms",
+                });
+            }
+        }
+        TriggerKind::DistinctPeerPerIsoWeek => {
+            let amount = t.amount_atoms.ok_or(RewardsPolicyError::MissingField {
+                trigger_id: id.clone(),
+                field: "amount_atoms",
+            })?;
+            require_positive(id, amount)?;
+            let cap = t.weekly_cap.ok_or(RewardsPolicyError::MissingField {
+                trigger_id: id.clone(),
+                field: "weekly_cap",
+            })?;
+            if cap == 0 || cap > 1000 {
+                return Err(RewardsPolicyError::InvalidWeeklyCap {
+                    trigger_id: id.clone(),
+                });
+            }
+            if event != RewardsPolicyEvent::NewPartner {
+                return Err(RewardsPolicyError::InvalidAmount {
+                    trigger_id: id.clone(),
+                    reason: "distinct_peer_per_iso_week expects event new_partner".to_string(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn require_positive(trigger_id: &str, amount: u128) -> Result<(), RewardsPolicyError> {
+    if amount == 0 {
+        return Err(RewardsPolicyError::InvalidAmount {
+            trigger_id: trigger_id.to_string(),
+            reason: "must be > 0".to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Canonical JSON bytes for hashing (sorted keys, compact).
+pub fn canonical_policy_bytes(policy: &RewardsPolicyV1) -> Result<Vec<u8>, RewardsPolicyError> {
+    validate_rewards_policy_value(policy)?;
+    serde_json::to_vec(policy).map_err(|e| RewardsPolicyError::InvalidJson(e.to_string()))
+}
+
+/// BLAKE3 hash of canonical policy JSON — stored on-chain as `policy_hash`.
+pub fn policy_hash(policy: &RewardsPolicyV1) -> Result<Hash, RewardsPolicyError> {
+    let bytes = canonical_policy_bytes(policy)?;
+    Ok(crate::types::hash::blake3_hash(&bytes))
+}
+
+/// Expected claim amount for an event at a given streak day (check-in only).
+pub fn expected_amount_for_trigger(
+    policy: &RewardsPolicyV1,
+    event: RewardsPolicyEvent,
+    streak_day: u32,
+) -> Option<u128> {
+    let trigger = policy.triggers.iter().find(|t| t.enabled && t.event == Some(event))?;
+    match trigger.kind {
+        TriggerKind::OncePerDid | TriggerKind::DistinctPeerPerIsoWeek => trigger.amount_atoms,
+        TriggerKind::OncePerUtcDay => {
+            if let Some(fixed) = trigger.amount_atoms {
+                Some(fixed)
+            } else {
+                let base = trigger.base_amount_atoms?;
+                let bonus = trigger.streak_bonus.as_ref().map(|sb| {
+                    let days = streak_day.saturating_sub(1).min(sb.cap_days) as u128;
+                    sb.per_day_atoms.saturating_mul(days)
+                })?;
+                Some(base.saturating_add(bonus))
+            }
+        }
+    }
+}
+
+/// BUBL canonical constants for regression tests (18-decimal atoms).
+pub mod bubl_canonical {
+    use super::*;
+
+    pub const WELCOME: u128 = 100 * ATOM_18;
+    pub const CHECKIN_BASE: u128 = 10 * ATOM_18;
+    pub const STREAK_PER_DAY: u128 = 1 * ATOM_18;
+    pub const STREAK_CAP_DAYS: u32 = 10;
+    pub const ACTIVE_SESSION: u128 = 2 * ATOM_18;
+    pub const NEW_PARTNER: u128 = 20 * ATOM_18;
+    pub const WEEKLY_PARTNER_CAP: u32 = 5;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bubl_canonical::*;
+    use super::*;
+    use crate::rewards_policy::types::{RewardsBudget, RewardsTrigger, StreakBonus};
+
+    fn example_bubl_policy() -> RewardsPolicyV1 {
+        RewardsPolicyV1 {
+            schema: REWARDS_POLICY_SCHEMA_V1.to_string(),
+            asset_id: "ab".repeat(32),
+            description: Some("test".to_string()),
+            triggers: vec![
+                RewardsTrigger {
+                    id: "welcome".to_string(),
+                    kind: TriggerKind::OncePerDid,
+                    enabled: true,
+                    event: Some(RewardsPolicyEvent::Welcome),
+                    amount_atoms: Some(WELCOME),
+                    base_amount_atoms: None,
+                    streak_bonus: None,
+                    weekly_cap: None,
+                },
+                RewardsTrigger {
+                    id: "daily_checkin".to_string(),
+                    kind: TriggerKind::OncePerUtcDay,
+                    enabled: true,
+                    event: Some(RewardsPolicyEvent::DailyCheckin),
+                    amount_atoms: None,
+                    base_amount_atoms: Some(CHECKIN_BASE),
+                    streak_bonus: Some(StreakBonus {
+                        per_day_atoms: STREAK_PER_DAY,
+                        cap_days: STREAK_CAP_DAYS,
+                    }),
+                    weekly_cap: None,
+                },
+                RewardsTrigger {
+                    id: "active_session".to_string(),
+                    kind: TriggerKind::OncePerUtcDay,
+                    enabled: true,
+                    event: Some(RewardsPolicyEvent::ActiveSession),
+                    amount_atoms: Some(ACTIVE_SESSION),
+                    base_amount_atoms: None,
+                    streak_bonus: None,
+                    weekly_cap: None,
+                },
+                RewardsTrigger {
+                    id: "new_partner".to_string(),
+                    kind: TriggerKind::DistinctPeerPerIsoWeek,
+                    enabled: true,
+                    event: Some(RewardsPolicyEvent::NewPartner),
+                    amount_atoms: Some(NEW_PARTNER),
+                    base_amount_atoms: None,
+                    streak_bonus: None,
+                    weekly_cap: Some(WEEKLY_PARTNER_CAP),
+                },
+            ],
+            budget: Some(RewardsBudget {
+                max_daily_outflow_atoms: None,
+                max_lifetime_per_did_atoms: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn example_file_validates() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../schemas/zhtp/rewards-policy/examples/bubl-v1.json"
+        );
+        let bytes = std::fs::read(path).expect("read bubl example");
+        let policy = validate_rewards_policy(&bytes).expect("valid");
+        assert_eq!(policy.triggers.len(), 4);
+    }
+
+    #[test]
+    fn bubl_amounts_match_executor_constants() {
+        let policy = example_bubl_policy();
+        assert_eq!(
+            expected_amount_for_trigger(&policy, RewardsPolicyEvent::Welcome, 1),
+            Some(WELCOME)
+        );
+        assert_eq!(
+            expected_amount_for_trigger(&policy, RewardsPolicyEvent::DailyCheckin, 1),
+            Some(CHECKIN_BASE)
+        );
+        assert_eq!(
+            expected_amount_for_trigger(&policy, RewardsPolicyEvent::DailyCheckin, 11),
+            Some(CHECKIN_BASE + STREAK_PER_DAY * 10)
+        );
+        assert_eq!(
+            expected_amount_for_trigger(&policy, RewardsPolicyEvent::ActiveSession, 1),
+            Some(ACTIVE_SESSION)
+        );
+        assert_eq!(
+            expected_amount_for_trigger(&policy, RewardsPolicyEvent::NewPartner, 1),
+            Some(NEW_PARTNER)
+        );
+        assert_eq!(NEW_PARTNER, 20 * ATOM_18, "C2: canonical new_partner is 20 BUBL");
+    }
+
+    #[test]
+    fn policy_hash_is_deterministic() {
+        let policy = example_bubl_policy();
+        let h1 = policy_hash(&policy).unwrap();
+        let h2 = policy_hash(&policy).unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn rejects_wrong_schema() {
+        let mut policy = example_bubl_policy();
+        policy.schema = "zhtp/rewards-policy/v0".to_string();
+        assert!(validate_rewards_policy_value(&policy).is_err());
+    }
+}

--- a/lib-blockchain/src/rewards_policy/validate.rs
+++ b/lib-blockchain/src/rewards_policy/validate.rs
@@ -133,14 +133,17 @@ fn validate_trigger(t: &RewardsTrigger) -> Result<(), RewardsPolicyError> {
 
     match t.kind {
         TriggerKind::OncePerDid => {
+            if event != RewardsPolicyEvent::Welcome {
+                return Err(RewardsPolicyError::InvalidAmount {
+                    trigger_id: id.clone(),
+                    reason: "once_per_did must pair with event welcome".to_string(),
+                });
+            }
             let amount = t.amount_atoms.ok_or(RewardsPolicyError::MissingField {
                 trigger_id: id.clone(),
                 field: "amount_atoms",
             })?;
             require_positive(id, amount)?;
-            if event != RewardsPolicyEvent::Welcome {
-                // allowed but warn via validation — welcome is the expected pairing
-            }
         }
         TriggerKind::OncePerUtcDay => {
             if let Some(amount) = t.amount_atoms {
@@ -199,10 +202,32 @@ fn require_positive(trigger_id: &str, amount: u128) -> Result<(), RewardsPolicyE
     Ok(())
 }
 
-/// Canonical JSON bytes for hashing (sorted keys, compact).
+fn canonicalize_json_value(value: &serde_json::Value) -> serde_json::Value {
+    use serde_json::{Map, Value};
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<_> = map.keys().cloned().collect();
+            keys.sort();
+            let mut out = Map::new();
+            for k in keys {
+                if let Some(v) = map.get(&k) {
+                    out.insert(k, canonicalize_json_value(v));
+                }
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(canonicalize_json_value).collect()),
+        other => other.clone(),
+    }
+}
+
+/// Canonical JSON bytes for hashing (recursively sorted object keys, compact).
 pub fn canonical_policy_bytes(policy: &RewardsPolicyV1) -> Result<Vec<u8>, RewardsPolicyError> {
     validate_rewards_policy_value(policy)?;
-    serde_json::to_vec(policy).map_err(|e| RewardsPolicyError::InvalidJson(e.to_string()))
+    let value =
+        serde_json::to_value(policy).map_err(|e| RewardsPolicyError::InvalidJson(e.to_string()))?;
+    let canon = canonicalize_json_value(&value);
+    serde_json::to_vec(&canon).map_err(|e| RewardsPolicyError::InvalidJson(e.to_string()))
 }
 
 /// BLAKE3 hash of canonical policy JSON — stored on-chain as `policy_hash`.
@@ -233,6 +258,72 @@ pub fn expected_amount_for_trigger(
             }
         }
     }
+}
+
+/// Canonical BUBL policy matching executor reward schedule (schema-backed).
+pub fn legacy_bubl_policy() -> RewardsPolicyV1 {
+    use super::types::StreakBonus;
+    use bubl_canonical::*;
+    RewardsPolicyV1 {
+        schema: REWARDS_POLICY_SCHEMA_V1.to_string(),
+        asset_id: "00".repeat(32),
+        description: Some("canonical BUBL TokenCreation rewards".to_string()),
+        triggers: vec![
+            RewardsTrigger {
+                id: "welcome".to_string(),
+                kind: TriggerKind::OncePerDid,
+                enabled: true,
+                event: Some(RewardsPolicyEvent::Welcome),
+                amount_atoms: Some(WELCOME),
+                base_amount_atoms: None,
+                streak_bonus: None,
+                weekly_cap: None,
+            },
+            RewardsTrigger {
+                id: "daily_checkin".to_string(),
+                kind: TriggerKind::OncePerUtcDay,
+                enabled: true,
+                event: Some(RewardsPolicyEvent::DailyCheckin),
+                amount_atoms: None,
+                base_amount_atoms: Some(CHECKIN_BASE),
+                streak_bonus: Some(StreakBonus {
+                    per_day_atoms: STREAK_PER_DAY,
+                    cap_days: STREAK_CAP_DAYS,
+                }),
+                weekly_cap: None,
+            },
+            RewardsTrigger {
+                id: "active_session".to_string(),
+                kind: TriggerKind::OncePerUtcDay,
+                enabled: true,
+                event: Some(RewardsPolicyEvent::ActiveSession),
+                amount_atoms: Some(ACTIVE_SESSION),
+                base_amount_atoms: None,
+                streak_bonus: None,
+                weekly_cap: None,
+            },
+            RewardsTrigger {
+                id: "new_partner".to_string(),
+                kind: TriggerKind::DistinctPeerPerIsoWeek,
+                enabled: true,
+                event: Some(RewardsPolicyEvent::NewPartner),
+                amount_atoms: Some(NEW_PARTNER),
+                base_amount_atoms: None,
+                streak_bonus: None,
+                weekly_cap: Some(WEEKLY_PARTNER_CAP),
+            },
+        ],
+        budget: None,
+    }
+}
+
+pub fn weekly_partner_cap(policy: &RewardsPolicyV1) -> u32 {
+    policy
+        .triggers
+        .iter()
+        .find(|t| t.enabled && t.event == Some(RewardsPolicyEvent::NewPartner))
+        .and_then(|t| t.weekly_cap)
+        .unwrap_or(0)
 }
 
 /// BUBL canonical constants for regression tests (18-decimal atoms).
@@ -360,6 +451,40 @@ mod tests {
     fn rejects_wrong_schema() {
         let mut policy = example_bubl_policy();
         policy.schema = "zhtp/rewards-policy/v0".to_string();
+        assert!(validate_rewards_policy_value(&policy).is_err());
+    }
+
+    #[test]
+    fn canonicalize_json_sorts_object_keys() {
+        use serde_json::json;
+        let unordered = json!({"z": 1, "a": 2, "m": 3});
+        let ordered = json!({"a": 2, "m": 3, "z": 1});
+        assert_eq!(
+            canonicalize_json_value(&unordered),
+            canonicalize_json_value(&ordered)
+        );
+    }
+
+    #[test]
+    fn canonical_policy_bytes_stable_across_field_order() {
+        let policy = example_bubl_policy();
+        let bytes_a = canonical_policy_bytes(&policy).unwrap();
+        let mut value = serde_json::to_value(&policy).unwrap();
+        if let serde_json::Value::Object(ref mut map) = value {
+            let desc = map.remove("description").unwrap();
+            let schema = map.remove("schema").unwrap();
+            map.insert("description".to_string(), desc);
+            map.insert("schema".to_string(), schema);
+        }
+        let policy_reordered: RewardsPolicyV1 = serde_json::from_value(value).unwrap();
+        let bytes_b = canonical_policy_bytes(&policy_reordered).unwrap();
+        assert_eq!(bytes_a, bytes_b);
+    }
+
+    #[test]
+    fn rejects_once_per_did_with_non_welcome_event() {
+        let mut policy = example_bubl_policy();
+        policy.triggers[0].event = Some(RewardsPolicyEvent::DailyCheckin);
         assert!(validate_rewards_policy_value(&policy).is_err());
     }
 }

--- a/lib-blockchain/src/rewards_policy/validate.rs
+++ b/lib-blockchain/src/rewards_policy/validate.rs
@@ -250,10 +250,14 @@ pub fn expected_amount_for_trigger(
                 Some(fixed)
             } else {
                 let base = trigger.base_amount_atoms?;
-                let bonus = trigger.streak_bonus.as_ref().map(|sb| {
-                    let days = streak_day.saturating_sub(1).min(sb.cap_days) as u128;
-                    sb.per_day_atoms.saturating_mul(days)
-                })?;
+                let bonus = trigger
+                    .streak_bonus
+                    .as_ref()
+                    .map(|sb| {
+                        let days = streak_day.saturating_sub(1).min(sb.cap_days) as u128;
+                        sb.per_day_atoms.saturating_mul(days)
+                    })
+                    .unwrap_or(0);
                 Some(base.saturating_add(bonus))
             }
         }
@@ -264,7 +268,7 @@ pub fn expected_amount_for_trigger(
 pub fn legacy_bubl_policy() -> RewardsPolicyV1 {
     use super::types::StreakBonus;
     use bubl_canonical::*;
-    RewardsPolicyV1 {
+    let policy = RewardsPolicyV1 {
         schema: REWARDS_POLICY_SCHEMA_V1.to_string(),
         asset_id: "00".repeat(32),
         description: Some("canonical BUBL TokenCreation rewards".to_string()),
@@ -314,7 +318,9 @@ pub fn legacy_bubl_policy() -> RewardsPolicyV1 {
             },
         ],
         budget: None,
-    }
+    };
+    validate_rewards_policy_value(&policy).expect("legacy BUBL policy must validate");
+    policy
 }
 
 pub fn weekly_partner_cap(policy: &RewardsPolicyV1) -> u32 {
@@ -411,6 +417,17 @@ mod tests {
         let bytes = std::fs::read(path).expect("read bubl example");
         let policy = validate_rewards_policy(&bytes).expect("valid");
         assert_eq!(policy.triggers.len(), 4);
+    }
+
+    #[test]
+    fn base_amount_without_streak_bonus_is_valid() {
+        let mut policy = example_bubl_policy();
+        policy.triggers[1].streak_bonus = None;
+        assert!(validate_rewards_policy_value(&policy).is_ok());
+        assert_eq!(
+            expected_amount_for_trigger(&policy, RewardsPolicyEvent::DailyCheckin, 5),
+            Some(CHECKIN_BASE)
+        );
     }
 
     #[test]

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -2116,6 +2116,89 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
         Ok(None)
     }
 
+    // =========================================================================
+    // BUBL reward claim eligibility (chain-native caps)
+    // =========================================================================
+
+    fn get_bubl_reward_welcome(&self, did: &str) -> StorageResult<Option<u64>> {
+        let _ = did;
+        Ok(None)
+    }
+
+    fn put_bubl_reward_welcome(&self, did: &str, height: u64) -> StorageResult<()> {
+        let _ = (did, height);
+        Ok(())
+    }
+
+    fn get_bubl_reward_daily(&self, key: &str) -> StorageResult<Option<u64>> {
+        let _ = key;
+        Ok(None)
+    }
+
+    fn put_bubl_reward_daily(&self, key: &str, height: u64) -> StorageResult<()> {
+        let _ = (key, height);
+        Ok(())
+    }
+
+    fn get_bubl_reward_partner(&self, key: &str) -> StorageResult<Option<u64>> {
+        let _ = key;
+        Ok(None)
+    }
+
+    fn put_bubl_reward_partner(&self, key: &str, height: u64) -> StorageResult<()> {
+        let _ = (key, height);
+        Ok(())
+    }
+
+    fn get_bubl_reward_partner_count(&self, key: &str) -> StorageResult<Option<u32>> {
+        let _ = key;
+        Ok(None)
+    }
+
+    fn put_bubl_reward_partner_count(&self, key: &str, count: u32) -> StorageResult<()> {
+        let _ = (key, count);
+        Ok(())
+    }
+
+    fn get_bubl_reward_streak(
+        &self,
+        did: &str,
+    ) -> StorageResult<Option<crate::transaction::RewardStreakRecord>> {
+        let _ = did;
+        Ok(None)
+    }
+
+    fn put_bubl_reward_streak(
+        &self,
+        did: &str,
+        streak: &crate::transaction::RewardStreakRecord,
+    ) -> StorageResult<()> {
+        let _ = (did, streak);
+        Ok(())
+    }
+
+    fn iter_bubl_reward_welcome(&self) -> StorageResult<Vec<(String, u64)>> {
+        Ok(vec![])
+    }
+
+    fn iter_bubl_reward_daily(&self) -> StorageResult<Vec<(String, u64)>> {
+        Ok(vec![])
+    }
+
+    fn iter_bubl_reward_partner(&self) -> StorageResult<Vec<(String, u64)>> {
+        Ok(vec![])
+    }
+
+    fn iter_bubl_reward_partner_count(&self) -> StorageResult<Vec<(String, u32)>> {
+        Ok(vec![])
+    }
+
+    fn iter_bubl_reward_streak(
+        &self,
+    ) -> StorageResult<Vec<(String, crate::transaction::RewardStreakRecord)>> {
+        Ok(vec![])
+    }
+
     /// Persist the canonical observer admission policy.
     ///
     /// This is a metadata write — like `save_oracle_state`, it does not

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -862,6 +862,10 @@ pub enum StorageError {
     #[error("Storage not initialized")]
     NotInitialized,
 
+    /// Store backend does not implement this method (fail closed).
+    #[error("Storage method not implemented: {0}")]
+    NotImplemented(String),
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -2118,46 +2122,65 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
 
     // =========================================================================
     // BUBL reward claim eligibility (chain-native caps)
+    //
+    // **P0:** Default impls return `NotImplemented` — never silently report
+    // "never claimed". Only `SledStore` (or explicit overrides) may serve reads.
     // =========================================================================
 
     fn get_bubl_reward_welcome(&self, did: &str) -> StorageResult<Option<u64>> {
         let _ = did;
-        Ok(None)
+        Err(StorageError::NotImplemented(
+            "get_bubl_reward_welcome requires SledStore".into(),
+        ))
     }
 
     fn put_bubl_reward_welcome(&self, did: &str, height: u64) -> StorageResult<()> {
         let _ = (did, height);
-        Ok(())
+        Err(StorageError::NotImplemented(
+            "put_bubl_reward_welcome requires SledStore".into(),
+        ))
     }
 
     fn get_bubl_reward_daily(&self, key: &str) -> StorageResult<Option<u64>> {
         let _ = key;
-        Ok(None)
+        Err(StorageError::NotImplemented(
+            "get_bubl_reward_daily requires SledStore".into(),
+        ))
     }
 
     fn put_bubl_reward_daily(&self, key: &str, height: u64) -> StorageResult<()> {
         let _ = (key, height);
-        Ok(())
+        Err(StorageError::NotImplemented(
+            "put_bubl_reward_daily requires SledStore".into(),
+        ))
     }
 
     fn get_bubl_reward_partner(&self, key: &str) -> StorageResult<Option<u64>> {
         let _ = key;
-        Ok(None)
+        Err(StorageError::NotImplemented(
+            "get_bubl_reward_partner requires SledStore".into(),
+        ))
     }
 
     fn put_bubl_reward_partner(&self, key: &str, height: u64) -> StorageResult<()> {
         let _ = (key, height);
-        Ok(())
+        Err(StorageError::NotImplemented(
+            "put_bubl_reward_partner requires SledStore".into(),
+        ))
     }
 
     fn get_bubl_reward_partner_count(&self, key: &str) -> StorageResult<Option<u32>> {
         let _ = key;
-        Ok(None)
+        Err(StorageError::NotImplemented(
+            "get_bubl_reward_partner_count requires SledStore".into(),
+        ))
     }
 
     fn put_bubl_reward_partner_count(&self, key: &str, count: u32) -> StorageResult<()> {
         let _ = (key, count);
-        Ok(())
+        Err(StorageError::NotImplemented(
+            "put_bubl_reward_partner_count requires SledStore".into(),
+        ))
     }
 
     fn get_bubl_reward_streak(
@@ -2165,7 +2188,9 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
         did: &str,
     ) -> StorageResult<Option<crate::transaction::RewardStreakRecord>> {
         let _ = did;
-        Ok(None)
+        Err(StorageError::NotImplemented(
+            "get_bubl_reward_streak requires SledStore".into(),
+        ))
     }
 
     fn put_bubl_reward_streak(
@@ -2174,29 +2199,41 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
         streak: &crate::transaction::RewardStreakRecord,
     ) -> StorageResult<()> {
         let _ = (did, streak);
-        Ok(())
+        Err(StorageError::NotImplemented(
+            "put_bubl_reward_streak requires SledStore".into(),
+        ))
     }
 
     fn iter_bubl_reward_welcome(&self) -> StorageResult<Vec<(String, u64)>> {
-        Ok(vec![])
+        Err(StorageError::NotImplemented(
+            "iter_bubl_reward_welcome requires SledStore".into(),
+        ))
     }
 
     fn iter_bubl_reward_daily(&self) -> StorageResult<Vec<(String, u64)>> {
-        Ok(vec![])
+        Err(StorageError::NotImplemented(
+            "iter_bubl_reward_daily requires SledStore".into(),
+        ))
     }
 
     fn iter_bubl_reward_partner(&self) -> StorageResult<Vec<(String, u64)>> {
-        Ok(vec![])
+        Err(StorageError::NotImplemented(
+            "iter_bubl_reward_partner requires SledStore".into(),
+        ))
     }
 
     fn iter_bubl_reward_partner_count(&self) -> StorageResult<Vec<(String, u32)>> {
-        Ok(vec![])
+        Err(StorageError::NotImplemented(
+            "iter_bubl_reward_partner_count requires SledStore".into(),
+        ))
     }
 
     fn iter_bubl_reward_streak(
         &self,
     ) -> StorageResult<Vec<(String, crate::transaction::RewardStreakRecord)>> {
-        Ok(vec![])
+        Err(StorageError::NotImplemented(
+            "iter_bubl_reward_streak requires SledStore".into(),
+        ))
     }
 
     /// Persist the canonical observer admission policy.

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -52,6 +52,11 @@ const TREE_PENDING_TRANSACTIONS: &str = "pending_transactions"; // Non-consensus
 const TREE_QUORUM_PROOFS: &str = "quorum_proofs"; // BFT quorum proofs by height
 const TREE_DAO_STAKES: &str = "dao_stakes"; // SOV stakes to sector DAOs: dao_key_id||staker → DaoStakeRecord
 const TREE_OBSERVER_REGISTRY: &str = "observer_registry"; // Observer admission records: did_hash → ObserverAdmissionRecord
+const TREE_BUBL_REWARD_WELCOME: &str = "bubl_reward_welcome";
+const TREE_BUBL_REWARD_DAILY: &str = "bubl_reward_daily";
+const TREE_BUBL_REWARD_PARTNER: &str = "bubl_reward_partner";
+const TREE_BUBL_REWARD_PARTNER_COUNT: &str = "bubl_reward_partner_count";
+const TREE_BUBL_REWARD_STREAK: &str = "bubl_reward_streak";
 const TREE_META: &str = "meta";
 const TREE_WAL: &str = "wal_block_commit"; // Write-ahead log for crash-safe block commits
 const TREE_FORK_POINTS: &str = "fork_points"; // Fork audit log — direct durable writes
@@ -112,6 +117,11 @@ pub struct SledStore {
     quorum_proofs: Tree,         // BFT quorum proofs by height
     dao_stakes: Tree,            // SOV stakes: dao_key_id (32) || staker (32) → DaoStakeRecord
     observer_registry: Tree,     // Observer admission: did_hash (32) → ObserverAdmissionRecord
+    bubl_reward_welcome: Tree,
+    bubl_reward_daily: Tree,
+    bubl_reward_partner: Tree,
+    bubl_reward_partner_count: Tree,
+    bubl_reward_streak: Tree,
     utxo_merkle_leaves: Tree,    // leaf_index (u64 BE) → [u8; 32] leaf hash
     utxo_merkle_index: Tree,     // outpoint (36 bytes) → leaf_index (u64 BE)
     utxo_merkle_meta: Tree,      // metadata: next_leaf_index, current_root
@@ -390,6 +400,21 @@ impl SledStore {
         let observer_registry = db
             .open_tree(TREE_OBSERVER_REGISTRY)
             .map_err(|e| StorageError::Database(e.to_string()))?;
+        let bubl_reward_welcome = db
+            .open_tree(TREE_BUBL_REWARD_WELCOME)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let bubl_reward_daily = db
+            .open_tree(TREE_BUBL_REWARD_DAILY)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let bubl_reward_partner = db
+            .open_tree(TREE_BUBL_REWARD_PARTNER)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let bubl_reward_partner_count = db
+            .open_tree(TREE_BUBL_REWARD_PARTNER_COUNT)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        let bubl_reward_streak = db
+            .open_tree(TREE_BUBL_REWARD_STREAK)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
         let utxo_merkle_leaves = db
             .open_tree(TREE_UTXO_MERKLE_LEAVES)
             .map_err(|e| StorageError::Database(e.to_string()))?;
@@ -482,6 +507,11 @@ impl SledStore {
             quorum_proofs,
             dao_stakes,
             observer_registry,
+            bubl_reward_welcome,
+            bubl_reward_daily,
+            bubl_reward_partner,
+            bubl_reward_partner_count,
+            bubl_reward_streak,
             utxo_merkle_leaves,
             utxo_merkle_index,
             utxo_merkle_meta,
@@ -898,6 +928,11 @@ impl SledStore {
             TREE_CBE_ACCOUNTS => &self.cbe_accounts,
             TREE_DAO_STAKES => &self.dao_stakes,
             TREE_OBSERVER_REGISTRY => &self.observer_registry,
+            TREE_BUBL_REWARD_WELCOME => &self.bubl_reward_welcome,
+            TREE_BUBL_REWARD_DAILY => &self.bubl_reward_daily,
+            TREE_BUBL_REWARD_PARTNER => &self.bubl_reward_partner,
+            TREE_BUBL_REWARD_PARTNER_COUNT => &self.bubl_reward_partner_count,
+            TREE_BUBL_REWARD_STREAK => &self.bubl_reward_streak,
             TREE_UTXO_MERKLE_LEAVES => &self.utxo_merkle_leaves,
             TREE_UTXO_MERKLE_INDEX => &self.utxo_merkle_index,
             TREE_UTXO_MERKLE_META => &self.utxo_merkle_meta,
@@ -1065,6 +1100,40 @@ impl SledStore {
             .flush()
             .map_err(|e| StorageError::Database(e.to_string()))?;
         Ok(())
+    }
+
+    fn staged_u64_lookup(&self, tree: &'static str, key: &[u8]) -> Option<Option<u64>> {
+        let batch_guard = self.tx_batch.lock().ok()?;
+        let batch = batch_guard.as_ref()?;
+        let staged = batch.tree_lookup(tree, key)?;
+        staged.map(|bytes| {
+            let arr: [u8; 8] = bytes.as_ref().try_into().ok()?;
+            Some(u64::from_le_bytes(arr))
+        })
+    }
+
+    fn staged_u32_lookup(&self, tree: &'static str, key: &[u8]) -> Option<Option<u32>> {
+        let batch_guard = self.tx_batch.lock().ok()?;
+        let batch = batch_guard.as_ref()?;
+        let staged = batch.tree_lookup(tree, key)?;
+        staged.map(|bytes| {
+            let arr: [u8; 4] = bytes.as_ref().try_into().ok()?;
+            Some(u32::from_le_bytes(arr))
+        })
+    }
+
+    fn put_in_block_batch(&self, tree: &'static str, key: &[u8], value: Vec<u8>) -> StorageResult<()> {
+        let mut guard = self.tx_batch.lock().map_err(|e| {
+            StorageError::Database(format!("lock poisoned in put_in_block_batch: {e}"))
+        })?;
+        if let Some(batch) = guard.as_mut() {
+            batch.tree(tree).insert(key, value);
+            Ok(())
+        } else {
+            Err(StorageError::Database(
+                "put_in_block_batch called outside begin_block/commit_block".to_owned(),
+            ))
+        }
     }
 }
 
@@ -3349,6 +3418,192 @@ impl BlockchainStore for SledStore {
             }
         }
         Ok(records)
+    }
+
+    // =========================================================================
+    // BUBL reward claim eligibility
+    // =========================================================================
+
+    fn get_bubl_reward_welcome(&self, did: &str) -> StorageResult<Option<u64>> {
+        let key = did.as_bytes();
+        if let Some(staged) = self.staged_u64_lookup(TREE_BUBL_REWARD_WELCOME, key) {
+            return Ok(staged);
+        }
+        match self.bubl_reward_welcome.get(key) {
+            Ok(Some(bytes)) if bytes.len() == 8 => Ok(Some(u64::from_le_bytes(
+                bytes.as_ref().try_into().unwrap(),
+            ))),
+            Ok(_) => Ok(None),
+            Err(e) => Err(StorageError::Database(e.to_string())),
+        }
+    }
+
+    fn put_bubl_reward_welcome(&self, did: &str, height: u64) -> StorageResult<()> {
+        self.put_in_block_batch(
+            TREE_BUBL_REWARD_WELCOME,
+            did.as_bytes(),
+            height.to_le_bytes().to_vec(),
+        )
+    }
+
+    fn get_bubl_reward_daily(&self, key: &str) -> StorageResult<Option<u64>> {
+        let key = key.as_bytes();
+        if let Some(staged) = self.staged_u64_lookup(TREE_BUBL_REWARD_DAILY, key) {
+            return Ok(staged);
+        }
+        match self.bubl_reward_daily.get(key) {
+            Ok(Some(bytes)) if bytes.len() == 8 => Ok(Some(u64::from_le_bytes(
+                bytes.as_ref().try_into().unwrap(),
+            ))),
+            Ok(_) => Ok(None),
+            Err(e) => Err(StorageError::Database(e.to_string())),
+        }
+    }
+
+    fn put_bubl_reward_daily(&self, key: &str, height: u64) -> StorageResult<()> {
+        self.put_in_block_batch(
+            TREE_BUBL_REWARD_DAILY,
+            key.as_bytes(),
+            height.to_le_bytes().to_vec(),
+        )
+    }
+
+    fn get_bubl_reward_partner(&self, key: &str) -> StorageResult<Option<u64>> {
+        let key = key.as_bytes();
+        if let Some(staged) = self.staged_u64_lookup(TREE_BUBL_REWARD_PARTNER, key) {
+            return Ok(staged);
+        }
+        match self.bubl_reward_partner.get(key) {
+            Ok(Some(bytes)) if bytes.len() == 8 => Ok(Some(u64::from_le_bytes(
+                bytes.as_ref().try_into().unwrap(),
+            ))),
+            Ok(_) => Ok(None),
+            Err(e) => Err(StorageError::Database(e.to_string())),
+        }
+    }
+
+    fn put_bubl_reward_partner(&self, key: &str, height: u64) -> StorageResult<()> {
+        self.put_in_block_batch(
+            TREE_BUBL_REWARD_PARTNER,
+            key.as_bytes(),
+            height.to_le_bytes().to_vec(),
+        )
+    }
+
+    fn get_bubl_reward_partner_count(&self, key: &str) -> StorageResult<Option<u32>> {
+        let key = key.as_bytes();
+        if let Some(staged) = self.staged_u32_lookup(TREE_BUBL_REWARD_PARTNER_COUNT, key) {
+            return Ok(staged);
+        }
+        match self.bubl_reward_partner_count.get(key) {
+            Ok(Some(bytes)) if bytes.len() == 4 => Ok(Some(u32::from_le_bytes(
+                bytes.as_ref().try_into().unwrap(),
+            ))),
+            Ok(_) => Ok(None),
+            Err(e) => Err(StorageError::Database(e.to_string())),
+        }
+    }
+
+    fn put_bubl_reward_partner_count(&self, key: &str, count: u32) -> StorageResult<()> {
+        self.put_in_block_batch(
+            TREE_BUBL_REWARD_PARTNER_COUNT,
+            key.as_bytes(),
+            count.to_le_bytes().to_vec(),
+        )
+    }
+
+    fn get_bubl_reward_streak(
+        &self,
+        did: &str,
+    ) -> StorageResult<Option<crate::transaction::RewardStreakRecord>> {
+        let key = did.as_bytes();
+        {
+            let batch_guard = self.tx_batch.lock().map_err(|e| {
+                StorageError::Database(format!("lock poisoned in get_bubl_reward_streak: {e}"))
+            })?;
+            if let Some(ref batch) = *batch_guard {
+                if let Some(staged) = batch.tree_lookup(TREE_BUBL_REWARD_STREAK, key) {
+                    return match staged {
+                        Some(bytes) => Ok(Some(Self::deserialize(&bytes)?)),
+                        None => Ok(None),
+                    };
+                }
+            }
+        }
+        match self.bubl_reward_streak.get(key) {
+            Ok(Some(bytes)) => Ok(Some(Self::deserialize(&bytes)?)),
+            Ok(None) => Ok(None),
+            Err(e) => Err(StorageError::Database(e.to_string())),
+        }
+    }
+
+    fn put_bubl_reward_streak(
+        &self,
+        did: &str,
+        streak: &crate::transaction::RewardStreakRecord,
+    ) -> StorageResult<()> {
+        let bytes = Self::serialize(streak)?;
+        self.put_in_block_batch(TREE_BUBL_REWARD_STREAK, did.as_bytes(), bytes)
+    }
+
+    fn iter_bubl_reward_welcome(&self) -> StorageResult<Vec<(String, u64)>> {
+        let mut out = Vec::new();
+        for result in self.bubl_reward_welcome.iter() {
+            let (key, bytes) = result.map_err(|e| StorageError::Database(e.to_string()))?;
+            if bytes.len() == 8 {
+                let height = u64::from_le_bytes(bytes.as_ref().try_into().unwrap());
+                out.push((String::from_utf8_lossy(&key).into_owned(), height));
+            }
+        }
+        Ok(out)
+    }
+
+    fn iter_bubl_reward_daily(&self) -> StorageResult<Vec<(String, u64)>> {
+        let mut out = Vec::new();
+        for result in self.bubl_reward_daily.iter() {
+            let (key, bytes) = result.map_err(|e| StorageError::Database(e.to_string()))?;
+            if bytes.len() == 8 {
+                let height = u64::from_le_bytes(bytes.as_ref().try_into().unwrap());
+                out.push((String::from_utf8_lossy(&key).into_owned(), height));
+            }
+        }
+        Ok(out)
+    }
+
+    fn iter_bubl_reward_partner(&self) -> StorageResult<Vec<(String, u64)>> {
+        let mut out = Vec::new();
+        for result in self.bubl_reward_partner.iter() {
+            let (key, bytes) = result.map_err(|e| StorageError::Database(e.to_string()))?;
+            if bytes.len() == 8 {
+                let height = u64::from_le_bytes(bytes.as_ref().try_into().unwrap());
+                out.push((String::from_utf8_lossy(&key).into_owned(), height));
+            }
+        }
+        Ok(out)
+    }
+
+    fn iter_bubl_reward_partner_count(&self) -> StorageResult<Vec<(String, u32)>> {
+        let mut out = Vec::new();
+        for result in self.bubl_reward_partner_count.iter() {
+            let (key, bytes) = result.map_err(|e| StorageError::Database(e.to_string()))?;
+            if bytes.len() == 4 {
+                let count = u32::from_le_bytes(bytes.as_ref().try_into().unwrap());
+                out.push((String::from_utf8_lossy(&key).into_owned(), count));
+            }
+        }
+        Ok(out)
+    }
+
+    fn iter_bubl_reward_streak(
+        &self,
+    ) -> StorageResult<Vec<(String, crate::transaction::RewardStreakRecord)>> {
+        let mut out = Vec::new();
+        for result in self.bubl_reward_streak.iter() {
+            let (key, bytes) = result.map_err(|e| StorageError::Database(e.to_string()))?;
+            let streak: crate::transaction::RewardStreakRecord = Self::deserialize(&bytes)?;
+            out.push((String::from_utf8_lossy(&key).into_owned(), streak));
+        }
+        Ok(out)
     }
 
     fn get_observer_policy(

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1102,24 +1102,52 @@ impl SledStore {
         Ok(())
     }
 
-    fn staged_u64_lookup(&self, tree: &'static str, key: &[u8]) -> Option<Option<u64>> {
-        let batch_guard = self.tx_batch.lock().ok()?;
-        let batch = batch_guard.as_ref()?;
-        let staged = batch.tree_lookup(tree, key)?;
-        staged.map(|bytes| {
-            let arr: [u8; 8] = bytes.as_ref().try_into().ok()?;
-            Some(u64::from_le_bytes(arr))
-        })
+    fn staged_u64_lookup(
+        &self,
+        tree: &'static str,
+        key: &[u8],
+    ) -> StorageResult<Option<Option<u64>>> {
+        let batch_guard = self.tx_batch.lock().map_err(|e| {
+            StorageError::Database(format!("tx_batch lock poisoned in staged_u64_lookup: {e}"))
+        })?;
+        let Some(batch) = batch_guard.as_ref() else {
+            return Ok(None);
+        };
+        let Some(staged) = batch.tree_lookup(tree, key) else {
+            return Ok(None);
+        };
+        let Some(bytes) = staged else {
+            return Ok(Some(None));
+        };
+        let arr: [u8; 8] = bytes
+            .as_ref()
+            .try_into()
+            .map_err(|_| StorageError::Database("staged u64 value wrong length".into()))?;
+        Ok(Some(Some(u64::from_le_bytes(arr))))
     }
 
-    fn staged_u32_lookup(&self, tree: &'static str, key: &[u8]) -> Option<Option<u32>> {
-        let batch_guard = self.tx_batch.lock().ok()?;
-        let batch = batch_guard.as_ref()?;
-        let staged = batch.tree_lookup(tree, key)?;
-        staged.map(|bytes| {
-            let arr: [u8; 4] = bytes.as_ref().try_into().ok()?;
-            Some(u32::from_le_bytes(arr))
-        })
+    fn staged_u32_lookup(
+        &self,
+        tree: &'static str,
+        key: &[u8],
+    ) -> StorageResult<Option<Option<u32>>> {
+        let batch_guard = self.tx_batch.lock().map_err(|e| {
+            StorageError::Database(format!("tx_batch lock poisoned in staged_u32_lookup: {e}"))
+        })?;
+        let Some(batch) = batch_guard.as_ref() else {
+            return Ok(None);
+        };
+        let Some(staged) = batch.tree_lookup(tree, key) else {
+            return Ok(None);
+        };
+        let Some(bytes) = staged else {
+            return Ok(Some(None));
+        };
+        let arr: [u8; 4] = bytes
+            .as_ref()
+            .try_into()
+            .map_err(|_| StorageError::Database("staged u32 value wrong length".into()))?;
+        Ok(Some(Some(u32::from_le_bytes(arr))))
     }
 
     fn put_in_block_batch(&self, tree: &'static str, key: &[u8], value: Vec<u8>) -> StorageResult<()> {
@@ -3426,7 +3454,7 @@ impl BlockchainStore for SledStore {
 
     fn get_bubl_reward_welcome(&self, did: &str) -> StorageResult<Option<u64>> {
         let key = did.as_bytes();
-        if let Some(staged) = self.staged_u64_lookup(TREE_BUBL_REWARD_WELCOME, key) {
+        if let Some(staged) = self.staged_u64_lookup(TREE_BUBL_REWARD_WELCOME, key)? {
             return Ok(staged);
         }
         match self.bubl_reward_welcome.get(key) {
@@ -3448,7 +3476,7 @@ impl BlockchainStore for SledStore {
 
     fn get_bubl_reward_daily(&self, key: &str) -> StorageResult<Option<u64>> {
         let key = key.as_bytes();
-        if let Some(staged) = self.staged_u64_lookup(TREE_BUBL_REWARD_DAILY, key) {
+        if let Some(staged) = self.staged_u64_lookup(TREE_BUBL_REWARD_DAILY, key)? {
             return Ok(staged);
         }
         match self.bubl_reward_daily.get(key) {
@@ -3470,7 +3498,7 @@ impl BlockchainStore for SledStore {
 
     fn get_bubl_reward_partner(&self, key: &str) -> StorageResult<Option<u64>> {
         let key = key.as_bytes();
-        if let Some(staged) = self.staged_u64_lookup(TREE_BUBL_REWARD_PARTNER, key) {
+        if let Some(staged) = self.staged_u64_lookup(TREE_BUBL_REWARD_PARTNER, key)? {
             return Ok(staged);
         }
         match self.bubl_reward_partner.get(key) {
@@ -3492,7 +3520,7 @@ impl BlockchainStore for SledStore {
 
     fn get_bubl_reward_partner_count(&self, key: &str) -> StorageResult<Option<u32>> {
         let key = key.as_bytes();
-        if let Some(staged) = self.staged_u32_lookup(TREE_BUBL_REWARD_PARTNER_COUNT, key) {
+        if let Some(staged) = self.staged_u32_lookup(TREE_BUBL_REWARD_PARTNER_COUNT, key)? {
             return Ok(staged);
         }
         match self.bubl_reward_partner_count.get(key) {

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -880,6 +880,26 @@ impl Transaction {
         }
     }
 
+    /// Create a BUBL reward claim transaction (chain-enforced eligibility).
+    pub fn new_reward_claim_with_chain_id(
+        chain_id: u8,
+        data: crate::transaction::reward_claim::RewardClaimData,
+        signature: Signature,
+        memo: Vec<u8>,
+    ) -> Self {
+        Transaction {
+            version: TX_VERSION_V8,
+            chain_id,
+            transaction_type: TransactionType::RewardClaim,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            fee: 0,
+            signature,
+            memo,
+            payload: TransactionPayload::RewardClaim(data),
+        }
+    }
+
     /// Create a new token mint transaction (balance model).
     pub fn new_token_mint(
         token_mint_data: TokenMintData,
@@ -1370,6 +1390,12 @@ impl Transaction {
     pub fn token_transfer_data(&self) -> Option<&TokenTransferData> {
         match &self.payload {
             TransactionPayload::TokenTransfer(d) => Some(d),
+            _ => None,
+        }
+    }
+    pub fn reward_claim_data(&self) -> Option<&crate::transaction::reward_claim::RewardClaimData> {
+        match &self.payload {
+            TransactionPayload::RewardClaim(d) => Some(d),
             _ => None,
         }
     }
@@ -2842,4 +2868,5 @@ pub enum TransactionPayload {
     // User credentials (username + password for public zone access)
     RegisterCredential(crate::transaction::credentials::RegisterCredentialData),
     UpdateCredentialPassword(crate::transaction::credentials::UpdateCredentialPasswordData),
+    RewardClaim(crate::transaction::reward_claim::RewardClaimData),
 }

--- a/lib-blockchain/src/transaction/creation.rs
+++ b/lib-blockchain/src/transaction/creation.rs
@@ -744,6 +744,11 @@ pub mod utils {
                     return Err(TransactionCreateError::InvalidOutputs);
                 }
             }
+            TransactionType::RewardClaim => {
+                if !inputs.is_empty() || !outputs.is_empty() {
+                    return Err(TransactionCreateError::InvalidInputs);
+                }
+            }
             TransactionType::GovernanceConfigUpdate => {
                 // Governance config updates - validation will be handled during transaction validation
                 // Requires governance_config_data and caller must have Governance role

--- a/lib-blockchain/src/transaction/domain.rs
+++ b/lib-blockchain/src/transaction/domain.rs
@@ -295,4 +295,256 @@ mod tests {
         let bogus = b"DOMREG9:garbage".to_vec();
         assert!(DomainRegistrationPayload::decode_memo(&bogus).is_err());
     }
+
+    #[test]
+    fn cons516_rejects_fee_tx_hash_not_in_mempool() {
+        use crate::blockchain::Blockchain;
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+        use crate::transaction::Transaction;
+        use crate::types::transaction_type::TransactionType;
+
+        let bc = Blockchain::default();
+        let signer = [0x11u8; 32];
+        let payload = DomainRegistrationPayload {
+            domain: "evil.sov".to_string(),
+            owner_did: format!("did:zhtp:{}", hex::encode(signer)),
+            manifest_cid: String::new(),
+            build_hash: String::new(),
+            title: String::new(),
+            description: String::new(),
+            category: "test".to_string(),
+            tags: vec![],
+            duration_days: 365,
+            fee_tx_hash: "ab".repeat(32),
+            fee_amount_atoms: 0,
+            fee_payer_wallet_id: [0u8; 32],
+        };
+        let domain_tx = Transaction {
+            version: 2,
+            chain_id: 0x03,
+            transaction_type: TransactionType::DomainRegistration,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: Signature {
+                signature: vec![0u8; 64],
+                public_key: PublicKey {
+                    dilithium_pk: [0u8; 2592],
+                    kyber_pk: [0u8; 1568],
+                    key_id: signer,
+                },
+                algorithm: SignatureAlgorithm::Dilithium5,
+                timestamp: 0,
+            },
+            memo: payload.encode_memo().unwrap(),
+            payload: crate::transaction::TransactionPayload::None,
+        };
+
+        let err = validate_cons516_companion_fee(&bc, &domain_tx, &payload).unwrap_err();
+        assert!(
+            err.contains("not found in mempool"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn cons516_accepts_valid_companion_token_transfer() {
+        use crate::blockchain::Blockchain;
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+        use crate::transaction::fee::DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS;
+        use crate::transaction::{TokenTransferData, Transaction};
+        use crate::types::transaction_type::TransactionType;
+
+        let mut bc = Blockchain::default();
+        let signer = [0x22u8; 32];
+        let sig = Signature {
+            signature: vec![0u8; 64],
+            public_key: PublicKey {
+                dilithium_pk: [0u8; 2592],
+                kyber_pk: [0u8; 1568],
+                key_id: signer,
+            },
+            algorithm: SignatureAlgorithm::Dilithium5,
+            timestamp: 0,
+        };
+        let treasury = crate::Blockchain::deterministic_treasury_wallet_id().as_array();
+        let fee_tx = Transaction::new_token_transfer(
+            TokenTransferData {
+                token_id: generate_lib_token_id(),
+                from: signer,
+                to: treasury,
+                amount: DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS,
+                nonce: 0,
+            },
+            sig.clone(),
+            vec![],
+        );
+        let fee_hash = hex::encode(fee_tx.hash().as_bytes());
+        bc.pending_transactions.push(fee_tx);
+
+        let payload = DomainRegistrationPayload {
+            domain: "paid.sov".to_string(),
+            owner_did: format!("did:zhtp:{}", hex::encode(signer)),
+            manifest_cid: String::new(),
+            build_hash: String::new(),
+            title: String::new(),
+            description: String::new(),
+            category: "test".to_string(),
+            tags: vec![],
+            duration_days: 365,
+            fee_tx_hash: fee_hash,
+            fee_amount_atoms: 0,
+            fee_payer_wallet_id: [0u8; 32],
+        };
+        let domain_tx = Transaction {
+            version: 2,
+            chain_id: 0x03,
+            transaction_type: TransactionType::DomainRegistration,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: sig,
+            memo: payload.encode_memo().unwrap(),
+            payload: crate::transaction::TransactionPayload::None,
+        };
+
+        validate_cons516_companion_fee(&bc, &domain_tx, &payload)
+            .expect("valid companion fee tx in mempool");
+    }
+
+    #[test]
+    fn cons516_rejects_underpaid_companion() {
+        use crate::blockchain::Blockchain;
+        use crate::contracts::utils::generate_lib_token_id;
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+        use crate::transaction::fee::DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS;
+        use crate::transaction::{TokenTransferData, Transaction};
+        use crate::types::transaction_type::TransactionType;
+
+        let mut bc = Blockchain::default();
+        let signer = [0x33u8; 32];
+        let sig = Signature {
+            signature: vec![0u8; 64],
+            public_key: PublicKey {
+                dilithium_pk: [0u8; 2592],
+                kyber_pk: [0u8; 1568],
+                key_id: signer,
+            },
+            algorithm: SignatureAlgorithm::Dilithium5,
+            timestamp: 0,
+        };
+        let treasury = crate::Blockchain::deterministic_treasury_wallet_id().as_array();
+        let fee_tx = Transaction::new_token_transfer(
+            TokenTransferData {
+                token_id: generate_lib_token_id(),
+                from: signer,
+                to: treasury,
+                amount: DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS - 1,
+                nonce: 0,
+            },
+            sig.clone(),
+            vec![],
+        );
+        let fee_hash = hex::encode(fee_tx.hash().as_bytes());
+        bc.pending_transactions.push(fee_tx);
+
+        let payload = DomainRegistrationPayload {
+            domain: "cheap.sov".to_string(),
+            owner_did: format!("did:zhtp:{}", hex::encode(signer)),
+            manifest_cid: String::new(),
+            build_hash: String::new(),
+            title: String::new(),
+            description: String::new(),
+            category: "test".to_string(),
+            tags: vec![],
+            duration_days: 365,
+            fee_tx_hash: fee_hash,
+            fee_amount_atoms: 0,
+            fee_payer_wallet_id: [0u8; 32],
+        };
+        let domain_tx = Transaction {
+            version: 2,
+            chain_id: 0x03,
+            transaction_type: TransactionType::DomainRegistration,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: sig,
+            memo: payload.encode_memo().unwrap(),
+            payload: crate::transaction::TransactionPayload::None,
+        };
+
+        let err = validate_cons516_companion_fee(&bc, &domain_tx, &payload).unwrap_err();
+        assert!(err.contains("below required"), "unexpected error: {err}");
+    }
+}
+
+/// Validate CONS-516 companion-fee binding for DOMREG2 registrations.
+///
+/// When inline fee fields are zero, `fee_tx_hash` must reference a **pending**
+/// mempool `TokenTransfer` that pays ≥ `domain_registration_fee_atoms` SOV from
+/// the domain signer's key to the DAO treasury wallet.
+pub fn validate_cons516_companion_fee(
+    bc: &crate::blockchain::Blockchain,
+    domain_tx: &crate::transaction::Transaction,
+    payload: &DomainRegistrationPayload,
+) -> Result<(), String> {
+    use crate::types::transaction_type::TransactionType;
+
+    let fee_hash_hex = payload.fee_tx_hash.trim();
+    if fee_hash_hex.len() != 64
+        || !fee_hash_hex.chars().all(|c| c.is_ascii_hexdigit())
+    {
+        return Err("fee_tx_hash must be 64 hex chars".into());
+    }
+    let fee_hash_bytes =
+        hex::decode(fee_hash_hex).map_err(|_| "fee_tx_hash is not valid hex".to_string())?;
+    if fee_hash_bytes.len() != 32 {
+        return Err("fee_tx_hash must decode to 32 bytes".into());
+    }
+    let mut fee_hash = [0u8; 32];
+    fee_hash.copy_from_slice(&fee_hash_bytes);
+
+    let fee_tx = bc
+        .get_pending_transactions()
+        .into_iter()
+        .find(|t| t.hash().as_array() == fee_hash)
+        .ok_or_else(|| {
+            format!(
+                "fee_tx_hash {} not found in mempool (companion TokenTransfer required)",
+                fee_hash_hex
+            )
+        })?;
+
+    if fee_tx.transaction_type != TransactionType::TokenTransfer {
+        return Err(format!(
+            "fee_tx_hash must reference TokenTransfer, got {:?}",
+            fee_tx.transaction_type
+        ));
+    }
+    let transfer = fee_tx
+        .token_transfer_data()
+        .ok_or_else(|| "companion tx missing TokenTransfer payload".to_string())?;
+
+    let required = bc.tx_fee_config.domain_registration_fee_atoms;
+    let sov_id = crate::contracts::utils::generate_lib_token_id();
+    if transfer.token_id != sov_id {
+        return Err("companion fee must use SOV token".into());
+    }
+    if transfer.amount < required {
+        return Err(format!(
+            "companion fee {} atoms below required {} atoms",
+            transfer.amount, required
+        ));
+    }
+    let signer_key = domain_tx.signature.public_key.key_id;
+    if transfer.from != signer_key {
+        return Err("companion fee must be sent from domain signer key".into());
+    }
+    let treasury = crate::Blockchain::deterministic_treasury_wallet_id();
+    if transfer.to != treasury.as_array() {
+        return Err("companion fee recipient must be DAO treasury wallet".into());
+    }
+    Ok(())
 }

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -15,6 +15,7 @@ pub mod fee;
 pub mod hashing;
 pub mod mint_authorization;
 pub mod oracle_governance;
+pub mod reward_claim;
 pub mod signing;
 pub mod system_tx_signature;
 pub mod threshold_approval;
@@ -24,6 +25,11 @@ pub mod validation;
 
 pub use credentials::{
     RegisterCredentialData, UpdateCredentialPasswordData, UserCredential,
+};
+pub use reward_claim::{
+    checkin_amount_for_day, expected_amount_for_event, key_id_from_did, RewardClaimData,
+    RewardEventKind, RewardStreakRecord, REWARD_ACTIVE_SESSION_ATOMS, REWARD_CHECKIN_BASE_ATOMS,
+    REWARD_CLAIM_MEMO, REWARD_NEW_PARTNER_ATOMS, REWARD_WELCOME_ATOMS, WEEKLY_PARTNER_CAP,
 };
 pub use domain::{
     DomainRegistrationPayload, DomainUpdatePayload, OnChainDomainRecord,

--- a/lib-blockchain/src/transaction/reward_claim.rs
+++ b/lib-blockchain/src/transaction/reward_claim.rs
@@ -99,15 +99,34 @@ pub fn checkin_amount_for_day(streak_day: u32) -> u128 {
 }
 
 pub fn expected_amount_for_event(event: RewardEventKind, streak_day: u32) -> u128 {
+    use crate::rewards_policy::{expected_amount_for_trigger, legacy_bubl_policy};
+    let policy = legacy_bubl_policy();
+    let policy_event = reward_event_to_policy_event(event);
+    expected_amount_for_trigger(&policy, policy_event, streak_day).unwrap_or(0)
+}
+
+pub fn reward_event_to_policy_event(event: RewardEventKind) -> crate::rewards_policy::RewardsPolicyEvent {
+    use crate::rewards_policy::RewardsPolicyEvent;
     match event {
-        RewardEventKind::Welcome => REWARD_WELCOME_ATOMS,
-        RewardEventKind::DailyCheckin => checkin_amount_for_day(streak_day),
-        RewardEventKind::ActiveSession => REWARD_ACTIVE_SESSION_ATOMS,
-        RewardEventKind::NewPartner => REWARD_NEW_PARTNER_ATOMS,
+        RewardEventKind::Welcome => RewardsPolicyEvent::Welcome,
+        RewardEventKind::DailyCheckin => RewardsPolicyEvent::DailyCheckin,
+        RewardEventKind::ActiveSession => RewardsPolicyEvent::ActiveSession,
+        RewardEventKind::NewPartner => RewardsPolicyEvent::NewPartner,
     }
 }
 
-/// Parse `did:zhtp:{64-hex}` → 32-byte key_id.
+/// Canonical BUBL `token_id` for reward claims.
+pub fn bubl_token_id() -> [u8; 32] {
+    crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL")
+}
+
+/// Normalize `did:zhtp:{hex}` to lowercase hex suffix for stable storage keys.
+pub fn canonical_owner_did(did: &str) -> Option<String> {
+    let key_id = key_id_from_did(did)?;
+    Some(format!("did:zhtp:{}", hex::encode(key_id)))
+}
+
+/// Parse `did:zhtp:{64-hex}` → 32-byte key_id (hex case-insensitive).
 pub fn key_id_from_did(did: &str) -> Option<[u8; 32]> {
     const MAX_DID_LEN: usize = 256;
     if did.is_empty() || did.len() > MAX_DID_LEN {
@@ -117,7 +136,8 @@ pub fn key_id_from_did(did: &str) -> Option<[u8; 32]> {
     if hex_part.len() != 64 || !hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
         return None;
     }
-    let bytes = hex::decode(hex_part).ok()?;
+    let lower = hex_part.to_ascii_lowercase();
+    let bytes = hex::decode(&lower).ok()?;
     let mut out = [0u8; 32];
     out.copy_from_slice(&bytes);
     Some(out)
@@ -184,5 +204,22 @@ mod tests {
     fn key_id_from_did_valid() {
         let did = "did:zhtp:e0b9757663f55797ff06cdce1d0dc18329455b9a18d8e0b5bc05a8f10c969bf4";
         assert!(key_id_from_did(did).is_some());
+    }
+
+    #[test]
+    fn key_id_from_did_uppercase_hex_matches_lowercase() {
+        let lower = "did:zhtp:e0b9757663f55797ff06cdce1d0dc18329455b9a18d8e0b5bc05a8f10c969bf4";
+        let upper = "did:zhtp:E0B9757663F55797FF06CDCE1D0DC18329455B9A18D8E0B5BC05A8F10C969BF4";
+        assert_eq!(key_id_from_did(lower), key_id_from_did(upper));
+        assert_eq!(canonical_owner_did(lower), canonical_owner_did(upper));
+    }
+
+    #[test]
+    fn expected_amount_matches_legacy_constants() {
+        assert_eq!(expected_amount_for_event(RewardEventKind::Welcome, 1), REWARD_WELCOME_ATOMS);
+        assert_eq!(
+            expected_amount_for_event(RewardEventKind::NewPartner, 1),
+            REWARD_NEW_PARTNER_ATOMS
+        );
     }
 }

--- a/lib-blockchain/src/transaction/reward_claim.rs
+++ b/lib-blockchain/src/transaction/reward_claim.rs
@@ -1,0 +1,188 @@
+//! BUBL reward claim transaction payload and canonical reward constants.
+//!
+//! Reward eligibility is enforced on-chain at the executor; validators submit
+//! signed `RewardClaim` transactions instead of bare `TokenTransfer`s.
+
+use chrono::Datelike;
+use serde::{Deserialize, Serialize};
+
+/// 18-decimal atom multiplier for BUBL.
+pub const BUBL_ATOM_18: u128 = 1_000_000_000_000_000_000;
+
+/// Welcome bonus — 100 BUBL, once per DID lifetime.
+pub const REWARD_WELCOME_ATOMS: u128 = 100 * BUBL_ATOM_18;
+/// Base daily check-in reward — 10 BUBL plus streak bonus.
+pub const REWARD_CHECKIN_BASE_ATOMS: u128 = 10 * BUBL_ATOM_18;
+/// Per-day streak bonus, capped at +10 BUBL.
+pub const REWARD_STREAK_BONUS_PER_DAY_ATOMS: u128 = 1 * BUBL_ATOM_18;
+pub const REWARD_STREAK_BONUS_CAP_DAYS: u32 = 10;
+/// Active-session reward — 2 BUBL, once per UTC day per DID.
+pub const REWARD_ACTIVE_SESSION_ATOMS: u128 = 2 * BUBL_ATOM_18;
+/// New-conversation-partner reward — 20 BUBL per distinct peer per ISO week.
+pub const REWARD_NEW_PARTNER_ATOMS: u128 = 20 * BUBL_ATOM_18;
+/// Weekly cap on new-partner rewards.
+pub const WEEKLY_PARTNER_CAP: u32 = 5;
+
+/// Memo tag for reward claim transactions.
+pub const REWARD_CLAIM_MEMO: &[u8] = b"bubl:reward:claim:v1";
+
+/// Reward event kinds — explicit `repr(u8)` for stable bincode layout.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum RewardEventKind {
+    Welcome = 0,
+    DailyCheckin = 1,
+    ActiveSession = 2,
+    NewPartner = 3,
+}
+
+impl RewardEventKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Welcome => "welcome",
+            Self::DailyCheckin => "daily_checkin",
+            Self::ActiveSession => "active_session",
+            Self::NewPartner => "new_partner",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "welcome" => Some(Self::Welcome),
+            "daily_checkin" => Some(Self::DailyCheckin),
+            "active_session" => Some(Self::ActiveSession),
+            "new_partner" => Some(Self::NewPartner),
+            _ => None,
+        }
+    }
+}
+
+/// On-chain streak state for daily check-in rewards.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct RewardStreakRecord {
+    /// UTC ordinal day (days since CE) of the last check-in.
+    pub last_day: i32,
+    pub current_streak: u32,
+    pub longest_streak: u32,
+}
+
+/// Payload for `TransactionType::RewardClaim`.
+///
+/// Signed by the BUBL `TokenCreation` creator (or future authorized delegate).
+/// Amount must match the canonical schedule for `event` at execution time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RewardClaimData {
+    pub event: RewardEventKind,
+    /// Beneficiary DID — must exist in the identity registry.
+    pub owner_did: String,
+    /// Recipient wallet key_id (hex suffix of `did:zhtp:{hex}`).
+    pub recipient_key_id: [u8; 32],
+    /// BUBL token id (`generate_custom_token_id("Bubble","BUBL")`).
+    pub token_id: [u8; 32],
+    /// Treasury spender key_id (BUBL creator allocation).
+    pub from: [u8; 32],
+    /// Claim amount in 18-decimal atoms — validated against event + streak.
+    pub amount: u128,
+    /// Per-(token, from) transfer nonce.
+    pub nonce: u64,
+    /// Required when `event == NewPartner`.
+    pub peer_did: Option<String>,
+}
+
+pub fn streak_bonus_for_day(streak_day: u32) -> u128 {
+    let bonus_days = streak_day.saturating_sub(1).min(REWARD_STREAK_BONUS_CAP_DAYS);
+    REWARD_STREAK_BONUS_PER_DAY_ATOMS * (bonus_days as u128)
+}
+
+pub fn checkin_amount_for_day(streak_day: u32) -> u128 {
+    REWARD_CHECKIN_BASE_ATOMS + streak_bonus_for_day(streak_day)
+}
+
+pub fn expected_amount_for_event(event: RewardEventKind, streak_day: u32) -> u128 {
+    match event {
+        RewardEventKind::Welcome => REWARD_WELCOME_ATOMS,
+        RewardEventKind::DailyCheckin => checkin_amount_for_day(streak_day),
+        RewardEventKind::ActiveSession => REWARD_ACTIVE_SESSION_ATOMS,
+        RewardEventKind::NewPartner => REWARD_NEW_PARTNER_ATOMS,
+    }
+}
+
+/// Parse `did:zhtp:{64-hex}` → 32-byte key_id.
+pub fn key_id_from_did(did: &str) -> Option<[u8; 32]> {
+    const MAX_DID_LEN: usize = 256;
+    if did.is_empty() || did.len() > MAX_DID_LEN {
+        return None;
+    }
+    let hex_part = did.strip_prefix("did:zhtp:")?;
+    if hex_part.len() != 64 || !hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let bytes = hex::decode(hex_part).ok()?;
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Some(out)
+}
+
+/// UTC date string `YYYY-MM-DD` from unix timestamp.
+pub fn utc_date_from_ts(ts: u64) -> String {
+    chrono::DateTime::from_timestamp(ts as i64, 0)
+        .map(|dt| dt.date_naive().format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "1970-01-01".to_string())
+}
+
+/// UTC ordinal day (days since CE) from unix timestamp.
+pub fn utc_day_ordinal_from_ts(ts: u64) -> i32 {
+    chrono::DateTime::from_timestamp(ts as i64, 0)
+        .map(|dt| dt.date_naive().num_days_from_ce())
+        .unwrap_or(0)
+}
+
+/// ISO week key `YYYY-Www` from unix timestamp.
+pub fn iso_week_from_ts(ts: u64) -> String {
+    use chrono::Datelike;
+    chrono::DateTime::from_timestamp(ts as i64, 0)
+        .map(|dt| {
+            let iso = dt.date_naive().iso_week();
+            format!("{}-W{:02}", iso.year(), iso.week())
+        })
+        .unwrap_or_else(|| "1970-W01".to_string())
+}
+
+pub const REWARD_KEY_SEP: u8 = 0x1f;
+
+pub fn daily_claim_key(date: &str, did: &str, event: RewardEventKind) -> String {
+    format!("{}|{}|{}", date, did, event.as_str())
+}
+
+pub fn partner_claim_key(week: &str, did: &str, peer_did: &str) -> String {
+    format!("{}|{}|{}", week, did, peer_did)
+}
+
+pub fn partner_count_key(week: &str, did: &str) -> String {
+    format!("{}|{}", week, did)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checkin_amount_streak_schedule() {
+        assert_eq!(checkin_amount_for_day(1), REWARD_CHECKIN_BASE_ATOMS);
+        assert_eq!(
+            checkin_amount_for_day(2),
+            REWARD_CHECKIN_BASE_ATOMS + REWARD_STREAK_BONUS_PER_DAY_ATOMS
+        );
+        assert_eq!(
+            checkin_amount_for_day(11),
+            REWARD_CHECKIN_BASE_ATOMS
+                + REWARD_STREAK_BONUS_PER_DAY_ATOMS * (REWARD_STREAK_BONUS_CAP_DAYS as u128)
+        );
+    }
+
+    #[test]
+    fn key_id_from_did_valid() {
+        let did = "did:zhtp:e0b9757663f55797ff06cdce1d0dc18329455b9a18d8e0b5bc05a8f10c969bf4";
+        assert!(key_id_from_did(did).is_some());
+    }
+}

--- a/lib-blockchain/src/transaction/system_tx_signature.rs
+++ b/lib-blockchain/src/transaction/system_tx_signature.rs
@@ -22,6 +22,7 @@ pub fn system_tx_signature_policy(ty: TransactionType) -> SystemTxSignaturePolic
     match ty {
         TransactionType::Transfer
         | TransactionType::TokenTransfer
+        | TransactionType::RewardClaim
         | TransactionType::IdentityRegistration
         | TransactionType::IdentityUpdate
         | TransactionType::IdentityRevocation

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -241,6 +241,7 @@ impl TransactionValidator {
             || matches!(
                 transaction.transaction_type,
                 TransactionType::TokenTransfer
+                    | TransactionType::RewardClaim
                     | TransactionType::RegisterObserver
                     | TransactionType::UpdateObserverMetadata
                     | TransactionType::SuspendObserver
@@ -304,6 +305,7 @@ impl TransactionValidator {
         if matches!(
             transaction.transaction_type,
             TransactionType::TokenTransfer
+                | TransactionType::RewardClaim
                 | TransactionType::TokenCreation
                 | TransactionType::AssetLaunch
                 | TransactionType::AssetModuleUpgrade
@@ -427,6 +429,11 @@ impl TransactionValidator {
                 // Sender authorization is validated in the stateful phase
                 // (StatefulTransactionValidator) which has wallet registry access
                 // to resolve legacy HD-derived wallet_ids that differ from key_id.
+            }
+            TransactionType::RewardClaim => {
+                if !transaction.inputs.is_empty() || !transaction.outputs.is_empty() {
+                    return Err(ValidationError::InvalidInputs);
+                }
             }
             TransactionType::GovernanceConfigUpdate => {
                 // Governance config updates - validate governance_config_data exists
@@ -783,6 +790,25 @@ impl TransactionValidator {
                 }
                 if data.from != transaction.signature.public_key.key_id {
                     return Err(ValidationError::InvalidTransaction);
+                }
+            }
+            TransactionType::RewardClaim => {
+                let data = transaction
+                    .reward_claim_data()
+                    .ok_or(ValidationError::MissingRequiredData)?;
+                if data.amount == 0 {
+                    return Err(ValidationError::InvalidAmount);
+                }
+                if !transaction.inputs.is_empty() || !transaction.outputs.is_empty() {
+                    return Err(ValidationError::InvalidInputs);
+                }
+                if data.from != transaction.signature.public_key.key_id {
+                    return Err(ValidationError::InvalidTransaction);
+                }
+                if data.event == crate::transaction::RewardEventKind::NewPartner
+                    && data.peer_did.as_deref().unwrap_or("").is_empty()
+                {
+                    return Err(ValidationError::MissingRequiredData);
                 }
             }
             TransactionType::TokenMint => {
@@ -1796,6 +1822,7 @@ impl<'a> StatefulTransactionValidator<'a> {
         if matches!(
             transaction.transaction_type,
             TransactionType::TokenTransfer
+                | TransactionType::RewardClaim
                 | TransactionType::TokenCreation
                 | TransactionType::AssetLaunch
                 | TransactionType::AssetModuleUpgrade
@@ -2361,7 +2388,8 @@ impl<'a> StatefulTransactionValidator<'a> {
             | TransactionType::AssetModuleUpgrade
             | TransactionType::AssetManifestUpdate
             | TransactionType::AssetAuthorityTransfer
-            | TransactionType::AssetRewardsDelegateRotate => {}
+            | TransactionType::AssetRewardsDelegateRotate
+            | TransactionType::RewardClaim => {}
         }
 
         //  CRITICAL FIX: Verify sender identity exists on blockchain
@@ -2434,6 +2462,7 @@ impl<'a> StatefulTransactionValidator<'a> {
         // TokenTransfer and DaoStake have no UTXO inputs — fee is deducted from the amount
         // at block processing time. Skip UTXO-based fee validation entirely.
         if transaction.transaction_type == TransactionType::TokenTransfer
+            || transaction.transaction_type == TransactionType::RewardClaim
             || transaction.transaction_type == TransactionType::DaoStake
             || transaction.transaction_type == TransactionType::DaoUnstake
         {
@@ -3475,6 +3504,11 @@ pub mod utils {
             }
             TransactionType::TokenTransfer => {
                 transaction.token_transfer_data().is_some() && transaction.outputs.is_empty()
+            }
+            TransactionType::RewardClaim => {
+                transaction.reward_claim_data().is_some()
+                    && transaction.inputs.is_empty()
+                    && transaction.outputs.is_empty()
             }
             TransactionType::TokenMint => {
                 transaction.version >= 2

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -2257,7 +2257,18 @@ impl<'a> StatefulTransactionValidator<'a> {
                     crate::transaction::domain::DOMAIN_REGISTRATION_PREFIX_V2,
                 );
                 if memo_is_v2 {
-                    if let Some(bc) = self.blockchain {
+                    // CONS-516 companion-fee path: DOMREG2 memo with zeroed inline
+                    // fee fields + non-empty fee_tx_hash. Payment is enforced by the
+                    // user-signed TokenTransfer referenced in fee_tx_hash (validated
+                    // by the API handler before this tx reaches mempool). Matches
+                    // process_domain_transactions which skips apply_domain_registration_fee
+                    // when both inline fee fields are zero.
+                    let is_cons516_companion = payload.fee_amount_atoms == 0
+                        && payload.fee_payer_wallet_id == [0u8; 32]
+                        && !payload.fee_tx_hash.is_empty();
+                    if is_cons516_companion {
+                        // owner_did vs signer check above is sufficient here.
+                    } else if let Some(bc) = self.blockchain {
                         let required = bc.tx_fee_config.domain_registration_fee_atoms;
                         if payload.fee_amount_atoms < required {
                             tracing::warn!(

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -2267,7 +2267,18 @@ impl<'a> StatefulTransactionValidator<'a> {
                         && payload.fee_payer_wallet_id == [0u8; 32]
                         && !payload.fee_tx_hash.is_empty();
                     if is_cons516_companion {
-                        // owner_did vs signer check above is sufficient here.
+                        let bc = self
+                            .blockchain
+                            .ok_or(ValidationError::InvalidTransaction)?;
+                        crate::transaction::domain::validate_cons516_companion_fee(
+                            bc,
+                            transaction,
+                            &payload,
+                        )
+                        .map_err(|e| {
+                            tracing::warn!("[DOMAIN_REG] CONS-516 companion fee invalid: {e}");
+                            ValidationError::InvalidTransaction
+                        })?;
                     } else if let Some(bc) = self.blockchain {
                         let required = bc.tx_fee_config.domain_registration_fee_atoms;
                         if payload.fee_amount_atoms < required {

--- a/lib-blockchain/src/types/transaction_type.rs
+++ b/lib-blockchain/src/types/transaction_type.rs
@@ -239,6 +239,12 @@ pub enum TransactionType {
     AssetAuthorityTransfer = 65,
     /// Rotate the rewards spend delegate key.
     AssetRewardsDelegateRotate = 66,
+    /// BUBL reward claim — chain-enforced eligibility + treasury token transfer.
+    ///
+    /// Signed by the BUBL `TokenCreation` creator (or authorized delegate).
+    /// Executor validates per-event caps (welcome once, daily check-in/session,
+    /// weekly partner limits) before debiting the creator allocation.
+    RewardClaim = 67,
 }
 
 impl TransactionType {
@@ -440,6 +446,7 @@ impl TransactionType {
             TransactionType::AssetRewardsDelegateRotate => {
                 "Rotate Sovereign Asset rewards spend delegate"
             }
+            TransactionType::RewardClaim => "BUBL reward claim (chain-enforced eligibility)",
         }
     }
 
@@ -513,6 +520,7 @@ impl TransactionType {
             TransactionType::AssetManifestUpdate => "asset_manifest_update",
             TransactionType::AssetAuthorityTransfer => "asset_authority_transfer",
             TransactionType::AssetRewardsDelegateRotate => "asset_rewards_delegate_rotate",
+            TransactionType::RewardClaim => "reward_claim",
         }
     }
 
@@ -586,6 +594,7 @@ impl TransactionType {
             "asset_manifest_update" => Some(TransactionType::AssetManifestUpdate),
             "asset_authority_transfer" => Some(TransactionType::AssetAuthorityTransfer),
             "asset_rewards_delegate_rotate" => Some(TransactionType::AssetRewardsDelegateRotate),
+            "reward_claim" => Some(TransactionType::RewardClaim),
             _ => None,
         }
     }

--- a/lib-blockchain/src/validation/tx_validate.rs
+++ b/lib-blockchain/src/validation/tx_validate.rs
@@ -60,6 +60,7 @@ const PHASE2_ALLOWED_TYPES: &[TransactionType] = &[
     TransactionType::AssetManifestUpdate,
     TransactionType::AssetAuthorityTransfer,
     TransactionType::AssetRewardsDelegateRotate,
+    TransactionType::RewardClaim,
     TransactionType::OracleAttestation,
     TransactionType::RegisterCredential,
     TransactionType::UpdateCredentialPassword,

--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -851,6 +851,26 @@ pub fn fee_tx_hash_from_hex(fee_payment_tx_hex: &str) -> Result<String, String> 
     Ok(hex::encode(tx.hash().as_bytes()))
 }
 
+/// Extract canonical fee amount and payer wallet from a signed fee TokenTransfer.
+pub fn fee_transfer_fields_from_hex(
+    fee_payment_tx_hex: &str,
+) -> Result<(u128, [u8; 32]), String> {
+    let bytes = hex::decode(fee_payment_tx_hex.trim())
+        .map_err(|e| format!("fee_payment_tx is not valid hex: {}", e))?;
+    let tx = lib_blockchain::transaction::decode_client_transaction(&bytes)
+        .map_err(|e| format!("fee_payment_tx decode failed: {}", e))?;
+    if tx.transaction_type != lib_blockchain::TransactionType::TokenTransfer {
+        return Err(format!(
+            "fee_payment_tx must be a TokenTransfer, got {:?}",
+            tx.transaction_type
+        ));
+    }
+    let transfer = tx
+        .token_transfer_data()
+        .ok_or_else(|| "fee_payment_tx missing TokenTransfer payload".to_string())?;
+    Ok((transfer.amount, transfer.from))
+}
+
 fn domain_registration_title_description_tags(
     domain: &str,
     metadata: Option<&serde_json::Value>,
@@ -885,6 +905,8 @@ pub fn sign_domain_registration_system_tx(
     domain: &str,
     owner_did: &str,
     fee_tx_hash_hex: &str,
+    fee_amount_atoms: u128,
+    fee_payer_wallet_id: [u8; 32],
     timestamp: u64,
     title: &str,
     description: &str,
@@ -905,8 +927,8 @@ pub fn sign_domain_registration_system_tx(
         tags,
         duration_days: 365,
         fee_tx_hash: fee_tx_hash_hex.to_string(),
-        fee_amount_atoms: 0,
-        fee_payer_wallet_id: [0u8; 32],
+        fee_amount_atoms,
+        fee_payer_wallet_id,
     };
     let memo = payload
         .encode_memo()
@@ -1014,14 +1036,17 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
     }
 
     let fee_tx_hash_hex = fee_tx_hash_from_hex(&fee_payment_tx)?;
+    let (fee_amount_atoms, fee_payer_wallet_id) = fee_transfer_fields_from_hex(&fee_payment_tx)?;
+    const SOV_ATOM_18: u128 = 1_000_000_000_000_000_000;
+    let fee_whole = (fee_amount_atoms / SOV_ATOM_18) as u64;
 
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| format!("Failed to get timestamp: {}", e))?
         .as_secs();
 
-    // Sign: domain|timestamp|fee_amount
-    let message = format!("{}|{}|{}", domain, timestamp, DOMAIN_REGISTRATION_FEE);
+    // Sign: domain|timestamp|fee_amount (whole SOV, must match fee_payment_tx)
+    let message = format!("{}|{}|{}", domain, timestamp, fee_whole);
     let signature = Dilithium5::sign(message.as_bytes(), &identity.private_key)
         .map_err(|e| format!("Failed to sign: {}", e))?;
 
@@ -1032,6 +1057,8 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
         domain,
         &identity.did,
         &fee_tx_hash_hex,
+        fee_amount_atoms,
+        fee_payer_wallet_id,
         timestamp,
         &title,
         &description,
@@ -1046,7 +1073,7 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
         metadata,
         signature: hex::encode(&signature),
         timestamp,
-        fee: Some(DOMAIN_REGISTRATION_FEE),
+        fee: Some(fee_whole),
         fee_payment_tx: Some(fee_payment_tx),
         domain_tx_signature_hex,
     };

--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -851,26 +851,6 @@ pub fn fee_tx_hash_from_hex(fee_payment_tx_hex: &str) -> Result<String, String> 
     Ok(hex::encode(tx.hash().as_bytes()))
 }
 
-/// Extract canonical fee amount and payer wallet from a signed fee TokenTransfer.
-pub fn fee_transfer_fields_from_hex(
-    fee_payment_tx_hex: &str,
-) -> Result<(u128, [u8; 32]), String> {
-    let bytes = hex::decode(fee_payment_tx_hex.trim())
-        .map_err(|e| format!("fee_payment_tx is not valid hex: {}", e))?;
-    let tx = lib_blockchain::transaction::decode_client_transaction(&bytes)
-        .map_err(|e| format!("fee_payment_tx decode failed: {}", e))?;
-    if tx.transaction_type != lib_blockchain::TransactionType::TokenTransfer {
-        return Err(format!(
-            "fee_payment_tx must be a TokenTransfer, got {:?}",
-            tx.transaction_type
-        ));
-    }
-    let transfer = tx
-        .token_transfer_data()
-        .ok_or_else(|| "fee_payment_tx missing TokenTransfer payload".to_string())?;
-    Ok((transfer.amount, transfer.from))
-}
-
 fn domain_registration_title_description_tags(
     domain: &str,
     metadata: Option<&serde_json::Value>,
@@ -905,8 +885,6 @@ pub fn sign_domain_registration_system_tx(
     domain: &str,
     owner_did: &str,
     fee_tx_hash_hex: &str,
-    fee_amount_atoms: u128,
-    fee_payer_wallet_id: [u8; 32],
     timestamp: u64,
     title: &str,
     description: &str,
@@ -927,8 +905,8 @@ pub fn sign_domain_registration_system_tx(
         tags,
         duration_days: 365,
         fee_tx_hash: fee_tx_hash_hex.to_string(),
-        fee_amount_atoms,
-        fee_payer_wallet_id,
+        fee_amount_atoms: 0,
+        fee_payer_wallet_id: [0u8; 32],
     };
     let memo = payload
         .encode_memo()
@@ -1036,17 +1014,14 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
     }
 
     let fee_tx_hash_hex = fee_tx_hash_from_hex(&fee_payment_tx)?;
-    let (fee_amount_atoms, fee_payer_wallet_id) = fee_transfer_fields_from_hex(&fee_payment_tx)?;
-    const SOV_ATOM_18: u128 = 1_000_000_000_000_000_000;
-    let fee_whole = (fee_amount_atoms / SOV_ATOM_18) as u64;
 
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| format!("Failed to get timestamp: {}", e))?
         .as_secs();
 
-    // Sign: domain|timestamp|fee_amount (whole SOV, must match fee_payment_tx)
-    let message = format!("{}|{}|{}", domain, timestamp, fee_whole);
+    // Sign: domain|timestamp|fee_amount
+    let message = format!("{}|{}|{}", domain, timestamp, DOMAIN_REGISTRATION_FEE);
     let signature = Dilithium5::sign(message.as_bytes(), &identity.private_key)
         .map_err(|e| format!("Failed to sign: {}", e))?;
 
@@ -1057,8 +1032,6 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
         domain,
         &identity.did,
         &fee_tx_hash_hex,
-        fee_amount_atoms,
-        fee_payer_wallet_id,
         timestamp,
         &title,
         &description,
@@ -1073,7 +1046,7 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
         metadata,
         signature: hex::encode(&signature),
         timestamp,
-        fee: Some(fee_whole),
+        fee: Some(DOMAIN_REGISTRATION_FEE),
         fee_payment_tx: Some(fee_payment_tx),
         domain_tx_signature_hex,
     };

--- a/lib-network/src/web4/domain_registry.rs
+++ b/lib-network/src/web4/domain_registry.rs
@@ -1077,16 +1077,9 @@ impl DomainRegistry {
             return Ok(false);
         }
 
-        let expected_fee =
-            Self::expected_registration_fee_whole(&request.domain, request.duration_days);
-        if request.registration_fee_whole != expected_fee {
-            warn!(
-                "Domain registration rejected: fee {} does not match expected {} for {}",
-                request.registration_fee_whole, expected_fee, request.domain
-            );
-            return Ok(false);
-        }
-
+        // Fee amount is validated by the API handler against TxFeeConfig and
+        // bound into the authorization signature below — do not re-check against
+        // the legacy dynamic pricing formula here (it diverged from governance rates).
         verify_domain_registration_signature(
             request.owner.public_key.dilithium_pk.as_slice(),
             &request.domain,

--- a/schemas/zhtp/rewards-policy/examples/bubl-v1.json
+++ b/schemas/zhtp/rewards-policy/examples/bubl-v1.json
@@ -1,0 +1,44 @@
+{
+  "schema": "zhtp/rewards-policy/v1",
+  "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+  "description": "Canonical BUBL mobile rewards policy. Replace asset_id with launch tx hash after AssetLaunch migration. Amounts match on-chain constants in reward_claim.rs and rewards/mod.rs (C2 resolved: new_partner = 20 BUBL, not 200).",
+  "triggers": [
+    {
+      "id": "welcome",
+      "event": "welcome",
+      "kind": "once_per_did",
+      "enabled": true,
+      "amount_atoms": "100000000000000000000"
+    },
+    {
+      "id": "daily_checkin",
+      "event": "daily_checkin",
+      "kind": "once_per_utc_day",
+      "enabled": true,
+      "base_amount_atoms": "10000000000000000000",
+      "streak_bonus": {
+        "per_day_atoms": "1000000000000000000",
+        "cap_days": 10
+      }
+    },
+    {
+      "id": "active_session",
+      "event": "active_session",
+      "kind": "once_per_utc_day",
+      "enabled": true,
+      "amount_atoms": "2000000000000000000"
+    },
+    {
+      "id": "new_partner",
+      "event": "new_partner",
+      "kind": "distinct_peer_per_iso_week",
+      "enabled": true,
+      "amount_atoms": "20000000000000000000",
+      "weekly_cap": 5
+    }
+  ],
+  "budget": {
+    "max_daily_outflow_atoms": "10000000000000000000000",
+    "max_lifetime_per_did_atoms": "1000000000000000000000"
+  }
+}

--- a/schemas/zhtp/rewards-policy/v1.schema.json
+++ b/schemas/zhtp/rewards-policy/v1.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zhtp.network/schemas/rewards-policy/v1.schema.json",
+  "title": "ZHTP Rewards Policy v1",
+  "description": "DAO-configurable reward distribution policy referenced by SovereignAsset RewardsModule policy_hash on-chain.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "asset_id", "triggers"],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "zhtp/rewards-policy/v1"
+    },
+    "asset_id": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$",
+      "description": "32-byte asset_id as 64-char hex (launch tx hash)."
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 512
+    },
+    "triggers": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": { "$ref": "#/$defs/trigger" }
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_daily_outflow_atoms": {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "max_lifetime_per_did_atoms": {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "atoms_string": {
+      "type": "string",
+      "pattern": "^[0-9]+$"
+    },
+    "trigger_kind": {
+      "type": "string",
+      "enum": [
+        "once_per_did",
+        "once_per_utc_day",
+        "distinct_peer_per_iso_week"
+      ]
+    },
+    "trigger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "enabled"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]{0,31}$"
+        },
+        "kind": { "$ref": "#/$defs/trigger_kind" },
+        "enabled": { "type": "boolean" },
+        "amount_atoms": { "$ref": "#/$defs/atoms_string" },
+        "base_amount_atoms": { "$ref": "#/$defs/atoms_string" },
+        "streak_bonus": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["per_day_atoms", "cap_days"],
+          "properties": {
+            "per_day_atoms": { "$ref": "#/$defs/atoms_string" },
+            "cap_days": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 365
+            }
+          }
+        },
+        "weekly_cap": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "event": {
+          "type": "string",
+          "enum": ["welcome", "daily_checkin", "active_session", "new_partner"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "kind": { "const": "once_per_did" } },
+            "required": ["kind"]
+          },
+          "then": { "required": ["amount_atoms", "event"] }
+        },
+        {
+          "if": {
+            "properties": { "kind": { "const": "once_per_utc_day" } },
+            "required": ["kind"]
+          },
+          "then": {
+            "anyOf": [
+              { "required": ["amount_atoms", "event"] },
+              { "required": ["base_amount_atoms", "event"] }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": { "kind": { "const": "distinct_peer_per_iso_week" } },
+            "required": ["kind"]
+          },
+          "then": { "required": ["amount_atoms", "weekly_cap", "event"] }
+        }
+      ]
+    }
+  }
+}

--- a/tools/seed_founding_dao.rs
+++ b/tools/seed_founding_dao.rs
@@ -205,8 +205,26 @@ fn build_signed_token_creation(
     Ok((tx, expected_id))
 }
 
+fn validate_canonical_rewards_policy() -> Result<lib_blockchain::types::Hash> {
+    use lib_blockchain::rewards_policy::{policy_hash, validate_rewards_policy};
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../schemas/zhtp/rewards-policy/examples/bubl-v1.json"
+    );
+    let bytes = std::fs::read(path).context("read canonical BUBL rewards policy example")?;
+    let policy = validate_rewards_policy(&bytes).context("validate rewards policy")?;
+    policy_hash(&policy).map_err(|e| anyhow::anyhow!("policy_hash: {e}"))
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
+    if matches!(args.token, FoundingToken::Bubl) {
+        let policy_hash = validate_canonical_rewards_policy()?;
+        eprintln!(
+            "rewards policy validated (zhtp/rewards-policy/v1); policy_hash={}",
+            hex::encode(policy_hash.as_bytes())
+        );
+    }
     let keypair = load_keypair(&args.keystore_dir)?;
     let treasury = treasury_key_id(&args)?;
     if treasury == keypair.public_key.key_id {

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -6,7 +6,7 @@ use crate::web4_manifest::{
 use anyhow::anyhow;
 use base64::{engine::general_purpose, Engine as _};
 use lib_blockchain::BlockchainQuery;
-use lib_identity::{types::IdentityView, ZhtpIdentity};
+use lib_identity::{types::IdentityView, wallets::wallet_types::WalletType, ZhtpIdentity};
 use lib_access_control::{SecurityPrincipal, Role};
 use lib_types::NodeType;
 use lib_network::web4::{
@@ -928,7 +928,7 @@ impl Web4Handler {
             .wallet_manager
             .wallets
             .iter()
-            .find(|(_, wallet)| wallet.wallet_type == "Primary")
+            .find(|(_, wallet)| wallet.wallet_type == WalletType::Primary)
         {
             let wallet_id = primary_wallet.id.clone();
             drop(wallet_manager_lock); // Release lock before async operations

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -787,12 +787,10 @@ impl Web4Handler {
             simple_request.domain, total_fees
         );
 
-        // Insert into blockchain.domain_registry so the catalog reflects this immediately.
-        {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
+        // Enqueue the client-signed DomainRegistration / DomainUpdate system tx on the
+        // normal mempool path (same as fee_payment_tx). On-chain domain_registry is
+        // updated only after the tx is committed in a block.
+        let domain_system_tx_hash = {
             let title = simple_request
                 .metadata
                 .as_ref()
@@ -874,11 +872,24 @@ impl Web4Handler {
                 memo,
                 simple_request.timestamp,
             )?;
+            let domain_tx_hash_hex = hex::encode(domain_tx.hash().as_bytes());
             let mut blockchain = self.blockchain.write().await;
-            if let Err(e) = blockchain.add_system_transaction(domain_tx, lib_blockchain::SystemOriginator::Web4DomainRegister) {
-                warn!("Failed to submit domain {} tx: {}", if is_update { "update" } else { "registration" }, e);
-            }
-        }
+            blockchain
+                .add_pending_transaction(domain_tx)
+                .map_err(|e| {
+                    anyhow!(
+                        "domain {} tx rejected by mempool: {}",
+                        if is_update { "update" } else { "registration" },
+                        e
+                    )
+                })?;
+            info!(
+                " Domain {} tx submitted: {}",
+                if is_update { "update" } else { "registration" },
+                &domain_tx_hash_hex[..16.min(domain_tx_hash_hex.len())]
+            );
+            domain_tx_hash_hex
+        };
 
         // Get the ACTUAL content mappings from domain registry (with correct DHT hashes)
         let actual_content_mappings = match self.name_resolver.resolve(&simple_request.domain).await
@@ -894,12 +905,12 @@ impl Web4Handler {
 
         // ========================================================================
         // NOTE: Domain registration fees are paid via canonical SOV TokenTransfer above.
-        // Contract deployment handled separately from fee payment
+        // Both fee_payment_tx and domain system tx sit in mempool until the next block.
         // ========================================================================
-        let domain_tx_hash = Some(fee_tx_hash_hex);
         info!(
-            " Web4 domain registration transaction completed: {:?}",
-            domain_tx_hash
+            " Web4 domain registration txs submitted: fee={} domain={}",
+            &fee_tx_hash_hex[..16.min(fee_tx_hash_hex.len())],
+            &domain_system_tx_hash[..16.min(domain_system_tx_hash.len())]
         );
 
         // Register content ownership with wallet using ACTUAL owner identity
@@ -952,11 +963,12 @@ impl Web4Handler {
             "message": "Domain registered successfully on Web4 blockchain"
         });
 
-        // Add blockchain transaction hash if deployment succeeded
-        if let Some(tx_hash) = domain_tx_hash {
-            response["blockchain_transaction"] = serde_json::json!(tx_hash);
-            response["contract_deployed"] = serde_json::json!(true);
-        }
+        response["tx_hash"] = serde_json::json!(domain_system_tx_hash);
+        response["fee_payment_tx_hash"] = serde_json::json!(fee_tx_hash_hex);
+        response["domain_tx_hash"] = serde_json::json!(domain_system_tx_hash);
+        response["blockchain_transaction"] = serde_json::json!(domain_system_tx_hash);
+        response["contract_deployed"] = serde_json::json!(true);
+        response["pending_confirmation"] = serde_json::json!(true);
 
         let response_json = serde_json::to_vec(&response)
             .map_err(|e| anyhow!("Failed to serialize response: {}", e))?;
@@ -1117,12 +1129,7 @@ impl Web4Handler {
 
         // Submit domain registration/update transaction. Uses DomainUpdate for
         // existing domains to preserve version incrementing in block processor.
-        {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-
+        let domain_system_tx_hash = {
             let is_update = {
                 let blockchain = self.blockchain.read().await;
                 blockchain.domain_registry.contains_key(&request.domain)
@@ -1196,11 +1203,19 @@ impl Web4Handler {
                 memo,
                 request.timestamp,
             )?;
+            let domain_tx_hash_hex = hex::encode(domain_tx.hash().as_bytes());
             let mut blockchain = self.blockchain.write().await;
-            if let Err(e) = blockchain.add_system_transaction(domain_tx, lib_blockchain::SystemOriginator::Web4DomainUpdate) {
-                warn!("Failed to submit domain {} tx: {}", if is_update { "update" } else { "registration" }, e);
-            }
-        }
+            blockchain
+                .add_pending_transaction(domain_tx)
+                .map_err(|e| {
+                    anyhow!(
+                        "domain {} tx rejected by mempool: {}",
+                        if is_update { "update" } else { "registration" },
+                        e
+                    )
+                })?;
+            domain_tx_hash_hex
+        };
 
         let response = serde_json::json!({
             "status": "success",
@@ -1210,6 +1225,9 @@ impl Web4Handler {
             "registration_id": registration_result.registration_id,
             "fees_charged": registration_fee_whole,
             "fee_payment_tx_hash": fee_tx_hash_hex,
+            "domain_tx_hash": domain_system_tx_hash,
+            "tx_hash": domain_system_tx_hash,
+            "pending_confirmation": true,
             "message": "Domain registered successfully"
         });
 

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -923,8 +923,13 @@ impl Web4Handler {
         // Register content ownership with wallet using ACTUAL owner identity
         let wallet_manager_lock = self.wallet_content_manager.write().await;
 
-        // Get primary wallet from owner's identity
-        if let Some(primary_wallet) = owner_identity.wallet_manager.wallets.values().next() {
+        // Get primary wallet from owner's identity (HashMap iteration is non-deterministic).
+        if let Some((_, primary_wallet)) = owner_identity
+            .wallet_manager
+            .wallets
+            .iter()
+            .find(|(_, wallet)| wallet.wallet_type == "Primary")
+        {
             let wallet_id = primary_wallet.id.clone();
             drop(wallet_manager_lock); // Release lock before async operations
 
@@ -1428,15 +1433,14 @@ impl Web4Handler {
             }
         };
 
-        let on_chain = {
-            let blockchain = self.blockchain.read().await;
-            blockchain.get_all_domains().clone()
-        };
         let sled_records = self.domain_registry.list_all_domain_records().await;
-        let entries = filter_catalog_entries_by_owner(
-            &merge_catalog_entries(&on_chain, sled_records),
-            &owner,
-        );
+        let entries = {
+            let blockchain = self.blockchain.read().await;
+            filter_catalog_entries_by_owner(
+                &merge_catalog_entries(blockchain.get_all_domains(), sled_records),
+                &owner,
+            )
+        };
 
         let domains: Vec<serde_json::Value> = entries
             .into_iter()

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -855,8 +855,11 @@ impl Web4Handler {
                     tags,
                     duration_days: 365,
                     fee_tx_hash: fee_tx_hash_hex.clone(),
-                    fee_amount_atoms: registration_fee_sov,
-                    fee_payer_wallet_id: owner_wallet_id_bytes,
+                    // CONS-516: fee paid by companion TokenTransfer; V2 memo
+                    // carries fee_tx_hash binding only. Inline fee fields zeroed
+                    // so client/server skeletons stay byte-identical.
+                    fee_amount_atoms: 0,
+                    fee_payer_wallet_id: [0u8; 32],
                 };
                 (lib_blockchain::TransactionType::DomainRegistration, payload.encode_memo()
                     .map_err(|e| anyhow::anyhow!("Failed to encode domain registration: {}", e))?)

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -1399,7 +1399,7 @@ impl Web4Handler {
     /// List domains for an owner
     /// GET /api/v1/web4/domains?owner={did}
     pub async fn list_domains(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
-        let owner = request.uri.splitn(2, '?').nth(1).and_then(|query| {
+        let owner_raw = request.uri.splitn(2, '?').nth(1).and_then(|query| {
             query.split('&').find_map(|pair| {
                 let mut parts = pair.splitn(2, '=');
                 let key = parts.next()?;
@@ -1411,8 +1411,12 @@ impl Web4Handler {
                 }
             })
         });
-        let _owner = match owner {
-            Some(value) if !value.is_empty() => value,
+        let owner = match owner_raw {
+            Some(value) if !value.is_empty() => {
+                urlencoding::decode(value)
+                    .map(|s| s.into_owned())
+                    .unwrap_or_else(|_| value.to_string())
+            }
             _ => {
                 return Ok(ZhtpResponse::error(
                     ZhtpStatus::BadRequest,
@@ -1421,16 +1425,51 @@ impl Web4Handler {
             }
         };
 
-        // NOTE: list_domains_by_owner requires iterating all persisted domains, which is not
-        // yet implemented in the DomainRegistry. This endpoint is reserved for future use.
-        // For now, we return a not-implemented error rather than silently returning empty results,
-        // which would confuse API clients expecting functional behavior.
-        return Err(anyhow!(
-            "The list_domains_by_owner endpoint is not yet implemented. \
-             This feature requires registry support for domain enumeration by owner. \
-             Please use domain lookup endpoints for specific domains or track deployments \
-             in your application state."
-        ));
+        let on_chain = {
+            let blockchain = self.blockchain.read().await;
+            blockchain.get_all_domains().clone()
+        };
+        let sled_records = self.domain_registry.list_all_domain_records().await;
+        let entries = filter_catalog_entries_by_owner(
+            &merge_catalog_entries(&on_chain, sled_records),
+            &owner,
+        );
+
+        let domains: Vec<serde_json::Value> = entries
+            .into_iter()
+            .map(|entry| {
+                let expires_at = entry
+                    .get("expires_at")
+                    .map(|v| {
+                        if let Some(n) = v.as_u64() {
+                            n.to_string()
+                        } else {
+                            v.as_str().unwrap_or("").to_string()
+                        }
+                    })
+                    .unwrap_or_default();
+                serde_json::json!({
+                    "domain": entry.get("domain").and_then(|v| v.as_str()).unwrap_or(""),
+                    "owner": entry.get("owner").and_then(|v| v.as_str()).unwrap_or(""),
+                    "expires_at": expires_at,
+                    "content_cid": entry.get("manifest_cid").and_then(|v| v.as_str()),
+                    "classification": "commercial",
+                })
+            })
+            .collect();
+
+        let count = domains.len();
+        let body = serde_json::to_vec(&serde_json::json!({
+            "domains": domains,
+            "count": count,
+        }))
+        .map_err(|e| anyhow!("Failed to serialize domain list: {}", e))?;
+
+        Ok(ZhtpResponse::success_with_content_type(
+            body,
+            "application/json".to_string(),
+            None,
+        ))
     }
 
     /// Transfer domain to new owner
@@ -2212,6 +2251,22 @@ impl Web4Handler {
 /// and the corresponding sled record (if any) is silently dropped. Sled-only domains
 /// are appended and tagged `"sled_cache"`. The returned list is sorted alphabetically
 /// by domain name for deterministic output.
+fn filter_catalog_entries_by_owner(
+    entries: &[serde_json::Value],
+    owner: &str,
+) -> Vec<serde_json::Value> {
+    entries
+        .iter()
+        .filter(|entry| {
+            entry
+                .get("owner")
+                .and_then(|v| v.as_str())
+                .is_some_and(|record_owner| record_owner == owner)
+        })
+        .cloned()
+        .collect()
+}
+
 fn merge_catalog_entries(
     on_chain: &std::collections::HashMap<String, lib_blockchain::transaction::OnChainDomainRecord>,
     sled_records: Vec<lib_network::web4::DomainRecord>,

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -494,7 +494,7 @@ impl Web4Handler {
         let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
         let owner_identity_hash = lib_blockchain::Hash::from_slice(&owner_identity.id.0);
 
-        let fee_tx_hash_hex = if is_register {
+        let (fee_tx_hash_hex, owner_wallet_id_bytes) = if is_register {
             // Resolve the owner's Primary wallet and run the optimistic
             // SOV balance preview. Only relevant on the register path;
             // updates skip this entire block (reviewer #2691/L455).
@@ -640,7 +640,7 @@ impl Web4Handler {
                 registration_fee_whole,
                 hex::encode(&owner_wallet_id_bytes[..8])
             );
-            hex_hash
+            (hex_hash, owner_wallet_id_bytes)
         } else {
             // Update path: no consensus-level fee, no balance preview,
             // no wallet resolution. The handler still records the legacy
@@ -650,7 +650,7 @@ impl Web4Handler {
                 " Domain {} already registered — applying as DomainUpdate (no fee debit)",
                 simple_request.domain
             );
-            String::new()
+            (String::new(), [0u8; 32])
         };
 
         // Prepare content mappings WITH RICH METADATA for storage
@@ -781,6 +781,15 @@ impl Web4Handler {
         let registration_response =
             registration_result.map_err(|e| anyhow!("Domain registration failed: {}", e))?;
 
+        if !registration_response.success {
+            return Err(anyhow!(
+                "Domain registration failed: {}",
+                registration_response
+                    .error
+                    .unwrap_or_else(|| "invalid registration proof".to_string())
+            ));
+        }
+
         let total_fees = registration_response.fees_charged;
         info!(
             " Domain {} registered with {} SOV fees",
@@ -846,13 +855,8 @@ impl Web4Handler {
                     tags,
                     duration_days: 365,
                     fee_tx_hash: fee_tx_hash_hex.clone(),
-                    // CONS-516: V1 fields (zeroed) so `process_domain_transactions`
-                    // takes the legacy no-debit branch. The fee is paid by the
-                    // separate user-signed TokenTransfer enqueued above; the
-                    // chain debit-attempt path is unreachable from an unsigned
-                    // system tx (signer key_id is zeroed → owner re-check fails).
-                    fee_amount_atoms: 0,
-                    fee_payer_wallet_id: [0u8; 32],
+                    fee_amount_atoms: registration_fee_sov,
+                    fee_payer_wallet_id: owner_wallet_id_bytes,
                 };
                 (lib_blockchain::TransactionType::DomainRegistration, payload.encode_memo()
                     .map_err(|e| anyhow::anyhow!("Failed to encode domain registration: {}", e))?)


### PR DESCRIPTION
## Epic
Closes #2822 · Parent #2799

## Summary
Publish `zhtp/rewards-policy/v1` JSON Schema, Rust validation library in `lib-blockchain`, and canonical BUBL example policy. Resolves conflict **C2**: `new_partner` reward is **20 BUBL** (matches `reward_claim.rs` and `rewards/mod.rs`).

## Acceptance criteria
- [x] Schema file in repo with version tag `zhtp/rewards-policy/v1`
- [x] Validator crate/lib used by CLI and node (`lib-blockchain::rewards_policy`)
- [x] Canonical BUBL example policy committed (`schemas/.../examples/bubl-v1.json`)
- [x] C2 resolved with single documented amount (20 BUBL per new partner, weekly cap 5)

## Files
- `schemas/zhtp/rewards-policy/v1.schema.json`
- `schemas/zhtp/rewards-policy/examples/bubl-v1.json`
- `lib-blockchain/src/rewards_policy/{mod,types,validate}.rs`

## Tests
```
cargo test -p lib-blockchain --lib rewards_policy::validate
```

## Next
Stacked: D2 operator bootstrap doc (#2823)