### PR TITLE
feat(rewards): D3 legacy BUBL rewards module upgrade

### DIFF
--- a/lib-blockchain/src/execution/sovereign_asset.rs
+++ b/lib-blockchain/src/execution/sovereign_asset.rs
@@ -1,10 +1,11 @@
 //! Sovereign Asset executor apply helpers (SA-3..SA-7).
 
 use crate::contracts::sovereign_asset::{
-    validate_governance_verifier, AssetAuthority, AssetIdSource, AssetModuleFlags,
-    CurveModuleHeader, GovernanceModuleHeader, GovernanceModuleState, GovernanceVerifierKind,
-    GovernanceVerifierState, PendingAuthorityTransfer, RewardsModuleHeader, RewardsModuleState,
-    SovereignAsset, SupplyMode, AUTHORITY_TRANSFER_TIMELOCK_BLOCKS,
+    project_from_token_contract, validate_governance_verifier, AssetAuthority, AssetIdSource,
+    AssetModuleFlags, CurveModuleHeader, GovernanceModuleHeader, GovernanceModuleState,
+    GovernanceVerifierKind, GovernanceVerifierState, PendingAuthorityTransfer,
+    RewardsModuleHeader, RewardsModuleState, SovereignAsset, SupplyMode,
+    AUTHORITY_TRANSFER_TIMELOCK_BLOCKS,
 };
 use crate::execution::tx_apply::{apply_token_mint, StateMutator};
 use crate::execution::{TxApplyError, TxApplyResult};
@@ -144,15 +145,30 @@ pub fn apply_asset_launch(
     })
 }
 
+/// Resolve a sovereign asset for upgrade: sled record first, else legacy token projection.
+fn resolve_sovereign_asset_for_upgrade(
+    mutator: &StateMutator<'_>,
+    asset_id: &[u8; 32],
+) -> TxApplyResult<SovereignAsset> {
+    if let Some(asset) = mutator.get_sovereign_asset(asset_id)? {
+        return Ok(asset);
+    }
+    let token_id = TokenId::new(*asset_id);
+    let contract = mutator
+        .get_token_contract(&token_id)?
+        .ok_or_else(|| TxApplyError::InvalidType("asset not found".to_string()))?;
+    project_from_token_contract(&contract, None).ok_or_else(|| {
+        TxApplyError::InvalidType("legacy asset cannot be upgraded".to_string())
+    })
+}
+
 pub fn apply_asset_module_upgrade(
     mutator: &StateMutator<'_>,
     signer_key_id: [u8; 32],
     payload: &AssetModuleUpgradePayloadV1,
     block_height: u64,
 ) -> TxApplyResult<()> {
-    let mut asset = mutator
-        .get_sovereign_asset(&payload.asset_id)?
-        .ok_or_else(|| TxApplyError::InvalidType("asset not found".to_string()))?;
+    let mut asset = resolve_sovereign_asset_for_upgrade(mutator, &payload.asset_id)?;
 
     ensure_creator_or_governance(mutator, &asset, signer_key_id)?;
 
@@ -263,7 +279,7 @@ fn enable_rewards(
     asset: &mut SovereignAsset,
     cfg: &RewardsLaunchConfig,
 ) -> TxApplyResult<()> {
-    if asset.module_flags.has_rewards() {
+    if mutator.get_rewards_module_state(&asset.asset_id)?.is_some() {
         return Err(TxApplyError::InvalidType("rewards module already enabled".into()));
     }
     asset.module_flags.0 |= AssetModuleFlags::REWARDS;

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -953,6 +953,25 @@ impl Transaction {
         }
     }
 
+    /// Create a new Sovereign Asset module upgrade transaction.
+    pub fn new_asset_module_upgrade_with_chain_id(
+        chain_id: u8,
+        signature: Signature,
+        memo: Vec<u8>,
+    ) -> Self {
+        Transaction {
+            version: TX_VERSION_V8,
+            chain_id,
+            transaction_type: TransactionType::AssetModuleUpgrade,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            fee: 0,
+            signature,
+            memo,
+            payload: TransactionPayload::None,
+        }
+    }
+
     /// Create a new token creation transaction with an explicit chain id.
     pub fn new_token_creation_with_chain_id(
         chain_id: u8,

--- a/lib-blockchain/tests/common/mod.rs
+++ b/lib-blockchain/tests/common/mod.rs
@@ -4,3 +4,4 @@ pub mod block_builders;
 pub mod crypto_fixtures;
 pub mod oracle_harness;
 pub mod replay_gate;
+pub mod reward_claim_harness;

--- a/lib-blockchain/tests/common/reward_claim_harness.rs
+++ b/lib-blockchain/tests/common/reward_claim_harness.rs
@@ -1,0 +1,173 @@
+//! Shared RewardClaim integration-test harness (mempool + executor paths).
+
+use std::sync::Arc;
+
+use lib_blockchain::block::Block;
+use lib_blockchain::contracts::utils::generate_custom_token_id;
+use lib_blockchain::contracts::TokenContract;
+use lib_blockchain::storage::{
+    convert_legacy_identity, Address, BlockchainStore, TokenId,
+};
+use lib_blockchain::transaction::reward_claim::{
+    expected_amount_for_event, RewardClaimData, RewardEventKind, REWARD_CLAIM_MEMO,
+};
+use lib_blockchain::transaction::signing::sign_transaction;
+use lib_blockchain::transaction::{IdentityTransactionData, Transaction};
+use lib_blockchain::types::Hash;
+use lib_blockchain::Blockchain;
+use lib_crypto::{KeyPair, PublicKey, SignatureAlgorithm};
+
+use super::block_builders;
+
+const TEST_CREATED_AT: u64 = 1_700_000_000;
+
+/// Treasury signer + beneficiary for welcome-claim scenarios.
+pub struct RewardClaimActors {
+    pub treasury: KeyPair,
+    pub beneficiary: KeyPair,
+    pub owner_did: String,
+    pub token_id: [u8; 32],
+}
+
+impl RewardClaimActors {
+    pub fn generate() -> Self {
+        let treasury = KeyPair::generate().expect("treasury keypair");
+        let beneficiary = KeyPair::generate().expect("beneficiary keypair");
+        let owner_did = did_from_key_id(&beneficiary.public_key.key_id);
+        let token_id = generate_custom_token_id("Bubble", "BUBL");
+        Self {
+            treasury,
+            beneficiary,
+            owner_did,
+            token_id,
+        }
+    }
+}
+
+pub fn did_from_key_id(key_id: &[u8; 32]) -> String {
+    format!("did:zhtp:{}", hex::encode(key_id))
+}
+
+pub fn identity_data(did: &str, pubkey: &PublicKey) -> IdentityTransactionData {
+    IdentityTransactionData {
+        did: did.to_string(),
+        display_name: "reward_claim_test".to_string(),
+        public_key: pubkey.dilithium_pk.to_vec(),
+        ownership_proof: vec![],
+        identity_type: "human".to_string(),
+        did_document_hash: Hash::zero(),
+        created_at: TEST_CREATED_AT,
+        registration_fee: 0,
+        dao_fee: 0,
+        controlled_nodes: vec![],
+        owned_wallets: vec![],
+        kyber_public_key: Vec::new(),
+    }
+}
+
+fn bubl_token_contract(treasury: &PublicKey) -> TokenContract {
+    let token = TokenContract::new_custom(
+        "Bubble".to_string(),
+        "BUBL".to_string(),
+        0,
+        treasury.clone(),
+    );
+    assert_eq!(token.token_id, generate_custom_token_id("Bubble", "BUBL"));
+    token
+}
+
+fn register_identity_shadow(blockchain: &mut Blockchain, did: &str, pubkey: &PublicKey) {
+    blockchain.insert_identity_shadow(did.to_string(), identity_data(did, pubkey));
+    blockchain.identity_blocks.insert(did.to_string(), 0);
+}
+
+fn put_identity_direct(store: &dyn BlockchainStore, did: &str, pubkey: &PublicKey) {
+    let (consensus, metadata) = convert_legacy_identity(&identity_data(did, pubkey));
+    store
+        .put_identity_direct(&consensus.did_hash, &consensus)
+        .expect("seed identity");
+    store
+        .put_identity_metadata_direct(&consensus.did_hash, &metadata)
+        .expect("seed identity metadata");
+}
+
+fn register_actor_identities_shadow(blockchain: &mut Blockchain, actors: &RewardClaimActors) {
+    let treasury_did = did_from_key_id(&actors.treasury.public_key.key_id);
+    register_identity_shadow(blockchain, &treasury_did, &actors.treasury.public_key);
+    register_identity_shadow(blockchain, &actors.owner_did, &actors.beneficiary.public_key);
+}
+
+fn register_actor_identities_store(store: &dyn BlockchainStore, actors: &RewardClaimActors) {
+    let treasury_did = did_from_key_id(&actors.treasury.public_key.key_id);
+    put_identity_direct(store, &treasury_did, &actors.treasury.public_key);
+    put_identity_direct(store, &actors.owner_did, &actors.beneficiary.public_key);
+}
+
+/// In-memory blockchain with identities + BUBL contract for mempool admission tests.
+pub fn mempool_blockchain(actors: &RewardClaimActors) -> Blockchain {
+    let mut blockchain = Blockchain::new().expect("blockchain construct");
+    register_actor_identities_shadow(&mut blockchain, actors);
+    let bubl = bubl_token_contract(&actors.treasury.public_key);
+    blockchain.insert_token_contract(actors.token_id, bubl);
+    blockchain.insert_token_nonce_shadow(
+        actors.token_id,
+        actors.treasury.public_key.key_id,
+        0,
+    );
+    blockchain
+}
+
+/// Persist identities, BUBL contract, treasury balance; returns the setup block at height 1.
+pub fn seed_executor_store(
+    store: &Arc<dyn BlockchainStore>,
+    genesis: &Block,
+    actors: &RewardClaimActors,
+) -> Block {
+    register_actor_identities_store(store.as_ref(), actors);
+
+    let bubl = bubl_token_contract(&actors.treasury.public_key);
+    let treasury_addr = Address::new(actors.treasury.public_key.key_id);
+    let welcome_amount = expected_amount_for_event(RewardEventKind::Welcome, 1);
+
+    store.begin_block(1).expect("begin setup block");
+    store.put_token_contract(&bubl).expect("install BUBL contract");
+    store
+        .set_token_balance(
+            &TokenId::new(actors.token_id),
+            &treasury_addr,
+            welcome_amount.saturating_mul(2),
+        )
+        .expect("fund treasury");
+    let setup_block = block_builders::block_at_height(1, genesis.header.block_hash);
+    store.append_block(&setup_block).expect("append setup block");
+    store.commit_block().expect("commit setup block");
+    setup_block
+}
+
+/// Signed welcome `RewardClaim` for `actors.beneficiary` at `nonce`.
+pub fn welcome_claim_tx(actors: &RewardClaimActors, nonce: u64) -> Transaction {
+    let data = RewardClaimData {
+        event: RewardEventKind::Welcome,
+        owner_did: actors.owner_did.clone(),
+        recipient_key_id: actors.beneficiary.public_key.key_id,
+        token_id: actors.token_id,
+        from: actors.treasury.public_key.key_id,
+        amount: expected_amount_for_event(RewardEventKind::Welcome, 1),
+        nonce,
+        peer_did: None,
+    };
+
+    let mut tx = Transaction::new_reward_claim_with_chain_id(
+        0x03,
+        data,
+        lib_crypto::Signature {
+            signature: Vec::new(),
+            public_key: actors.treasury.public_key.clone(),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 0,
+        },
+        REWARD_CLAIM_MEMO.to_vec(),
+    );
+    sign_transaction(&mut tx, &actors.treasury.private_key).expect("sign reward claim");
+    tx
+}

--- a/lib-blockchain/tests/reward_claim_mempool_tests.rs
+++ b/lib-blockchain/tests/reward_claim_mempool_tests.rs
@@ -1,0 +1,100 @@
+//! Integration tests for RewardClaim mempool deduplication and executor rejection.
+//!
+//! Covers the P0 fix from PR #2844: duplicate same-DID welcome claims must not
+//! occupy multiple mempool slots or silently no-op during block application.
+
+use std::sync::Arc;
+
+use lib_blockchain::execution::executor::BlockExecutor;
+use lib_blockchain::storage::{BlockchainStore, SledStore};
+use lib_blockchain::transaction::reward_claim::welcome_claim_key;
+use tempfile::tempdir;
+
+mod common;
+
+use common::block_builders;
+use common::reward_claim_harness::{mempool_blockchain, seed_executor_store, welcome_claim_tx, RewardClaimActors};
+
+#[test]
+fn duplicate_welcome_claim_rejected_from_mempool() {
+    let actors = RewardClaimActors::generate();
+    let mut blockchain = mempool_blockchain(&actors);
+
+    blockchain
+        .add_pending_transaction(welcome_claim_tx(&actors, 0))
+        .expect("first welcome claim should enter mempool");
+    assert_eq!(
+        blockchain.get_pending_transactions().len(),
+        1,
+        "exactly one mempool entry after first submit"
+    );
+
+    let err = blockchain
+        .add_pending_transaction(welcome_claim_tx(&actors, 0))
+        .expect_err("duplicate welcome claim must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("conflicting RewardClaim"),
+        "expected mempool conflict rejection, got: {msg}"
+    );
+    assert_eq!(
+        blockchain.get_pending_transactions().len(),
+        1,
+        "mempool must still hold only the first welcome claim"
+    );
+}
+
+#[test]
+fn executor_rejects_duplicate_welcome_claim_after_first_applied() {
+    let actors = RewardClaimActors::generate();
+    let temp = tempdir().expect("tempdir");
+    let store: Arc<dyn BlockchainStore> = Arc::new(
+        SledStore::open(temp.path().join("reward_claim_store")).expect("sled store"),
+    );
+    let executor = BlockExecutor::with_store(store.clone());
+
+    let genesis = block_builders::genesis_block();
+    executor.apply_block(&genesis).expect("apply genesis");
+
+    let setup_block = seed_executor_store(&store, &genesis, &actors);
+
+    let welcome_block = block_builders::block_at_height_with_txs(
+        2,
+        setup_block.header.block_hash,
+        vec![welcome_claim_tx(&actors, 0)],
+    );
+    executor
+        .apply_block(&welcome_block)
+        .expect("first welcome claim should commit");
+    assert_eq!(store.latest_height().unwrap(), 2);
+
+    let welcome_key = welcome_claim_key(&actors.token_id, &actors.owner_did);
+    assert!(
+        store
+            .get_bubl_reward_welcome(&welcome_key)
+            .expect("read welcome marker")
+            .is_some(),
+        "welcome claim must be recorded on-chain after first apply"
+    );
+
+    // Nonce 1 so stateful validation reaches apply_reward_claim (nonce 0 would
+    // be soft-dropped as ReplayDropped after the first claim increments treasury nonce).
+    let duplicate_block = block_builders::block_at_height_with_txs(
+        3,
+        welcome_block.header.block_hash,
+        vec![welcome_claim_tx(&actors, 1)],
+    );
+    let err = executor
+        .apply_block(&duplicate_block)
+        .expect_err("duplicate welcome claim must fail block apply");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("welcome already claimed"),
+        "expected hard rejection, not silent no-op; got: {msg}"
+    );
+    assert_eq!(
+        store.latest_height().unwrap(),
+        2,
+        "failed duplicate must roll back — chain stays at first committed claim"
+    );
+}

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -23,6 +23,10 @@ path = "sled_migration.rs"
 name = "testnet_reset"
 path = "testnet_reset.rs"
 
+[[bin]]
+name = "drop_pending_tx"
+path = "drop_pending_tx.rs"
+
 [dependencies]
 lib-identity = { path = "../lib-identity" }
 lib-protocols = { path = "../lib-protocols" }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -60,5 +60,9 @@ name = "seed_asset_launch"
 path = "seed_asset_launch.rs"
 
 [[bin]]
+name = "seed_bubl_rewards_upgrade"
+path = "seed_bubl_rewards_upgrade.rs"
+
+[[bin]]
 name = "replay_divergence"
 path = "replay_divergence.rs"

--- a/tools/drop_pending_tx.rs
+++ b/tools/drop_pending_tx.rs
@@ -1,0 +1,34 @@
+//! Remove a pending transaction from sled recovery storage (operator tool).
+//!
+//! Usage: drop_pending_tx <sled-dir> <tx-hash-hex>
+
+use std::path::PathBuf;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: drop_pending_tx <sled-dir> <tx-hash-hex>");
+        std::process::exit(1);
+    }
+    let sled_path = PathBuf::from(&args[1]);
+    let hash_bytes = hex::decode(&args[2]).expect("invalid tx hash hex");
+    if hash_bytes.len() != 32 {
+        eprintln!("tx hash must be 32 bytes (64 hex chars)");
+        std::process::exit(1);
+    }
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&hash_bytes);
+
+    let db = sled::open(&sled_path).expect("open sled");
+    let tree = db
+        .open_tree("pending_transactions")
+        .expect("open pending_transactions tree");
+    let before = tree.len();
+    let removed = tree.remove(&key).expect("remove pending tx");
+    db.flush().expect("flush sled");
+    println!(
+        "pending_transactions: {} entries before, removed={}",
+        before,
+        removed.is_some()
+    );
+}

--- a/tools/seed_bubl_rewards_upgrade.rs
+++ b/tools/seed_bubl_rewards_upgrade.rs
@@ -1,0 +1,208 @@
+//! D3: enable on-chain `RewardsModuleState` for legacy testnet BUBL via `AssetModuleUpgrade`.
+//!
+//! Usage:
+//!   cargo run -p tools --bin seed_bubl_rewards_upgrade -- \
+//!     --keystore-dir /opt/zhtp/keystores/bubl-creator \
+//!     --asset-id 6948e43dea1fa98ac4f0d2b713774f9ca3f70d63365ad17ad12ffa0b5394050d \
+//!     --rewards-delegate-dir /opt/zhtp/keystores/bubl-creator \
+//!     --chain-id 2
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use lib_blockchain::{
+    integration::crypto_integration::{Signature, SignatureAlgorithm},
+    rewards_policy::{policy_hash, validate_rewards_policy},
+    transaction::{
+        asset_tx::{AssetModuleUpgradePayloadV1, AssetUpgradeModule, RewardsLaunchConfig},
+        Transaction,
+    },
+};
+use lib_crypto::{KeyPair, PrivateKey, PublicKey};
+use lib_identity::identity::ZhtpIdentity;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+struct KeystorePrivateKey {
+    #[serde(with = "hex_bytes")]
+    dilithium_sk: [u8; 4896],
+    #[serde(default = "default_dilithium_pk", with = "hex_bytes")]
+    dilithium_pk: [u8; 2592],
+    #[serde(with = "hex_bytes")]
+    kyber_sk: [u8; 3168],
+    #[serde(with = "hex_bytes")]
+    master_seed: [u8; 64],
+}
+
+fn default_dilithium_pk() -> [u8; 2592] {
+    [0u8; 2592]
+}
+
+mod hex_bytes {
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D, const N: usize>(deserializer: D) -> Result<[u8; N], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let bytes = hex::decode(s).map_err(serde::de::Error::custom)?;
+        if bytes.len() != N {
+            return Err(serde::de::Error::custom(format!(
+                "expected {N} bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut arr = [0u8; N];
+        arr.copy_from_slice(&bytes);
+        Ok(arr)
+    }
+}
+
+const USER_IDENTITY_FILENAME: &str = "user_identity.json";
+const USER_PRIVATE_KEY_FILENAME: &str = "user_private_key.json";
+
+#[derive(Parser)]
+#[command(name = "seed_bubl_rewards_upgrade")]
+struct Args {
+    /// Creator keystore (signs the upgrade tx).
+    #[arg(long)]
+    keystore_dir: PathBuf,
+    /// Legacy BUBL token_id / asset_id (32-byte hex).
+    #[arg(long)]
+    asset_id: String,
+    /// Spend-delegate keystore whose key_id is written on-chain.
+    #[arg(long)]
+    rewards_delegate_dir: PathBuf,
+    #[arg(long, default_value = "schemas/zhtp/rewards-policy/examples/bubl-v1.json")]
+    policy_file: PathBuf,
+    #[arg(long, default_value_t = 0x02)]
+    chain_id: u8,
+    #[arg(long, default_value_t = 0)]
+    fee: u64,
+}
+
+fn load_keypair(keystore_dir: &std::path::Path) -> Result<KeyPair> {
+    let identity_file = keystore_dir.join(USER_IDENTITY_FILENAME);
+    let priv_file = keystore_dir.join(USER_PRIVATE_KEY_FILENAME);
+    let identity_json = std::fs::read_to_string(&identity_file)
+        .with_context(|| format!("read {}", identity_file.display()))?;
+    let priv_json = std::fs::read_to_string(&priv_file)
+        .with_context(|| format!("read {}", priv_file.display()))?;
+    let stored: KeystorePrivateKey = serde_json::from_str(&priv_json).context("parse private key")?;
+    let private_key = PrivateKey {
+        dilithium_sk: stored.dilithium_sk,
+        dilithium_pk: stored.dilithium_pk,
+        kyber_sk: stored.kyber_sk,
+        master_seed: stored.master_seed,
+    };
+    let identity = ZhtpIdentity::from_serialized(&identity_json, &private_key)
+        .context("restore identity from keystore")?;
+    Ok(KeyPair {
+        public_key: identity.public_key,
+        private_key,
+    })
+}
+
+fn parse_asset_id(hex_str: &str) -> Result<[u8; 32]> {
+    let trimmed = hex_str.trim();
+    let bytes = hex::decode(trimmed).context("asset_id hex")?;
+    anyhow::ensure!(bytes.len() == 32, "asset_id must be 32 bytes");
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+fn load_rewards_policy_bundle(
+    policy_path: &std::path::Path,
+    asset_id: &[u8; 32],
+) -> Result<([u8; 32], [u8; 32], Vec<u8>)> {
+    let raw = std::fs::read(policy_path)
+        .with_context(|| format!("read rewards policy {}", policy_path.display()))?;
+    let mut doc: serde_json::Value =
+        serde_json::from_slice(&raw).context("parse rewards policy json")?;
+    if let Some(obj) = doc.as_object_mut() {
+        obj.insert("asset_id".into(), serde_json::Value::String(hex::encode(asset_id)));
+    }
+    let bytes = serde_json::to_vec(&doc).context("canonicalize policy json")?;
+    let policy = validate_rewards_policy(&bytes).context("validate rewards policy")?;
+    let hash = policy_hash(&policy).context("hash rewards policy")?;
+    let policy_hash = hash.as_array();
+    let mut cid_input = b"zhtp/rewards-policy/cid/v1\0".to_vec();
+    cid_input.extend_from_slice(&bytes);
+    let policy_cid = lib_crypto::hash_blake3(&cid_input);
+    Ok((policy_cid, policy_hash, bytes))
+}
+
+fn build_signed_upgrade(
+    keypair: &KeyPair,
+    asset_id: [u8; 32],
+    rewards: RewardsLaunchConfig,
+    chain_id: u8,
+    fee: u64,
+) -> Result<Transaction> {
+    let payload = AssetModuleUpgradePayloadV1 {
+        asset_id,
+        module: AssetUpgradeModule::Rewards(rewards),
+        transfer_authority: false,
+    };
+    let memo = payload
+        .encode_memo()
+        .map_err(|e| anyhow::anyhow!("encode asset upgrade memo: {e}"))?;
+
+    let mut tx = Transaction::new_asset_module_upgrade_with_chain_id(
+        chain_id,
+        Signature {
+            signature: Vec::new(),
+            public_key: PublicKey::new(keypair.public_key.dilithium_pk),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 0,
+        },
+        memo,
+    );
+    tx.fee = fee;
+
+    let sig = keypair
+        .sign(tx.signing_hash().as_bytes())
+        .context("sign AssetModuleUpgrade")?;
+    tx.signature = sig;
+    Ok(tx)
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let asset_id = parse_asset_id(&args.asset_id)?;
+    let creator = load_keypair(&args.keystore_dir)?;
+    let delegate = load_keypair(&args.rewards_delegate_dir)?;
+    let (policy_cid, policy_hash, policy_document) =
+        load_rewards_policy_bundle(&args.policy_file, &asset_id)?;
+
+    let rewards = RewardsLaunchConfig {
+        spend_delegate_key_id: delegate.public_key.key_id,
+        policy_cid,
+        policy_hash,
+        policy_document: Some(policy_document),
+    };
+
+    let tx = build_signed_upgrade(&creator, asset_id, rewards, args.chain_id, args.fee)?;
+    let signed_hex = hex::encode(bincode::serialize(&tx)?);
+
+    let output = serde_json::json!({
+        "migration": "D3-legacy-bubl-rewards-upgrade",
+        "asset_id": hex::encode(asset_id),
+        "creator_key_id": hex::encode(creator.public_key.key_id),
+        "spend_delegate_key_id": hex::encode(delegate.public_key.key_id),
+        "tx_hash": hex::encode(tx.hash().as_bytes()),
+        "signed_tx": signed_hex,
+        "broadcast_hint": "zhtp-cli -s <validator>:9334 blockchain ... or POST /api/v1/blockchain/transaction/broadcast",
+        "activation_hint": {
+            "rewards_activation.toml": {
+                "asset_id": hex::encode(asset_id),
+                "delegate_keystore_dir": args.rewards_delegate_dir.display().to_string(),
+            }
+        }
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Enables on-chain `RewardsModuleState` for legacy testnet BUBL (pre-`AssetLaunch` `TokenCreation`) via `AssetModuleUpgrade`, plus an operator seed tool.

- **Executor:** materialize legacy `TokenContract` projection when upgrading an asset not yet in `assets/` sled
- **Executor:** treat rewards as enabled only when `RewardsModuleState` exists (projection flag alone is not enough)
- **Tool:** `seed_bubl_rewards_upgrade` — build signed `AssetModuleUpgrade` + policy bundle for broadcast

## Testnet ops (already executed)

| Step | Result |
|------|--------|
| Deploy binary `092c6926…` | g1/g2/g3 |
| Broadcast upgrade `836ea97a…` | committed ~34693 |
| `rewards_activation.toml` on validators | endpoints active |
| Welcome claim smoke | `submitted: true`, `RewardClaim` in mempool |

Spend delegate: `bubl-creator` (interim; dedicated hot wallet rotation later).

## Closes

Part of DAO epic #2799 / D3 BUBL migration. Unblocks N2 claim path on live testnet after N3 activation config.

## Checklist

- [x] `seed_bubl_rewards_upgrade` builds signed tx
- [x] Legacy BUBL upgrade applies on testnet
- [x] Rewards claim endpoint returns 200 + `submitted: true`