### PR TITLE
DAO P5: Spend delegate enforcement (#2804)

### DIFF
--- a/lib-blockchain/src/execution/reward_claim.rs
+++ b/lib-blockchain/src/execution/reward_claim.rs
@@ -103,9 +103,20 @@ pub fn apply_reward_claim(
         }
     };
 
-    if contract.creator.key_id != data.from {
+    if let Some(rewards_state) = mutator.get_rewards_module_state(&data.token_id)? {
+        if data.from != rewards_state.spend_delegate_key_id {
+            warn!(
+                "RewardClaim rejected at height {}: signer {} is not spend delegate {} for token {}",
+                block_height,
+                hex::encode(data.from),
+                hex::encode(rewards_state.spend_delegate_key_id),
+                hex::encode(data.token_id)
+            );
+            return Ok(None);
+        }
+    } else if contract.creator.key_id != data.from {
         warn!(
-            "RewardClaim rejected at height {}: signer is not token creator",
+            "RewardClaim rejected at height {}: signer is not token creator (legacy path)",
             block_height
         );
         return Ok(None);


### PR DESCRIPTION
Closes #2804 (partial — delegate signer gate)

Stacked on #2839 (P4).

## Changes

- `apply_reward_claim`: when `RewardsModuleState` exists, `from` must equal `spend_delegate_key_id`
- Legacy `TokenCreation` tokens without rewards module still require creator signer

## Acceptance criteria

- [x] Claims rejected if `from != spend_delegate_key_id` (sovereign asset path)
- [ ] Delegate cannot invoke mint paths — existing executor gates (unchanged)
- [x] `AssetRewardsDelegateRotate` updates on-chain state (SA-4, already in `sovereign_asset.rs`)
- [ ] Pre-handoff creator rotate vs governance — documented in SA-4; CLI in C4 (#2819)

## Stack

`… → #2838 P3 → #2839 P4 → this PR`