### PR TITLE
fix(cli): dao launch treasury_recipient borrow fix

### DIFF
--- a/zhtp-cli/src/commands/dao.rs
+++ b/zhtp-cli/src/commands/dao.rs
@@ -374,7 +374,9 @@ async fn handle_dao_command_impl(
     } = args.action
     {
         output.header("DAO Launch (TokenCreation)")?;
-        let treasury = treasury_recipient.unwrap_or_else(default_protocol_treasury_key_id_hex);
+        let treasury = treasury_recipient
+            .clone()
+            .unwrap_or_else(default_protocol_treasury_key_id_hex);
         output.info(&format!(
             "Launching {} ({}) — 80% creator / 20% treasury ({})",
             name,


### PR DESCRIPTION
## Summary
- Fix `E0507` in `zhtp-cli/src/commands/dao.rs`: `treasury_recipient` is borrowed from the `Launch` match arm, so `unwrap_or_else` cannot take ownership.
- Clone the optional before falling back to the default protocol treasury key id.

## Test plan
- [x] `cargo check -p zhtp-cli` passes locally