### PR TITLE
DAO M2: Field gating server validation (#2827)

### DIFF
--- a/lib-blockchain/src/transaction/token_creation.rs
+++ b/lib-blockchain/src/transaction/token_creation.rs
@@ -12,6 +12,10 @@ pub const TOKEN_CREATION_MEMO_PREFIX: &[u8] = b"ZHTP_TOKEN_CREATE_V1:";
 pub const MAX_TOKEN_NAME_BYTES: usize = 64;
 /// Maximum token symbol length.
 pub const MAX_TOKEN_SYMBOL_BYTES: usize = 10;
+/// SovSwap / DAO launch UI symbol cap (stricter than protocol max).
+pub const DAO_LAUNCH_MAX_SYMBOL_CHARS: usize = 6;
+/// Minimum whole-token supply for DAO launch (atoms = whole * 10^decimals).
+pub const DAO_LAUNCH_MIN_WHOLE_SUPPLY: u128 = 1_000;
 /// Maximum memo bytes accepted for token creation payload.
 pub const MAX_TOKEN_CREATION_MEMO_BYTES: usize = 4096;
 /// Canonical treasury allocation for non-SOV token deployments (20%).
@@ -85,6 +89,51 @@ impl TokenCreationPayloadV1 {
             return Err("treasury_recipient must be non-zero".to_string());
         }
         Ok(())
+    }
+
+    /// Stricter SovSwap-aligned constraints for the DAO launch user path (M2).
+    ///
+    /// Protocol `validate()` allows symbols up to 10 chars; the app uses ≤6
+    /// uppercase. Minimum supply is 1_000 whole tokens at `decimals` precision.
+    pub fn validate_dao_launch_ui_constraints(&self) -> Result<(), String> {
+        self.validate()?;
+        if self.symbol.len() > DAO_LAUNCH_MAX_SYMBOL_CHARS {
+            return Err(format!(
+                "symbol length {} exceeds DAO launch max {}",
+                self.symbol.len(),
+                DAO_LAUNCH_MAX_SYMBOL_CHARS
+            ));
+        }
+        if !self
+            .symbol
+            .chars()
+            .all(|c| c.is_ascii_uppercase() && c.is_ascii_alphabetic())
+        {
+            return Err("symbol must be uppercase A-Z".to_string());
+        }
+        let scale = 10u128
+            .checked_pow(self.decimals as u32)
+            .ok_or_else(|| format!("decimals {} overflow for supply scale", self.decimals))?;
+        let min_atoms = DAO_LAUNCH_MIN_WHOLE_SUPPLY
+            .checked_mul(scale)
+            .ok_or_else(|| "minimum supply atoms overflow".to_string())?;
+        if self.initial_supply < min_atoms {
+            return Err(format!(
+                "initial_supply must be at least {} whole tokens ({} atoms at {} decimals)",
+                DAO_LAUNCH_MIN_WHOLE_SUPPLY, min_atoms, self.decimals
+            ));
+        }
+        Ok(())
+    }
+
+    /// Minimum launch supply in atomic units for the given display decimals.
+    pub fn dao_launch_min_supply_atoms(decimals: u8) -> Result<u128, String> {
+        let scale = 10u128
+            .checked_pow(decimals as u32)
+            .ok_or_else(|| format!("decimals {} overflow for supply scale", decimals))?;
+        DAO_LAUNCH_MIN_WHOLE_SUPPLY
+            .checked_mul(scale)
+            .ok_or_else(|| "minimum supply atoms overflow".to_string())
     }
 
     /// Deterministically split initial supply into (creator, treasury) allocation.
@@ -204,5 +253,36 @@ mod tests {
         };
 
         assert!(payload.validate().is_err());
+    }
+
+    #[test]
+    fn dao_launch_ui_constraints_enforce_symbol_and_supply() {
+        let ok = TokenCreationPayloadV1 {
+            name: "Bubble".to_string(),
+            symbol: "BUBL".to_string(),
+            initial_supply: 1_000 * 10u128.pow(18),
+            decimals: 18,
+            treasury_allocation_bps: TOKEN_CREATION_TREASURY_ALLOCATION_BPS,
+            treasury_recipient: [1u8; 32],
+        };
+        assert!(ok.validate_dao_launch_ui_constraints().is_ok());
+
+        let long_symbol = TokenCreationPayloadV1 {
+            symbol: "SEVENNN".to_string(),
+            ..ok.clone()
+        };
+        assert!(long_symbol.validate_dao_launch_ui_constraints().is_err());
+
+        let lowercase = TokenCreationPayloadV1 {
+            symbol: "bubl".to_string(),
+            ..ok.clone()
+        };
+        assert!(lowercase.validate_dao_launch_ui_constraints().is_err());
+
+        let low_supply = TokenCreationPayloadV1 {
+            initial_supply: 999 * 10u128.pow(18),
+            ..ok
+        };
+        assert!(low_supply.validate_dao_launch_ui_constraints().is_err());
     }
 }

--- a/zhtp-cli/src/commands/dao.rs
+++ b/zhtp-cli/src/commands/dao.rs
@@ -11,6 +11,7 @@ use crate::commands::web4_utils::{
 use crate::error::{CliError, CliResult};
 use crate::output::Output;
 use lib_blockchain::contracts::derive_dao_id;
+use lib_blockchain::transaction::TokenCreationPayloadV1;
 use lib_blockchain::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
 use lib_blockchain::transaction::DaoExecutionData;
 use lib_blockchain::types::dao::DAOType;
@@ -380,6 +381,17 @@ async fn handle_dao_command_impl(
             symbol,
             &treasury[..16.min(treasury.len())]
         ))?;
+        let draft = TokenCreationPayloadV1 {
+            name: name.clone(),
+            symbol: symbol.clone(),
+            initial_supply: supply,
+            decimals,
+            treasury_allocation_bps: 2_000,
+            treasury_recipient: [1u8; 32],
+        };
+        draft.validate_dao_launch_ui_constraints().map_err(|e| {
+            CliError::ConfigError(format!("DAO launch validation failed: {e}"))
+        })?;
         token::handle_create(cli, output, &name, &symbol, supply, decimals, &treasury).await?;
         let token_id = hex::encode(lib_blockchain::contracts::utils::generate_custom_token_id(
             &name, &symbol,

--- a/zhtp-cli/src/commands/dao.rs
+++ b/zhtp-cli/src/commands/dao.rs
@@ -381,18 +381,29 @@ async fn handle_dao_command_impl(
             symbol,
             &treasury[..16.min(treasury.len())]
         ))?;
+        let treasury_key_id = parse_hex_32("treasury_recipient", &treasury)?;
         let draft = TokenCreationPayloadV1 {
             name: name.clone(),
             symbol: symbol.clone(),
             initial_supply: supply,
             decimals,
             treasury_allocation_bps: 2_000,
-            treasury_recipient: [1u8; 32],
+            treasury_recipient: treasury_key_id,
         };
         draft.validate_dao_launch_ui_constraints().map_err(|e| {
             CliError::ConfigError(format!("DAO launch validation failed: {e}"))
         })?;
-        token::handle_create(cli, output, &name, &symbol, supply, decimals, &treasury).await?;
+        token::handle_create(
+            cli,
+            output,
+            &name,
+            &symbol,
+            supply,
+            decimals,
+            &treasury,
+            true,
+        )
+        .await?;
         let token_id = hex::encode(lib_blockchain::contracts::utils::generate_custom_token_id(
             &name, &symbol,
         ));

--- a/zhtp-cli/src/commands/token.rs
+++ b/zhtp-cli/src/commands/token.rs
@@ -253,6 +253,7 @@ pub async fn handle_token_command_with_output<O: Output>(
                 supply,
                 decimals,
                 &treasury_recipient,
+                false,
             )
             .await
         }
@@ -285,6 +286,7 @@ pub async fn handle_create(
     supply: u128,
     decimals: u8,
     treasury_recipient: &str,
+    enforce_dao_launch_constraints: bool,
 ) -> CliResult<()> {
     validate_decimals(decimals)?;
     output.info(&format!("Creating token: {} ({})", name, symbol))?;
@@ -343,7 +345,10 @@ pub async fn handle_create(
     }
     let tx_bytes = bincode::serialize(&tx)
         .map_err(|e| CliError::ConfigError(format!("Failed to serialize tx: {}", e)))?;
-    let request_body = json!({ "signed_tx": hex::encode(tx_bytes) });
+    let request_body = json!({
+        "signed_tx": hex::encode(tx_bytes),
+        "enforce_dao_launch_constraints": enforce_dao_launch_constraints,
+    });
 
     // Reuse the QUIC client already opened above for the fee lookup.
     let response = client

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -52,6 +52,9 @@ pub struct SubmitTokenTransactionRequest {
 #[derive(Debug, Deserialize)]
 pub struct CreateTokenRequest {
     pub signed_tx: String,
+    /// When true, apply SovSwap/DAO-launch UI constraints (M2) in addition to protocol validation.
+    #[serde(default)]
+    pub enforce_dao_launch_constraints: bool,
 }
 
 /// Request to mint tokens (client must provide signed tx)
@@ -248,12 +251,14 @@ impl TokenHandler {
                 ));
             }
         };
-        if let Err(e) = payload.validate_dao_launch_ui_constraints() {
-            tracing::error!("[token/create] DAO launch constraints FAILED: {}", e);
-            return Ok(create_error_response(
-                ZhtpStatus::BadRequest,
-                format!("DAO launch validation failed: {}", e),
-            ));
+        if create_req.enforce_dao_launch_constraints {
+            if let Err(e) = payload.validate_dao_launch_ui_constraints() {
+                tracing::error!("[token/create] token creation constraints FAILED: {}", e);
+                return Ok(create_error_response(
+                    ZhtpStatus::BadRequest,
+                    format!("Token creation validation failed: {}", e),
+                ));
+            }
         }
         let (creator_allocation, treasury_allocation) = payload.split_initial_supply();
         let TokenCreationPayloadV1 {

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -248,6 +248,13 @@ impl TokenHandler {
                 ));
             }
         };
+        if let Err(e) = payload.validate_dao_launch_ui_constraints() {
+            tracing::error!("[token/create] DAO launch constraints FAILED: {}", e);
+            return Ok(create_error_response(
+                ZhtpStatus::BadRequest,
+                format!("DAO launch validation failed: {}", e),
+            ));
+        }
         let (creator_allocation, treasury_allocation) = payload.split_initial_supply();
         let TokenCreationPayloadV1 {
             name,


### PR DESCRIPTION
Closes #2827 (server-side slice)

Part of DAO Launch v1 epic #2799. Stacked on #2836 (C1).

## Summary

Enforces SovSwap-aligned DAO launch constraints on the server and CLI before mempool submit.

## Changes

- `TokenCreationPayloadV1::validate_dao_launch_ui_constraints()` in `lib-blockchain`
  - Symbol: ≤6 chars, uppercase `A-Z` only (protocol still allows 10 via direct broadcast)
  - Supply: minimum 1_000 whole tokens at `decimals` precision
- `/api/v1/token/create` rejects payloads failing constraints
- `zhtp-cli dao launch` validates before signing

## Acceptance criteria

- [ ] Phase 1: unsupported fields disabled with roadmap tooltip — **mobile** (SovSwap CreateDaoTab not in `Sovereign-Network-Mobile` yet; blocked on app UI)
- [x] Server validates same constraints as client (symbol/supply)
- [ ] Phase 4: enable fields as P8/P9/Q9 land — deferred
- [ ] Payload mapping doc aligned with C1 flags — deferred (no doc file in this PR)

## Test plan

- [x] `cargo test -p lib-blockchain --lib dao_launch_ui_constraints_enforce_symbol_and_supply`
- [x] `cargo test -p zhtp-cli --lib`

## Stack

```
development → #2832 D1 → #2833 D2 → #2834 C3 → #2835 C2 → #2836 C1 → this PR
```

## Follow-up

Mobile M2/M5 (#2830) require SovSwap `CreateDaoTab` in the wallet app repo once that screen lands.