### PR TITLE
DAO P7: AssetRewardsPolicyUpdate tx (#2806)

### DIFF
--- a/lib-blockchain/src/contracts/sovereign_asset/state.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/state.rs
@@ -36,6 +36,14 @@ impl Default for CurveModuleState {
     }
 }
 
+/// Queued rewards policy update (decrease-only timelock per DAO P7 / Q5).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingRewardsPolicyUpdate {
+    pub policy_cid: [u8; 32],
+    pub policy_hash: [u8; 32],
+    pub effective_height: u64,
+}
+
 /// Rewards delegate + policy refs in `asset_rewards/`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RewardsModuleState {
@@ -43,6 +51,8 @@ pub struct RewardsModuleState {
     pub policy_cid: [u8; 32],
     pub policy_hash: [u8; 32],
     pub nonce: u64,
+    #[serde(default)]
+    pub pending_policy: Option<PendingRewardsPolicyUpdate>,
 }
 
 /// Governance verifier persisted in `asset_governance/`.
@@ -96,6 +106,9 @@ pub const GOVERNANCE_MIN_SIGNERS: usize = 1;
 pub const GOVERNANCE_MULTISIG_MIN_SIGNERS: usize = 2;
 pub const GOVERNANCE_MAX_SIGNERS: usize = 10;
 pub const AUTHORITY_TRANSFER_TIMELOCK_BLOCKS: u64 = 7_200;
+
+/// Timelock before a decrease-only rewards policy update becomes effective (DAO P7 / Q5).
+pub const REWARDS_POLICY_DECREASE_TIMELOCK_BLOCKS: u64 = AUTHORITY_TRANSFER_TIMELOCK_BLOCKS;
 
 /// Default multisig threshold: floor(N/2) + 1.
 pub fn default_governance_threshold(n: usize) -> u8 {

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -45,6 +45,7 @@ use crate::transaction::{
     asset_tx::{
         AssetAuthorityTransferPayloadV1, AssetLaunchPayloadV1, AssetManifestUpdatePayloadV1,
         AssetModuleUpgradePayloadV1, AssetRewardsDelegateRotatePayloadV1,
+        AssetRewardsPolicyUpdatePayloadV1,
     },
     contract_deployment::ContractDeploymentPayloadV1,
     contract_execution::DecodedContractExecutionMemo, decode_canonical_bonding_curve_tx,
@@ -56,8 +57,9 @@ use crate::types::TransactionType;
 
 use super::errors::{BlockApplyError, BlockApplyResult, TxApplyError};
 use super::sovereign_asset::{
-    apply_asset_authority_transfer, apply_asset_launch, apply_asset_manifest_update,
-    apply_asset_module_upgrade, apply_asset_rewards_delegate_rotate, AssetLaunchOutcome,
+    activate_pending_rewards_policies, apply_asset_authority_transfer, apply_asset_launch,
+    apply_asset_manifest_update, apply_asset_module_upgrade, apply_asset_rewards_delegate_rotate,
+    apply_asset_rewards_policy_update, AssetLaunchOutcome,
 };
 use super::tx_apply::{self, CoinbaseOutcome, StateMutator, TransferOutcome};
 
@@ -657,6 +659,12 @@ impl BlockExecutor {
         // Initialize block-level resource accumulator
         let mut accumulator = BlockAccumulator::new();
 
+        activate_pending_rewards_policies(&mutator, block_height).map_err(|e| {
+            BlockApplyError::ValidationFailed(format!(
+                "activate pending rewards policies failed: {e}"
+            ))
+        })?;
+
         // =====================================================================
         // Pre-step: Coinbase position validation
         // =====================================================================
@@ -1066,6 +1074,7 @@ impl BlockExecutor {
             TransactionType::AssetManifestUpdate => {}
             TransactionType::AssetAuthorityTransfer => {}
             TransactionType::AssetRewardsDelegateRotate => {}
+            TransactionType::AssetRewardsPolicyUpdate => {}
             TransactionType::ContractDeployment => {}
             TransactionType::ContractExecution => {}
             TransactionType::DaoProposal => {}
@@ -1325,6 +1334,18 @@ impl BlockExecutor {
                 AssetRewardsDelegateRotatePayloadV1::decode_memo(&tx.memo).map_err(|e| {
                     TxApplyError::InvalidType(format!(
                         "AssetRewardsDelegateRotate requires canonical memo payload: {e}"
+                    ))
+                })?;
+            }
+            TransactionType::AssetRewardsPolicyUpdate => {
+                if !tx.inputs.is_empty() || !tx.outputs.is_empty() {
+                    return Err(TxApplyError::InvalidType(
+                        "AssetRewardsPolicyUpdate must not have UTXO inputs or outputs".to_string(),
+                    ));
+                }
+                AssetRewardsPolicyUpdatePayloadV1::decode_memo(&tx.memo).map_err(|e| {
+                    TxApplyError::InvalidType(format!(
+                        "AssetRewardsPolicyUpdate requires canonical memo payload: {e}"
                     ))
                 })?;
             }
@@ -3554,6 +3575,17 @@ impl BlockExecutor {
                 apply_asset_rewards_delegate_rotate(mutator, signer, &payload)?;
                 Ok(TxOutcome::LegacySystem)
             }
+            TransactionType::AssetRewardsPolicyUpdate => {
+                let payload =
+                    AssetRewardsPolicyUpdatePayloadV1::decode_memo(&tx.memo).map_err(|e| {
+                        TxApplyError::InvalidType(format!(
+                            "AssetRewardsPolicyUpdate requires canonical memo payload: {e}"
+                        ))
+                    })?;
+                let signer = tx.signature.public_key.key_id;
+                apply_asset_rewards_policy_update(mutator, signer, &payload, block_height)?;
+                Ok(TxOutcome::LegacySystem)
+            }
             TransactionType::AssetAuthorityTransfer => {
                 let payload = AssetAuthorityTransferPayloadV1::decode_memo(&tx.memo).map_err(|e| {
                     TxApplyError::InvalidType(format!(
@@ -5171,6 +5203,7 @@ mod tests {
                 policy_cid,
                 policy_hash: policy_hash_arr,
                 nonce: 0,
+                pending_policy: None,
             }
         );
         let stored_doc = store
@@ -5178,6 +5211,199 @@ mod tests {
             .expect("read policy doc")
             .expect("policy doc exists");
         assert!(!stored_doc.is_empty());
+    }
+
+    fn rewards_policy_for_asset(
+        asset_id: [u8; 32],
+        welcome_atoms: u128,
+    ) -> crate::rewards_policy::RewardsPolicyV1 {
+        use crate::rewards_policy::{legacy_bubl_policy, RewardsPolicyEvent};
+        let mut policy = legacy_bubl_policy();
+        policy.asset_id = hex::encode(asset_id);
+        for trigger in &mut policy.triggers {
+            if trigger.event == Some(RewardsPolicyEvent::Welcome) {
+                trigger.amount_atoms = Some(welcome_atoms);
+            }
+        }
+        policy
+    }
+
+    fn launch_rewards_asset(executor: &BlockExecutor, genesis: &Block) -> ([u8; 32], Block) {
+        use crate::contracts::sovereign_asset::SupplyMode;
+        use crate::rewards_policy::{legacy_bubl_policy, policy_hash, validate_rewards_policy_value};
+        use crate::transaction::asset_tx::{AssetLaunchPayloadV1, RewardsLaunchConfig};
+
+        let delegate_key = create_dummy_signature().public_key.key_id;
+        let policy = legacy_bubl_policy();
+        validate_rewards_policy_value(&policy).expect("policy valid");
+        let policy_hash_arr = policy_hash(&policy).expect("hash").as_array();
+        let policy_document = serde_json::to_vec(&policy).expect("json");
+        let mut policy_cid_input = b"zhtp/rewards-policy/cid/v1\0".to_vec();
+        policy_cid_input.extend_from_slice(&policy_document);
+        let policy_cid = lib_crypto::hash_blake3(&policy_cid_input);
+
+        let payload = AssetLaunchPayloadV1 {
+            name: "Bubble".to_string(),
+            symbol: "RBPL".to_string(),
+            decimals: 18,
+            initial_supply: 1_000,
+            treasury_key_id: [0xAA; 32],
+            treasury_bps: 2_000,
+            supply_mode: SupplyMode::Fixed,
+            manifest_cid: [1u8; 32],
+            manifest_hash: [2u8; 32],
+            curve: None,
+            rewards: Some(RewardsLaunchConfig {
+                spend_delegate_key_id: delegate_key,
+                policy_cid,
+                policy_hash: policy_hash_arr,
+                policy_document: Some(policy_document),
+            }),
+            governance: None,
+            transfer_authority: false,
+        };
+        let memo = payload.encode_memo().expect("memo");
+        let launch_tx = Transaction {
+            version: 2,
+            chain_id: 0x03,
+            transaction_type: TransactionType::AssetLaunch,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: create_dummy_signature(),
+            memo,
+            payload: crate::transaction::TransactionPayload::None,
+        };
+        let asset_id = hash_transaction(&launch_tx).as_array();
+
+        let block1 = create_block_with_txs(1, genesis.header.block_hash, vec![launch_tx]);
+        executor.apply_block(&block1).expect("launch");
+
+        let bind_tx = policy_update_tx(
+            asset_id,
+            crate::transaction::reward_claim::REWARD_WELCOME_ATOMS,
+            create_dummy_signature(),
+        );
+        let block2 = create_block_with_txs(2, block1.header.block_hash, vec![bind_tx]);
+        executor.apply_block(&block2).expect("bind asset_id in policy");
+
+        (asset_id, block2)
+    }
+
+    fn policy_update_tx(
+        asset_id: [u8; 32],
+        welcome_atoms: u128,
+        signer: Signature,
+    ) -> Transaction {
+        use crate::rewards_policy::{policy_hash, validate_rewards_policy_value};
+        use crate::transaction::asset_tx::{
+            AssetAuthorityProof, AssetRewardsPolicyUpdatePayloadV1, RewardsPolicyUpdateConfig,
+        };
+
+        let policy = rewards_policy_for_asset(asset_id, welcome_atoms);
+        validate_rewards_policy_value(&policy).expect("policy valid");
+        let policy_hash_arr = policy_hash(&policy).expect("hash").as_array();
+        let policy_document = serde_json::to_vec(&policy).expect("json");
+        let mut policy_cid_input = b"zhtp/rewards-policy/cid/v1\0".to_vec();
+        policy_cid_input.extend_from_slice(&policy_document);
+        let policy_cid = lib_crypto::hash_blake3(&policy_cid_input);
+
+        let payload = AssetRewardsPolicyUpdatePayloadV1 {
+            asset_id,
+            policy: RewardsPolicyUpdateConfig {
+                policy_cid,
+                policy_hash: policy_hash_arr,
+                policy_document: Some(policy_document),
+            },
+            authority_proof: AssetAuthorityProof::CreatorSig,
+        };
+        let memo = payload.encode_memo().expect("memo");
+        Transaction {
+            version: 2,
+            chain_id: 0x03,
+            transaction_type: TransactionType::AssetRewardsPolicyUpdate,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: signer,
+            memo,
+            payload: crate::transaction::TransactionPayload::None,
+        }
+    }
+
+    #[test]
+    fn test_asset_rewards_policy_increase_applies_immediately() {
+        use crate::transaction::reward_claim::REWARD_WELCOME_ATOMS as WELCOME;
+
+        let store = create_test_store();
+        let executor = create_test_executor(store.clone());
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let (asset_id, launch_block) = launch_rewards_asset(&executor, &genesis);
+        let increased_welcome = WELCOME * 2;
+        let update_tx = policy_update_tx(
+            asset_id,
+            increased_welcome,
+            create_dummy_signature(),
+        );
+        let block3 = create_block_with_txs(3, launch_block.header.block_hash, vec![update_tx]);
+        executor.apply_block(&block3).expect("policy increase");
+
+        let state = store
+            .get_rewards_module_state(&asset_id)
+            .expect("read")
+            .expect("state");
+        assert!(state.pending_policy.is_none());
+        assert_eq!(state.nonce, 2);
+
+        let doc = store
+            .get_rewards_policy_document(&state.policy_hash)
+            .expect("read doc")
+            .expect("doc");
+        let policy = crate::rewards_policy::validate_rewards_policy(&doc).expect("valid");
+        assert_eq!(
+            crate::rewards_policy::expected_amount_for_trigger(
+                &policy,
+                crate::rewards_policy::RewardsPolicyEvent::Welcome,
+                1
+            ),
+            Some(increased_welcome)
+        );
+    }
+
+    #[test]
+    fn test_asset_rewards_policy_decrease_queues_timelock() {
+        use crate::contracts::sovereign_asset::REWARDS_POLICY_DECREASE_TIMELOCK_BLOCKS;
+        use crate::transaction::reward_claim::REWARD_WELCOME_ATOMS as WELCOME;
+
+        let store = create_test_store();
+        let executor = create_test_executor(store.clone());
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let (asset_id, launch_block) = launch_rewards_asset(&executor, &genesis);
+        let old_hash = store
+            .get_rewards_module_state(&asset_id)
+            .expect("read")
+            .expect("state")
+            .policy_hash;
+
+        let update_tx = policy_update_tx(asset_id, WELCOME / 2, create_dummy_signature());
+        let block3 = create_block_with_txs(3, launch_block.header.block_hash, vec![update_tx]);
+        executor.apply_block(&block3).expect("policy decrease queue");
+
+        let state = store
+            .get_rewards_module_state(&asset_id)
+            .expect("read")
+            .expect("state");
+        assert_eq!(state.policy_hash, old_hash);
+        assert_eq!(state.nonce, 1);
+        let pending = state.pending_policy.expect("pending decrease");
+        assert_eq!(
+            pending.effective_height,
+            3u64.saturating_add(REWARDS_POLICY_DECREASE_TIMELOCK_BLOCKS)
+        );
     }
 
     #[test]

--- a/lib-blockchain/src/execution/sovereign_asset.rs
+++ b/lib-blockchain/src/execution/sovereign_asset.rs
@@ -4,16 +4,17 @@ use crate::contracts::sovereign_asset::{
     project_from_token_contract, validate_governance_verifier, AssetAuthority, AssetIdSource,
     AssetModuleFlags, CurveModuleHeader, GovernanceModuleHeader, GovernanceModuleState,
     GovernanceVerifierKind, GovernanceVerifierState, PendingAuthorityTransfer,
-    RewardsModuleHeader, RewardsModuleState, SovereignAsset, SupplyMode,
-    AUTHORITY_TRANSFER_TIMELOCK_BLOCKS,
+    PendingRewardsPolicyUpdate, RewardsModuleHeader, RewardsModuleState, SovereignAsset,
+    SupplyMode, AUTHORITY_TRANSFER_TIMELOCK_BLOCKS, REWARDS_POLICY_DECREASE_TIMELOCK_BLOCKS,
 };
 use crate::execution::tx_apply::{apply_token_mint, StateMutator};
 use crate::execution::{TxApplyError, TxApplyResult};
 use crate::storage::{Address, TokenId};
 use crate::transaction::asset_tx::{
     AssetAuthorityProof, AssetAuthorityTransferPayloadV1, AssetLaunchPayloadV1,
-    AssetManifestUpdatePayloadV1, AssetModuleUpgradePayloadV1, AssetRewardsDelegateRotatePayloadV1,
-    AssetUpgradeModule, GovernanceLaunchConfig, RewardsLaunchConfig,
+    AssetManifestUpdatePayloadV1, AssetModuleUpgradePayloadV1,
+    AssetRewardsDelegateRotatePayloadV1, AssetRewardsPolicyUpdatePayloadV1, AssetUpgradeModule,
+    GovernanceLaunchConfig, RewardsLaunchConfig,
 };
 use crate::types::Hash;
 
@@ -82,6 +83,7 @@ pub fn apply_asset_launch(
                 policy_cid: rewards_cfg.policy_cid,
                 policy_hash: rewards_cfg.policy_hash,
                 nonce: 0,
+                pending_policy: None,
             },
         )?;
         if let Some(doc) = &rewards_cfg.policy_document {
@@ -241,6 +243,123 @@ pub fn apply_asset_manifest_update(
     Ok(())
 }
 
+pub fn apply_asset_rewards_policy_update(
+    mutator: &StateMutator<'_>,
+    signer_key_id: [u8; 32],
+    payload: &AssetRewardsPolicyUpdatePayloadV1,
+    block_height: u64,
+) -> TxApplyResult<()> {
+    let asset = mutator
+        .get_sovereign_asset(&payload.asset_id)?
+        .ok_or_else(|| TxApplyError::InvalidType("asset not found".to_string()))?;
+
+    if !asset.module_flags.has_rewards() {
+        return Err(TxApplyError::InvalidType("rewards module not enabled".into()));
+    }
+    verify_authority_proof(mutator, &asset, signer_key_id, &payload.authority_proof)?;
+
+    let doc = payload
+        .policy
+        .policy_document
+        .as_ref()
+        .ok_or_else(|| TxApplyError::InvalidType("policy_document required".into()))?;
+    let new_policy = crate::rewards_policy::validate_rewards_policy(doc)
+        .map_err(|e| TxApplyError::InvalidType(format!("invalid rewards policy: {e}")))?;
+    let expected_asset_id = hex::encode(payload.asset_id);
+    if new_policy.asset_id != expected_asset_id {
+        return Err(TxApplyError::InvalidType(
+            "policy asset_id does not match payload asset_id".into(),
+        ));
+    }
+
+    let mut state = mutator
+        .get_rewards_module_state(&payload.asset_id)?
+        .ok_or_else(|| TxApplyError::InvalidType("rewards state missing".into()))?;
+
+    if payload.policy.policy_hash == state.policy_hash {
+        return Err(TxApplyError::InvalidType(
+            "rewards policy hash unchanged".into(),
+        ));
+    }
+
+    let current_policy = mutator
+        .get_rewards_policy_document(&state.policy_hash)?
+        .ok_or_else(|| TxApplyError::InvalidType("current policy document missing".into()))?;
+    let current_policy = crate::rewards_policy::validate_rewards_policy(&current_policy)
+        .map_err(|e| TxApplyError::InvalidType(format!("invalid current policy: {e}")))?;
+
+    let is_decrease =
+        crate::rewards_policy::is_rewards_policy_decrease(&current_policy, &new_policy);
+    if is_decrease {
+        if state.pending_policy.is_some() {
+            return Err(TxApplyError::InvalidType(
+                "rewards policy decrease already pending".into(),
+            ));
+        }
+        state.pending_policy = Some(PendingRewardsPolicyUpdate {
+            policy_cid: payload.policy.policy_cid,
+            policy_hash: payload.policy.policy_hash,
+            effective_height: block_height.saturating_add(REWARDS_POLICY_DECREASE_TIMELOCK_BLOCKS),
+        });
+        mutator.put_rewards_policy_document(&payload.policy.policy_hash, doc)?;
+        mutator.put_rewards_module_state(&payload.asset_id, &state)?;
+        return Ok(());
+    }
+
+    apply_rewards_policy_now(mutator, &payload.asset_id, &mut state, &payload.policy, doc)?;
+    Ok(())
+}
+
+/// Activate queued decrease-only policy updates whose timelock has expired.
+pub fn activate_pending_rewards_policies(
+    mutator: &StateMutator<'_>,
+    block_height: u64,
+) -> TxApplyResult<()> {
+    let asset_ids = mutator.list_rewards_module_asset_ids()?;
+    for asset_id in asset_ids {
+        let Some(mut state) = mutator.get_rewards_module_state(&asset_id)? else {
+            continue;
+        };
+        let Some(pending) = state.pending_policy.clone() else {
+            continue;
+        };
+        if pending.effective_height > block_height {
+            continue;
+        }
+        let doc = mutator
+            .get_rewards_policy_document(&pending.policy_hash)?
+            .ok_or_else(|| {
+                TxApplyError::InvalidType(format!(
+                    "pending rewards policy document missing for {}",
+                    hex::encode(asset_id)
+                ))
+            })?;
+        state.policy_cid = pending.policy_cid;
+        state.policy_hash = pending.policy_hash;
+        state.pending_policy = None;
+        state.nonce = state.nonce.saturating_add(1);
+        mutator.put_rewards_module_state(&asset_id, &state)?;
+        let _ = doc;
+    }
+    Ok(())
+}
+
+fn apply_rewards_policy_now(
+    mutator: &StateMutator<'_>,
+    asset_id: &[u8; 32],
+    state: &mut RewardsModuleState,
+    policy_cfg: &crate::transaction::asset_tx::RewardsPolicyUpdateConfig,
+    doc: &[u8],
+) -> TxApplyResult<()> {
+    state.policy_cid = policy_cfg.policy_cid;
+    state.policy_hash = policy_cfg.policy_hash;
+    state.pending_policy = None;
+    state.nonce = state.nonce.saturating_add(1);
+    mutator.put_rewards_policy_document(&policy_cfg.policy_hash, doc)?;
+    mutator.put_rewards_module_state(asset_id, state)?;
+    Ok(())
+}
+
 pub fn apply_asset_rewards_delegate_rotate(
     mutator: &StateMutator<'_>,
     signer_key_id: [u8; 32],
@@ -293,6 +412,7 @@ fn enable_rewards(
             policy_cid: cfg.policy_cid,
             policy_hash: cfg.policy_hash,
             nonce: 0,
+            pending_policy: None,
         },
     )?;
     if let Some(doc) = &cfg.policy_document {

--- a/lib-blockchain/src/execution/tx_apply.rs
+++ b/lib-blockchain/src/execution/tx_apply.rs
@@ -327,6 +327,10 @@ impl<'a> StateMutator<'a> {
         Ok(())
     }
 
+    pub fn list_rewards_module_asset_ids(&self) -> TxApplyResult<Vec<[u8; 32]>> {
+        Ok(self.store.list_rewards_module_asset_ids()?)
+    }
+
     pub fn get_rewards_policy_document(
         &self,
         policy_hash: &[u8; 32],

--- a/lib-blockchain/src/rewards_policy/mod.rs
+++ b/lib-blockchain/src/rewards_policy/mod.rs
@@ -8,6 +8,7 @@ mod validate;
 
 pub use types::*;
 pub use validate::{
-    canonical_policy_bytes, expected_amount_for_trigger, legacy_bubl_policy, policy_hash,
-    validate_rewards_policy, validate_rewards_policy_value, weekly_partner_cap, RewardsPolicyError,
+    canonical_policy_bytes, expected_amount_for_trigger, is_rewards_policy_decrease,
+    legacy_bubl_policy, policy_hash, validate_rewards_policy, validate_rewards_policy_value,
+    weekly_partner_cap, RewardsPolicyError,
 };

--- a/lib-blockchain/src/rewards_policy/validate.rs
+++ b/lib-blockchain/src/rewards_policy/validate.rs
@@ -292,6 +292,68 @@ pub fn legacy_bubl_policy() -> RewardsPolicyV1 {
     }
 }
 
+/// Maximum payout for a trigger at peak streak (daily check-in) or fixed amount.
+fn max_trigger_payout(trigger: &RewardsTrigger) -> u128 {
+    if !trigger.enabled {
+        return 0;
+    }
+    match trigger.kind {
+        TriggerKind::OncePerDid | TriggerKind::DistinctPeerPerIsoWeek => {
+            trigger.amount_atoms.unwrap_or(0)
+        }
+        TriggerKind::OncePerUtcDay => {
+            if let Some(fixed) = trigger.amount_atoms {
+                fixed
+            } else {
+                let base = trigger.base_amount_atoms.unwrap_or(0);
+                let bonus = trigger
+                    .streak_bonus
+                    .as_ref()
+                    .map(|sb| sb.per_day_atoms.saturating_mul(sb.cap_days as u128))
+                    .unwrap_or(0);
+                base.saturating_add(bonus)
+            }
+        }
+    }
+}
+
+fn max_payout_for_event(policy: &RewardsPolicyV1, event: RewardsPolicyEvent) -> u128 {
+    policy
+        .triggers
+        .iter()
+        .filter(|t| t.enabled && t.event == Some(event))
+        .map(max_trigger_payout)
+        .max()
+        .unwrap_or(0)
+}
+
+/// Returns true when the new policy reduces rewards vs the current policy.
+///
+/// A decrease is any lower per-event ceiling, disabling a previously enabled
+/// event trigger, or a lower optional budget cap.
+pub fn is_rewards_policy_decrease(old: &RewardsPolicyV1, new: &RewardsPolicyV1) -> bool {
+    for event in [
+        RewardsPolicyEvent::Welcome,
+        RewardsPolicyEvent::DailyCheckin,
+        RewardsPolicyEvent::ActiveSession,
+        RewardsPolicyEvent::NewPartner,
+    ] {
+        let old_max = max_payout_for_event(old, event);
+        let new_max = max_payout_for_event(new, event);
+        if new_max < old_max {
+            return true;
+        }
+    }
+
+    let old_daily_cap = old.budget.as_ref().and_then(|b| b.max_daily_outflow_atoms);
+    let new_daily_cap = new.budget.as_ref().and_then(|b| b.max_daily_outflow_atoms);
+    match (old_daily_cap, new_daily_cap) {
+        (Some(old_cap), Some(new_cap)) if new_cap < old_cap => true,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
 pub fn weekly_partner_cap(policy: &RewardsPolicyV1) -> u32 {
     policy
         .triggers
@@ -427,5 +489,21 @@ mod tests {
         let mut policy = example_bubl_policy();
         policy.schema = "zhtp/rewards-policy/v0".to_string();
         assert!(validate_rewards_policy_value(&policy).is_err());
+    }
+
+    #[test]
+    fn detects_policy_decrease_on_lower_welcome_amount() {
+        let old = example_bubl_policy();
+        let mut decreased = example_bubl_policy();
+        decreased.triggers[0].amount_atoms = Some(WELCOME / 2);
+        assert!(is_rewards_policy_decrease(&old, &decreased));
+    }
+
+    #[test]
+    fn increase_is_not_policy_decrease() {
+        let old = example_bubl_policy();
+        let mut increased = example_bubl_policy();
+        increased.triggers[0].amount_atoms = Some(WELCOME * 2);
+        assert!(!is_rewards_policy_decrease(&old, &increased));
     }
 }

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -1177,6 +1177,10 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
         Ok(())
     }
 
+    fn list_rewards_module_asset_ids(&self) -> StorageResult<Vec<[u8; 32]>> {
+        Ok(Vec::new())
+    }
+
     fn get_rewards_policy_document(
         &self,
         policy_hash: &[u8; 32],

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -832,6 +832,37 @@ impl SledStore {
         bincode::deserialize(bytes).map_err(|e| StorageError::Serialization(e.to_string()))
     }
 
+    /// Deserialize rewards module state, migrating pre-P7 records without `pending_policy`.
+    fn deserialize_rewards_module_state(
+        bytes: &[u8],
+    ) -> StorageResult<crate::contracts::sovereign_asset::RewardsModuleState> {
+        use crate::contracts::sovereign_asset::RewardsModuleState;
+        use serde::Deserialize;
+
+        #[derive(Deserialize)]
+        struct LegacyRewardsModuleState {
+            spend_delegate_key_id: [u8; 32],
+            policy_cid: [u8; 32],
+            policy_hash: [u8; 32],
+            nonce: u64,
+        }
+
+        match bincode::deserialize::<RewardsModuleState>(bytes) {
+            Ok(state) => Ok(state),
+            Err(_) => {
+                let legacy: LegacyRewardsModuleState =
+                    bincode::deserialize(bytes).map_err(|e| StorageError::Serialization(e.to_string()))?;
+                Ok(RewardsModuleState {
+                    spend_delegate_key_id: legacy.spend_delegate_key_id,
+                    policy_cid: legacy.policy_cid,
+                    policy_hash: legacy.policy_hash,
+                    nonce: legacy.nonce,
+                    pending_policy: None,
+                })
+            }
+        }
+    }
+
     /// Serialize a WAL record with an explicit byte limit.
     ///
     /// The limit is applied symmetrically with [`Self::deserialize_wal`]; both
@@ -1780,7 +1811,7 @@ impl BlockchainStore for SledStore {
     ) -> StorageResult<Option<crate::contracts::sovereign_asset::RewardsModuleState>> {
         let key = keys::asset_module_state_key(asset_id);
         match self.asset_rewards.get(key) {
-            Ok(Some(bytes)) => Ok(Some(Self::deserialize(&bytes)?)),
+            Ok(Some(bytes)) => Ok(Some(Self::deserialize_rewards_module_state(&bytes)?)),
             Ok(None) => Ok(None),
             Err(e) => Err(StorageError::Database(e.to_string())),
         }
@@ -1799,6 +1830,18 @@ impl BlockchainStore for SledStore {
             batch.tree(TREE_ASSET_REWARDS).insert(key.as_ref(), value);
         }
         Ok(())
+    }
+
+    fn list_rewards_module_asset_ids(&self) -> StorageResult<Vec<[u8; 32]>> {
+        let mut ids = Vec::new();
+        for entry in self.asset_rewards.iter().flatten() {
+            if entry.0.len() == 32 {
+                let mut asset_id = [0u8; 32];
+                asset_id.copy_from_slice(&entry.0);
+                ids.push(asset_id);
+            }
+        }
+        Ok(ids)
     }
 
     fn get_rewards_policy_document(

--- a/lib-blockchain/src/transaction/asset_tx.rs
+++ b/lib-blockchain/src/transaction/asset_tx.rs
@@ -14,6 +14,7 @@ pub const ASSET_MODULE_UPGRADE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_UPGRADE_V1:";
 pub const ASSET_MANIFEST_UPDATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_MANIFEST_V1:";
 pub const ASSET_AUTHORITY_TRANSFER_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_AUTH_XFER_V1:";
 pub const ASSET_REWARDS_DELEGATE_ROTATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_REWARDS_ROT_V1:";
+pub const ASSET_REWARDS_POLICY_UPDATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_REWARDS_POL_V1:";
 
 pub const MAX_ASSET_MEMO_BYTES: usize = 8192;
 pub const MAX_ASSET_NAME_BYTES: usize = 64;
@@ -326,5 +327,69 @@ impl AssetRewardsDelegateRotatePayloadV1 {
             .with_limit(MAX_ASSET_MEMO_BYTES as u64)
             .deserialize(&memo[ASSET_REWARDS_DELEGATE_ROTATE_MEMO_PREFIX.len()..])
             .map_err(|e| format!("invalid rewards delegate rotate payload: {e}"))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RewardsPolicyUpdateConfig {
+    pub policy_cid: [u8; 32],
+    pub policy_hash: [u8; 32],
+    /// Canonical JSON policy document (DHT pin source). Stored on-chain keyed by `policy_hash`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_document: Option<Vec<u8>>,
+}
+
+impl RewardsPolicyUpdateConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        use crate::rewards_policy::{policy_hash, validate_rewards_policy};
+        if self.policy_cid == [0u8; 32] {
+            return Err("rewards policy_cid must be non-zero".to_string());
+        }
+        if self.policy_hash == [0u8; 32] {
+            return Err("rewards policy_hash must be non-zero".to_string());
+        }
+        let doc = self
+            .policy_document
+            .as_ref()
+            .ok_or_else(|| "rewards policy_document is required".to_string())?;
+        let policy = validate_rewards_policy(doc)
+            .map_err(|e| format!("invalid rewards policy_document: {e}"))?;
+        let hash = policy_hash(&policy).map_err(|e| format!("policy hash failed: {e}"))?;
+        if hash.as_array() != self.policy_hash {
+            return Err("policy_document does not match policy_hash".to_string());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AssetRewardsPolicyUpdatePayloadV1 {
+    pub asset_id: [u8; 32],
+    pub policy: RewardsPolicyUpdateConfig,
+    pub authority_proof: AssetAuthorityProof,
+}
+
+impl AssetRewardsPolicyUpdatePayloadV1 {
+    pub fn encode_memo(&self) -> Result<Vec<u8>, String> {
+        self.policy.validate()?;
+        let encoded = bincode::DefaultOptions::new()
+            .with_limit(MAX_ASSET_MEMO_BYTES as u64)
+            .serialize(self)
+            .map_err(|e| format!("serialize rewards policy update: {e}"))?;
+        let mut memo = ASSET_REWARDS_POLICY_UPDATE_MEMO_PREFIX.to_vec();
+        memo.extend_from_slice(&encoded);
+        Ok(memo)
+    }
+
+    pub fn decode_memo(memo: &[u8]) -> Result<Self, String> {
+        if !memo.starts_with(ASSET_REWARDS_POLICY_UPDATE_MEMO_PREFIX) {
+            return Err("missing rewards policy update memo prefix".to_string());
+        }
+        let payload: Self = bincode::DefaultOptions::new()
+            .with_limit(MAX_ASSET_MEMO_BYTES as u64)
+            .deserialize(&memo[ASSET_REWARDS_POLICY_UPDATE_MEMO_PREFIX.len()..])
+            .map_err(|e| format!("invalid rewards policy update payload: {e}"))?;
+        payload.policy.validate()?;
+        Ok(payload)
     }
 }

--- a/lib-blockchain/src/transaction/creation.rs
+++ b/lib-blockchain/src/transaction/creation.rs
@@ -762,6 +762,7 @@ pub mod utils {
             | TransactionType::AssetManifestUpdate
             | TransactionType::AssetAuthorityTransfer
             | TransactionType::AssetRewardsDelegateRotate
+            | TransactionType::AssetRewardsPolicyUpdate
             | TransactionType::TokenSwap
             | TransactionType::CreatePool
             | TransactionType::AddLiquidity

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -95,6 +95,7 @@ pub use fee::{required_token_creation_fee, TxFeeConfig, DEFAULT_TOKEN_CREATION_F
 pub use asset_tx::{
     AssetAuthorityProof, AssetAuthorityTransferPayloadV1, AssetLaunchPayloadV1,
     AssetManifestUpdatePayloadV1, AssetModuleUpgradePayloadV1, AssetRewardsDelegateRotatePayloadV1,
+    AssetRewardsPolicyUpdatePayloadV1, RewardsPolicyUpdateConfig,
     AssetUpgradeModule, CurveLaunchConfig, GovernanceLaunchConfig, RewardsLaunchConfig,
     ASSET_LAUNCH_MEMO_PREFIX, ASSET_LAUNCH_TREASURY_BPS, MAX_ASSET_MEMO_BYTES,
 };

--- a/lib-blockchain/src/transaction/system_tx_signature.rs
+++ b/lib-blockchain/src/transaction/system_tx_signature.rs
@@ -48,6 +48,7 @@ pub fn system_tx_signature_policy(ty: TransactionType) -> SystemTxSignaturePolic
         | TransactionType::AssetManifestUpdate
         | TransactionType::AssetAuthorityTransfer
         | TransactionType::AssetRewardsDelegateRotate
+        | TransactionType::AssetRewardsPolicyUpdate
         | TransactionType::TokenSwap
         | TransactionType::CreatePool
         | TransactionType::AddLiquidity

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -12,7 +12,7 @@ use crate::transaction::mint_authorization::validate_token_mint_authorization;
 use crate::transaction::system_tx_signature::requires_system_tx_signature;
 use crate::transaction::asset_tx::{
     AssetLaunchPayloadV1, AssetManifestUpdatePayloadV1, AssetModuleUpgradePayloadV1,
-    AssetRewardsDelegateRotatePayloadV1,
+    AssetRewardsDelegateRotatePayloadV1, AssetRewardsPolicyUpdatePayloadV1,
 };
 use crate::transaction::token_creation::TokenCreationPayloadV1;
 use crate::transaction::{
@@ -312,6 +312,7 @@ impl TransactionValidator {
                 | TransactionType::AssetManifestUpdate
                 | TransactionType::AssetAuthorityTransfer
                 | TransactionType::AssetRewardsDelegateRotate
+                | TransactionType::AssetRewardsPolicyUpdate
                 | TransactionType::RegisterObserver
                 | TransactionType::UpdateObserverMetadata
                 | TransactionType::SuspendObserver
@@ -481,6 +482,13 @@ impl TransactionValidator {
                     return Err(ValidationError::InvalidInputs);
                 }
                 AssetRewardsDelegateRotatePayloadV1::decode_memo(&transaction.memo)
+                    .map_err(|_| ValidationError::InvalidMemo)?;
+            }
+            TransactionType::AssetRewardsPolicyUpdate => {
+                if !transaction.inputs.is_empty() || !transaction.outputs.is_empty() {
+                    return Err(ValidationError::InvalidInputs);
+                }
+                AssetRewardsPolicyUpdatePayloadV1::decode_memo(&transaction.memo)
                     .map_err(|_| ValidationError::InvalidMemo)?;
             }
             TransactionType::AssetAuthorityTransfer => {
@@ -848,7 +856,8 @@ impl TransactionValidator {
             | TransactionType::AssetModuleUpgrade
             | TransactionType::AssetManifestUpdate
             | TransactionType::AssetAuthorityTransfer
-            | TransactionType::AssetRewardsDelegateRotate => {
+            | TransactionType::AssetRewardsDelegateRotate
+            | TransactionType::AssetRewardsPolicyUpdate => {
                 if !transaction.inputs.is_empty() || !transaction.outputs.is_empty() {
                     return Err(ValidationError::InvalidInputs);
                 }
@@ -1829,6 +1838,7 @@ impl<'a> StatefulTransactionValidator<'a> {
                 | TransactionType::AssetManifestUpdate
                 | TransactionType::AssetAuthorityTransfer
                 | TransactionType::AssetRewardsDelegateRotate
+                | TransactionType::AssetRewardsPolicyUpdate
                 | TransactionType::RegisterObserver
                 | TransactionType::UpdateObserverMetadata
                 | TransactionType::SuspendObserver
@@ -2411,6 +2421,7 @@ impl<'a> StatefulTransactionValidator<'a> {
             | TransactionType::AssetManifestUpdate
             | TransactionType::AssetAuthorityTransfer
             | TransactionType::AssetRewardsDelegateRotate
+            | TransactionType::AssetRewardsPolicyUpdate
             | TransactionType::RewardClaim => {}
         }
 
@@ -3548,6 +3559,7 @@ pub mod utils {
             | TransactionType::AssetManifestUpdate
             | TransactionType::AssetAuthorityTransfer
             | TransactionType::AssetRewardsDelegateRotate
+            | TransactionType::AssetRewardsPolicyUpdate
             | TransactionType::BondingCurveDeploy
             | TransactionType::BondingCurveBuy
             | TransactionType::BondingCurveSell

--- a/lib-blockchain/src/types/transaction_type.rs
+++ b/lib-blockchain/src/types/transaction_type.rs
@@ -239,6 +239,8 @@ pub enum TransactionType {
     AssetAuthorityTransfer = 65,
     /// Rotate the rewards spend delegate key.
     AssetRewardsDelegateRotate = 66,
+    /// Update the DHT-pinned rewards policy (CID + hash) for an asset.
+    AssetRewardsPolicyUpdate = 68,
     /// BUBL reward claim — chain-enforced eligibility + treasury token transfer.
     ///
     /// Signed by the BUBL `TokenCreation` creator (or authorized delegate).
@@ -446,6 +448,9 @@ impl TransactionType {
             TransactionType::AssetRewardsDelegateRotate => {
                 "Rotate Sovereign Asset rewards spend delegate"
             }
+            TransactionType::AssetRewardsPolicyUpdate => {
+                "Update Sovereign Asset rewards policy"
+            }
             TransactionType::RewardClaim => "BUBL reward claim (chain-enforced eligibility)",
         }
     }
@@ -520,6 +525,7 @@ impl TransactionType {
             TransactionType::AssetManifestUpdate => "asset_manifest_update",
             TransactionType::AssetAuthorityTransfer => "asset_authority_transfer",
             TransactionType::AssetRewardsDelegateRotate => "asset_rewards_delegate_rotate",
+            TransactionType::AssetRewardsPolicyUpdate => "asset_rewards_policy_update",
             TransactionType::RewardClaim => "reward_claim",
         }
     }
@@ -594,6 +600,7 @@ impl TransactionType {
             "asset_manifest_update" => Some(TransactionType::AssetManifestUpdate),
             "asset_authority_transfer" => Some(TransactionType::AssetAuthorityTransfer),
             "asset_rewards_delegate_rotate" => Some(TransactionType::AssetRewardsDelegateRotate),
+            "asset_rewards_policy_update" => Some(TransactionType::AssetRewardsPolicyUpdate),
             "reward_claim" => Some(TransactionType::RewardClaim),
             _ => None,
         }

--- a/lib-blockchain/src/validation/tx_validate.rs
+++ b/lib-blockchain/src/validation/tx_validate.rs
@@ -60,6 +60,7 @@ const PHASE2_ALLOWED_TYPES: &[TransactionType] = &[
     TransactionType::AssetManifestUpdate,
     TransactionType::AssetAuthorityTransfer,
     TransactionType::AssetRewardsDelegateRotate,
+    TransactionType::AssetRewardsPolicyUpdate,
     TransactionType::RewardClaim,
     TransactionType::OracleAttestation,
     TransactionType::RegisterCredential,


### PR DESCRIPTION
## Summary

Implements **P7 / #2806** — governance-signed rewards policy updates for Sovereign Assets.

- New `TransactionType::AssetRewardsPolicyUpdate` (discriminant `68`) with memo payload `AssetRewardsPolicyUpdatePayloadV1`
- Updates `RewardsModuleState.policy_cid` + `policy_hash`; stores canonical policy document on-chain
- Requires `AssetAuthorityProof` (creator pre-handoff or governance)
- **Q5 decrease timelock:** reward decreases queue `pending_policy` for `REWARDS_POLICY_DECREASE_TIMELOCK_BLOCKS` (7_200); increases apply immediately
- Block prologue activates pending policies at `effective_height`; `RewardClaim` resolves the active `policy_hash` (stale amounts rejected)

## Tests

- `is_rewards_policy_decrease` unit tests
- Executor tests: immediate increase + decrease queues timelock
- Legacy `RewardsModuleState` bincode migration on read (testnet D3 compat)

Closes #2806