### PR TITLE
DAO C3: identity init / keystore wizard

### DIFF
--- a/docs/ops/dao-launch-bootstrap.md
+++ b/docs/ops/dao-launch-bootstrap.md
@@ -32,6 +32,16 @@ v1 testnet used `chain_id = 1`; do not reuse those values on v2.
 
 ## Step 1 — Creator keystore
 
+### CLI wizard (preferred)
+
+```bash
+zhtp-cli identity init --display-name "My DAO Creator"
+```
+
+Creates `~/.zhtp/keystore/` (`user_identity.json` + `user_private_key.json`) and registers on-chain (identity + Primary/UBI/Savings wallets + SOV welcome bonus).
+
+### Manual (operators / validators)
+
 On the operator host (or validator), create a directory:
 
 ```bash

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -733,8 +733,8 @@ pub enum IdentityAction {
     },
     /// Zero-to-creator wizard: generate keystore (if needed) + on-chain registration.
     ///
-    /// Preferred entry point before `dao launch`. Equivalent to `register` with
-    /// documented next steps for DAO token deployment.
+    /// Preferred entry point before `token create`. Equivalent to `register` with
+    /// documented next steps for DAO token deployment (`dao launch` coming in #2816).
     Init {
         /// Display name for the new identity
         #[arg(short, long)]

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -731,6 +731,21 @@ pub enum IdentityAction {
         #[arg(short, long)]
         recovery_options: Vec<String>,
     },
+    /// Zero-to-creator wizard: generate keystore (if needed) + on-chain registration.
+    ///
+    /// Preferred entry point before `dao launch`. Equivalent to `register` with
+    /// documented next steps for DAO token deployment.
+    Init {
+        /// Display name for the new identity
+        #[arg(short, long)]
+        display_name: String,
+        /// Device identifier
+        #[arg(long, default_value = "cli-device")]
+        device_id: String,
+        /// Path to identity keystore directory
+        #[arg(short, long)]
+        keystore: Option<String>,
+    },
     /// Register identity on-chain (creates identity + wallets + SOV welcome bonus)
     ///
     /// If no local keystore exists, generates keys first. Then calls the node's

--- a/zhtp-cli/src/commands/identity.rs
+++ b/zhtp-cli/src/commands/identity.rs
@@ -30,6 +30,7 @@ use super::web4_utils::{build_trust_config, connect_client, load_identity_from_k
 pub enum IdentityOperation {
     Create,
     CreateWithType,
+    Init,
     Verify,
     List,
     Import,
@@ -42,6 +43,7 @@ impl IdentityOperation {
         match self {
             IdentityOperation::Create => "Create standard identity",
             IdentityOperation::CreateWithType => "Create identity with specific type",
+            IdentityOperation::Init => "Initialize creator identity (keystore + on-chain register)",
             IdentityOperation::Verify => "Verify identity on blockchain",
             IdentityOperation::List => "List blockchain identities",
             IdentityOperation::Import => "Import identity from backup",
@@ -57,7 +59,7 @@ pub fn action_to_operation(action: &IdentityAction) -> IdentityOperation {
     match action {
         IdentityAction::Create { .. } => IdentityOperation::Create,
         IdentityAction::CreateDid { .. } => IdentityOperation::CreateWithType,
-        IdentityAction::Register { .. } => IdentityOperation::Create,
+        IdentityAction::Init { .. } | IdentityAction::Register { .. } => IdentityOperation::Create,
         IdentityAction::Verify { .. } => IdentityOperation::Verify,
         IdentityAction::List => IdentityOperation::List,
         IdentityAction::Import { .. } => IdentityOperation::Import,
@@ -110,6 +112,20 @@ async fn handle_identity_command_impl(
 
             // Imperative: File I/O
             create_identity_with_type_impl(&name, &identity_type, output).await
+        }
+        IdentityAction::Init {
+            display_name,
+            device_id,
+            keystore,
+        } => {
+            init_creator_identity(
+                &display_name,
+                &device_id,
+                keystore.as_deref(),
+                cli,
+                output,
+            )
+            .await
         }
         IdentityAction::Register {
             display_name,
@@ -439,6 +455,31 @@ async fn create_identity_impl(
     output.success(&format!("Private key saved to: {:?}", private_key_file))?;
     output.warning("Keep your identity secure! It contains cryptographic material.")?;
 
+    Ok(())
+}
+
+/// DAO creator wizard: keystore + on-chain registration + next-step guidance.
+async fn init_creator_identity(
+    display_name: &str,
+    device_id: &str,
+    keystore_path: Option<&str>,
+    cli: &ZhtpCli,
+    output: &dyn Output,
+) -> CliResult<()> {
+    output.header("DAO Creator Identity Init")?;
+    register_identity_on_chain(display_name, device_id, keystore_path, cli, output).await?;
+
+    let keystore = match keystore_path {
+        Some(path) => PathBuf::from(path),
+        None => get_default_keystore_path()?,
+    };
+    output.print("")?;
+    output.success("Creator identity ready.")?;
+    output.print("Next steps:")?;
+    output.print(&format!("  1. Keystore: {:?}", keystore))?;
+    output.print("  2. Launch DAO token: zhtp-cli dao launch (see #2816) or zhtp-cli token create")?;
+    output.print("  3. Operator runbook: docs/ops/dao-launch-bootstrap.md")?;
+    output.print("  4. Rewards policy: schemas/zhtp/rewards-policy/examples/bubl-v1.json")?;
     Ok(())
 }
 

--- a/zhtp-cli/src/commands/identity.rs
+++ b/zhtp-cli/src/commands/identity.rs
@@ -59,7 +59,8 @@ pub fn action_to_operation(action: &IdentityAction) -> IdentityOperation {
     match action {
         IdentityAction::Create { .. } => IdentityOperation::Create,
         IdentityAction::CreateDid { .. } => IdentityOperation::CreateWithType,
-        IdentityAction::Init { .. } | IdentityAction::Register { .. } => IdentityOperation::Create,
+        IdentityAction::Init { .. } => IdentityOperation::Init,
+        IdentityAction::Register { .. } => IdentityOperation::Create,
         IdentityAction::Verify { .. } => IdentityOperation::Verify,
         IdentityAction::List => IdentityOperation::List,
         IdentityAction::Import { .. } => IdentityOperation::Import,
@@ -477,7 +478,7 @@ async fn init_creator_identity(
     output.success("Creator identity ready.")?;
     output.print("Next steps:")?;
     output.print(&format!("  1. Keystore: {:?}", keystore))?;
-    output.print("  2. Launch DAO token: zhtp-cli dao launch (see #2816) or zhtp-cli token create")?;
+    output.print("  2. Launch DAO token: zhtp-cli token create (dao launch coming in #2816)")?;
     output.print("  3. Operator runbook: docs/ops/dao-launch-bootstrap.md")?;
     output.print("  4. Rewards policy: schemas/zhtp/rewards-policy/examples/bubl-v1.json")?;
     Ok(())
@@ -735,6 +736,16 @@ mod tests {
     }
 
     #[test]
+    fn test_action_to_operation_init() {
+        let action = IdentityAction::Init {
+            display_name: "creator".to_string(),
+            device_id: "cli-device".to_string(),
+            keystore: None,
+        };
+        assert_eq!(action_to_operation(&action), IdentityOperation::Init);
+    }
+
+    #[test]
     fn test_action_to_operation_create_with_type() {
         let action = IdentityAction::CreateDid {
             name: "test".to_string(),
@@ -770,6 +781,10 @@ mod tests {
         assert_eq!(
             IdentityOperation::CreateWithType.description(),
             "Create identity with specific type"
+        );
+        assert_eq!(
+            IdentityOperation::Init.description(),
+            "Initialize creator identity (keystore + on-chain register)"
         );
         assert_eq!(
             IdentityOperation::Verify.description(),


### PR DESCRIPTION
## Epic
Closes #2818 · Parent #2799 · Stacked on #2833

## Summary
`zhtp-cli identity init` — generate keystore (if needed), register on-chain, print DAO launch next steps.

## Acceptance criteria
- [x] `zhtp-cli identity init` creates keystore pair usable for launch
- [x] Docs cover DID registration prerequisite (via on-chain register in same command)
- [x] Output paths compatible with `dao launch` and rewards delegate

## Usage
```bash
zhtp-cli identity init --display-name "My DAO Creator"
```

## Next
Stacked: C2 rewards live API (#2817)