### PR TITLE
DAO M1: Real launch backend (AssetLaunch API + CLI) (#2826)

### DIFF
--- a/lib-blockchain/src/transaction/asset_tx.rs
+++ b/lib-blockchain/src/transaction/asset_tx.rs
@@ -149,6 +149,41 @@ impl AssetLaunchPayloadV1 {
         Ok(())
     }
 
+    /// Stricter SovSwap-aligned constraints for the DAO launch user path (M2/M1).
+    pub fn validate_dao_launch_ui_constraints(&self) -> Result<(), String> {
+        use super::token_creation::{
+            DAO_LAUNCH_MAX_SYMBOL_CHARS, DAO_LAUNCH_MIN_WHOLE_SUPPLY,
+        };
+        self.validate()?;
+        if self.symbol.len() > DAO_LAUNCH_MAX_SYMBOL_CHARS {
+            return Err(format!(
+                "symbol length {} exceeds DAO launch max {}",
+                self.symbol.len(),
+                DAO_LAUNCH_MAX_SYMBOL_CHARS
+            ));
+        }
+        if !self
+            .symbol
+            .chars()
+            .all(|c| c.is_ascii_uppercase() && c.is_ascii_alphabetic())
+        {
+            return Err("symbol must be uppercase A-Z".to_string());
+        }
+        let scale = 10u128
+            .checked_pow(self.decimals as u32)
+            .ok_or_else(|| format!("decimals {} overflow for supply scale", self.decimals))?;
+        let min_atoms = DAO_LAUNCH_MIN_WHOLE_SUPPLY
+            .checked_mul(scale)
+            .ok_or_else(|| "minimum supply atoms overflow".to_string())?;
+        if self.initial_supply < min_atoms {
+            return Err(format!(
+                "initial_supply must be at least {} whole tokens ({} atoms at {} decimals)",
+                DAO_LAUNCH_MIN_WHOLE_SUPPLY, min_atoms, self.decimals
+            ));
+        }
+        Ok(())
+    }
+
     pub fn split_initial_supply(&self) -> (u128, u128) {
         let bps = self.treasury_bps as u128;
         let treasury = self
@@ -391,5 +426,36 @@ impl AssetRewardsPolicyUpdatePayloadV1 {
             .map_err(|e| format!("invalid rewards policy update payload: {e}"))?;
         payload.policy.validate()?;
         Ok(payload)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_launch() -> AssetLaunchPayloadV1 {
+        AssetLaunchPayloadV1 {
+            name: "Bubble".to_string(),
+            symbol: "BUBL".to_string(),
+            decimals: 18,
+            initial_supply: 1_000 * 10u128.pow(18),
+            treasury_key_id: [0xAA; 32],
+            treasury_bps: ASSET_LAUNCH_TREASURY_BPS,
+            supply_mode: SupplyMode::Fixed,
+            manifest_cid: [0x11; 32],
+            manifest_hash: [0x22; 32],
+            curve: None,
+            rewards: None,
+            governance: None,
+            transfer_authority: false,
+        }
+    }
+
+    #[test]
+    fn asset_launch_dao_ui_constraints_match_m2_rules() {
+        assert!(sample_launch().validate_dao_launch_ui_constraints().is_ok());
+        let mut long = sample_launch();
+        long.symbol = "TOOLONG".to_string();
+        assert!(long.validate_dao_launch_ui_constraints().is_err());
     }
 }

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -513,7 +513,7 @@ pub enum OracleAction {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum DaoAction {
-    /// Launch a DAO token (TokenCreation + 80/20 split). Phase 1 minimal.
+    /// Launch a DAO sovereign asset (AssetLaunch + 80/20 split).
     Launch {
         /// Token name (e.g. Bubble)
         #[arg(short, long)]

--- a/zhtp-cli/src/commands/dao.rs
+++ b/zhtp-cli/src/commands/dao.rs
@@ -11,7 +11,7 @@ use crate::commands::web4_utils::{
 use crate::error::{CliError, CliResult};
 use crate::output::Output;
 use lib_blockchain::contracts::derive_dao_id;
-use lib_blockchain::transaction::TokenCreationPayloadV1;
+
 use lib_blockchain::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
 use lib_blockchain::transaction::DaoExecutionData;
 use lib_blockchain::types::dao::DAOType;
@@ -373,7 +373,7 @@ async fn handle_dao_command_impl(
         ref treasury_recipient,
     } = args.action
     {
-        output.header("DAO Launch (TokenCreation)")?;
+        output.header("DAO Launch (AssetLaunch)")?;
         let treasury = treasury_recipient
             .clone()
             .unwrap_or_else(default_protocol_treasury_key_id_hex);
@@ -383,19 +383,7 @@ async fn handle_dao_command_impl(
             symbol,
             &treasury[..16.min(treasury.len())]
         ))?;
-        let treasury_key_id = parse_hex_32("treasury_recipient", &treasury)?;
-        let draft = TokenCreationPayloadV1 {
-            name: name.clone(),
-            symbol: symbol.clone(),
-            initial_supply: supply,
-            decimals,
-            treasury_allocation_bps: 2_000,
-            treasury_recipient: treasury_key_id,
-        };
-        draft.validate_dao_launch_ui_constraints().map_err(|e| {
-            CliError::ConfigError(format!("DAO launch validation failed: {e}"))
-        })?;
-        token::handle_create(
+        token::handle_dao_asset_launch(
             cli,
             output,
             &name,
@@ -403,28 +391,8 @@ async fn handle_dao_command_impl(
             supply,
             decimals,
             &treasury,
-            true,
         )
         .await?;
-        let token_id = hex::encode(lib_blockchain::contracts::utils::generate_custom_token_id(
-            &name, &symbol,
-        ));
-        const TREASURY_BPS: u128 = 2_000; // 20% — matches TokenCreationPayloadV1
-        let treasury_atoms = supply.saturating_mul(TREASURY_BPS) / 10_000;
-        let creator_atoms = supply.saturating_sub(treasury_atoms);
-        output.print("")?;
-        output.success("DAO token deployed.")?;
-        output.print(&format!("Deterministic token_id: {}", token_id))?;
-        output.print(&format!(
-            "Creator allocation: {} atoms (80%)",
-            creator_atoms
-        ))?;
-        output.print(&format!(
-            "Treasury allocation: {} atoms (20%) → {}",
-            treasury_atoms,
-            &treasury[..16.min(treasury.len())]
-        ))?;
-        output.print(&format!("Share (future): zhtp://asset/{}", token_id))?;
         output.print(
             "Next: publish rewards policy (D1), fund delegate (C4), enable rewards (N3)",
         )?;

--- a/zhtp-cli/src/commands/token.rs
+++ b/zhtp-cli/src/commands/token.rs
@@ -11,6 +11,8 @@ use crate::argument_parsing::{format_output, TokenAction, TokenArgs, ZhtpCli};
 use crate::commands::web4_utils::{connect_default, load_identity_from_keystore};
 use crate::error::{CliError, CliResult};
 use crate::output::Output;
+use lib_blockchain::contracts::sovereign_asset::SupplyMode;
+use lib_blockchain::transaction::asset_tx::AssetLaunchPayloadV1;
 use lib_blockchain::transaction::{
     TokenCreationPayloadV1, TokenMintData, TokenTransferData, DEFAULT_TOKEN_CREATION_FEE,
 };
@@ -392,6 +394,133 @@ pub async fn handle_create(
         output.error(&format!("Failed to create token: {}", error))?;
         Err(CliError::ApiCallFailed {
             endpoint: "/api/v1/token/create".to_string(),
+            status: 0,
+            reason: error.to_string(),
+        })
+    }
+}
+
+fn build_dao_launch_manifest(name: &str, symbol: &str, decimals: u8) -> ([u8; 32], [u8; 32]) {
+    let manifest = json!({
+        "schema": "zhtp/asset-manifest/v1",
+        "name": name,
+        "symbol": symbol,
+        "decimals": decimals,
+        "interface": {
+            "version": "1.0.0",
+            "tx_kinds": ["TokenTransfer", "AssetTransfer"]
+        }
+    });
+    let bytes = serde_json::to_vec(&manifest).expect("manifest json");
+    let hash = lib_crypto::hash_blake3(&bytes);
+    let mut cid = [0u8; 32];
+    cid[..16].copy_from_slice(&hash[..16]);
+    (cid, hash)
+}
+
+/// Submit a signed `AssetLaunch` for the DAO Create New path (M1).
+pub async fn handle_dao_asset_launch(
+    cli: &ZhtpCli,
+    output: &dyn Output,
+    name: &str,
+    symbol: &str,
+    supply: u128,
+    decimals: u8,
+    treasury_recipient: &str,
+) -> CliResult<()> {
+    validate_decimals(decimals)?;
+    output.info(&format!("Launching sovereign asset: {} ({})", name, symbol))?;
+    output.info(&format!("Initial supply: {} atoms ({} decimals)", supply, decimals))?;
+    output.info("Signing AssetLaunch transaction with local keypair")?;
+
+    let keypair = load_default_keypair()?;
+    let treasury_key = parse_public_key(treasury_recipient)?;
+    if treasury_key.key_id == keypair.public_key.key_id {
+        return Err(CliError::ConfigError(
+            "treasury_recipient must differ from creator".to_string(),
+        ));
+    }
+
+    let (manifest_cid, manifest_hash) = build_dao_launch_manifest(name, symbol, decimals);
+    let payload = AssetLaunchPayloadV1 {
+        name: name.to_string(),
+        symbol: symbol.to_string(),
+        decimals,
+        initial_supply: supply,
+        treasury_key_id: treasury_key.key_id,
+        treasury_bps: 2_000,
+        supply_mode: SupplyMode::Fixed,
+        manifest_cid,
+        manifest_hash,
+        curve: None,
+        rewards: None,
+        governance: None,
+        transfer_authority: false,
+    };
+    payload.validate_dao_launch_ui_constraints().map_err(|e| {
+        CliError::ConfigError(format!("DAO launch validation failed: {e}"))
+    })?;
+    let memo = payload
+        .encode_memo()
+        .map_err(|e| CliError::ConfigError(format!("Failed to encode asset launch payload: {e}")))?;
+
+    let mut tx = Transaction::new_asset_launch_with_chain_id(
+        0x03,
+        lib_crypto::Signature::default(),
+        memo,
+    );
+    tx.signature = keypair
+        .sign(tx.signing_hash().as_bytes())
+        .map_err(|e| CliError::ConfigError(format!("Failed to sign asset launch tx: {e}")))?;
+
+    let tx_bytes = bincode::serialize(&tx)
+        .map_err(|e| CliError::ConfigError(format!("Failed to serialize tx: {}", e)))?;
+    let request_body = json!({
+        "signed_tx": hex::encode(tx_bytes),
+        "enforce_dao_launch_constraints": true,
+    });
+
+    let client = connect_default(&cli.server).await?;
+    let response = client
+        .post_json("/api/v1/assets/launch", &request_body)
+        .await
+        .map_err(|e| CliError::ApiCallFailed {
+            endpoint: "/api/v1/assets/launch".to_string(),
+            status: 0,
+            reason: e.to_string(),
+        })?;
+
+    let response_json: serde_json::Value =
+        ZhtpClient::parse_json(&response).map_err(|e| CliError::ApiCallFailed {
+            endpoint: "/api/v1/assets/launch".to_string(),
+            status: 0,
+            reason: format!("Failed to parse response: {}", e),
+        })?;
+
+    let formatted = format_output(&response_json, &cli.format)?;
+    output.print(&formatted)?;
+
+    if response_json
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        output.success("DAO asset launched successfully!")?;
+        if let Some(asset_id) = response_json.get("asset_id").and_then(|v| v.as_str()) {
+            output.info(&format!("Asset ID: {asset_id}"))?;
+        }
+        if let Some(link) = response_json.get("share_link").and_then(|v| v.as_str()) {
+            output.info(&format!("Share link: {link}"))?;
+        }
+        Ok(())
+    } else {
+        let error = response_json
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown error");
+        output.error(&format!("Failed to launch asset: {}", error))?;
+        Err(CliError::ApiCallFailed {
+            endpoint: "/api/v1/assets/launch".to_string(),
             status: 0,
             reason: error.to_string(),
         })

--- a/zhtp/src/api/handlers/assets/mod.rs
+++ b/zhtp/src/api/handlers/assets/mod.rs
@@ -4,8 +4,12 @@ use anyhow::Result;
 use lib_blockchain::contracts::sovereign_asset::{
     AssetIdSource, RewardsModuleState, SovereignAsset, SupplyMode,
 };
+use lib_blockchain::transaction::asset_tx::AssetLaunchPayloadV1;
+use lib_blockchain::transaction::{hash_transaction, Transaction};
+use lib_blockchain::types::transaction_type::TransactionType;
 use lib_blockchain::{Blockchain, BlockchainQuery};
 use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
+use serde::Deserialize;
 use lib_protocols::zhtp::ZhtpRequestHandler;
 use serde::Serialize;
 use serde_json::json;
@@ -31,6 +35,14 @@ fn create_json_response(data: serde_json::Value) -> Result<ZhtpResponse> {
 
 fn create_error_response(status: ZhtpStatus, message: String) -> ZhtpResponse {
     ZhtpResponse::error(status, message)
+}
+
+/// POST /api/v1/assets/launch — submit a signed `AssetLaunch` tx (M1 CreateDaoTab path).
+#[derive(Debug, Deserialize)]
+struct LaunchAssetRequest {
+    pub signed_tx: String,
+    #[serde(default)]
+    pub enforce_dao_launch_constraints: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -288,6 +300,86 @@ impl AssetsHandler {
         Self { blockchain }
     }
 
+    async fn handle_launch(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
+        let launch_req: LaunchAssetRequest = serde_json::from_slice(&request.body)
+            .map_err(|e| anyhow::anyhow!("Invalid request: {}", e))?;
+
+        let tx = decode_signed_tx_raw(&launch_req.signed_tx).map_err(|e| {
+            tracing::error!("[assets/launch] decode_signed_tx FAILED: {}", e);
+            e
+        })?;
+
+        if tx.transaction_type != TransactionType::AssetLaunch {
+            return Ok(create_error_response(
+                ZhtpStatus::BadRequest,
+                format!(
+                    "Invalid transaction type for assets/launch: expected AssetLaunch, got {:?}",
+                    tx.transaction_type
+                ),
+            ));
+        }
+
+        let payload = match AssetLaunchPayloadV1::decode_memo(&tx.memo) {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(create_error_response(
+                    ZhtpStatus::BadRequest,
+                    format!("Invalid asset launch payload: {e}"),
+                ));
+            }
+        };
+
+        if launch_req.enforce_dao_launch_constraints {
+            if let Err(e) = payload.validate_dao_launch_ui_constraints() {
+                return Ok(create_error_response(
+                    ZhtpStatus::BadRequest,
+                    format!("DAO launch validation failed: {e}"),
+                ));
+            }
+        }
+
+        {
+            let bc = self.blockchain.read().await;
+            if bc
+                .iter_sovereign_assets()
+                .iter()
+                .any(|a| a.symbol.eq_ignore_ascii_case(&payload.symbol))
+            {
+                return Ok(create_error_response(
+                    ZhtpStatus::Conflict,
+                    format!(
+                        "Asset with symbol '{}' already exists",
+                        payload.symbol
+                    ),
+                ));
+            }
+        }
+
+        let asset_id = hash_transaction(&tx).as_array();
+        if let Err(e) = self.submit_to_mempool(tx).await {
+            tracing::error!("[assets/launch] submit_to_mempool FAILED: {}", e);
+            return Ok(create_error_response(ZhtpStatus::BadRequest, e.to_string()));
+        }
+
+        let (creator_alloc, treasury_alloc) = payload.split_initial_supply();
+        info!(
+            "AssetLaunch submitted: {} ({}) asset_id={}",
+            payload.name,
+            payload.symbol,
+            hex::encode(asset_id)
+        );
+        create_json_response(json!({
+            "success": true,
+            "asset_id": hex::encode(asset_id),
+            "share_link": asset_share_link(&asset_id),
+            "name": payload.name,
+            "symbol": payload.symbol,
+            "creator_allocation": creator_alloc.to_string(),
+            "treasury_allocation": treasury_alloc.to_string(),
+            "tx_status": "submitted_to_mempool",
+        }))
+    }
+
     async fn handle_list(&self) -> Result<ZhtpResponse> {
         let bc = self.blockchain.read().await;
         let mut assets: Vec<AssetListItem> =
@@ -372,6 +464,22 @@ impl AssetsHandler {
             .filter(|s| !s.is_empty())
             .collect()
     }
+
+    async fn submit_to_mempool(&self, tx: Transaction) -> Result<()> {
+        let tx_type = tx.transaction_type;
+        let mut blockchain = self.blockchain.write().await;
+        blockchain
+            .add_pending_transaction(tx)
+            .map_err(|e| anyhow::anyhow!("Failed to submit transaction to mempool: {}", e))?;
+        tracing::debug!("assets submit_to_mempool: type={:?} accepted", tx_type);
+        Ok(())
+    }
+}
+
+fn decode_signed_tx_raw(signed_tx: &str) -> Result<Transaction> {
+    let tx_bytes = hex::decode(signed_tx).map_err(|_| anyhow::anyhow!("Invalid signed_tx hex"))?;
+    lib_blockchain::transaction::decode_client_transaction(&tx_bytes)
+        .map_err(|e| anyhow::anyhow!("Invalid signed_tx payload: {}", e))
 }
 
 fn parse_asset_id(hex_str: &str) -> Result<[u8; 32]> {
@@ -390,7 +498,16 @@ impl ZhtpRequestHandler for AssetsHandler {
         &self,
         request: ZhtpRequest,
     ) -> lib_protocols::zhtp::ZhtpResult<ZhtpResponse> {
+        if crate::session_manager::is_request_password_session(&request).await {
+            return Ok(create_error_response(
+                ZhtpStatus::Forbidden,
+                "Asset launch requires key authentication (mobile app or seed phrase recovery)"
+                    .to_string(),
+            ));
+        }
+
         let result = match (request.method.clone(), request.uri.as_str()) {
+            (ZhtpMethod::Post, "/api/v1/assets/launch") => self.handle_launch(request).await,
             (ZhtpMethod::Get, "/api/v1/assets" | "/api/v1/assets/") => self.handle_list().await,
             (ZhtpMethod::Get, uri) if uri.starts_with("/api/v1/assets/") => {
                 let segments = Self::parse_path_segments(uri);

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -211,19 +211,31 @@ impl TokenHandler {
             let payload = AssetLaunchPayloadV1::decode_memo(&tx.memo).map_err(|e| {
                 anyhow::anyhow!("Invalid asset launch payload: {e}")
             })?;
+            if create_req.enforce_dao_launch_constraints {
+                if let Err(e) = payload.validate_dao_launch_ui_constraints() {
+                    return Ok(create_error_response(
+                        ZhtpStatus::BadRequest,
+                        format!("DAO launch validation failed: {e}"),
+                    ));
+                }
+            }
             let asset_id = hash_transaction(&tx).as_array();
             if let Err(e) = self.submit_to_mempool(tx).await {
                 return Ok(create_error_response(ZhtpStatus::BadRequest, e.to_string()));
             }
             let (creator_alloc, treasury_alloc) = payload.split_initial_supply();
+            let share_link =
+                crate::api::handlers::assets::asset_share_link(&asset_id);
             return create_json_response(json!({
                 "success": true,
                 "asset_id": hex::encode(asset_id),
+                "share_link": share_link,
                 "name": payload.name,
                 "symbol": payload.symbol,
                 "creator_allocation": creator_alloc.to_string(),
                 "treasury_allocation": treasury_alloc.to_string(),
-                "deprecated_route": "/api/v1/token/create accepts AssetLaunch during migration — prefer direct broadcast",
+                "tx_status": "submitted_to_mempool",
+                "deprecated_route": "/api/v1/token/create accepts AssetLaunch during migration — prefer POST /api/v1/assets/launch",
             }));
         }
 


### PR DESCRIPTION
## Summary

SOVN backend for **M1 (#2826)** — canonical on-chain launch path for CreateDaoTab / `dao launch`.

Mobile SovSwap wiring (remove mock Alert) remains in the ZHTPPM repo; this PR delivers the node API and CLI the app should call.

## Changes

- **`POST /api/v1/assets/launch`** — accepts `signed_tx` + `enforce_dao_launch_constraints`; returns `asset_id`, `share_link` (`zhtp://asset/...`), allocations, `tx_status`
- **`dao launch` CLI** — builds/signs `AssetLaunch` (not legacy `TokenCreation`), posts to `/api/v1/assets/launch`
- **`AssetLaunchPayloadV1::validate_dao_launch_ui_constraints`** — M2 symbol/supply rules for launch path
- **`POST /api/v1/token/create`** — AssetLaunch branch now applies M2 constraints and returns `share_link`

## Acceptance criteria (SOVN scope)

- [x] Submit calls real launch API backend (`/api/v1/assets/launch`)
- [x] Success response includes `asset_id` and `share_link`
- [x] Error states surface mempool/validation failures (400 with message)
- [ ] Mock Alert removed — **SovSwap mobile** (out of repo)

## Tests

```bash
cargo test -p lib-blockchain --lib asset_launch_dao_ui
cargo check -p zhtp -p zhtp-cli
```

Relates to #2826 (closes when mobile lands, or close backend sub-scope here)