### PR TITLE
DAO N2: Hybrid rewards settlement (Path C) (#2812)

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2266,51 +2266,89 @@ impl Blockchain {
     /// Check whether a transaction's nonce is still valid against committed chain state.
     ///
     /// Returns `true` for transaction types that don't carry nonces (they are
-    /// validated by other means).  For `TokenTransfer`, the nonce must equal
-    /// the sender's current on-chain nonce for the target token — anything
-    /// lower has already been applied and is a replay.
+    /// validated by other means). For `TokenTransfer` and `RewardClaim`, the
+    /// nonce must equal the sender's current on-chain nonce for the target
+    /// token — anything lower is a replay, anything higher is a gap.
     pub fn is_nonce_current(&self, tx: &Transaction) -> bool {
-        if tx.transaction_type == TransactionType::TokenTransfer {
-            if let Some(transfer) = tx.token_transfer_data() {
+        let (token_id, from, nonce) = match tx.transaction_type {
+            TransactionType::TokenTransfer => {
+                let Some(transfer) = tx.token_transfer_data() else {
+                    return true;
+                };
                 let token_id = if transfer.token_id == [0u8; 32] {
                     crate::contracts::utils::generate_lib_token_id()
                 } else {
                     transfer.token_id
                 };
-                let expected = match self.token_nonce(&token_id, &transfer.from) {
-                    Ok(n) => n,
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            tx = %tx.hash(),
-                            "is_nonce_current: nonce read failed; failing closed (rejecting tx)"
-                        );
-                        return false;
-                    }
+                (token_id, transfer.from, transfer.nonce)
+            }
+            TransactionType::RewardClaim => {
+                let Some(claim) = tx.reward_claim_data() else {
+                    return true;
                 };
-                if transfer.nonce < expected {
-                    tracing::debug!(
-                        "Stale nonce: tx {} has nonce {} but chain expects {} for sender {}",
-                        tx.hash(),
-                        transfer.nonce,
-                        expected,
-                        hex::encode(&transfer.from[..8]),
-                    );
-                    return false;
-                }
-                if transfer.nonce > expected {
-                    tracing::debug!(
-                        "Future nonce: tx {} has nonce {} but chain expects {} for sender {}",
-                        tx.hash(),
-                        transfer.nonce,
-                        expected,
-                        hex::encode(&transfer.from[..8]),
-                    );
-                    return false;
+                (claim.token_id, claim.from, claim.nonce)
+            }
+            _ => return true,
+        };
+
+        let expected = match self.token_nonce(&token_id, &from) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    tx = %tx.hash(),
+                    "is_nonce_current: nonce read failed; failing closed (rejecting tx)"
+                );
+                return false;
+            }
+        };
+        if nonce != expected {
+            tracing::debug!(
+                "Nonce mismatch: tx {} has nonce {} but chain expects {} for sender {}",
+                tx.hash(),
+                nonce,
+                expected,
+                hex::encode(&from[..8]),
+            );
+            return false;
+        }
+        true
+    }
+
+    /// Reject duplicate or conflicting `RewardClaim` txs already in the mempool.
+    fn pending_reward_claim_conflicts(&self, incoming: &crate::transaction::reward_claim::RewardClaimData) -> bool {
+        use crate::transaction::reward_claim::RewardEventKind;
+        for tx in &self.pending_transactions {
+            if tx.transaction_type != TransactionType::RewardClaim {
+                continue;
+            }
+            let Some(data) = tx.reward_claim_data() else {
+                continue;
+            };
+            if data.token_id == incoming.token_id
+                && data.from == incoming.from
+                && data.nonce == incoming.nonce
+            {
+                return true;
+            }
+            if data.token_id != incoming.token_id || data.owner_did != incoming.owner_did {
+                continue;
+            }
+            if data.event != incoming.event {
+                continue;
+            }
+            match data.event {
+                RewardEventKind::Welcome
+                | RewardEventKind::DailyCheckin
+                | RewardEventKind::ActiveSession => return true,
+                RewardEventKind::NewPartner => {
+                    if data.peer_did == incoming.peer_did {
+                        return true;
+                    }
                 }
             }
         }
-        true
+        false
     }
 
     /// Get pending transactions
@@ -2412,6 +2450,18 @@ impl Blockchain {
                 "Transaction {} rejected: stale or future nonce",
                 &tx_hash[..16]
             ));
+        }
+
+        if transaction.transaction_type == TransactionType::RewardClaim {
+            if let Some(data) = transaction.reward_claim_data() {
+                if self.pending_reward_claim_conflicts(data) {
+                    let tx_hash = hex::encode(transaction.hash().as_bytes());
+                    return Err(anyhow::anyhow!(
+                        "Transaction {} rejected: conflicting RewardClaim already pending",
+                        &tx_hash[..16]
+                    ));
+                }
+            }
         }
 
         // Atomic with the push: update admission state so subsequent admit()

--- a/lib-blockchain/src/blockchain/rewards.rs
+++ b/lib-blockchain/src/blockchain/rewards.rs
@@ -1,105 +1,165 @@
-//! BUBL reward eligibility facades (sled-first reads).
+//! Reward eligibility facades — sled/consensus tree reads (authoritative).
 
-use crate::contracts::utils::generate_custom_token_id;
+use crate::rewards_policy::{
+    expected_amount_for_trigger, legacy_bubl_policy, policy_hash, validate_rewards_policy,
+    weekly_partner_cap, RewardsPolicyV1,
+};
 use crate::transaction::reward_claim::{
-    daily_claim_key, partner_claim_key, partner_count_key, streak_key, welcome_claim_key,
-    RewardEventKind, RewardStreakRecord,
+    daily_claim_key, partner_claim_key, partner_count_key, reward_event_to_policy_event,
+    streak_key, welcome_claim_key, RewardEventKind, RewardStreakRecord,
 };
 
-fn bubl_token_id() -> [u8; 32] {
-    generate_custom_token_id("Bubble", "BUBL")
-}
-
 impl crate::blockchain::Blockchain {
-    /// Whether this DID has already claimed the one-shot welcome reward on-chain.
-    pub fn bubl_reward_welcome_claimed(&self, did: &str) -> bool {
-        let key = welcome_claim_key(&bubl_token_id(), did);
+    /// Resolve the rewards policy document for `token_id` (on-chain module or legacy BUBL).
+    pub fn rewards_policy_for_token(&self, token_id: &[u8; 32]) -> Option<RewardsPolicyV1> {
         if let Some(store) = self.get_store() {
-            match store.get_bubl_reward_welcome(&key) {
-                Ok(Some(_)) => return true,
-                Ok(None) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "bubl_reward_welcome_claimed: sled read failed; failing closed"
-                    );
-                    return true;
+            if let Ok(Some(state)) = store.get_rewards_module_state(token_id) {
+                if let Ok(Some(doc)) = store.get_rewards_policy_document(&state.policy_hash) {
+                    if let Ok(policy) = validate_rewards_policy(&doc) {
+                        if let Ok(hash) = policy_hash(&policy) {
+                            if hash.as_array() == state.policy_hash {
+                                return Some(policy);
+                            }
+                        }
+                    }
                 }
             }
         }
-        false
+        if crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL") == *token_id {
+            return Some(legacy_bubl_policy());
+        }
+        None
     }
 
-    /// Whether a daily reward event was already claimed for `did` on `date` (UTC).
-    pub fn bubl_reward_daily_claimed(
+    pub fn reward_welcome_claimed(&self, token_id: &[u8; 32], did: &str) -> bool {
+        let key = welcome_claim_key(token_id, did);
+        self.reward_tree_has_height(|store| store.get_bubl_reward_welcome(&key))
+    }
+
+    pub fn reward_daily_claimed(
         &self,
+        token_id: &[u8; 32],
         date: &str,
         did: &str,
         event: RewardEventKind,
     ) -> bool {
-        let key = daily_claim_key(&bubl_token_id(), date, did, event);
-        if let Some(store) = self.get_store() {
-            match store.get_bubl_reward_daily(&key) {
-                Ok(Some(_)) => return true,
-                Ok(None) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "bubl_reward_daily_claimed: sled read failed; failing closed"
-                    );
-                    return true;
-                }
-            }
-        }
-        false
+        let key = daily_claim_key(token_id, date, did, event);
+        self.reward_tree_has_height(|store| store.get_bubl_reward_daily(&key))
     }
 
-    pub fn bubl_reward_partner_claimed(&self, week: &str, did: &str, peer_did: &str) -> bool {
-        let key = partner_claim_key(&bubl_token_id(), week, did, peer_did);
-        if let Some(store) = self.get_store() {
-            match store.get_bubl_reward_partner(&key) {
-                Ok(Some(_)) => return true,
-                Ok(None) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "bubl_reward_partner_claimed: sled read failed; failing closed"
-                    );
-                    return true;
-                }
-            }
-        }
-        false
+    pub fn reward_partner_claimed(
+        &self,
+        token_id: &[u8; 32],
+        week: &str,
+        did: &str,
+        peer_did: &str,
+    ) -> bool {
+        let key = partner_claim_key(token_id, week, did, peer_did);
+        self.reward_tree_has_height(|store| store.get_bubl_reward_partner(&key))
     }
 
-    pub fn bubl_reward_partners_this_week(&self, week: &str, did: &str) -> u32 {
-        let key = partner_count_key(&bubl_token_id(), week, did);
+    pub fn reward_partners_this_week(&self, token_id: &[u8; 32], week: &str, did: &str) -> u32 {
+        let key = partner_count_key(token_id, week, did);
         if let Some(store) = self.get_store() {
             match store.get_bubl_reward_partner_count(&key) {
                 Ok(Some(c)) => return c,
                 Ok(None) => {}
                 Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "bubl_reward_partners_this_week: sled read failed"
-                    );
+                    tracing::warn!(error = %e, "reward_partners_this_week: sled read failed");
                 }
             }
         }
         0
     }
 
-    pub fn bubl_reward_streak(&self, did: &str) -> RewardStreakRecord {
-        let key = streak_key(&bubl_token_id(), did);
+    pub fn reward_streak(&self, token_id: &[u8; 32], did: &str) -> RewardStreakRecord {
+        let key = streak_key(token_id, did);
         if let Some(store) = self.get_store() {
             match store.get_bubl_reward_streak(&key) {
                 Ok(Some(s)) => return s,
                 Ok(None) => {}
                 Err(e) => {
-                    tracing::warn!(error = %e, "bubl_reward_streak: sled read failed");
+                    tracing::warn!(error = %e, "reward_streak: sled read failed");
                 }
             }
         }
         RewardStreakRecord::default()
     }
+
+    pub fn reward_weekly_partner_cap(&self, token_id: &[u8; 32]) -> u32 {
+        self.rewards_policy_for_token(token_id)
+            .map(|p| weekly_partner_cap(&p))
+            .unwrap_or(0)
+    }
+
+    pub fn reward_expected_amount(
+        &self,
+        token_id: &[u8; 32],
+        event: RewardEventKind,
+        streak_day: u32,
+    ) -> Option<u128> {
+        let policy = self.rewards_policy_for_token(token_id)?;
+        let policy_event = reward_event_to_policy_event(event);
+        expected_amount_for_trigger(&policy, policy_event, streak_day)
+    }
+
+    pub fn reward_checkin_amount_for_streak(
+        &self,
+        token_id: &[u8; 32],
+        streak_day: u32,
+    ) -> Option<u128> {
+        self.reward_expected_amount(token_id, RewardEventKind::DailyCheckin, streak_day)
+    }
+
+    // ── Legacy BUBL aliases (deprecated — use token_id methods) ─────────
+
+    pub fn bubl_reward_welcome_claimed(&self, did: &str) -> bool {
+        let token_id = crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL");
+        self.reward_welcome_claimed(&token_id, did)
+    }
+
+    pub fn bubl_reward_daily_claimed(
+        &self,
+        date: &str,
+        did: &str,
+        event: RewardEventKind,
+    ) -> bool {
+        let token_id = crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL");
+        self.reward_daily_claimed(&token_id, date, did, event)
+    }
+
+    pub fn bubl_reward_partner_claimed(&self, week: &str, did: &str, peer_did: &str) -> bool {
+        let token_id = crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL");
+        self.reward_partner_claimed(&token_id, week, did, peer_did)
+    }
+
+    pub fn bubl_reward_partners_this_week(&self, week: &str, did: &str) -> u32 {
+        let token_id = crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL");
+        self.reward_partners_this_week(&token_id, week, did)
+    }
+
+    pub fn bubl_reward_streak(&self, did: &str) -> RewardStreakRecord {
+        let token_id = crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL");
+        self.reward_streak(&token_id, did)
+    }
+
+    fn reward_tree_has_height<F>(&self, read: F) -> bool
+    where
+        F: FnOnce(
+            &dyn crate::storage::BlockchainStore,
+        ) -> crate::storage::StorageResult<Option<u64>>,
+    {
+        if let Some(store) = self.get_store() {
+            match read(store.as_ref()) {
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, "reward eligibility read failed; failing closed");
+                    return true;
+                }
+            }
+        }
+        false
+    }
 }
+

--- a/lib-blockchain/src/blockchain/rewards.rs
+++ b/lib-blockchain/src/blockchain/rewards.rs
@@ -111,38 +111,6 @@ impl crate::blockchain::Blockchain {
         self.reward_expected_amount(token_id, RewardEventKind::DailyCheckin, streak_day)
     }
 
-    // ── Legacy BUBL aliases (deprecated — use token_id methods) ─────────
-
-    pub fn bubl_reward_welcome_claimed(&self, did: &str) -> bool {
-        let token_id = crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL");
-        self.reward_welcome_claimed(&token_id, did)
-    }
-
-    pub fn bubl_reward_daily_claimed(
-        &self,
-        date: &str,
-        did: &str,
-        event: RewardEventKind,
-    ) -> bool {
-        let token_id = crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL");
-        self.reward_daily_claimed(&token_id, date, did, event)
-    }
-
-    pub fn bubl_reward_partner_claimed(&self, week: &str, did: &str, peer_did: &str) -> bool {
-        let token_id = crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL");
-        self.reward_partner_claimed(&token_id, week, did, peer_did)
-    }
-
-    pub fn bubl_reward_partners_this_week(&self, week: &str, did: &str) -> u32 {
-        let token_id = crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL");
-        self.reward_partners_this_week(&token_id, week, did)
-    }
-
-    pub fn bubl_reward_streak(&self, did: &str) -> RewardStreakRecord {
-        let token_id = crate::contracts::utils::generate_custom_token_id("Bubble", "BUBL");
-        self.reward_streak(&token_id, did)
-    }
-
     fn reward_tree_has_height<F>(&self, read: F) -> bool
     where
         F: FnOnce(

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -3343,16 +3343,16 @@ impl BlockExecutor {
                     )
                 })?;
                 let fee_sink = *self.fee_model.protocol_params.fee_sink_address();
-                match crate::execution::reward_claim::apply_reward_claim(
+                let outcome = crate::execution::reward_claim::apply_reward_claim(
                     mutator,
                     data,
                     block_height,
                     block_timestamp,
                     &fee_sink,
-                )? {
-                    Some(outcome) => Ok(TxOutcome::TokenTransfer(outcome)),
-                    None => Ok(TxOutcome::LegacySystem),
-                }
+                )?;
+                Ok(TxOutcome::TokenTransfer(
+                    outcome.expect("apply_reward_claim returns Err on ineligibility"),
+                ))
             }
             TransactionType::TokenMint => {
                 let mint_data = tx.token_mint_data().ok_or_else(|| {

--- a/lib-blockchain/src/execution/reward_claim.rs
+++ b/lib-blockchain/src/execution/reward_claim.rs
@@ -55,10 +55,14 @@ fn resolve_rewards_policy(
         "rewards module state required for reward claims".to_string(),
     ))
 }
+fn reject_claim(msg: impl Into<String>) -> TxApplyResult<Option<TokenTransferOutcome>> {
+    Err(TxApplyError::InvalidType(msg.into()))
+}
+
 /// Apply a `RewardClaim` inside the executor block window.
 ///
-/// Returns `Ok(None)` when the claim is ineligible (tx is a no-op, block continues).
-/// Returns `Ok(Some(outcome))` on success.
+/// Ineligible claims return `Err` so the tx is rejected outright (never a silent
+/// no-op block entry). Returns `Ok(Some(outcome))` on success.
 pub fn apply_reward_claim(
     mutator: &StateMutator<'_>,
     data: &RewardClaimData,
@@ -68,7 +72,7 @@ pub fn apply_reward_claim(
 ) -> TxApplyResult<Option<TokenTransferOutcome>> {
     if data.amount == 0 {
         warn!("RewardClaim rejected at height {}: zero amount", block_height);
-        return Ok(None);
+        return reject_claim("RewardClaim amount must be greater than 0");
     }
 
     if key_id_from_did(&data.owner_did) != Some(data.recipient_key_id) {
@@ -76,7 +80,7 @@ pub fn apply_reward_claim(
             "RewardClaim rejected at height {}: recipient_key_id does not match owner_did",
             block_height
         );
-        return Ok(None);
+        return reject_claim("recipient_key_id does not match owner_did");
     }
 
     let did_hash = crate::types::hash::blake3_hash(data.owner_did.as_bytes());
@@ -87,7 +91,7 @@ pub fn apply_reward_claim(
             block_height,
             &data.owner_did[..20.min(data.owner_did.len())]
         );
-        return Ok(None);
+        return reject_claim("owner DID not registered");
     }
 
     let token = TokenId::new(data.token_id);
@@ -99,7 +103,7 @@ pub fn apply_reward_claim(
                 "RewardClaim rejected at height {}: token contract not found",
                 block_height
             );
-            return Ok(None);
+            return reject_claim("token contract not found");
         }
     };
 
@@ -112,14 +116,14 @@ pub fn apply_reward_claim(
                 hex::encode(rewards_state.spend_delegate_key_id),
                 hex::encode(data.token_id)
             );
-            return Ok(None);
+            return reject_claim("signer is not on-chain spend delegate");
         }
     } else if contract.creator.key_id != data.from {
         warn!(
             "RewardClaim rejected at height {}: signer is not token creator (legacy path)",
             block_height
         );
-        return Ok(None);
+        return reject_claim("signer is not authorized token creator");
     }
 
     let date = utc_date_from_ts(block_timestamp);
@@ -150,7 +154,7 @@ pub fn apply_reward_claim(
                 "RewardClaim rejected at height {}: no enabled trigger for {:?}",
                 block_height, data.event
             );
-            return Ok(None);
+            return reject_claim(format!("no enabled policy trigger for {:?}", data.event));
         }
     };
     if data.amount != expected {
@@ -158,7 +162,10 @@ pub fn apply_reward_claim(
             "RewardClaim rejected at height {}: amount {} != expected {} for {:?}",
             block_height, data.amount, expected, data.event
         );
-        return Ok(None);
+        return reject_claim(format!(
+            "amount {} does not match policy expected {} for {:?}",
+            data.amount, expected, data.event
+        ));
     }
     let partner_cap = weekly_partner_cap(&policy);
 
@@ -171,7 +178,7 @@ pub fn apply_reward_claim(
                     block_height,
                     &data.owner_did[..20.min(data.owner_did.len())]
                 );
-                return Ok(None);
+                return reject_claim("welcome already claimed");
             }
         }
         RewardEventKind::DailyCheckin | RewardEventKind::ActiveSession => {
@@ -181,7 +188,7 @@ pub fn apply_reward_claim(
                     "RewardClaim rejected at height {}: daily claim already recorded ({})",
                     block_height, key
                 );
-                return Ok(None);
+                return reject_claim(format!("{:?} already claimed for {}", data.event, date));
             }
         }
         RewardEventKind::NewPartner => {
@@ -192,7 +199,7 @@ pub fn apply_reward_claim(
                         "RewardClaim rejected at height {}: invalid peer_did",
                         block_height
                     );
-                    return Ok(None);
+                    return reject_claim("invalid peer_did");
                 }
             };
             if key_id_from_did(peer).is_none() {
@@ -200,7 +207,7 @@ pub fn apply_reward_claim(
                     "RewardClaim rejected at height {}: peer_did format invalid",
                     block_height
                 );
-                return Ok(None);
+                return reject_claim("peer_did format invalid");
             }
             let slot_key = partner_claim_key(token_id, &week, &data.owner_did, peer);
             if mutator.get_bubl_reward_partner(&slot_key)?.is_some() {
@@ -208,7 +215,7 @@ pub fn apply_reward_claim(
                     "RewardClaim rejected at height {}: partner already counted ({})",
                     block_height, slot_key
                 );
-                return Ok(None);
+                return reject_claim("partner already counted this week");
             }
             let count_key = partner_count_key(token_id, &week, &data.owner_did);
             let count = mutator.get_bubl_reward_partner_count(&count_key)?.unwrap_or(0);
@@ -217,7 +224,7 @@ pub fn apply_reward_claim(
                     "RewardClaim rejected at height {}: weekly partner cap reached",
                     block_height
                 );
-                return Ok(None);
+                return reject_claim("weekly partner cap reached");
             }
         }
     }
@@ -230,7 +237,10 @@ pub fn apply_reward_claim(
             "RewardClaim dropped at height {}: nonce replay (expected {})",
             block_height, expected_nonce
         );
-        return Ok(None);
+        return Err(TxApplyError::ReplayDropped {
+            expected: expected_nonce,
+            actual: data.nonce,
+        });
     }
     if data.nonce > expected_nonce {
         return Err(TxApplyError::InvalidType(format!(

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -383,204 +383,114 @@ impl RewardsHandler {
             Ok(k) => k,
             Err(msg) => return Self::bad(msg),
         };
-        match req.event.as_str() {
-            "welcome" => self.do_welcome(&req.did, key_id).await,
-            "daily_checkin" => self.do_daily_checkin(&req.did, key_id).await,
-            "active_session" => self.do_active_session(&req.did, key_id).await,
-            other => Self::bad(format!("unknown event type: '{}'", other)),
+        let spec = match req.event.as_str() {
+            "welcome" => settlement::ClaimSpec::welcome(),
+            "daily_checkin" => settlement::ClaimSpec::daily_checkin(),
+            "active_session" => settlement::ClaimSpec::active_session(),
+            other => return Self::bad(format!("unknown event type: '{}'", other)),
+        };
+        self.execute_claim(&req.did, key_id, spec).await
+    }
+
+    fn claim_ineligible_response(
+        spec: &settlement::ClaimSpec,
+        reason: &str,
+        partners_this_week: Option<u32>,
+    ) -> ZhtpResponse {
+        let mut body = json!({
+            "awarded": false,
+            "amount": "0",
+            "reason": reason,
+        });
+        if let Some(obj) = body.as_object_mut() {
+            if matches!(
+                spec.event,
+                RewardEventKind::DailyCheckin | RewardEventKind::ActiveSession
+            ) {
+                obj.insert(
+                    "next_eligible_at".into(),
+                    json!(Self::next_utc_midnight_secs()),
+                );
+            }
+            if let (RewardEventKind::NewPartner, Some(count)) = (spec.event, partners_this_week) {
+                obj.insert("partners_this_week".into(), json!(count));
+            }
         }
+        Self::ok_json(body)
     }
 
-    async fn do_welcome(&self, did: &str, key_id: [u8; 32]) -> ZhtpResponse {
-        let treasury = match self.treasury.as_ref() {
-            Some(t) => t,
-            None => return Self::unavailable(),
-        };
-        let token_id = treasury.rewards_asset_id;
-
-        let plan = {
-            let bc = self.blockchain.read().await;
-            settlement::plan_reward_claim(&bc, &token_id, did, RewardEventKind::Welcome, None)
-        };
-        let plan = match plan {
-            Ok(p) => p,
-            Err(reason) if reason == "welcome_already_claimed" => {
-                return Self::ok_json(json!({
-                    "awarded": false,
-                    "amount": "0",
-                    "reason": reason,
-                }));
-            }
-            Err(reason) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::ServiceUnavailable,
-                    format!("rewards claim unavailable: {reason}"),
-                );
-            }
-        };
-
-        let tx_hash = match settlement::submit_reward_claim(
-            &self.blockchain,
-            treasury,
-            did,
-            key_id,
-            RewardEventKind::Welcome,
-            plan.amount,
-            None,
-        )
-        .await
-        {
-            Ok(h) => h,
-            Err(e) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::InternalServerError,
-                    format!("reward claim submit failed: {}", e),
-                );
-            }
-        };
-
-        Self::ok_json(json!({
+    fn claim_awarded_response(
+        spec: &settlement::ClaimSpec,
+        submitted: &settlement::SubmittedClaim,
+    ) -> ZhtpResponse {
+        let plan = &submitted.plan;
+        let mut body = json!({
             "awarded": true,
             "submitted": true,
             "amount": plan.amount.to_string(),
             "amount_display": (plan.amount / ATOM_18).to_string(),
-            "event": "welcome",
-            "tx_hash": tx_hash,
-        }))
+            "event": spec.event_label,
+            "tx_hash": submitted.tx_hash,
+        });
+        if let Some(obj) = body.as_object_mut() {
+            if let Some(day) = plan.streak_day {
+                obj.insert("streak_day".into(), json!(day));
+            }
+            if matches!(
+                spec.event,
+                RewardEventKind::DailyCheckin | RewardEventKind::ActiveSession
+            ) {
+                obj.insert(
+                    "next_eligible_at".into(),
+                    json!(Self::next_utc_midnight_secs()),
+                );
+            }
+            if let Some(count) = plan.partners_this_week {
+                obj.insert("partners_this_week".into(), json!(count.saturating_add(1)));
+            }
+            if let Some(cap) = plan.weekly_cap {
+                obj.insert("weekly_cap".into(), json!(cap));
+            }
+        }
+        Self::ok_json(body)
     }
 
-    async fn do_daily_checkin(&self, did: &str, key_id: [u8; 32]) -> ZhtpResponse {
+    async fn execute_claim(
+        &self,
+        did: &str,
+        key_id: [u8; 32],
+        spec: settlement::ClaimSpec,
+    ) -> ZhtpResponse {
         let treasury = match self.treasury.as_ref() {
             Some(t) => t,
             None => return Self::unavailable(),
         };
-        let token_id = treasury.rewards_asset_id;
 
-        let plan = {
-            let bc = self.blockchain.read().await;
-            settlement::plan_reward_claim(
-                &bc,
-                &token_id,
-                did,
-                RewardEventKind::DailyCheckin,
-                None,
-            )
-        };
-        let plan = match plan {
-            Ok(p) => p,
-            Err(reason) if reason == "checkin_already_claimed_today" => {
-                return Self::ok_json(json!({
-                    "awarded": false,
-                    "amount": "0",
-                    "reason": reason,
-                    "next_eligible_at": Self::next_utc_midnight_secs(),
-                }));
+        match settlement::run_claim_flow(&self.blockchain, treasury, did, key_id, &spec).await {
+            Ok(submitted) => Self::claim_awarded_response(&spec, &submitted),
+            Err(settlement::ClaimFlowError::Ineligible { reason }) => {
+                let partners_this_week = if spec.event == RewardEventKind::NewPartner {
+                    let week = Self::iso_week();
+                    let bc = self.blockchain.read().await;
+                    Some(bc.reward_partners_this_week(
+                        &treasury.rewards_asset_id,
+                        &week,
+                        did,
+                    ))
+                } else {
+                    None
+                };
+                Self::claim_ineligible_response(&spec, &reason, partners_this_week)
             }
-            Err(reason) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::ServiceUnavailable,
-                    format!("rewards claim unavailable: {reason}"),
-                );
-            }
-        };
-        let next_streak = plan.streak_day.unwrap_or(1);
-
-        let tx_hash = match settlement::submit_reward_claim(
-            &self.blockchain,
-            treasury,
-            did,
-            key_id,
-            RewardEventKind::DailyCheckin,
-            plan.amount,
-            None,
-        )
-        .await
-        {
-            Ok(h) => h,
-            Err(e) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::InternalServerError,
-                    format!("reward claim submit failed: {}", e),
-                );
-            }
-        };
-
-        Self::ok_json(json!({
-            "awarded": true,
-            "submitted": true,
-            "amount": plan.amount.to_string(),
-            "amount_display": (plan.amount / ATOM_18).to_string(),
-            "event": "daily_checkin",
-            "streak_day": next_streak,
-            "tx_hash": tx_hash,
-            "next_eligible_at": Self::next_utc_midnight_secs(),
-        }))
-    }
-
-    async fn do_active_session(&self, did: &str, key_id: [u8; 32]) -> ZhtpResponse {
-        let treasury = match self.treasury.as_ref() {
-            Some(t) => t,
-            None => return Self::unavailable(),
-        };
-        let token_id = treasury.rewards_asset_id;
-
-        let plan = {
-            let bc = self.blockchain.read().await;
-            settlement::plan_reward_claim(
-                &bc,
-                &token_id,
-                did,
-                RewardEventKind::ActiveSession,
-                None,
-            )
-        };
-        let plan = match plan {
-            Ok(p) => p,
-            Err(reason) if reason == "session_already_claimed_today" => {
-                return Self::ok_json(json!({
-                    "awarded": false,
-                    "amount": "0",
-                    "reason": reason,
-                    "next_eligible_at": Self::next_utc_midnight_secs(),
-                }));
-            }
-            Err(reason) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::ServiceUnavailable,
-                    format!("rewards claim unavailable: {reason}"),
-                );
-            }
-        };
-
-        let tx_hash = match settlement::submit_reward_claim(
-            &self.blockchain,
-            treasury,
-            did,
-            key_id,
-            RewardEventKind::ActiveSession,
-            plan.amount,
-            None,
-        )
-        .await
-        {
-            Ok(h) => h,
-            Err(e) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::InternalServerError,
-                    format!("reward claim submit failed: {}", e),
-                );
-            }
-        };
-
-        Self::ok_json(json!({
-            "awarded": true,
-            "submitted": true,
-            "amount": plan.amount.to_string(),
-            "amount_display": (plan.amount / ATOM_18).to_string(),
-            "event": "active_session",
-            "tx_hash": tx_hash,
-            "next_eligible_at": Self::next_utc_midnight_secs(),
-        }))
+            Err(settlement::ClaimFlowError::Unavailable(reason)) => ZhtpResponse::error(
+                ZhtpStatus::ServiceUnavailable,
+                format!("rewards claim unavailable: {reason}"),
+            ),
+            Err(settlement::ClaimFlowError::SubmitFailed(e)) => ZhtpResponse::error(
+                ZhtpStatus::InternalServerError,
+                format!("reward claim submit failed: {e}"),
+            ),
+        }
     }
 
     async fn handle_conversation(&self, request: ZhtpRequest) -> ZhtpResponse {
@@ -602,84 +512,12 @@ impl RewardsHandler {
             return Self::bad(format!("peer_did invalid: {}", msg));
         }
 
-        let treasury = match self.treasury.as_ref() {
-            Some(t) => t,
-            None => return Self::unavailable(),
-        };
-        let token_id = treasury.rewards_asset_id;
-        let week = Self::iso_week();
-
-        let plan = {
-            let bc = self.blockchain.read().await;
-            settlement::plan_reward_claim(
-                &bc,
-                &token_id,
-                &req.did,
-                RewardEventKind::NewPartner,
-                Some(&req.peer_did),
-            )
-        };
-        let partners_this_week = {
-            let bc = self.blockchain.read().await;
-            bc.reward_partners_this_week(&token_id, &week, &req.did)
-        };
-        let weekly_cap = {
-            let bc = self.blockchain.read().await;
-            let policy_cap = bc.reward_weekly_partner_cap(&token_id);
-            if policy_cap > 0 { policy_cap } else { WEEKLY_PARTNER_CAP }
-        };
-
-        let plan = match plan {
-            Ok(p) => p,
-            Err(reason)
-                if reason == "partner_already_counted_this_week"
-                    || reason == "weekly_partner_cap_reached" =>
-            {
-                return Self::ok_json(json!({
-                    "awarded": false,
-                    "amount": "0",
-                    "reason": reason,
-                    "partners_this_week": partners_this_week,
-                }));
-            }
-            Err(reason) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::ServiceUnavailable,
-                    format!("rewards claim unavailable: {reason}"),
-                );
-            }
-        };
-
-        let tx_hash = match settlement::submit_reward_claim(
-            &self.blockchain,
-            treasury,
+        self.execute_claim(
             &req.did,
             key_id,
-            RewardEventKind::NewPartner,
-            plan.amount,
-            Some(req.peer_did.clone()),
+            settlement::ClaimSpec::new_partner(req.peer_did),
         )
         .await
-        {
-            Ok(h) => h,
-            Err(e) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::InternalServerError,
-                    format!("reward claim submit failed: {}", e),
-                );
-            }
-        };
-
-        Self::ok_json(json!({
-            "awarded": true,
-            "submitted": true,
-            "amount": plan.amount.to_string(),
-            "amount_display": (plan.amount / ATOM_18).to_string(),
-            "event": "new_partner",
-            "partners_this_week": partners_this_week.saturating_add(1),
-            "weekly_cap": weekly_cap,
-            "tx_hash": tx_hash,
-        }))
     }
 
     async fn handle_balance(&self, did: &str) -> ZhtpResponse {

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -1,8 +1,8 @@
 //! BUBL rewards endpoints.
 //!
-//! Inline-mint reward distribution from the BUBL treasury identity to
-//! end-user DIDs. Server-enforced caps; no body signing required (see
-//! `notifications/mod.rs` for the same rationale).
+//! Hybrid reward settlement (N2): spend-delegate attestation via signed
+//! `RewardClaim` txs. Eligibility reads consensus trees; executor enforces
+//! policy at commit. No request-body signing (see `notifications/mod.rs`).
 //!
 //! ## Configuration
 //!
@@ -46,16 +46,17 @@ use tokio::sync::RwLock;
 use tracing::{info, warn};
 
 
-use lib_blockchain::transaction::{Transaction, TokenTransferData};
+use lib_blockchain::transaction::reward_claim::RewardEventKind;
 use lib_blockchain::Blockchain;
 use lib_crypto::keypair::KeyPair;
 use lib_crypto::types::keys::{PrivateKey, PublicKey};
-use lib_crypto::Signature;
 use lib_identity::ZhtpIdentity;
 use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_protocols::zhtp::ZhtpRequestHandler;
 
 use crate::keyfile_names::{KeystorePrivateKey, USER_IDENTITY_FILENAME, USER_PRIVATE_KEY_FILENAME};
+
+mod settlement;
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -82,12 +83,6 @@ const WEEKLY_PARTNER_CAP: u32 = 5;
 const HISTORY_DEFAULT_LIMIT: usize = 50;
 const HISTORY_MAX_LIMIT: usize = 200;
 const MAX_DID_LEN: usize = 256;
-
-/// Sentinel value written into a reservation slot via `compare_and_swap`
-/// before the mint, then either overwritten with the real marker on
-/// success or removed on mint failure. Any non-empty byte is sufficient —
-/// `compare_and_swap` distinguishes `None` from `Some(_)` only.
-const SLOT_PENDING: &[u8] = b"P";
 
 const TREE_WELCOMED: &str = "welcomed";
 const TREE_CHECKINS: &str = "checkins";
@@ -410,92 +405,8 @@ impl RewardsHandler {
         }
     }
 
-    fn load_streak(&self, did: &str) -> StreakState {
-        match self.streak.get(did.as_bytes()) {
-            Ok(Some(bytes)) => bincode::deserialize(&bytes).unwrap_or_default(),
-            _ => StreakState::default(),
-        }
-    }
-
-    fn save_streak(&self, did: &str, state: &StreakState) -> Result<()> {
-        let bytes = bincode::serialize(state)?;
-        self.streak.insert(did.as_bytes(), bytes)?;
-        Ok(())
-    }
-
-    fn count_partners_this_week(&self, did: &str) -> u32 {
-        let week = Self::iso_week();
-        let key = Self::partners_count_key(&week, did);
-        self.partners_count
-            .get(&key)
-            .ok()
-            .flatten()
-            .and_then(|v| v.as_ref().try_into().ok().map(u32::from_le_bytes))
-            .unwrap_or(0)
-    }
-
-    /// Build, sign, and submit a TokenTransfer from the BUBL creator
-    /// (= the loaded rewards keystore) → recipient. Returns the tx hash hex
-    /// on success.
-    ///
-    /// The keystore configured via `ZHTP_REWARDS_TREASURY_KEYSTORE` MUST be
-    /// the keypair that signed the original BUBL `TokenCreation` transaction.
-    /// At deploy time TokenCreation credits the creator's `creator_allocation`
-    /// to the creator's full `PublicKey`, so a normal TokenTransfer signed by
-    /// the same keypair can debit it. The "treasury" 20 % allocation is
-    /// minted to `PublicKey { dilithium_pk: [0; 2592], kyber_pk: [0; 1568],
-    /// key_id: treasury_recipient }` (an unsignable address — see
-    /// `lib-blockchain/src/blockchain/contracts.rs:688-692`) and is therefore
-    /// inaccessible by design. Rewards are funded out of the creator share.
-    async fn mint_to_user(&self, recipient_key_id: [u8; 32], amount: u128) -> Result<String> {
-        let treasury = self
-            .treasury
-            .as_ref()
-            .ok_or_else(|| anyhow!("rewards treasury not configured"))?;
-
-        // Chain enforces strict per-(token, from) nonce equality via
-        // `is_nonce_current` (`blockchain.rs:2262-2290`). Read the expected
-        // nonce inside the same read-lock window we hold for submission. The
-        // write-lock during `add_pending_transaction` below serialises
-        // concurrent claims so this read-then-use is safe.
-        let nonce = {
-            let bc = self.blockchain.read().await;
-            bc.token_nonce(&treasury.rewards_asset_id, &treasury.signer_key_id)
-                .map_err(|e| anyhow!("nonce lookup failed: {e}"))?
-        };
-
-        let data = TokenTransferData {
-            token_id: treasury.rewards_asset_id,
-            from: treasury.signer_key_id,
-            to: recipient_key_id,
-            amount,
-            nonce,
-        };
-
-        let mut tx = Transaction::new_token_transfer_with_chain_id(
-            chain_id_from_env(),
-            data,
-            Signature::default(),
-            b"bubl:reward:v1".to_vec(),
-        );
-        let sig = treasury
-            .keypair
-            .sign(tx.signing_hash().as_bytes())
-            .map_err(|e| anyhow!("rewards sign failed: {}", e))?;
-        // No PublicKey mutation: `data.from = signer_key_id =
-        // keypair.public_key.key_id`, kyber_pk is the keystore's real kyber,
-        // and the key_id binding check at `validation.rs:1170-1192` expects
-        // `blake3(dilithium || kyber)` when kyber is non-zero — which is how
-        // `KeyPair::new` derives `public_key.key_id` in the first place. The
-        // `balance_of(&sender_pk)` lookup at `contracts.rs:374` then matches
-        // the creator-allocation entry written by `TokenCreation`.
-        tx.signature = sig;
-
-        let tx_hash = hex::encode(tx.hash().as_bytes());
-        let mut bc = self.blockchain.write().await;
-        bc.add_pending_transaction(tx)
-            .map_err(|e| anyhow!("Failed to submit reward tx: {}", e))?;
-        Ok(tx_hash)
+    fn rewards_asset_id(&self) -> Option<[u8; 32]> {
+        self.treasury.as_ref().map(|t| t.rewards_asset_id)
     }
 
     // ── handlers ─────────────────────────────────────────────────────
@@ -521,50 +432,55 @@ impl RewardsHandler {
     }
 
     async fn do_welcome(&self, did: &str, key_id: [u8; 32]) -> ZhtpResponse {
-        // Atomically reserve the welcome slot BEFORE minting. The previous
-        // `get` → mint → `insert` sequence let two concurrent claims both
-        // pass the check and double-mint. CAS the slot from `None` to a
-        // pending sentinel; rivals see Some(_) and bail with
-        // `welcome_already_claimed`. If the mint fails afterwards we
-        // release the slot so retries succeed.
-        match self.welcomed.compare_and_swap(
-            did.as_bytes(),
-            None::<&[u8]>,
-            Some(SLOT_PENDING),
-        ) {
-            Ok(Ok(())) => {}
-            Ok(Err(_)) => {
+        let treasury = match self.treasury.as_ref() {
+            Some(t) => t,
+            None => return Self::unavailable(),
+        };
+        let token_id = treasury.rewards_asset_id;
+
+        {
+            let bc = self.blockchain.read().await;
+            if bc.reward_welcome_claimed(&token_id, did) {
                 return Self::ok_json(json!({
                     "awarded": false,
                     "amount": "0",
                     "reason": "welcome_already_claimed",
                 }));
             }
-            Err(e) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::InternalServerError,
-                    format!("welcome reservation failed: {}", e),
-                );
-            }
         }
-        let tx_hash = match self.mint_to_user(key_id, REWARD_WELCOME).await {
+
+        let amount = {
+            let bc = self.blockchain.read().await;
+            bc.reward_expected_amount(&token_id, RewardEventKind::Welcome, 1)
+                .unwrap_or(REWARD_WELCOME)
+        };
+
+        let tx_hash = match settlement::submit_reward_claim(
+            &self.blockchain,
+            treasury,
+            did,
+            key_id,
+            RewardEventKind::Welcome,
+            amount,
+            None,
+        )
+        .await
+        {
             Ok(h) => h,
             Err(e) => {
-                // Release the pending slot so the next attempt can retry.
-                let _ = self.welcomed.remove(did.as_bytes());
                 return ZhtpResponse::error(
                     ZhtpStatus::InternalServerError,
-                    format!("mint failed: {}", e),
+                    format!("reward claim submit failed: {}", e),
                 );
             }
         };
-        let now = Self::now_secs();
-        let _ = self.welcomed.insert(did.as_bytes(), &now.to_le_bytes());
 
-        let event = RewardEvent { seq: 0, // filled by record_event below
+        let now = Self::now_secs();
+        let event = RewardEvent {
+            seq: 0,
             at: now,
             event: "welcome".into(),
-            amount: REWARD_WELCOME,
+            amount,
             tx_hash: tx_hash.clone(),
             meta_streak_day: None,
             meta_peer_did: None,
@@ -573,25 +489,25 @@ impl RewardsHandler {
 
         Self::ok_json(json!({
             "awarded": true,
-            "amount": REWARD_WELCOME.to_string(),
-            "amount_display": (REWARD_WELCOME / ATOM_18).to_string(),
+            "amount": amount.to_string(),
+            "amount_display": (amount / ATOM_18).to_string(),
             "event": "welcome",
             "tx_hash": tx_hash,
         }))
     }
 
     async fn do_daily_checkin(&self, did: &str, key_id: [u8; 32]) -> ZhtpResponse {
+        let treasury = match self.treasury.as_ref() {
+            Some(t) => t,
+            None => return Self::unavailable(),
+        };
+        let token_id = treasury.rewards_asset_id;
         let date = Self::utc_date();
-        let key = Self::day_compound_key(&date, did);
+        let today_ord = Self::utc_day_ordinal();
 
-        // CAS-reserve today's slot before doing any work. See `do_welcome`
-        // for rationale — same race fix.
-        match self
-            .checkins
-            .compare_and_swap(&key, None::<&[u8]>, Some(SLOT_PENDING))
         {
-            Ok(Ok(())) => {}
-            Ok(Err(_)) => {
+            let bc = self.blockchain.read().await;
+            if bc.reward_daily_claimed(&token_id, &date, did, RewardEventKind::DailyCheckin) {
                 return Self::ok_json(json!({
                     "awarded": false,
                     "amount": "0",
@@ -599,48 +515,46 @@ impl RewardsHandler {
                     "next_eligible_at": Self::next_utc_midnight_secs(),
                 }));
             }
-            Err(e) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::InternalServerError,
-                    format!("checkin reservation failed: {}", e),
-                );
-            }
         }
 
-        // Compute streak: consecutive if last_day == today-1, else reset to 1.
-        let today_ord = Self::utc_day_ordinal();
-        let mut streak = self.load_streak(did);
-        let next_streak = if streak.last_day == today_ord - 1 {
-            streak.current_streak.saturating_add(1)
-        } else {
-            1
+        let (next_streak, amount, longest_streak) = {
+            let bc = self.blockchain.read().await;
+            let streak = bc.reward_streak(&token_id, did);
+            let next_streak = if streak.last_day == today_ord - 1 {
+                streak.current_streak.saturating_add(1)
+            } else {
+                1
+            };
+            let amount = bc
+                .reward_checkin_amount_for_streak(&token_id, next_streak)
+                .unwrap_or_else(|| Self::checkin_amount_for_day(next_streak));
+            let longest = next_streak.max(streak.longest_streak);
+            (next_streak, amount, longest)
         };
-        let amount = Self::checkin_amount_for_day(next_streak);
 
-        let tx_hash = match self.mint_to_user(key_id, amount).await {
+        let tx_hash = match settlement::submit_reward_claim(
+            &self.blockchain,
+            treasury,
+            did,
+            key_id,
+            RewardEventKind::DailyCheckin,
+            amount,
+            None,
+        )
+        .await
+        {
             Ok(h) => h,
             Err(e) => {
-                let _ = self.checkins.remove(&key);
                 return ZhtpResponse::error(
                     ZhtpStatus::InternalServerError,
-                    format!("mint failed: {}", e),
+                    format!("reward claim submit failed: {}", e),
                 );
             }
         };
 
-        // Promote the pending slot to a permanent marker.
-        let _ = self.checkins.insert(&key, &[1u8]);
-
-        // Update streak state.
-        streak.last_day = today_ord;
-        streak.current_streak = next_streak;
-        if next_streak > streak.longest_streak {
-            streak.longest_streak = next_streak;
-        }
-        let _ = self.save_streak(did, &streak);
-
         let now = Self::now_secs();
-        let event = RewardEvent { seq: 0, // filled by record_event below
+        let event = RewardEvent {
+            seq: 0,
             at: now,
             event: "daily_checkin".into(),
             amount,
@@ -649,7 +563,7 @@ impl RewardsHandler {
             meta_peer_did: None,
         };
         let streak_snapshot = next_streak;
-        let longest_snapshot = streak.longest_streak;
+        let longest_snapshot = longest_streak;
         self.record_event(did, event, move |s| {
             s.checkin_count = s.checkin_count.saturating_add(1);
             s.current_streak = streak_snapshot;
@@ -668,16 +582,16 @@ impl RewardsHandler {
     }
 
     async fn do_active_session(&self, did: &str, key_id: [u8; 32]) -> ZhtpResponse {
+        let treasury = match self.treasury.as_ref() {
+            Some(t) => t,
+            None => return Self::unavailable(),
+        };
+        let token_id = treasury.rewards_asset_id;
         let date = Self::utc_date();
-        let key = Self::day_compound_key(&date, did);
 
-        // CAS-reserve today's slot (see `do_welcome` for the race rationale).
-        match self
-            .sessions
-            .compare_and_swap(&key, None::<&[u8]>, Some(SLOT_PENDING))
         {
-            Ok(Ok(())) => {}
-            Ok(Err(_)) => {
+            let bc = self.blockchain.read().await;
+            if bc.reward_daily_claimed(&token_id, &date, did, RewardEventKind::ActiveSession) {
                 return Self::ok_json(json!({
                     "awarded": false,
                     "amount": "0",
@@ -685,31 +599,40 @@ impl RewardsHandler {
                     "next_eligible_at": Self::next_utc_midnight_secs(),
                 }));
             }
-            Err(e) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::InternalServerError,
-                    format!("session reservation failed: {}", e),
-                );
-            }
         }
 
-        let tx_hash = match self.mint_to_user(key_id, REWARD_ACTIVE_SESSION).await {
+        let amount = {
+            let bc = self.blockchain.read().await;
+            bc.reward_expected_amount(&token_id, RewardEventKind::ActiveSession, 1)
+                .unwrap_or(REWARD_ACTIVE_SESSION)
+        };
+
+        let tx_hash = match settlement::submit_reward_claim(
+            &self.blockchain,
+            treasury,
+            did,
+            key_id,
+            RewardEventKind::ActiveSession,
+            amount,
+            None,
+        )
+        .await
+        {
             Ok(h) => h,
             Err(e) => {
-                let _ = self.sessions.remove(&key);
                 return ZhtpResponse::error(
                     ZhtpStatus::InternalServerError,
-                    format!("mint failed: {}", e),
+                    format!("reward claim submit failed: {}", e),
                 );
             }
         };
-        let _ = self.sessions.insert(&key, &[1u8]);
 
         let now = Self::now_secs();
-        let event = RewardEvent { seq: 0, // filled by record_event below
+        let event = RewardEvent {
+            seq: 0,
             at: now,
             event: "active_session".into(),
-            amount: REWARD_ACTIVE_SESSION,
+            amount,
             tx_hash: tx_hash.clone(),
             meta_streak_day: None,
             meta_peer_did: None,
@@ -720,8 +643,8 @@ impl RewardsHandler {
 
         Self::ok_json(json!({
             "awarded": true,
-            "amount": REWARD_ACTIVE_SESSION.to_string(),
-            "amount_display": (REWARD_ACTIVE_SESSION / ATOM_18).to_string(),
+            "amount": amount.to_string(),
+            "amount_display": (amount / ATOM_18).to_string(),
             "event": "active_session",
             "tx_hash": tx_hash,
             "next_eligible_at": Self::next_utc_midnight_secs(),
@@ -747,104 +670,67 @@ impl RewardsHandler {
             return Self::bad(format!("peer_did invalid: {}", msg));
         }
 
+        let treasury = match self.treasury.as_ref() {
+            Some(t) => t,
+            None => return Self::unavailable(),
+        };
+        let token_id = treasury.rewards_asset_id;
         let week = Self::iso_week();
-        let already_key = Self::partner_compound_key(&week, &req.did, &req.peer_did);
-        let count_key = Self::partners_count_key(&week, &req.did);
 
-        // Atomically reserve the (week, did, peer) slot. Same-peer twice in
-        // the same week gets rejected here. Concurrent requests for two
-        // different peers will both pass this gate — the count CAS below
-        // handles the weekly cap.
-        match self
-            .partners
-            .compare_and_swap(&already_key, None::<&[u8]>, Some(SLOT_PENDING))
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(_)) => {
+        let (partners_this_week, weekly_cap, amount) = {
+            let bc = self.blockchain.read().await;
+            if bc.reward_partner_claimed(&token_id, &week, &req.did, &req.peer_did) {
                 return Self::ok_json(json!({
                     "awarded": false,
                     "amount": "0",
                     "reason": "partner_already_counted_this_week",
-                    "partners_this_week": self.count_partners_this_week(&req.did),
+                    "partners_this_week": bc.reward_partners_this_week(&token_id, &week, &req.did),
                 }));
             }
-            Err(e) => {
-                return ZhtpResponse::error(
-                    ZhtpStatus::InternalServerError,
-                    format!("partner reservation failed: {}", e),
-                );
-            }
-        }
-
-        // Spin-CAS the weekly count to enforce the cap atomically.
-        // `update_and_fetch` would also work but conflates "no change"
-        // with "delete" via its `Option` return.
-        let new_count = loop {
-            let current_iv = match self.partners_count.get(&count_key) {
-                Ok(v) => v,
-                Err(e) => {
-                    let _ = self.partners.remove(&already_key);
-                    return ZhtpResponse::error(
-                        ZhtpStatus::InternalServerError,
-                        format!("partner count read failed: {}", e),
-                    );
-                }
-            };
-            let current = current_iv
-                .as_ref()
-                .and_then(|v| <[u8; 4]>::try_from(v.as_ref()).ok())
-                .map(u32::from_le_bytes)
-                .unwrap_or(0);
-            if current >= WEEKLY_PARTNER_CAP {
-                let _ = self.partners.remove(&already_key);
+            let policy_cap = bc.reward_weekly_partner_cap(&token_id);
+            let weekly_cap = if policy_cap > 0 { policy_cap } else { WEEKLY_PARTNER_CAP };
+            let partners_this_week =
+                bc.reward_partners_this_week(&token_id, &week, &req.did);
+            if weekly_cap > 0 && partners_this_week >= weekly_cap {
                 return Self::ok_json(json!({
                     "awarded": false,
                     "amount": "0",
                     "reason": "weekly_partner_cap_reached",
-                    "partners_this_week": WEEKLY_PARTNER_CAP,
+                    "partners_this_week": partners_this_week,
                 }));
             }
-            let next = current.saturating_add(1);
-            match self.partners_count.compare_and_swap(
-                &count_key,
-                current_iv.as_deref(),
-                Some(&next.to_le_bytes()),
-            ) {
-                Ok(Ok(())) => break next,
-                Ok(Err(_)) => continue, // racer mutated count; retry
-                Err(e) => {
-                    let _ = self.partners.remove(&already_key);
-                    return ZhtpResponse::error(
-                        ZhtpStatus::InternalServerError,
-                        format!("partner count CAS failed: {}", e),
-                    );
-                }
-            }
+            let amount = bc
+                .reward_expected_amount(&token_id, RewardEventKind::NewPartner, 1)
+                .unwrap_or(REWARD_NEW_PARTNER);
+            (partners_this_week, weekly_cap, amount)
         };
 
-        let tx_hash = match self.mint_to_user(key_id, REWARD_NEW_PARTNER).await {
+        let tx_hash = match settlement::submit_reward_claim(
+            &self.blockchain,
+            treasury,
+            &req.did,
+            key_id,
+            RewardEventKind::NewPartner,
+            amount,
+            Some(req.peer_did.clone()),
+        )
+        .await
+        {
             Ok(h) => h,
             Err(e) => {
-                // Roll back both the slot reservation and the count.
-                let _ = self.partners.remove(&already_key);
-                let _ = self
-                    .partners_count
-                    .insert(&count_key, &new_count.saturating_sub(1).to_le_bytes());
                 return ZhtpResponse::error(
                     ZhtpStatus::InternalServerError,
-                    format!("mint failed: {}", e),
+                    format!("reward claim submit failed: {}", e),
                 );
             }
         };
 
-        // Promote the pending reservation to a permanent marker.
-        let _ = self.partners.insert(&already_key, &[1u8]);
-
         let now = Self::now_secs();
-        let event = RewardEvent { seq: 0, // filled by record_event below
+        let event = RewardEvent {
+            seq: 0,
             at: now,
             event: "new_partner".into(),
-            amount: REWARD_NEW_PARTNER,
+            amount,
             tx_hash: tx_hash.clone(),
             meta_streak_day: None,
             meta_peer_did: Some(req.peer_did.clone()),
@@ -855,10 +741,11 @@ impl RewardsHandler {
 
         Self::ok_json(json!({
             "awarded": true,
-            "amount": REWARD_NEW_PARTNER.to_string(),
-            "amount_display": (REWARD_NEW_PARTNER / ATOM_18).to_string(),
+            "amount": amount.to_string(),
+            "amount_display": (amount / ATOM_18).to_string(),
             "event": "new_partner",
-            "partners_this_week": new_count,
+            "partners_this_week": partners_this_week.saturating_add(1),
+            "weekly_cap": weekly_cap,
             "tx_hash": tx_hash,
         }))
     }
@@ -910,39 +797,51 @@ impl RewardsHandler {
     }
 
     async fn handle_status(&self, did: &str) -> ZhtpResponse {
-        // READS don't need the treasury keystore — see `handle_balance`.
         if let Err(msg) = Self::validate_did(did) {
             return Self::bad(msg);
         }
 
+        let token_id = self.rewards_asset_id().unwrap_or_else(|| {
+            lib_blockchain::contracts::utils::generate_custom_token_id("Bubble", "BUBL")
+        });
+
         let now = Self::now_secs();
         let date = Self::utc_date();
+        let week = Self::iso_week();
         let next_midnight = Self::next_utc_midnight_secs();
-
-        let welcome_available = !matches!(self.welcomed.get(did.as_bytes()), Ok(Some(_)));
-
-        let checkin_done = matches!(
-            self.checkins.get(&Self::day_compound_key(&date, did)),
-            Ok(Some(_))
-        );
-        let streak = self.load_streak(did);
         let today_ord = Self::utc_day_ordinal();
+
+        let bc = self.blockchain.read().await;
+
+        let welcome_available = !bc.reward_welcome_claimed(&token_id, did);
+        let checkin_done =
+            bc.reward_daily_claimed(&token_id, &date, did, RewardEventKind::DailyCheckin);
+        let streak = bc.reward_streak(&token_id, did);
         let next_streak = if streak.last_day == today_ord - 1 {
             streak.current_streak.saturating_add(1)
         } else if streak.last_day == today_ord {
-            // already checked in today — show what TODAY's value was
             streak.current_streak.max(1)
         } else {
             1
         };
-        let checkin_amount = Self::checkin_amount_for_day(next_streak);
+        let checkin_amount = bc
+            .reward_checkin_amount_for_streak(&token_id, next_streak)
+            .unwrap_or_else(|| Self::checkin_amount_for_day(next_streak));
+        let welcome_amount = bc
+            .reward_expected_amount(&token_id, RewardEventKind::Welcome, 1)
+            .unwrap_or(REWARD_WELCOME);
+        let session_amount = bc
+            .reward_expected_amount(&token_id, RewardEventKind::ActiveSession, 1)
+            .unwrap_or(REWARD_ACTIVE_SESSION);
+        let partner_amount = bc
+            .reward_expected_amount(&token_id, RewardEventKind::NewPartner, 1)
+            .unwrap_or(REWARD_NEW_PARTNER);
 
-        let session_done = matches!(
-            self.sessions.get(&Self::day_compound_key(&date, did)),
-            Ok(Some(_))
-        );
-
-        let partners_this_week = self.count_partners_this_week(did);
+        let session_done =
+            bc.reward_daily_claimed(&token_id, &date, did, RewardEventKind::ActiveSession);
+        let partners_this_week = bc.reward_partners_this_week(&token_id, &week, did);
+        let policy_cap = bc.reward_weekly_partner_cap(&token_id);
+        let weekly_cap = if policy_cap > 0 { policy_cap } else { WEEKLY_PARTNER_CAP };
 
         Self::ok_json(json!({
             "did": did,
@@ -950,7 +849,7 @@ impl RewardsHandler {
             "claimable": {
                 "welcome": {
                     "available": welcome_available,
-                    "amount_display": (REWARD_WELCOME / ATOM_18).to_string(),
+                    "amount_display": (welcome_amount / ATOM_18).to_string(),
                 },
                 "daily_checkin": {
                     "available": !checkin_done,
@@ -960,14 +859,14 @@ impl RewardsHandler {
                 },
                 "active_session": {
                     "available": !session_done,
-                    "amount_display": (REWARD_ACTIVE_SESSION / ATOM_18).to_string(),
+                    "amount_display": (session_amount / ATOM_18).to_string(),
                     "next_eligible_at": if session_done { Some(next_midnight) } else { None },
                 },
                 "new_partner": {
                     "partners_this_week": partners_this_week,
-                    "weekly_cap": WEEKLY_PARTNER_CAP,
-                    "remaining": WEEKLY_PARTNER_CAP.saturating_sub(partners_this_week),
-                    "amount_display_per_partner": (REWARD_NEW_PARTNER / ATOM_18).to_string(),
+                    "weekly_cap": weekly_cap,
+                    "remaining": weekly_cap.saturating_sub(partners_this_week),
+                    "amount_display_per_partner": (partner_amount / ATOM_18).to_string(),
                 },
             },
             "current_streak": streak.current_streak,
@@ -1167,7 +1066,7 @@ impl ZhtpRequestHandler for RewardsHandler {
 /// Resolve the chain_id used to bind a TokenTransfer tx. Mirrors
 /// `runtime::token_utils::chain_id_from_env` so reward txes ride the same
 /// chain_id as every other server-built tx (testnet=0x02, mainnet=0x03).
-fn chain_id_from_env() -> u8 {
+pub(crate) fn chain_id_from_env() -> u8 {
     std::env::var("ZHTP_CHAIN_ID")
         .ok()
         .and_then(|v| v.parse::<u8>().ok())

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -17,24 +17,8 @@
 //!
 //! ## Storage
 //!
-//! Sled DB under `node_data_dir()/rewards.sled`. Trees:
-//! - `welcomed`         — set of DIDs that have claimed the one-shot
-//!                        welcome bonus. value = unix-secs of claim.
-//! - `checkins`         — `{utc_date_str}|{did}` → 1u8. Day-keyed dedup.
-//! - `sessions`         — same shape, for active-session reward.
-//! - `streak`           — did → bincode(StreakState).
-//! - `partners`         — `{iso_week_str}|{did}|{peer_did}` → 1u8.
-//!                        Compound key gives O(1) "have we counted this
-//!                        peer this week" check.
-//! - `partners_count`   — `{iso_week_str}|{did}` → u32-le count. Lets us
-//!                        enforce the 5-per-week cap without iterating.
-//! - `history`          — `{did}|{seq_u64_be}` → bincode(RewardEvent).
-//!                        Iterating rev() yields newest first.
-//! - `history_seq`      — `next` → u64-le. Monotonic counter for the
-//!                        history tree's secondary key.
-//! - `lifetime`         — did → bincode(LifetimeStats). Totals + counts
-//!                        + longest streak so the balance endpoint
-//!                        doesn't have to re-scan history every call.
+//! Eligibility and streak state live on-chain (consensus trees). Node-local
+//! `rewards.sled` retains only `history` + `lifetime` caches until N4 (#2814).
 
 use anyhow::{anyhow, Result};
 use chrono::{Datelike, Utc};
@@ -84,12 +68,6 @@ const HISTORY_DEFAULT_LIMIT: usize = 50;
 const HISTORY_MAX_LIMIT: usize = 200;
 const MAX_DID_LEN: usize = 256;
 
-const TREE_WELCOMED: &str = "welcomed";
-const TREE_CHECKINS: &str = "checkins";
-const TREE_SESSIONS: &str = "sessions";
-const TREE_STREAK: &str = "streak";
-const TREE_PARTNERS: &str = "partners";
-const TREE_PARTNERS_COUNT: &str = "partners_count";
 const TREE_HISTORY: &str = "history";
 const TREE_HISTORY_SEQ: &str = "history_seq";
 const TREE_LIFETIME: &str = "lifetime";
@@ -154,12 +132,6 @@ pub struct RewardsHandler {
     /// None when the treasury keystore env var is unset or load failed.
     /// All POST/GET endpoints return 503 in that case.
     treasury: Option<TreasuryConfig>,
-    welcomed: sled::Tree,
-    checkins: sled::Tree,
-    sessions: sled::Tree,
-    streak: sled::Tree,
-    partners: sled::Tree,
-    partners_count: sled::Tree,
     history: sled::Tree,
     history_seq: sled::Tree,
     lifetime: sled::Tree,
@@ -178,12 +150,6 @@ impl RewardsHandler {
         let path = crate::node_data_dir().join("rewards.sled");
         let db = sled::open(&path)
             .map_err(|e| anyhow!("Failed to open rewards sled at {:?}: {}", path, e))?;
-        let welcomed = db.open_tree(TREE_WELCOMED)?;
-        let checkins = db.open_tree(TREE_CHECKINS)?;
-        let sessions = db.open_tree(TREE_SESSIONS)?;
-        let streak = db.open_tree(TREE_STREAK)?;
-        let partners = db.open_tree(TREE_PARTNERS)?;
-        let partners_count = db.open_tree(TREE_PARTNERS_COUNT)?;
         let history = db.open_tree(TREE_HISTORY)?;
         let history_seq = db.open_tree(TREE_HISTORY_SEQ)?;
         let lifetime = db.open_tree(TREE_LIFETIME)?;
@@ -212,12 +178,6 @@ impl RewardsHandler {
         Ok(Self {
             blockchain,
             treasury,
-            welcomed,
-            checkins,
-            sessions,
-            streak,
-            partners,
-            partners_count,
             history,
             history_seq,
             lifetime,
@@ -438,21 +398,25 @@ impl RewardsHandler {
         };
         let token_id = treasury.rewards_asset_id;
 
-        {
+        let plan = {
             let bc = self.blockchain.read().await;
-            if bc.reward_welcome_claimed(&token_id, did) {
+            settlement::plan_reward_claim(&bc, &token_id, did, RewardEventKind::Welcome, None)
+        };
+        let plan = match plan {
+            Ok(p) => p,
+            Err(reason) if reason == "welcome_already_claimed" => {
                 return Self::ok_json(json!({
                     "awarded": false,
                     "amount": "0",
-                    "reason": "welcome_already_claimed",
+                    "reason": reason,
                 }));
             }
-        }
-
-        let amount = {
-            let bc = self.blockchain.read().await;
-            bc.reward_expected_amount(&token_id, RewardEventKind::Welcome, 1)
-                .unwrap_or(REWARD_WELCOME)
+            Err(reason) => {
+                return ZhtpResponse::error(
+                    ZhtpStatus::ServiceUnavailable,
+                    format!("rewards claim unavailable: {reason}"),
+                );
+            }
         };
 
         let tx_hash = match settlement::submit_reward_claim(
@@ -461,7 +425,7 @@ impl RewardsHandler {
             did,
             key_id,
             RewardEventKind::Welcome,
-            amount,
+            plan.amount,
             None,
         )
         .await
@@ -475,22 +439,11 @@ impl RewardsHandler {
             }
         };
 
-        let now = Self::now_secs();
-        let event = RewardEvent {
-            seq: 0,
-            at: now,
-            event: "welcome".into(),
-            amount,
-            tx_hash: tx_hash.clone(),
-            meta_streak_day: None,
-            meta_peer_did: None,
-        };
-        self.record_event(did, event, |s| s.welcome_claimed = true);
-
         Self::ok_json(json!({
             "awarded": true,
-            "amount": amount.to_string(),
-            "amount_display": (amount / ATOM_18).to_string(),
+            "submitted": true,
+            "amount": plan.amount.to_string(),
+            "amount_display": (plan.amount / ATOM_18).to_string(),
             "event": "welcome",
             "tx_hash": tx_hash,
         }))
@@ -502,35 +455,35 @@ impl RewardsHandler {
             None => return Self::unavailable(),
         };
         let token_id = treasury.rewards_asset_id;
-        let date = Self::utc_date();
-        let today_ord = Self::utc_day_ordinal();
 
-        {
+        let plan = {
             let bc = self.blockchain.read().await;
-            if bc.reward_daily_claimed(&token_id, &date, did, RewardEventKind::DailyCheckin) {
+            settlement::plan_reward_claim(
+                &bc,
+                &token_id,
+                did,
+                RewardEventKind::DailyCheckin,
+                None,
+            )
+        };
+        let plan = match plan {
+            Ok(p) => p,
+            Err(reason) if reason == "checkin_already_claimed_today" => {
                 return Self::ok_json(json!({
                     "awarded": false,
                     "amount": "0",
-                    "reason": "checkin_already_claimed_today",
+                    "reason": reason,
                     "next_eligible_at": Self::next_utc_midnight_secs(),
                 }));
             }
-        }
-
-        let (next_streak, amount, longest_streak) = {
-            let bc = self.blockchain.read().await;
-            let streak = bc.reward_streak(&token_id, did);
-            let next_streak = if streak.last_day == today_ord - 1 {
-                streak.current_streak.saturating_add(1)
-            } else {
-                1
-            };
-            let amount = bc
-                .reward_checkin_amount_for_streak(&token_id, next_streak)
-                .unwrap_or_else(|| Self::checkin_amount_for_day(next_streak));
-            let longest = next_streak.max(streak.longest_streak);
-            (next_streak, amount, longest)
+            Err(reason) => {
+                return ZhtpResponse::error(
+                    ZhtpStatus::ServiceUnavailable,
+                    format!("rewards claim unavailable: {reason}"),
+                );
+            }
         };
+        let next_streak = plan.streak_day.unwrap_or(1);
 
         let tx_hash = match settlement::submit_reward_claim(
             &self.blockchain,
@@ -538,7 +491,7 @@ impl RewardsHandler {
             did,
             key_id,
             RewardEventKind::DailyCheckin,
-            amount,
+            plan.amount,
             None,
         )
         .await
@@ -552,28 +505,11 @@ impl RewardsHandler {
             }
         };
 
-        let now = Self::now_secs();
-        let event = RewardEvent {
-            seq: 0,
-            at: now,
-            event: "daily_checkin".into(),
-            amount,
-            tx_hash: tx_hash.clone(),
-            meta_streak_day: Some(next_streak),
-            meta_peer_did: None,
-        };
-        let streak_snapshot = next_streak;
-        let longest_snapshot = longest_streak;
-        self.record_event(did, event, move |s| {
-            s.checkin_count = s.checkin_count.saturating_add(1);
-            s.current_streak = streak_snapshot;
-            s.longest_streak = longest_snapshot;
-        });
-
         Self::ok_json(json!({
             "awarded": true,
-            "amount": amount.to_string(),
-            "amount_display": (amount / ATOM_18).to_string(),
+            "submitted": true,
+            "amount": plan.amount.to_string(),
+            "amount_display": (plan.amount / ATOM_18).to_string(),
             "event": "daily_checkin",
             "streak_day": next_streak,
             "tx_hash": tx_hash,
@@ -587,24 +523,33 @@ impl RewardsHandler {
             None => return Self::unavailable(),
         };
         let token_id = treasury.rewards_asset_id;
-        let date = Self::utc_date();
 
-        {
+        let plan = {
             let bc = self.blockchain.read().await;
-            if bc.reward_daily_claimed(&token_id, &date, did, RewardEventKind::ActiveSession) {
+            settlement::plan_reward_claim(
+                &bc,
+                &token_id,
+                did,
+                RewardEventKind::ActiveSession,
+                None,
+            )
+        };
+        let plan = match plan {
+            Ok(p) => p,
+            Err(reason) if reason == "session_already_claimed_today" => {
                 return Self::ok_json(json!({
                     "awarded": false,
                     "amount": "0",
-                    "reason": "session_already_claimed_today",
+                    "reason": reason,
                     "next_eligible_at": Self::next_utc_midnight_secs(),
                 }));
             }
-        }
-
-        let amount = {
-            let bc = self.blockchain.read().await;
-            bc.reward_expected_amount(&token_id, RewardEventKind::ActiveSession, 1)
-                .unwrap_or(REWARD_ACTIVE_SESSION)
+            Err(reason) => {
+                return ZhtpResponse::error(
+                    ZhtpStatus::ServiceUnavailable,
+                    format!("rewards claim unavailable: {reason}"),
+                );
+            }
         };
 
         let tx_hash = match settlement::submit_reward_claim(
@@ -613,7 +558,7 @@ impl RewardsHandler {
             did,
             key_id,
             RewardEventKind::ActiveSession,
-            amount,
+            plan.amount,
             None,
         )
         .await
@@ -627,24 +572,11 @@ impl RewardsHandler {
             }
         };
 
-        let now = Self::now_secs();
-        let event = RewardEvent {
-            seq: 0,
-            at: now,
-            event: "active_session".into(),
-            amount,
-            tx_hash: tx_hash.clone(),
-            meta_streak_day: None,
-            meta_peer_did: None,
-        };
-        self.record_event(did, event, |s| {
-            s.session_count = s.session_count.saturating_add(1);
-        });
-
         Self::ok_json(json!({
             "awarded": true,
-            "amount": amount.to_string(),
-            "amount_display": (amount / ATOM_18).to_string(),
+            "submitted": true,
+            "amount": plan.amount.to_string(),
+            "amount_display": (plan.amount / ATOM_18).to_string(),
             "event": "active_session",
             "tx_hash": tx_hash,
             "next_eligible_at": Self::next_utc_midnight_secs(),
@@ -677,32 +609,45 @@ impl RewardsHandler {
         let token_id = treasury.rewards_asset_id;
         let week = Self::iso_week();
 
-        let (partners_this_week, weekly_cap, amount) = {
+        let plan = {
             let bc = self.blockchain.read().await;
-            if bc.reward_partner_claimed(&token_id, &week, &req.did, &req.peer_did) {
-                return Self::ok_json(json!({
-                    "awarded": false,
-                    "amount": "0",
-                    "reason": "partner_already_counted_this_week",
-                    "partners_this_week": bc.reward_partners_this_week(&token_id, &week, &req.did),
-                }));
-            }
+            settlement::plan_reward_claim(
+                &bc,
+                &token_id,
+                &req.did,
+                RewardEventKind::NewPartner,
+                Some(&req.peer_did),
+            )
+        };
+        let partners_this_week = {
+            let bc = self.blockchain.read().await;
+            bc.reward_partners_this_week(&token_id, &week, &req.did)
+        };
+        let weekly_cap = {
+            let bc = self.blockchain.read().await;
             let policy_cap = bc.reward_weekly_partner_cap(&token_id);
-            let weekly_cap = if policy_cap > 0 { policy_cap } else { WEEKLY_PARTNER_CAP };
-            let partners_this_week =
-                bc.reward_partners_this_week(&token_id, &week, &req.did);
-            if weekly_cap > 0 && partners_this_week >= weekly_cap {
+            if policy_cap > 0 { policy_cap } else { WEEKLY_PARTNER_CAP }
+        };
+
+        let plan = match plan {
+            Ok(p) => p,
+            Err(reason)
+                if reason == "partner_already_counted_this_week"
+                    || reason == "weekly_partner_cap_reached" =>
+            {
                 return Self::ok_json(json!({
                     "awarded": false,
                     "amount": "0",
-                    "reason": "weekly_partner_cap_reached",
+                    "reason": reason,
                     "partners_this_week": partners_this_week,
                 }));
             }
-            let amount = bc
-                .reward_expected_amount(&token_id, RewardEventKind::NewPartner, 1)
-                .unwrap_or(REWARD_NEW_PARTNER);
-            (partners_this_week, weekly_cap, amount)
+            Err(reason) => {
+                return ZhtpResponse::error(
+                    ZhtpStatus::ServiceUnavailable,
+                    format!("rewards claim unavailable: {reason}"),
+                );
+            }
         };
 
         let tx_hash = match settlement::submit_reward_claim(
@@ -711,7 +656,7 @@ impl RewardsHandler {
             &req.did,
             key_id,
             RewardEventKind::NewPartner,
-            amount,
+            plan.amount,
             Some(req.peer_did.clone()),
         )
         .await
@@ -725,24 +670,11 @@ impl RewardsHandler {
             }
         };
 
-        let now = Self::now_secs();
-        let event = RewardEvent {
-            seq: 0,
-            at: now,
-            event: "new_partner".into(),
-            amount,
-            tx_hash: tx_hash.clone(),
-            meta_streak_day: None,
-            meta_peer_did: Some(req.peer_did.clone()),
-        };
-        self.record_event(&req.did, event, |s| {
-            s.partner_count = s.partner_count.saturating_add(1);
-        });
-
         Self::ok_json(json!({
             "awarded": true,
-            "amount": amount.to_string(),
-            "amount_display": (amount / ATOM_18).to_string(),
+            "submitted": true,
+            "amount": plan.amount.to_string(),
+            "amount_display": (plan.amount / ATOM_18).to_string(),
             "event": "new_partner",
             "partners_this_week": partners_this_week.saturating_add(1),
             "weekly_cap": weekly_cap,
@@ -826,16 +758,16 @@ impl RewardsHandler {
         };
         let checkin_amount = bc
             .reward_checkin_amount_for_streak(&token_id, next_streak)
-            .unwrap_or_else(|| Self::checkin_amount_for_day(next_streak));
+            .unwrap_or(0);
         let welcome_amount = bc
             .reward_expected_amount(&token_id, RewardEventKind::Welcome, 1)
-            .unwrap_or(REWARD_WELCOME);
+            .unwrap_or(0);
         let session_amount = bc
             .reward_expected_amount(&token_id, RewardEventKind::ActiveSession, 1)
-            .unwrap_or(REWARD_ACTIVE_SESSION);
+            .unwrap_or(0);
         let partner_amount = bc
             .reward_expected_amount(&token_id, RewardEventKind::NewPartner, 1)
-            .unwrap_or(REWARD_NEW_PARTNER);
+            .unwrap_or(0);
 
         let session_done =
             bc.reward_daily_claimed(&token_id, &date, did, RewardEventKind::ActiveSession);

--- a/zhtp/src/api/handlers/rewards/settlement.rs
+++ b/zhtp/src/api/handlers/rewards/settlement.rs
@@ -8,9 +8,93 @@ use tokio::sync::RwLock;
 use lib_blockchain::transaction::reward_claim::{RewardClaimData, RewardEventKind, REWARD_CLAIM_MEMO};
 use lib_blockchain::transaction::Transaction;
 use lib_blockchain::Blockchain;
+
 use lib_crypto::Signature;
 
 use super::TreasuryConfig;
+
+/// Planned claim after a single chain snapshot read (eligibility + policy amount).
+pub struct RewardClaimPlan {
+    pub amount: u128,
+    pub streak_day: Option<u32>,
+}
+
+/// Read eligibility and policy-derived amount from consensus state.
+pub fn plan_reward_claim(
+    bc: &Blockchain,
+    token_id: &[u8; 32],
+    did: &str,
+    event: RewardEventKind,
+    peer_did: Option<&str>,
+) -> Result<RewardClaimPlan, String> {
+    let date = lib_blockchain::transaction::reward_claim::utc_date_from_ts(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    );
+    let week = lib_blockchain::transaction::reward_claim::iso_week_from_ts(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    );
+    let today_ord = lib_blockchain::transaction::reward_claim::utc_day_ordinal_from_ts(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    );
+
+    match event {
+        RewardEventKind::Welcome => {
+            if bc.reward_welcome_claimed(token_id, did) {
+                return Err("welcome_already_claimed".into());
+            }
+        }
+        RewardEventKind::DailyCheckin => {
+            if bc.reward_daily_claimed(token_id, &date, did, event) {
+                return Err("checkin_already_claimed_today".into());
+            }
+        }
+        RewardEventKind::ActiveSession => {
+            if bc.reward_daily_claimed(token_id, &date, did, event) {
+                return Err("session_already_claimed_today".into());
+            }
+        }
+        RewardEventKind::NewPartner => {
+            let peer = peer_did.filter(|p| !p.is_empty() && *p != did).ok_or_else(|| {
+                "invalid peer_did".to_string()
+            })?;
+            if bc.reward_partner_claimed(token_id, &week, did, peer) {
+                return Err("partner_already_counted_this_week".into());
+            }
+            let cap = bc.reward_weekly_partner_cap(token_id);
+            let count = bc.reward_partners_this_week(token_id, &week, did);
+            if cap > 0 && count >= cap {
+                return Err("weekly_partner_cap_reached".into());
+            }
+        }
+    }
+
+    let streak_day = if event == RewardEventKind::DailyCheckin {
+        let streak = bc.reward_streak(token_id, did);
+        let day = if streak.last_day == today_ord - 1 {
+            streak.current_streak.saturating_add(1)
+        } else {
+            1
+        };
+        Some(day)
+    } else {
+        None
+    };
+
+    let amount = bc
+        .reward_expected_amount(token_id, event, streak_day.unwrap_or(1))
+        .ok_or_else(|| "rewards policy unavailable for this asset".to_string())?;
+
+    Ok(RewardClaimPlan { amount, streak_day })
+}
 
 /// Build, sign, and enqueue a `RewardClaim` for mempool (not `TokenTransfer`).
 pub async fn submit_reward_claim(

--- a/zhtp/src/api/handlers/rewards/settlement.rs
+++ b/zhtp/src/api/handlers/rewards/settlement.rs
@@ -5,7 +5,10 @@ use anyhow::{anyhow, Result};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use lib_blockchain::transaction::reward_claim::{RewardClaimData, RewardEventKind, REWARD_CLAIM_MEMO};
+use lib_blockchain::transaction::reward_claim::{
+    iso_week_from_ts, utc_date_from_ts, utc_day_ordinal_from_ts, RewardClaimData, RewardEventKind,
+    REWARD_CLAIM_MEMO,
+};
 use lib_blockchain::transaction::Transaction;
 use lib_blockchain::Blockchain;
 
@@ -13,10 +16,80 @@ use lib_crypto::Signature;
 
 use super::TreasuryConfig;
 
+const WEEKLY_PARTNER_CAP_FALLBACK: u32 = 5;
+
+fn claim_unix_ts() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 /// Planned claim after a single chain snapshot read (eligibility + policy amount).
 pub struct RewardClaimPlan {
     pub amount: u128,
     pub streak_day: Option<u32>,
+    pub partners_this_week: Option<u32>,
+    pub weekly_cap: Option<u32>,
+}
+
+pub struct ClaimSpec {
+    pub event: RewardEventKind,
+    pub event_label: &'static str,
+    pub peer_did: Option<String>,
+    pub soft_fail_reasons: &'static [&'static str],
+}
+
+impl ClaimSpec {
+    pub fn welcome() -> Self {
+        Self {
+            event: RewardEventKind::Welcome,
+            event_label: "welcome",
+            peer_did: None,
+            soft_fail_reasons: &["welcome_already_claimed"],
+        }
+    }
+
+    pub fn daily_checkin() -> Self {
+        Self {
+            event: RewardEventKind::DailyCheckin,
+            event_label: "daily_checkin",
+            peer_did: None,
+            soft_fail_reasons: &["checkin_already_claimed_today"],
+        }
+    }
+
+    pub fn active_session() -> Self {
+        Self {
+            event: RewardEventKind::ActiveSession,
+            event_label: "active_session",
+            peer_did: None,
+            soft_fail_reasons: &["session_already_claimed_today"],
+        }
+    }
+
+    pub fn new_partner(peer_did: String) -> Self {
+        Self {
+            event: RewardEventKind::NewPartner,
+            event_label: "new_partner",
+            peer_did: Some(peer_did),
+            soft_fail_reasons: &[
+                "partner_already_counted_this_week",
+                "weekly_partner_cap_reached",
+            ],
+        }
+    }
+}
+
+pub struct SubmittedClaim {
+    pub tx_hash: String,
+    pub plan: RewardClaimPlan,
+}
+
+pub enum ClaimFlowError {
+    Ineligible { reason: String },
+    Unavailable(String),
+    SubmitFailed(String),
 }
 
 /// Read eligibility and policy-derived amount from consensus state.
@@ -24,60 +97,61 @@ pub fn plan_reward_claim(
     bc: &Blockchain,
     token_id: &[u8; 32],
     did: &str,
-    event: RewardEventKind,
-    peer_did: Option<&str>,
+    spec: &ClaimSpec,
 ) -> Result<RewardClaimPlan, String> {
-    let date = lib_blockchain::transaction::reward_claim::utc_date_from_ts(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0),
-    );
-    let week = lib_blockchain::transaction::reward_claim::iso_week_from_ts(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0),
-    );
-    let today_ord = lib_blockchain::transaction::reward_claim::utc_day_ordinal_from_ts(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0),
-    );
+    let ts = claim_unix_ts();
+    let date = utc_date_from_ts(ts);
+    let week = iso_week_from_ts(ts);
+    let today_ord = utc_day_ordinal_from_ts(ts);
 
-    match event {
+    match spec.event {
         RewardEventKind::Welcome => {
             if bc.reward_welcome_claimed(token_id, did) {
                 return Err("welcome_already_claimed".into());
             }
         }
-        RewardEventKind::DailyCheckin => {
-            if bc.reward_daily_claimed(token_id, &date, did, event) {
-                return Err("checkin_already_claimed_today".into());
-            }
-        }
-        RewardEventKind::ActiveSession => {
-            if bc.reward_daily_claimed(token_id, &date, did, event) {
-                return Err("session_already_claimed_today".into());
+        RewardEventKind::DailyCheckin | RewardEventKind::ActiveSession => {
+            if bc.reward_daily_claimed(token_id, &date, did, spec.event) {
+                return Err(if spec.event == RewardEventKind::DailyCheckin {
+                    "checkin_already_claimed_today"
+                } else {
+                    "session_already_claimed_today"
+                }
+                .into());
             }
         }
         RewardEventKind::NewPartner => {
-            let peer = peer_did.filter(|p| !p.is_empty() && *p != did).ok_or_else(|| {
-                "invalid peer_did".to_string()
-            })?;
+            let peer = spec
+                .peer_did
+                .as_deref()
+                .filter(|p| !p.is_empty() && *p != did)
+                .ok_or_else(|| "invalid peer_did".to_string())?;
             if bc.reward_partner_claimed(token_id, &week, did, peer) {
                 return Err("partner_already_counted_this_week".into());
             }
-            let cap = bc.reward_weekly_partner_cap(token_id);
-            let count = bc.reward_partners_this_week(token_id, &week, did);
-            if cap > 0 && count >= cap {
+            let policy_cap = bc.reward_weekly_partner_cap(token_id);
+            let weekly_cap = if policy_cap > 0 {
+                policy_cap
+            } else {
+                WEEKLY_PARTNER_CAP_FALLBACK
+            };
+            let partners_this_week = bc.reward_partners_this_week(token_id, &week, did);
+            if weekly_cap > 0 && partners_this_week >= weekly_cap {
                 return Err("weekly_partner_cap_reached".into());
             }
+            let amount = bc
+                .reward_expected_amount(token_id, spec.event, 1)
+                .ok_or_else(|| "rewards policy unavailable for this asset".to_string())?;
+            return Ok(RewardClaimPlan {
+                amount,
+                streak_day: None,
+                partners_this_week: Some(partners_this_week),
+                weekly_cap: Some(weekly_cap),
+            });
         }
     }
 
-    let streak_day = if event == RewardEventKind::DailyCheckin {
+    let streak_day = if spec.event == RewardEventKind::DailyCheckin {
         let streak = bc.reward_streak(token_id, did);
         let day = if streak.last_day == today_ord - 1 {
             streak.current_streak.saturating_add(1)
@@ -90,14 +164,53 @@ pub fn plan_reward_claim(
     };
 
     let amount = bc
-        .reward_expected_amount(token_id, event, streak_day.unwrap_or(1))
+        .reward_expected_amount(token_id, spec.event, streak_day.unwrap_or(1))
         .ok_or_else(|| "rewards policy unavailable for this asset".to_string())?;
 
-    Ok(RewardClaimPlan { amount, streak_day })
+    Ok(RewardClaimPlan {
+        amount,
+        streak_day,
+        partners_this_week: None,
+        weekly_cap: None,
+    })
 }
 
-/// Build, sign, and enqueue a `RewardClaim` for mempool (not `TokenTransfer`).
-pub async fn submit_reward_claim(
+/// Plan, sign, and enqueue a `RewardClaim` (single entry point for all event types).
+pub async fn run_claim_flow(
+    blockchain: &Arc<RwLock<Blockchain>>,
+    treasury: &TreasuryConfig,
+    did: &str,
+    recipient_key_id: [u8; 32],
+    spec: &ClaimSpec,
+) -> Result<SubmittedClaim, ClaimFlowError> {
+    let token_id = treasury.rewards_asset_id;
+    let plan = {
+        let bc = blockchain.read().await;
+        plan_reward_claim(&bc, &token_id, did, spec).map_err(|reason| {
+            if spec.soft_fail_reasons.contains(&reason.as_str()) {
+                ClaimFlowError::Ineligible { reason }
+            } else {
+                ClaimFlowError::Unavailable(reason)
+            }
+        })?
+    };
+
+    let tx_hash = submit_reward_claim(
+        blockchain,
+        treasury,
+        did,
+        recipient_key_id,
+        spec.event,
+        plan.amount,
+        spec.peer_did.clone(),
+    )
+    .await
+    .map_err(|e| ClaimFlowError::SubmitFailed(e.to_string()))?;
+
+    Ok(SubmittedClaim { tx_hash, plan })
+}
+
+async fn submit_reward_claim(
     blockchain: &Arc<RwLock<Blockchain>>,
     treasury: &TreasuryConfig,
     did: &str,

--- a/zhtp/src/api/handlers/rewards/settlement.rs
+++ b/zhtp/src/api/handlers/rewards/settlement.rs
@@ -1,0 +1,59 @@
+//! N2 hybrid settlement (Path C): node attests eligibility and submits
+//! `RewardClaim` txs signed by the spend delegate (Q4 spend-delegate model).
+
+use anyhow::{anyhow, Result};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use lib_blockchain::transaction::reward_claim::{RewardClaimData, RewardEventKind, REWARD_CLAIM_MEMO};
+use lib_blockchain::transaction::Transaction;
+use lib_blockchain::Blockchain;
+use lib_crypto::Signature;
+
+use super::TreasuryConfig;
+
+/// Build, sign, and enqueue a `RewardClaim` for mempool (not `TokenTransfer`).
+pub async fn submit_reward_claim(
+    blockchain: &Arc<RwLock<Blockchain>>,
+    treasury: &TreasuryConfig,
+    did: &str,
+    recipient_key_id: [u8; 32],
+    event: RewardEventKind,
+    amount: u128,
+    peer_did: Option<String>,
+) -> Result<String> {
+    let nonce = {
+        let bc = blockchain.read().await;
+        bc.token_nonce(&treasury.rewards_asset_id, &treasury.signer_key_id)
+            .map_err(|e| anyhow!("nonce lookup failed: {e}"))?
+    };
+
+    let data = RewardClaimData {
+        event,
+        owner_did: did.to_string(),
+        recipient_key_id,
+        token_id: treasury.rewards_asset_id,
+        from: treasury.signer_key_id,
+        amount,
+        nonce,
+        peer_did,
+    };
+
+    let mut tx = Transaction::new_reward_claim_with_chain_id(
+        super::chain_id_from_env(),
+        data,
+        Signature::default(),
+        REWARD_CLAIM_MEMO.to_vec(),
+    );
+    let sig = treasury
+        .keypair
+        .sign(tx.signing_hash().as_bytes())
+        .map_err(|e| anyhow!("rewards sign failed: {e}"))?;
+    tx.signature = sig;
+
+    let tx_hash = hex::encode(tx.hash().as_bytes());
+    let mut bc = blockchain.write().await;
+    bc.add_pending_transaction(tx)
+        .map_err(|e| anyhow!("Failed to submit reward claim: {e}"))?;
+    Ok(tx_hash)
+}


### PR DESCRIPTION
## Summary

Implements N2 hybrid rewards settlement: claim endpoints now submit signed `RewardClaim` transactions to mempool instead of bare `TokenTransfer`s.

## Changes

- **`settlement.rs`**: spend-delegate attestation — node builds/signs `RewardClaim` with delegate keystore
- **`rewards/mod.rs`**: claim + status handlers read eligibility from consensus trees (via blockchain facades), not node-local sled reservation trees
- **`blockchain/rewards.rs`**: token-id-parameterized eligibility/policy facades (`reward_welcome_claimed`, `reward_expected_amount`, etc.)

## Acceptance criteria

- [x] POST `/api/v1/rewards/claim` enqueues `RewardClaim` (not `TokenTransfer`)
- [x] Eligibility read from consensus trees (sled store behind blockchain facade)
- [x] Spend-delegate attestation model (Q4/P5 delegate signs claims)
- [x] Balance endpoint already reflects on-chain token balance after commit

## Notes

- Node-local `rewards.sled` history/lifetime trees retained until N4 (#2814)
- Closes #2812