### PR TITLE
DAO P3: On-chain RewardsModuleState (#2802)

### DIFF
--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1355,6 +1355,15 @@ impl Blockchain {
             .find(|a| a.asset_id == *asset_id)
     }
 
+    /// On-chain rewards module state (`asset_rewards/` sled tree).
+    pub fn get_rewards_module_state(
+        &self,
+        asset_id: &[u8; 32],
+    ) -> Option<crate::contracts::sovereign_asset::RewardsModuleState> {
+        let store = self.get_store()?;
+        store.get_rewards_module_state(asset_id).ok().flatten()
+    }
+
     pub fn register_web4_contract(
         &mut self,
         contract_id: [u8; 32],

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1361,7 +1361,17 @@ impl Blockchain {
         asset_id: &[u8; 32],
     ) -> Option<crate::contracts::sovereign_asset::RewardsModuleState> {
         let store = self.get_store()?;
-        store.get_rewards_module_state(asset_id).ok().flatten()
+        match store.get_rewards_module_state(asset_id) {
+            Ok(state) => state,
+            Err(e) => {
+                warn!(
+                    "Failed to load rewards module state for asset {}: {}",
+                    hex::encode(asset_id),
+                    e
+                );
+                None
+            }
+        }
     }
 
     pub fn register_web4_contract(

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -5097,6 +5097,77 @@ mod tests {
     }
 
     #[test]
+    fn test_asset_launch_writes_rewards_module_state() {
+        use crate::contracts::sovereign_asset::{AssetModuleFlags, RewardsModuleState};
+        use crate::transaction::asset_tx::{AssetLaunchPayloadV1, RewardsLaunchConfig};
+
+        let store = create_test_store();
+        let executor = create_test_executor(store.clone());
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let delegate_key = [0xDD; 32];
+        let policy_cid = [0x11; 32];
+        let policy_hash = [0x22; 32];
+        let payload = AssetLaunchPayloadV1 {
+            name: "Bubble".to_string(),
+            symbol: "BUBL".to_string(),
+            decimals: 18,
+            initial_supply: 1_000,
+            treasury_key_id: [0xAA; 32],
+            treasury_bps: 2_000,
+            supply_mode: crate::contracts::sovereign_asset::SupplyMode::Fixed,
+            manifest_cid: [1u8; 32],
+            manifest_hash: [2u8; 32],
+            curve: None,
+            rewards: Some(RewardsLaunchConfig {
+                spend_delegate_key_id: delegate_key,
+                policy_cid,
+                policy_hash,
+            }),
+            governance: None,
+            transfer_authority: false,
+        };
+        let memo = payload.encode_memo().expect("valid asset launch memo");
+        let tx = Transaction {
+            version: 2,
+            chain_id: 0x03,
+            transaction_type: TransactionType::AssetLaunch,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: create_dummy_signature(),
+            memo,
+            payload: crate::transaction::TransactionPayload::None,
+        };
+        let expected_asset_id = hash_transaction(&tx).as_array();
+
+        let block1 = create_block_with_txs(1, genesis.header.block_hash, vec![tx]);
+        executor.apply_block(&block1).expect("AssetLaunch should apply");
+
+        let asset = store
+            .get_sovereign_asset(&expected_asset_id)
+            .expect("read asset")
+            .expect("asset exists");
+        assert!(asset.module_flags.has_rewards());
+        assert_eq!(asset.module_bitmask() & AssetModuleFlags::REWARDS, AssetModuleFlags::REWARDS);
+
+        let rewards_state = store
+            .get_rewards_module_state(&expected_asset_id)
+            .expect("read rewards state")
+            .expect("rewards state exists");
+        assert_eq!(
+            rewards_state,
+            RewardsModuleState {
+                spend_delegate_key_id: delegate_key,
+                policy_cid,
+                policy_hash,
+                nonce: 0,
+            }
+        );
+    }
+
+    #[test]
     fn test_contract_deployment_writes_contract_code() {
         let store = create_test_store();
         let executor = create_test_executor(store.clone());

--- a/lib-blockchain/src/transaction/asset_tx.rs
+++ b/lib-blockchain/src/transaction/asset_tx.rs
@@ -33,6 +33,21 @@ pub struct RewardsLaunchConfig {
     pub policy_hash: [u8; 32],
 }
 
+impl RewardsLaunchConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.spend_delegate_key_id == [0u8; 32] {
+            return Err("rewards spend_delegate_key_id must be non-zero".to_string());
+        }
+        if self.policy_cid == [0u8; 32] {
+            return Err("rewards policy_cid must be non-zero".to_string());
+        }
+        if self.policy_hash == [0u8; 32] {
+            return Err("rewards policy_hash must be non-zero".to_string());
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GovernanceLaunchConfig {
     pub verifier: GovernanceVerifierState,
@@ -108,9 +123,7 @@ impl AssetLaunchPayloadV1 {
             return Err("elastic supply_mode requires curve module at launch".to_string());
         }
         if let Some(rewards) = &self.rewards {
-            if rewards.spend_delegate_key_id == [0u8; 32] {
-                return Err("rewards spend_delegate_key_id must be non-zero".to_string());
-            }
+            rewards.validate()?;
         }
         if let Some(gov) = &self.governance {
             validate_governance_verifier(&gov.resolved_verifier())?;

--- a/tools/seed_asset_launch.rs
+++ b/tools/seed_asset_launch.rs
@@ -10,9 +10,10 @@
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use lib_blockchain::{
+    contracts::sovereign_asset::SupplyMode,
     integration::crypto_integration::{Signature, SignatureAlgorithm},
     protocol::ProtocolParams,
-    contracts::sovereign_asset::SupplyMode,
+    rewards_policy::{policy_hash, validate_rewards_policy},
     transaction::{
         asset_tx::{AssetLaunchPayloadV1, RewardsLaunchConfig},
         hash_transaction, Transaction,
@@ -84,6 +85,9 @@ struct Args {
     /// Keystore for rewards spend delegate (BUBL only).
     #[arg(long)]
     rewards_delegate_dir: Option<PathBuf>,
+    /// Rewards policy JSON (`zhtp/rewards-policy/v1`). Hashed for on-chain `policy_hash`.
+    #[arg(long, default_value = "schemas/zhtp/rewards-policy/examples/bubl-v1.json")]
+    policy_file: PathBuf,
     #[arg(long, default_value_t = 0x03)]
     chain_id: u8,
     #[arg(long, default_value_t = 0)]
@@ -133,6 +137,15 @@ fn token_meta(token: &FoundingToken) -> (&'static str, &'static str, u8, SupplyM
             (CBE_NAME, CBE_SYMBOL, CBE_DECIMALS, SupplyMode::Elastic)
         }
     }
+}
+
+fn load_rewards_policy_refs(policy_path: &std::path::Path) -> Result<([u8; 32], [u8; 32])> {
+    let bytes = std::fs::read(policy_path)
+        .with_context(|| format!("read rewards policy {}", policy_path.display()))?;
+    let policy = validate_rewards_policy(&bytes).context("validate rewards policy")?;
+    let hash = policy_hash(&policy).context("hash rewards policy")?;
+    let digest = hash.as_array();
+    Ok((digest, digest))
 }
 
 fn placeholder_manifest() -> ([u8; 32], [u8; 32]) {
@@ -216,7 +229,7 @@ fn main() -> Result<()> {
     let rewards = match (&args.token, &args.rewards_delegate_dir) {
         (FoundingToken::Bubl, Some(dir)) => {
             let delegate_kp = load_keypair(dir)?;
-            let (policy_cid, policy_hash) = placeholder_manifest();
+            let (policy_cid, policy_hash) = load_rewards_policy_refs(&args.policy_file)?;
             Some(RewardsLaunchConfig {
                 spend_delegate_key_id: delegate_kp.public_key.key_id,
                 policy_cid,

--- a/tools/seed_asset_launch.rs
+++ b/tools/seed_asset_launch.rs
@@ -144,8 +144,11 @@ fn load_rewards_policy_refs(policy_path: &std::path::Path) -> Result<([u8; 32], 
         .with_context(|| format!("read rewards policy {}", policy_path.display()))?;
     let policy = validate_rewards_policy(&bytes).context("validate rewards policy")?;
     let hash = policy_hash(&policy).context("hash rewards policy")?;
-    let digest = hash.as_array();
-    Ok((digest, digest))
+    let policy_hash = *hash.as_array();
+    let mut cid_input = b"zhtp/rewards-policy/cid/v1\0".to_vec();
+    cid_input.extend_from_slice(&bytes);
+    let policy_cid = lib_crypto::hash_blake3(&cid_input);
+    Ok((policy_cid, policy_hash))
 }
 
 fn placeholder_manifest() -> ([u8; 32], [u8; 32]) {

--- a/zhtp/src/api/handlers/assets/mod.rs
+++ b/zhtp/src/api/handlers/assets/mod.rs
@@ -219,6 +219,9 @@ impl AssetsHandler {
             .get_sovereign_asset(&asset_id)
             .ok_or_else(|| anyhow::anyhow!("Asset not found"))?;
         let rewards_state = bc.get_rewards_module_state(&asset_id);
+        if asset.module_flags.has_rewards() && rewards_state.is_none() {
+            anyhow::bail!("rewards module state unavailable for asset {}", asset_id_hex);
+        }
         create_json_response(serde_json::to_value(to_detail(
             &asset,
             rewards_state.as_ref(),

--- a/zhtp/src/api/handlers/assets/mod.rs
+++ b/zhtp/src/api/handlers/assets/mod.rs
@@ -1,7 +1,9 @@
 //! Sovereign Asset discovery API (ADR: docs/arch/sovereign-asset.md, SA-2).
 
 use anyhow::Result;
-use lib_blockchain::contracts::sovereign_asset::{AssetIdSource, SovereignAsset, SupplyMode};
+use lib_blockchain::contracts::sovereign_asset::{
+    AssetIdSource, RewardsModuleState, SovereignAsset, SupplyMode,
+};
 use lib_blockchain::{Blockchain, BlockchainQuery};
 use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_protocols::zhtp::ZhtpRequestHandler;
@@ -129,7 +131,25 @@ fn to_list_item(asset: &SovereignAsset) -> AssetListItem {
     }
 }
 
-fn to_detail(asset: &SovereignAsset) -> AssetDetailResponse {
+fn rewards_detail(
+    asset: &SovereignAsset,
+    state: Option<&RewardsModuleState>,
+) -> Option<serde_json::Value> {
+    if !asset.module_flags.has_rewards() {
+        return None;
+    }
+    let header = asset.rewards.as_ref();
+    Some(json!({
+        "spend_delegate_key_id": state
+            .map(|s| hex::encode(s.spend_delegate_key_id))
+            .or_else(|| header.and_then(|h| h.spend_delegate_key_id.map(hex::encode))),
+        "policy_cid": state.map(|s| hex::encode(s.policy_cid)),
+        "policy_hash": state.map(|s| hex::encode(s.policy_hash)),
+        "nonce": state.map(|s| s.nonce),
+    }))
+}
+
+fn to_detail(asset: &SovereignAsset, rewards_state: Option<&RewardsModuleState>) -> AssetDetailResponse {
     AssetDetailResponse {
         asset_id: hex::encode(asset.asset_id),
         id_source: id_source_label(asset.id_source).to_string(),
@@ -153,11 +173,7 @@ fn to_detail(asset: &SovereignAsset) -> AssetDetailResponse {
                 "sell_enabled": c.sell_enabled,
             })
         }),
-        rewards: asset.rewards.as_ref().map(|r| {
-            json!({
-                "spend_delegate_key_id": r.spend_delegate_key_id.map(hex::encode),
-            })
-        }),
+        rewards: rewards_detail(asset, rewards_state),
         governance: asset.governance.as_ref().map(|g| {
             json!({
                 "verifier": match g.verifier {
@@ -202,7 +218,11 @@ impl AssetsHandler {
         let asset = bc
             .get_sovereign_asset(&asset_id)
             .ok_or_else(|| anyhow::anyhow!("Asset not found"))?;
-        create_json_response(serde_json::to_value(to_detail(&asset))?)
+        let rewards_state = bc.get_rewards_module_state(&asset_id);
+        create_json_response(serde_json::to_value(to_detail(
+            &asset,
+            rewards_state.as_ref(),
+        ))?)
     }
 
     async fn handle_interface(&self, asset_id_hex: &str) -> Result<ZhtpResponse> {


### PR DESCRIPTION
Closes #2802

Part of DAO Launch v1 epic #2799. Stacked on #2837 (M2 server).

## Summary

Completes RewardsModuleState wiring for the sovereign-asset launch path: validation, persistence (already in executor), read API, and operator seed tooling.

## Changes

- `RewardsLaunchConfig::validate()` — non-zero `spend_delegate_key_id`, `policy_cid`, `policy_hash`
- `Blockchain::get_rewards_module_state()` — storage-backed read
- `GET /api/v1/assets/{id}` — returns `policy_cid`, `policy_hash`, `nonce` when rewards module enabled
- `seed_asset_launch --policy-file` — loads `bubl-v1.json`, computes BLAKE3 `policy_hash` (no placeholder)
- Integration test: `test_asset_launch_writes_rewards_module_state`

## Acceptance criteria

- [x] `RewardsModuleState` written at `AssetLaunch` when `rewards` config present
- [x] Module bit set on `SovereignAsset.module_flags`
- [x] State readable via storage API and asset projection
- [x] `seed_asset_launch` populates real policy CID/hash (not placeholder)

## Test plan

- [x] `cargo test -p lib-blockchain --lib test_asset_launch_writes_rewards_module_state`
- [x] `cargo build -p tools --bin seed_asset_launch`

## Stack

```
development → … → #2836 C1 → #2837 M2 → this PR
```