### PR TITLE
DAO C1: dao launch unified command (#2816)

### DIFF
--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -509,7 +509,7 @@ pub enum DaoAction {
         /// Token symbol (e.g. BUBL)
         #[arg(short, long)]
         symbol: String,
-        /// Initial supply in atomic units (18 decimals: 1 token = 10^18 atoms)
+        /// Initial supply in atomic units (whole_tokens * 10^--decimals)
         #[arg(short, long)]
         supply: u128,
         /// Display decimals

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -501,6 +501,24 @@ pub enum OracleAction {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum DaoAction {
+    /// Launch a DAO token (TokenCreation + 80/20 split). Phase 1 minimal.
+    Launch {
+        /// Token name (e.g. Bubble)
+        #[arg(short, long)]
+        name: String,
+        /// Token symbol (e.g. BUBL)
+        #[arg(short, long)]
+        symbol: String,
+        /// Initial supply in atomic units (18 decimals: 1 token = 10^18 atoms)
+        #[arg(short, long)]
+        supply: u128,
+        /// Display decimals
+        #[arg(short, long, default_value = "18")]
+        decimals: u8,
+        /// Treasury recipient key_id (32-byte hex). Defaults to protocol DAO treasury.
+        #[arg(long)]
+        treasury_recipient: Option<String>,
+    },
     /// Get DAO information (orchestrated)
     Info,
     /// Create new proposal (orchestrated)

--- a/zhtp-cli/src/commands/dao.rs
+++ b/zhtp-cli/src/commands/dao.rs
@@ -365,11 +365,11 @@ async fn handle_dao_command_impl(
 ) -> CliResult<()> {
     // Launch delegates to token::handle_create (connects internally).
     if let DaoAction::Launch {
-        name,
-        symbol,
+        ref name,
+        ref symbol,
         supply,
         decimals,
-        treasury_recipient,
+        ref treasury_recipient,
     } = args.action
     {
         output.header("DAO Launch (TokenCreation)")?;

--- a/zhtp-cli/src/commands/dao.rs
+++ b/zhtp-cli/src/commands/dao.rs
@@ -3,6 +3,7 @@
 //! Architecture: Functional Core, Imperative Shell (FCIS)
 
 use crate::argument_parsing::{format_output, DaoAction, DaoArgs, ZhtpCli};
+use crate::commands::token;
 use crate::commands::transaction_utils::{broadcast_signed_tx, parse_hex_32};
 use crate::commands::web4_utils::{
     connect_default, default_keystore_path, load_identity_from_keystore,
@@ -116,7 +117,8 @@ pub fn action_to_operation(action: &DaoAction) -> Option<DaoOperation> {
         DaoAction::Balance | DaoAction::TreasuryBalance => Some(DaoOperation::Balance),
         DaoAction::RegistryList => Some(DaoOperation::RegistryList),
         DaoAction::RegistryGet { .. } => Some(DaoOperation::RegistryGet),
-        DaoAction::RegistryRegister { .. }
+        DaoAction::Launch { .. }
+        | DaoAction::RegistryRegister { .. }
         | DaoAction::FactoryCreate { .. }
         | DaoAction::EntityRegistryInit { .. }
         | DaoAction::EntityRegistryStatus
@@ -352,14 +354,61 @@ fn build_registry_get_endpoint(dao_id: &str) -> String {
     format!("/api/v1/dao/registry/{}", dao_id.trim_start_matches("0x"))
 }
 
+fn default_protocol_treasury_key_id_hex() -> String {
+    hex::encode(lib_crypto::hash_blake3(b"SOV_DAO_TREASURY_V1"))
+}
+
 async fn handle_dao_command_impl(
     args: DaoArgs,
     cli: &ZhtpCli,
     output: &dyn Output,
 ) -> CliResult<()> {
-    let client = connect_default(&cli.server).await?;
+    // Launch delegates to token::handle_create (connects internally).
+    if let DaoAction::Launch {
+        name,
+        symbol,
+        supply,
+        decimals,
+        treasury_recipient,
+    } = args.action
+    {
+        output.header("DAO Launch (TokenCreation)")?;
+        let treasury = treasury_recipient.unwrap_or_else(default_protocol_treasury_key_id_hex);
+        output.info(&format!(
+            "Launching {} ({}) — 80% creator / 20% treasury ({})",
+            name,
+            symbol,
+            &treasury[..16.min(treasury.len())]
+        ))?;
+        token::handle_create(cli, output, &name, &symbol, supply, decimals, &treasury).await?;
+        let token_id = hex::encode(lib_blockchain::contracts::utils::generate_custom_token_id(
+            &name, &symbol,
+        ));
+        const TREASURY_BPS: u128 = 2_000; // 20% — matches TokenCreationPayloadV1
+        let treasury_atoms = supply.saturating_mul(TREASURY_BPS) / 10_000;
+        let creator_atoms = supply.saturating_sub(treasury_atoms);
+        output.print("")?;
+        output.success("DAO token deployed.")?;
+        output.print(&format!("Deterministic token_id: {}", token_id))?;
+        output.print(&format!(
+            "Creator allocation: {} atoms (80%)",
+            creator_atoms
+        ))?;
+        output.print(&format!(
+            "Treasury allocation: {} atoms (20%) → {}",
+            treasury_atoms,
+            &treasury[..16.min(treasury.len())]
+        ))?;
+        output.print(&format!("Share (future): zhtp://asset/{}", token_id))?;
+        output.print(
+            "Next: publish rewards policy (D1), fund delegate (C4), enable rewards (N3)",
+        )?;
+        return Ok(());
+    }
 
+    let client = connect_default(&cli.server).await?;
     match args.action {
+        DaoAction::Launch { .. } => unreachable!("handled above"),
         DaoAction::Info => {
             let operation = DaoOperation::Info;
             handle_dao_operation_impl(&client, operation, None, None, None, None, cli, output).await

--- a/zhtp-cli/src/commands/token.rs
+++ b/zhtp-cli/src/commands/token.rs
@@ -275,11 +275,11 @@ pub async fn handle_token_command_with_output<O: Output>(
     }
 }
 
-/// Handle token creation
+/// Handle token creation (also used by `dao launch`).
 /// NOTE: Creator identity is derived from authenticated session on server
-async fn handle_create<O: Output>(
+pub async fn handle_create(
     cli: &ZhtpCli,
-    output: &O,
+    output: &dyn Output,
     name: &str,
     symbol: &str,
     supply: u128,

--- a/zhtp-cli/src/commands/token.rs
+++ b/zhtp-cli/src/commands/token.rs
@@ -362,6 +362,9 @@ pub async fn handle_create(
             reason: format!("Failed to parse response: {}", e),
         })?;
 
+    let formatted = format_output(&response_json, &cli.format)?;
+    output.print(&formatted)?;
+
     if response_json
         .get("success")
         .and_then(|v| v.as_bool())
@@ -375,18 +378,19 @@ pub async fn handle_create(
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown")
         ))?;
+        Ok(())
     } else {
         let error = response_json
             .get("error")
             .and_then(|v| v.as_str())
             .unwrap_or("Unknown error");
         output.error(&format!("Failed to create token: {}", error))?;
+        Err(CliError::ApiCallFailed {
+            endpoint: "/api/v1/token/create".to_string(),
+            status: 0,
+            reason: error.to_string(),
+        })
     }
-
-    let formatted = format_output(&response_json, &cli.format)?;
-    output.print(&formatted)?;
-
-    Ok(())
 }
 
 /// Handle token minting


### PR DESCRIPTION
Closes #2816

Part of DAO Launch v1 epic #2799. Stacked on #2835 (C2).

## Summary

Adds Phase 1 minimal `zhtp-cli dao launch` — wraps `TokenCreation` with the protocol 80/20 split, default treasury (`blake3("SOV_DAO_TREASURY_V1")`), and operator-friendly output.

## Changes

- `DaoAction::Launch` subcommand (`--name`, `--symbol`, `--supply`, `--decimals`, optional `--treasury-recipient`)
- Handler delegates to `token::handle_create` for signing + broadcast
- Prints deterministic `token_id`, creator/treasury allocation atoms, and next-step hints

## Acceptance criteria

- [x] Phase 1: minimal launch works on testnet (name, symbol, supply, treasury)
- [x] Prints `asset_id` (deterministic token_id), creator/treasury allocation atoms
- [ ] Phase 3: all documented flags wired (manifest, rewards-policy, delegate, governance, dao-class) — deferred
- [x] Replaces manual `seed_founding_dao` + curl for user path (operators use `identity init` → `dao launch`)

## Test plan

- [x] `cargo test -p zhtp-cli --lib` (431 passed)
- [ ] Manual: `zhtp-cli dao launch --name Bubble --symbol BUBL --supply 1000000000000000000000` against testnet

## Stack

```
development → #2832 D1 → #2833 D2 → #2834 C3 → #2835 C2 → this PR
```