### PR TITLE
fix(api): wallet endpoints accept did:zhtp: identity_id

### DIFF
--- a/tools/seed_asset_launch.rs
+++ b/tools/seed_asset_launch.rs
@@ -146,7 +146,7 @@ fn load_rewards_policy_bundle(
         .with_context(|| format!("read rewards policy {}", policy_path.display()))?;
     let policy = validate_rewards_policy(&bytes).context("validate rewards policy")?;
     let hash = policy_hash(&policy).context("hash rewards policy")?;
-    let policy_hash = *hash.as_array();
+    let policy_hash = hash.as_array();
     let mut cid_input = b"zhtp/rewards-policy/cid/v1\0".to_vec();
     cid_input.extend_from_slice(&bytes);
     let policy_cid = lib_crypto::hash_blake3(&cid_input);

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -24,7 +24,7 @@ use lib_identity::{identity::ZhtpIdentity as Identity, IdentityManager};
 
 
 // Access control imports
-use crate::api::principal::extract_principal_from_request;
+use crate::api::principal::{extract_principal_from_request, parse_identity_id_bytes};
 use lib_access_control::{AccessDomain, AccessOperation, SecurityPrincipal};
 
 /// Helper function to create JSON responses correctly
@@ -69,7 +69,10 @@ impl WalletHandler {
         extract_principal_from_request(request)
     }
 
-
+    fn parse_identity_id_or_bad_request(identity_id: &str) -> Result<[u8; 32], ZhtpResponse> {
+        parse_identity_id_bytes(identity_id)
+            .map_err(|msg| create_error_response(ZhtpStatus::BadRequest, msg))
+    }
 }
 
 #[async_trait::async_trait]
@@ -93,13 +96,10 @@ impl ZhtpRequestHandler for WalletHandler {
             }
             // GET /api/v1/wallet/balance/{wallet_type}/{identity_id}
             (ZhtpMethod::Get, path) if path.starts_with("/api/v1/wallet/balance/") => {
-                let path_parts: Vec<&str> = path
-                    .strip_prefix("/api/v1/wallet/balance/")
-                    .unwrap_or("")
-                    .split('/')
-                    .collect();
-                if path_parts.len() >= 2 {
-                    self.handle_get_balance(path_parts[0], path_parts[1], &request).await
+                let rest = path.strip_prefix("/api/v1/wallet/balance/").unwrap_or("");
+                if let Some((wallet_type, identity_id)) = rest.split_once('/') {
+                    self.handle_get_balance(wallet_type, identity_id, &request)
+                        .await
                 } else {
                     Ok(create_error_response(
                         ZhtpStatus::BadRequest,
@@ -256,19 +256,10 @@ impl WalletHandler {
         identity_id: &str,
         request: &ZhtpRequest,
     ) -> Result<ZhtpResponse> {
-        // Parse identity ID from hex string
-        let identity_hash = hex::decode(identity_id)
-            .map_err(|e| anyhow::anyhow!("Invalid hex for identity_id: {}", e))?;
-
-        if identity_hash.len() != 32 {
-            return Ok(create_error_response(
-                ZhtpStatus::BadRequest,
-                "Identity ID must be 32 bytes".to_string(),
-            ));
-        }
-
-        let mut identity_id_bytes = [0u8; 32];
-        identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(identity_id) {
+            Ok(b) => b,
+            Err(resp) => return Ok(resp),
+        };
         let identity_hash = Hash(identity_id_bytes);
 
         // TODO: Gate cross-identity wallet list once mobile app is updated.
@@ -467,19 +458,10 @@ impl WalletHandler {
             }
         };
 
-        // Parse identity ID
-        let identity_hash = hex::decode(identity_id)
-            .map_err(|e| anyhow::anyhow!("Invalid hex for identity_id: {}", e))?;
-
-        if identity_hash.len() != 32 {
-            return Ok(ZhtpResponse::error(
-                ZhtpStatus::BadRequest,
-                "Identity ID must be 32 bytes".to_string(),
-            ));
-        }
-
-        let mut identity_id_bytes = [0u8; 32];
-        identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(identity_id) {
+            Ok(b) => b,
+            Err(resp) => return Ok(resp),
+        };
         let identity_hash = Hash(identity_id_bytes);
 
         // TODO: Gate cross-identity balance once mobile app is updated.
@@ -611,19 +593,10 @@ impl WalletHandler {
         identity_id: &str,
         request: &ZhtpRequest,
     ) -> Result<ZhtpResponse> {
-        // Parse identity ID
-        let identity_hash = hex::decode(identity_id)
-            .map_err(|e| anyhow::anyhow!("Invalid hex for identity_id: {}", e))?;
-
-        if identity_hash.len() != 32 {
-            return Ok(ZhtpResponse::error(
-                ZhtpStatus::BadRequest,
-                "Identity ID must be 32 bytes".to_string(),
-            ));
-        }
-
-        let mut identity_id_bytes = [0u8; 32];
-        identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(identity_id) {
+            Ok(b) => b,
+            Err(resp) => return Ok(resp),
+        };
         let identity_hash = Hash(identity_id_bytes);
 
         // TODO: Gate cross-identity statistics once mobile app is updated.
@@ -727,19 +700,10 @@ impl WalletHandler {
             }
         };
 
-        // Parse identity ID
-        let identity_hash = hex::decode(&req_data.identity_id)
-            .map_err(|e| anyhow::anyhow!("Invalid hex for identity_id: {}", e))?;
-
-        if identity_hash.len() != 32 {
-            return Ok(ZhtpResponse::error(
-                ZhtpStatus::BadRequest,
-                "Identity ID must be 32 bytes".to_string(),
-            ));
-        }
-
-        let mut identity_id_bytes = [0u8; 32];
-        identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&req_data.identity_id) {
+            Ok(b) => b,
+            Err(resp) => return Ok(resp),
+        };
 
         // Get the identity
         let identity = match self.get_identity_by_id(&identity_id_bytes).await {
@@ -825,19 +789,10 @@ impl WalletHandler {
             ));
         }
 
-        // Parse identity ID
-        let identity_hash = hex::decode(&req_data.identity_id)
-            .map_err(|e| anyhow::anyhow!("Invalid hex for identity_id: {}", e))?;
-
-        if identity_hash.len() != 32 {
-            return Ok(ZhtpResponse::error(
-                ZhtpStatus::BadRequest,
-                "Identity ID must be 32 bytes".to_string(),
-            ));
-        }
-
-        let mut identity_id_bytes = [0u8; 32];
-        identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&req_data.identity_id) {
+            Ok(b) => b,
+            Err(resp) => return Ok(resp),
+        };
 
         // Get the identity
         let identity = match self.get_identity_by_id(&identity_id_bytes).await {
@@ -931,19 +886,10 @@ impl WalletHandler {
             ));
         }
 
-        // Parse identity ID
-        let identity_hash = hex::decode(&req_data.identity_id)
-            .map_err(|e| anyhow::anyhow!("Invalid hex for identity_id: {}", e))?;
-
-        if identity_hash.len() != 32 {
-            return Ok(ZhtpResponse::error(
-                ZhtpStatus::BadRequest,
-                "Identity ID must be 32 bytes".to_string(),
-            ));
-        }
-
-        let mut identity_id_bytes = [0u8; 32];
-        identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&req_data.identity_id) {
+            Ok(b) => b,
+            Err(resp) => return Ok(resp),
+        };
 
         // Get the identity
         let identity = match self.get_identity_by_id(&identity_id_bytes).await {
@@ -1264,19 +1210,10 @@ impl WalletHandler {
         identity_id: &str,
         request: &ZhtpRequest,
     ) -> Result<ZhtpResponse> {
-        // Parse identity ID
-        let identity_hash = hex::decode(identity_id)
-            .map_err(|e| anyhow::anyhow!("Invalid hex for identity_id: {}", e))?;
-
-        if identity_hash.len() != 32 {
-            return Ok(create_error_response(
-                ZhtpStatus::BadRequest,
-                "Identity ID must be 32 bytes".to_string(),
-            ));
-        }
-
-        let mut identity_id_bytes = [0u8; 32];
-        identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(identity_id) {
+            Ok(b) => b,
+            Err(resp) => return Ok(resp),
+        };
         let identity_hash = Hash(identity_id_bytes);
 
         // Graph-traversal guard: WalletGraph / Read
@@ -1414,19 +1351,10 @@ impl WalletHandler {
             ));
         }
 
-        // Parse identity ID
-        let identity_hash = hex::decode(&send_req.from_identity)
-            .map_err(|e| anyhow::anyhow!("Invalid hex for from_identity: {}", e))?;
-
-        if identity_hash.len() != 32 {
-            return Ok(create_error_response(
-                ZhtpStatus::BadRequest,
-                "Identity ID must be 32 bytes".to_string(),
-            ));
-        }
-
-        let mut identity_id_bytes = [0u8; 32];
-        identity_id_bytes.copy_from_slice(&identity_hash);
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&send_req.from_identity) {
+            Ok(b) => b,
+            Err(resp) => return Ok(resp),
+        };
 
         // Parse recipient address (validate format)
         let _to_address_bytes = hex::decode(&send_req.to_address)

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -24,7 +24,9 @@ use lib_identity::{identity::ZhtpIdentity as Identity, IdentityManager};
 
 
 // Access control imports
-use crate::api::principal::{extract_principal_from_request, parse_identity_id_bytes};
+use crate::api::principal::{
+    extract_principal_from_request, identity_id_matches_caller, parse_identity_id_bytes,
+};
 use lib_access_control::{AccessDomain, AccessOperation, SecurityPrincipal};
 
 /// Helper function to create JSON responses correctly
@@ -69,7 +71,9 @@ impl WalletHandler {
         extract_principal_from_request(request)
     }
 
-    fn parse_identity_id_or_bad_request(identity_id: &str) -> Result<[u8; 32], ZhtpResponse> {
+    fn parse_identity_id_or_bad_request(
+        identity_id: &str,
+    ) -> std::result::Result<[u8; 32], ZhtpResponse> {
         parse_identity_id_bytes(identity_id)
             .map_err(|msg| create_error_response(ZhtpStatus::BadRequest, msg))
     }
@@ -670,9 +674,9 @@ impl WalletHandler {
         let principal = self.extract_principal(&request);
         let req_data: CrossWalletTransferRequest = serde_json::from_slice(&request.body)?;
 
-        // Verify caller owns the identity
-        let caller_hex = principal.did.strip_prefix("did:zhtp:").unwrap_or(&principal.did);
-        if caller_hex != req_data.identity_id && principal.role != lib_access_control::Role::Council {
+        if !identity_id_matches_caller(&req_data.identity_id, &principal.did)
+            && principal.role != lib_access_control::Role::Council
+        {
             return Ok(create_error_response(
                 ZhtpStatus::Forbidden,
                 "Cannot transfer from an identity you don't own".to_string(),
@@ -780,9 +784,9 @@ impl WalletHandler {
         let principal = self.extract_principal(&request);
         let req_data: StakingRequest = serde_json::from_slice(&request.body)?;
 
-        // Verify caller owns the identity
-        let caller_hex = principal.did.strip_prefix("did:zhtp:").unwrap_or(&principal.did);
-        if caller_hex != req_data.identity_id && principal.role != lib_access_control::Role::Council {
+        if !identity_id_matches_caller(&req_data.identity_id, &principal.did)
+            && principal.role != lib_access_control::Role::Council
+        {
             return Ok(create_error_response(
                 ZhtpStatus::Forbidden,
                 "Cannot stake from an identity you don't own".to_string(),
@@ -877,9 +881,9 @@ impl WalletHandler {
         let principal = self.extract_principal(&request);
         let req_data: StakingRequest = serde_json::from_slice(&request.body)?;
 
-        // Verify caller owns the identity
-        let caller_hex = principal.did.strip_prefix("did:zhtp:").unwrap_or(&principal.did);
-        if caller_hex != req_data.identity_id && principal.role != lib_access_control::Role::Council {
+        if !identity_id_matches_caller(&req_data.identity_id, &principal.did)
+            && principal.role != lib_access_control::Role::Council
+        {
             return Ok(create_error_response(
                 ZhtpStatus::Forbidden,
                 "Cannot unstake from an identity you don't own".to_string(),
@@ -1342,9 +1346,9 @@ impl WalletHandler {
         let send_req: SimpleSendRequest = serde_json::from_slice(&request.body)
             .map_err(|e| anyhow::anyhow!("Invalid request body: {}", e))?;
 
-        // Verify caller owns the from_identity
-        let caller_hex = principal.did.strip_prefix("did:zhtp:").unwrap_or(&principal.did);
-        if caller_hex != send_req.from_identity && principal.role != lib_access_control::Role::Council {
+        if !identity_id_matches_caller(&send_req.from_identity, &principal.did)
+            && principal.role != lib_access_control::Role::Council
+        {
             return Ok(create_error_response(
                 ZhtpStatus::Forbidden,
                 "Cannot send from an identity you don't own".to_string(),

--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -1,5 +1,40 @@
 //! Shared principal extraction for ZHTP API handlers.
 
+/// Parse `identity_id` from API paths or JSON — accepts canonical `did:zhtp:<64-hex>` or raw 64-char hex.
+#[cfg(test)]
+mod tests {
+    use super::parse_identity_id_bytes;
+
+    #[test]
+    fn parse_raw_hex_identity() {
+        let hex = "59e07e17556e2955581443538839d576974e4f8a9af424c0a2cc7df79c995c9d";
+        let bytes = parse_identity_id_bytes(hex).unwrap();
+        assert_eq!(hex::encode(bytes), hex);
+    }
+
+    #[test]
+    fn parse_did_zhtp_identity() {
+        let hex = "59e07e17556e2955581443538839d576974e4f8a9af424c0a2cc7df79c995c9d";
+        let did = format!("did:zhtp:{hex}");
+        let bytes = parse_identity_id_bytes(&did).unwrap();
+        assert_eq!(hex::encode(bytes), hex);
+    }
+}
+
+pub fn parse_identity_id_bytes(identity_id: &str) -> Result<[u8; 32], String> {
+    let hex_part = identity_id
+        .strip_prefix("did:zhtp:")
+        .unwrap_or(identity_id);
+    let bytes = hex::decode(hex_part)
+        .map_err(|e| format!("Invalid hex for identity_id: {e}"))?;
+    if bytes.len() != 32 {
+        return Err("Identity ID must be 32 bytes".to_string());
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
 use lib_access_control::{Role, SecurityPrincipal};
 use lib_protocols::types::ZhtpRequest;
 use lib_types::NodeType;

--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -21,7 +21,9 @@ mod tests {
     }
 }
 
-pub fn parse_identity_id_bytes(identity_id: &str) -> Result<[u8; 32], String> {
+pub(crate) fn parse_identity_id_bytes(
+    identity_id: &str,
+) -> std::result::Result<[u8; 32], String> {
     let hex_part = identity_id
         .strip_prefix("did:zhtp:")
         .unwrap_or(identity_id);
@@ -33,6 +35,15 @@ pub fn parse_identity_id_bytes(identity_id: &str) -> Result<[u8; 32], String> {
     let mut out = [0u8; 32];
     out.copy_from_slice(&bytes);
     Ok(out)
+}
+
+/// Compare request identity (raw hex or `did:zhtp:`) to caller DID.
+pub(crate) fn identity_id_matches_caller(request_identity: &str, caller_did: &str) -> bool {
+    let caller_hex = caller_did.strip_prefix("did:zhtp:").unwrap_or(caller_did);
+    let request_hex = request_identity
+        .strip_prefix("did:zhtp:")
+        .unwrap_or(request_identity);
+    caller_hex == request_hex
 }
 
 use lib_access_control::{Role, SecurityPrincipal};


### PR DESCRIPTION
## Problem
`zhtp-cli wallet list/balance/...` passes canonical `did:zhtp:<64-hex>` in ZHTP route paths. The server was calling `hex::decode()` on the full string → **500 Invalid hex: Odd number of digits**.

## Fix
- `parse_identity_id_bytes()` in `api/principal.rs` — accepts `did:zhtp:` prefix or raw hex
- All wallet handler identity_id parse sites updated

## Verify (QUIC only)
```bash
zhtp-cli -s 77.42.74.80:9334 wallet list did:zhtp:<your-did>
zhtp-cli -s 77.42.74.80:9334 wallet balance did:zhtp:<your-did>
```