### PR TITLE
DAO N3: Chain-native rewards activation (#2813)

### DIFF
--- a/tools/seed_asset_launch.rs
+++ b/tools/seed_asset_launch.rs
@@ -146,7 +146,7 @@ fn load_rewards_policy_bundle(
         .with_context(|| format!("read rewards policy {}", policy_path.display()))?;
     let policy = validate_rewards_policy(&bytes).context("validate rewards policy")?;
     let hash = policy_hash(&policy).context("hash rewards policy")?;
-    let policy_hash = *hash.as_array();
+    let policy_hash = hash.as_array();
     let mut cid_input = b"zhtp/rewards-policy/cid/v1\0".to_vec();
     cid_input.extend_from_slice(&bytes);
     let policy_cid = lib_crypto::hash_blake3(&cid_input);

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -340,6 +340,18 @@ pub enum NodeAction {
         #[arg(short, long, default_value = "upgrade")]
         reason: String,
     },
+    /// Write chain-native rewards activation config (N3 interim operator path)
+    ConfigureRewards {
+        /// Sovereign asset / token id (64-char hex)
+        #[arg(long)]
+        asset_id: String,
+        /// Spend-delegate keystore directory (user_identity.json + user_private_key.json)
+        #[arg(long)]
+        delegate_keystore: String,
+        /// Node data directory (default: --data-dir or ~/.zhtp)
+        #[arg(long, env = "ZHTP_DATA_DIR")]
+        data_dir: Option<String>,
+    },
 }
 
 /// Wallet operation commands

--- a/zhtp-cli/src/commands/node.rs
+++ b/zhtp-cli/src/commands/node.rs
@@ -53,7 +53,51 @@ pub fn action_to_operation(action: &NodeAction) -> NodeOperation {
         NodeAction::Restart => NodeOperation::Restart,
         NodeAction::SetupUi => NodeOperation::Status, // handled separately
         NodeAction::HaltConsensus { .. } => NodeOperation::Status, // handled separately
+        NodeAction::ConfigureRewards { .. } => NodeOperation::Status, // handled separately
     }
+}
+
+async fn handle_configure_rewards(
+    asset_id: &str,
+    delegate_keystore: &str,
+    data_dir: Option<&str>,
+    _cli: &ZhtpCli,
+    output: &dyn Output,
+) -> CliResult<()> {
+    let data_root = data_dir
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".zhtp")))
+        .ok_or_else(|| CliError::ConfigError("could not resolve node data directory".into()))?;
+
+    zhtp::set_node_data_dir(data_root);
+
+    let parsed_id = zhtp::rewards_activation::parse_asset_id_hex(asset_id).map_err(|e| {
+        CliError::ConfigError(format!("invalid --asset-id: {e}"))
+    })?;
+
+    let keystore_path = normalize_keystore_path(delegate_keystore)
+        .ok_or_else(|| CliError::ConfigError("invalid --delegate-keystore path".into()))?;
+    if !keystore_path.is_dir() {
+        return Err(CliError::ConfigError(format!(
+            "delegate keystore is not a directory: {}",
+            keystore_path.display()
+        )));
+    }
+
+    zhtp::rewards_activation::write_activation_config(&parsed_id, &keystore_path).map_err(|e| {
+        CliError::ConfigError(format!("failed to write rewards activation config: {e}"))
+    })?;
+
+    let out_path = zhtp::rewards_activation::activation_config_path();
+    output.header("Rewards activation configured")?;
+    output.print(&format!("Wrote: {}", out_path.display()))?;
+    output.print(&format!("asset_id: {}", hex::encode(parsed_id)))?;
+    output.print(&format!(
+        "delegate_keystore: {}",
+        keystore_path.display()
+    ))?;
+    output.print("Restart the node (or redeploy) for /api/v1/rewards/* to pick up the config.")?;
+    Ok(())
 }
 
 /// Parse environment/network type from string
@@ -105,6 +149,16 @@ async fn handle_node_command_impl(
     // Handle setup-ui separately (it starts its own HTTP server)
     if matches!(args.action, NodeAction::SetupUi) {
         return crate::commands::setup_ui::run_setup_ui(cli, output).await;
+    }
+
+    if let NodeAction::ConfigureRewards {
+        ref asset_id,
+        ref delegate_keystore,
+        ref data_dir,
+    } = args.action
+    {
+        return handle_configure_rewards(asset_id, delegate_keystore, data_dir.as_deref(), cli, output)
+            .await;
     }
 
     // Handle halt-consensus via QUIC API call
@@ -261,6 +315,9 @@ async fn handle_node_command_impl(
         NodeAction::HaltConsensus { .. } => {
             // Already handled above, unreachable
             unreachable!("HaltConsensus handled before match")
+        }
+        NodeAction::ConfigureRewards { .. } => {
+            unreachable!("ConfigureRewards handled before match")
         }
     }
 }

--- a/zhtp-cli/src/commands/node.rs
+++ b/zhtp-cli/src/commands/node.rs
@@ -83,6 +83,12 @@ async fn handle_configure_rewards(
             keystore_path.display()
         )));
     }
+    let keystore_path = keystore_path.canonicalize().map_err(|e| {
+        CliError::ConfigError(format!(
+            "failed to canonicalize delegate keystore path {}: {e}",
+            keystore_path.display()
+        ))
+    })?;
 
     zhtp::rewards_activation::write_activation_config(&parsed_id, &keystore_path).map_err(|e| {
         CliError::ConfigError(format!("failed to write rewards activation config: {e}"))
@@ -119,12 +125,17 @@ pub fn parse_network_environment(env_str: &str) -> CliResult<Environment> {
 ///
 /// Pure function - path manipulation only
 pub fn normalize_keystore_path(ks_str: &str) -> Option<PathBuf> {
+    if ks_str.is_empty() {
+        return None;
+    }
     if ks_str.starts_with("~/") {
-        dirs::home_dir().map(|home| home.join(&ks_str[2..]))
-    } else if ks_str.is_empty() {
-        None
+        return dirs::home_dir().map(|home| home.join(&ks_str[2..]));
+    }
+    let path = PathBuf::from(ks_str);
+    if path.is_absolute() {
+        Some(path)
     } else {
-        Some(PathBuf::from(ks_str))
+        std::env::current_dir().ok().map(|cwd| cwd.join(path))
     }
 }
 
@@ -625,8 +636,9 @@ mod tests {
 
     #[test]
     fn test_normalize_keystore_path_relative() {
+        let cwd = std::env::current_dir().expect("cwd");
         let result = normalize_keystore_path("./keystore");
-        assert_eq!(result, Some(PathBuf::from("./keystore")));
+        assert_eq!(result, Some(cwd.join("keystore")));
     }
 
     #[test]

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -1229,12 +1229,54 @@ fn rewards_signer_authorized(
 }
 
 fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {
+    let eligible = crate::rewards_activation::scan_chain_eligible_assets(blockchain);
+    if !eligible.is_empty() {
+        info!(
+            "rewards: chain scan found {} asset(s) with rewards module + funded delegate",
+            eligible.len()
+        );
+        for a in &eligible {
+            info!(
+                "rewards: eligible asset_id={} delegate={} balance={}",
+                hex::encode(&a.asset_id[..8]),
+                hex::encode(&a.spend_delegate_key_id[..8]),
+                a.delegate_balance
+            );
+        }
+    }
+
+    if let Some(activation) = crate::rewards_activation::resolve_activation() {
+        return load_treasury_from_dir(
+            blockchain,
+            &activation.delegate_keystore_dir,
+            Some(activation.asset_id),
+            activation.source,
+        );
+    }
+
+    // Legacy interim: env-only keystore + BUBL token_id discovery (TokenCreation path).
     let dir = std::env::var("ZHTP_REWARDS_TREASURY_KEYSTORE").ok()?;
-    let path = PathBuf::from(&dir);
+    warn!(
+        "rewards: ZHTP_REWARDS_TREASURY_KEYSTORE is deprecated — use `zhtp-cli node configure-rewards` (removal after 2026-09-01)"
+    );
+    load_treasury_from_dir(
+        blockchain,
+        &PathBuf::from(&dir),
+        None,
+        crate::rewards_activation::ActivationSource::LegacyEnv,
+    )
+}
+
+fn load_treasury_from_dir(
+    blockchain: &Blockchain,
+    path: &PathBuf,
+    asset_id_override: Option<[u8; 32]>,
+    source: crate::rewards_activation::ActivationSource,
+) -> Option<TreasuryConfig> {
     if !path.is_dir() {
         warn!(
-            "rewards: ZHTP_REWARDS_TREASURY_KEYSTORE='{}' is not a directory",
-            dir
+            "rewards: keystore path '{}' is not a directory",
+            path.display()
         );
         return None;
     }
@@ -1244,37 +1286,57 @@ fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {
         Ok(k) => k,
         Err(e) => {
             warn!(
-                "rewards: failed to load treasury keystore from {}: {}",
-                dir, e
+                "rewards: failed to load delegate keystore from {}: {}",
+                path.display(),
+                e
             );
             return None;
         }
     };
-    let rewards_asset_id = resolve_rewards_token_id(blockchain)?;
     let signer_key_id = keypair.public_key.key_id;
 
-    if !rewards_signer_authorized(blockchain, &rewards_asset_id, &signer_key_id) {
-        warn!(
-            "rewards: keystore key_id {} is not authorized to spend token {}; endpoint disabled",
-            hex::encode(&signer_key_id[..8]),
-            hex::encode(&rewards_asset_id[..8]),
-        );
-        return None;
-    }
+    let rewards_asset_id = if let Some(id) = asset_id_override {
+        match crate::rewards_activation::validate_activation_against_chain(
+            blockchain,
+            &id,
+            &signer_key_id,
+        ) {
+            Ok(_) => id,
+            Err(e) => {
+                warn!("rewards: chain-native activation rejected: {e}");
+                return None;
+            }
+        }
+    } else {
+        let token_id = resolve_rewards_token_id(blockchain)?;
+        if !rewards_signer_authorized(blockchain, &token_id, &signer_key_id) {
+            warn!(
+                "rewards: keystore key_id {} is not authorized to spend token {}; endpoint disabled",
+                hex::encode(&signer_key_id[..8]),
+                hex::encode(&token_id[..8]),
+            );
+            return None;
+        }
+        token_id
+    };
 
     let balance = blockchain
         .token_balance(&rewards_asset_id, &signer_key_id)
         .unwrap_or(0);
     if balance == 0 {
         warn!(
-            "rewards: signer keystore at {} holds 0 balance for token {}; endpoint disabled",
-            dir,
+            "rewards: delegate keystore at {} holds 0 balance for token {}; endpoint disabled",
+            path.display(),
             hex::encode(&rewards_asset_id[..8]),
         );
         return None;
     }
+    let source_label = match source {
+        crate::rewards_activation::ActivationSource::ConfigFile => "rewards_activation.toml",
+        crate::rewards_activation::ActivationSource::LegacyEnv => "ZHTP_REWARDS_TREASURY_KEYSTORE",
+    };
     info!(
-        "rewards: BUBL signer loaded — token_id={} key_id={} balance={}",
+        "rewards: signer loaded via {source_label} — token_id={} key_id={} balance={}",
         hex::encode(&rewards_asset_id[..8]),
         hex::encode(&signer_key_id[..8]),
         balance,

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -6,14 +6,14 @@
 //!
 //! ## Configuration
 //!
-//! Activated when `ZHTP_REWARDS_TREASURY_KEYSTORE` points at the BUBL DAO
-//! `TokenCreation` creator keystore AND that key holds a positive on-chain
-//! BUBL balance. BUBL is not native SOV and not an `AssetLaunch` sovereign
-//! asset — only the deterministic DAO contract
-//! (`generate_custom_token_id("Bubble","BUBL")`). `ZHTP_REWARDS_TOKEN_ID` may
-//! override that id. `ZHTP_REWARDS_ASSET_ID` is a deprecated alias (remove
-//! after 2026-09-01). Without a matching creator signer the handler installs
-//! but every endpoint returns 503.
+//! Activated via `rewards_activation.toml` (written by `zhtp-cli node
+//! configure-rewards`) or the deprecated `ZHTP_REWARDS_TREASURY_KEYSTORE` env
+//! path. Both require a spend-delegate keystore whose key_id matches the
+//! on-chain `RewardsModuleState` and holds a positive token balance.
+//! `ZHTP_REWARDS_TOKEN_ID` may override the asset id on the legacy env path.
+//! `ZHTP_REWARDS_ASSET_ID` is a deprecated alias (remove after 2026-09-01).
+//! Without a matching delegate signer the handler installs but every endpoint
+//! returns 503.
 //!
 //! ## Storage
 //!
@@ -45,7 +45,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
-use lib_blockchain::contracts::utils::generate_custom_token_id;
+
 use lib_blockchain::transaction::{Transaction, TokenTransferData};
 use lib_blockchain::Blockchain;
 use lib_crypto::keypair::KeyPair;
@@ -58,9 +58,6 @@ use lib_protocols::zhtp::ZhtpRequestHandler;
 use crate::keyfile_names::{KeystorePrivateKey, USER_IDENTITY_FILENAME, USER_PRIVATE_KEY_FILENAME};
 
 // ── Constants ────────────────────────────────────────────────────────
-
-const BUBL_TOKEN_NAME: &str = "Bubble";
-const BUBL_TOKEN_SYMBOL: &str = "BUBL";
 
 /// Deprecated env alias — use `ZHTP_REWARDS_TOKEN_ID`. Scheduled removal 2026-09-01.
 const DEPRECATED_REWARDS_ASSET_ID_ENV: &str = "ZHTP_REWARDS_ASSET_ID";
@@ -1203,29 +1200,18 @@ fn parse_token_id_hex(hex_id: &str) -> Option<[u8; 32]> {
     Some(out)
 }
 
-fn resolve_rewards_token_id(blockchain: &Blockchain) -> Option<[u8; 32]> {
+fn resolve_legacy_rewards_asset_id(
+    blockchain: &Blockchain,
+    signer_key_id: &[u8; 32],
+) -> Option<[u8; 32]> {
     if let Some(hex_id) = rewards_token_id_override() {
         return parse_token_id_hex(&hex_id);
     }
 
-    // Canonical BUBL: GENESIS-6 DAO `TokenCreation` (deterministic token_id).
-    let bubl_dao_id = generate_custom_token_id(BUBL_TOKEN_NAME, BUBL_TOKEN_SYMBOL);
-    if blockchain.get_token_contract(&bubl_dao_id).is_some() {
-        return Some(bubl_dao_id);
-    }
-
-    None
-}
-
-/// Returns true when `signer_key_id` is the on-chain creator of the DAO token.
-fn rewards_signer_authorized(
-    blockchain: &Blockchain,
-    token_id: &[u8; 32],
-    signer_key_id: &[u8; 32],
-) -> bool {
-    blockchain
-        .get_token_contract(token_id)
-        .is_some_and(|token| token.creator.key_id == *signer_key_id)
+    crate::rewards_activation::scan_chain_eligible_assets(blockchain)
+        .into_iter()
+        .find(|asset| asset.spend_delegate_key_id == *signer_key_id)
+        .map(|asset| asset.asset_id)
 }
 
 fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {
@@ -1308,21 +1294,30 @@ fn load_treasury_from_dir(
             }
         }
     } else {
-        let token_id = resolve_rewards_token_id(blockchain)?;
-        if !rewards_signer_authorized(blockchain, &token_id, &signer_key_id) {
+        let token_id = resolve_legacy_rewards_asset_id(blockchain, &signer_key_id)?;
+        match crate::rewards_activation::validate_activation_against_chain(
+            blockchain,
+            &token_id,
+            &signer_key_id,
+        ) {
+            Ok(_) => token_id,
+            Err(e) => {
+                warn!("rewards: legacy env activation rejected: {e}");
+                return None;
+            }
+        }
+    };
+
+    let balance = match blockchain.token_balance(&rewards_asset_id, &signer_key_id) {
+        Ok(balance) => balance,
+        Err(e) => {
             warn!(
-                "rewards: keystore key_id {} is not authorized to spend token {}; endpoint disabled",
-                hex::encode(&signer_key_id[..8]),
-                hex::encode(&token_id[..8]),
+                "rewards: token_balance lookup failed for token {}: {e}",
+                hex::encode(&rewards_asset_id[..8]),
             );
             return None;
         }
-        token_id
     };
-
-    let balance = blockchain
-        .token_balance(&rewards_asset_id, &signer_key_id)
-        .unwrap_or(0);
     if balance == 0 {
         warn!(
             "rewards: delegate keystore at {} holds 0 balance for token {}; endpoint disabled",

--- a/zhtp/src/lib.rs
+++ b/zhtp/src/lib.rs
@@ -68,6 +68,7 @@ pub mod messaging;
 pub mod monitoring;
 pub mod pouw;
 pub mod rewards;
+pub mod rewards_activation;
 pub mod runtime; // Proof-of-Useful-Work (Phase 1: Challenge Generation)
                  // CLI module moved to separate zhtp-cli crate
 pub mod api;

--- a/zhtp/src/rewards_activation.rs
+++ b/zhtp/src/rewards_activation.rs
@@ -52,13 +52,32 @@ pub fn write_activation_config(asset_id: &[u8; 32], delegate_keystore_dir: &Path
 
 pub fn read_activation_file() -> Option<RewardsActivationFile> {
     let path = activation_config_path();
-    let raw = std::fs::read_to_string(&path).ok()?;
-    toml::from_str(&raw).ok()
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            warn!("rewards: failed to read {}: {e}", path.display());
+            return None;
+        }
+    };
+    match toml::from_str(&raw) {
+        Ok(file) => Some(file),
+        Err(e) => {
+            warn!("rewards: failed to parse {}: {e}", path.display());
+            None
+        }
+    }
 }
 
 pub fn resolve_activation() -> Option<ResolvedActivation> {
     let file = read_activation_file()?;
-    let asset_id = parse_asset_id_hex(&file.asset_id).ok()?;
+    let asset_id = match parse_asset_id_hex(&file.asset_id) {
+        Ok(id) => id,
+        Err(e) => {
+            warn!("rewards_activation.toml has invalid asset_id: {e}");
+            return None;
+        }
+    };
     let dir = PathBuf::from(&file.delegate_keystore_dir);
     if !dir.is_dir() {
         warn!(
@@ -81,9 +100,17 @@ pub fn scan_chain_eligible_assets(blockchain: &Blockchain) -> Vec<ChainEligibleA
         let Some(state) = blockchain.get_rewards_module_state(&asset_id) else {
             continue;
         };
-        let balance = blockchain
-            .token_balance(&asset_id, &state.spend_delegate_key_id)
-            .unwrap_or(0);
+        let balance = match blockchain.token_balance(&asset_id, &state.spend_delegate_key_id) {
+            Ok(balance) => balance,
+            Err(e) => {
+                warn!(
+                    "rewards: token_balance lookup failed for asset {} delegate {}: {e}",
+                    hex::encode(&asset_id[..8]),
+                    hex::encode(&state.spend_delegate_key_id[..8]),
+                );
+                continue;
+            }
+        };
         if balance > 0 {
             out.push(ChainEligibleAsset {
                 asset_id,

--- a/zhtp/src/rewards_activation.rs
+++ b/zhtp/src/rewards_activation.rs
@@ -1,0 +1,149 @@
+//! Chain-native rewards handler activation (DAO N3, #2813).
+//!
+//! Operators bind a spend-delegate keystore to an on-chain asset via
+//! `rewards_activation.toml` under the node data dir (written by
+//! `zhtp-cli node configure-rewards`). Legacy `ZHTP_REWARDS_TREASURY_KEYSTORE`
+//! remains as a deprecated fallback for interim BUBL `TokenCreation` nodes.
+
+use std::path::{Path, PathBuf};
+
+use lib_blockchain::Blockchain;
+use lib_blockchain::contracts::sovereign_asset::RewardsModuleState;
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+pub const ACTIVATION_FILENAME: &str = "rewards_activation.toml";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewardsActivationFile {
+    /// Sovereign asset / token id (32-byte hex).
+    pub asset_id: String,
+    /// Directory containing `user_identity.json` + `user_private_key.json` for the spend delegate.
+    pub delegate_keystore_dir: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedActivation {
+    pub asset_id: [u8; 32],
+    pub delegate_keystore_dir: PathBuf,
+    pub source: ActivationSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationSource {
+    ConfigFile,
+    LegacyEnv,
+}
+
+pub fn activation_config_path() -> PathBuf {
+    crate::node_data_path(ACTIVATION_FILENAME)
+}
+
+pub fn write_activation_config(asset_id: &[u8; 32], delegate_keystore_dir: &Path) -> std::io::Result<()> {
+    let file = RewardsActivationFile {
+        asset_id: hex::encode(asset_id),
+        delegate_keystore_dir: delegate_keystore_dir.display().to_string(),
+    };
+    let path = activation_config_path();
+    let body = toml::to_string_pretty(&file)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(&path, body)
+}
+
+pub fn read_activation_file() -> Option<RewardsActivationFile> {
+    let path = activation_config_path();
+    let raw = std::fs::read_to_string(&path).ok()?;
+    toml::from_str(&raw).ok()
+}
+
+pub fn resolve_activation() -> Option<ResolvedActivation> {
+    let file = read_activation_file()?;
+    let asset_id = parse_asset_id_hex(&file.asset_id).ok()?;
+    let dir = PathBuf::from(&file.delegate_keystore_dir);
+    if !dir.is_dir() {
+        warn!(
+            "rewards_activation.toml delegate_keystore_dir '{}' is not a directory — ignoring",
+            file.delegate_keystore_dir
+        );
+        return None;
+    }
+    Some(ResolvedActivation {
+        asset_id,
+        delegate_keystore_dir: dir,
+        source: ActivationSource::ConfigFile,
+    })
+}
+
+/// Assets with on-chain rewards module and a funded spend delegate (no keystore required).
+pub fn scan_chain_eligible_assets(blockchain: &Blockchain) -> Vec<ChainEligibleAsset> {
+    let mut out = Vec::new();
+    for (asset_id, _) in blockchain.iter_token_contract_entries() {
+        let Some(state) = blockchain.get_rewards_module_state(&asset_id) else {
+            continue;
+        };
+        let balance = blockchain
+            .token_balance(&asset_id, &state.spend_delegate_key_id)
+            .unwrap_or(0);
+        if balance > 0 {
+            out.push(ChainEligibleAsset {
+                asset_id,
+                spend_delegate_key_id: state.spend_delegate_key_id,
+                delegate_balance: balance,
+                policy_hash: state.policy_hash,
+            });
+        }
+    }
+    out
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainEligibleAsset {
+    pub asset_id: [u8; 32],
+    pub spend_delegate_key_id: [u8; 32],
+    pub delegate_balance: u128,
+    pub policy_hash: [u8; 32],
+}
+
+pub fn validate_activation_against_chain(
+    blockchain: &Blockchain,
+    asset_id: &[u8; 32],
+    signer_key_id: &[u8; 32],
+) -> Result<RewardsModuleState, String> {
+    let Some(state) = blockchain.get_rewards_module_state(asset_id) else {
+        return Err(format!(
+            "asset {} has no on-chain RewardsModuleState",
+            hex::encode(asset_id)
+        ));
+    };
+    if state.spend_delegate_key_id != *signer_key_id {
+        return Err(format!(
+            "keystore key_id {} does not match on-chain spend_delegate {}",
+            hex::encode(signer_key_id),
+            hex::encode(state.spend_delegate_key_id)
+        ));
+    }
+    Ok(state)
+}
+
+pub fn parse_asset_id_hex(hex_str: &str) -> Result<[u8; 32], String> {
+    let trimmed = hex_str.trim();
+    if trimmed.len() != 64 {
+        return Err("asset_id must be 64 hex chars (32 bytes)".to_string());
+    }
+    let bytes = hex::decode(trimmed).map_err(|_| "asset_id is not valid hex".to_string())?;
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_asset_id_roundtrip() {
+        let id = [0xab_u8; 32];
+        let hex = hex::encode(id);
+        assert_eq!(parse_asset_id_hex(&hex).unwrap(), id);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `rewards_activation.toml` under node data dir for operator-driven activation
- New `zhtp-cli node configure-rewards --asset-id --delegate-keystore [--data-dir]`
- Startup chain scan: log assets with on-chain `RewardsModuleState` + funded spend delegate
- When config file present, validate keystore `key_id` matches on-chain `spend_delegate_key_id`
- Legacy `ZHTP_REWARDS_TREASURY_KEYSTORE` retained with deprecation warning (interim BUBL)

## Test plan
- [x] `cargo check --profile dev-release -p zhtp -p zhtp-cli`
- [ ] Deploy to testnet + `configure-rewards` + verify `/api/v1/rewards/*` via QUIC CLI
- [ ] Follow-up: N2 claim path, N4 sled retirement

Closes #2813