### PR TITLE
feat(cli): dao launch full flags (C1 #2816 Phase 3)

### DIFF
--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -551,11 +551,11 @@ pub enum DaoAction {
         /// Transfer creator authority to governance at launch (requires --governance-signers)
         #[arg(long)]
         transfer_authority: bool,
-        /// Supply mode: fixed | elastic
+        /// Supply mode (fixed only; elastic requires curve module, not yet supported)
         #[arg(long, default_value = "fixed")]
         supply_mode: String,
-        /// Chain id byte for signed tx (default: 3)
-        #[arg(long, default_value = "3", env = "ZHTP_CHAIN_ID")]
+        /// Chain id byte for signed tx (default: 3; explicit flag only — not read from env)
+        #[arg(long, default_value = "3")]
         chain_id: u8,
         /// DAO class hint for post-launch registry (np|fp)
         #[arg(long)]

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -533,6 +533,33 @@ pub enum DaoAction {
         /// Treasury recipient key_id (32-byte hex). Defaults to protocol DAO treasury.
         #[arg(long)]
         treasury_recipient: Option<String>,
+        /// Custom asset manifest JSON (`zhtp/asset-manifest/v1`)
+        #[arg(long)]
+        manifest_file: Option<String>,
+        /// Rewards policy JSON (`zhtp/rewards-policy/v1`)
+        #[arg(long)]
+        rewards_policy_file: Option<String>,
+        /// Rewards spend-delegate keystore directory
+        #[arg(long)]
+        rewards_delegate_keystore: Option<String>,
+        /// Governance multisig signer key_ids (comma-separated 32-byte hex)
+        #[arg(long)]
+        governance_signers: Option<String>,
+        /// Governance multisig threshold (default: floor(N/2)+1)
+        #[arg(long)]
+        governance_threshold: Option<u8>,
+        /// Transfer creator authority to governance at launch (requires --governance-signers)
+        #[arg(long)]
+        transfer_authority: bool,
+        /// Supply mode: fixed | elastic
+        #[arg(long, default_value = "fixed")]
+        supply_mode: String,
+        /// Chain id byte for signed tx (default: 3)
+        #[arg(long, default_value = "3", env = "ZHTP_CHAIN_ID")]
+        chain_id: u8,
+        /// DAO class hint for post-launch registry (np|fp)
+        #[arg(long)]
+        dao_class: Option<String>,
     },
     /// Get DAO information (orchestrated)
     Info,
@@ -767,7 +794,7 @@ pub enum IdentityAction {
     /// Zero-to-creator wizard: generate keystore (if needed) + on-chain registration.
     ///
     /// Preferred entry point before `token create`. Equivalent to `register` with
-    /// documented next steps for DAO token deployment (`dao launch` coming in #2816).
+    /// documented next steps for DAO token deployment (`zhtp-cli dao launch`).
     Init {
         /// Display name for the new identity
         #[arg(short, long)]

--- a/zhtp-cli/src/commands/dao.rs
+++ b/zhtp-cli/src/commands/dao.rs
@@ -442,9 +442,10 @@ async fn handle_dao_command_impl(
         let mut next: Vec<&str> = Vec::new();
         if rewards_policy_file.is_none() {
             next.push("`reward configure --template --asset-id <hex> --out ./policy.json`");
-        }
-        if rewards_policy_file.is_none() || rewards_delegate_keystore.is_none() {
-            next.push("relaunch with `--rewards-policy-file` + `--rewards-delegate-keystore`");
+            next.push(
+                "post-launch rewards enablement via AssetModuleUpgrade is not exposed in the CLI yet — \
+                 include `--rewards-policy-file` + `--rewards-delegate-keystore` at launch",
+            );
         } else {
             next.push("`asset rewards fund-delegate --asset-id <hex> --amount <atoms>`");
             next.push("`node configure-rewards` (N3)");

--- a/zhtp-cli/src/commands/dao.rs
+++ b/zhtp-cli/src/commands/dao.rs
@@ -364,25 +364,69 @@ async fn handle_dao_command_impl(
     cli: &ZhtpCli,
     output: &dyn Output,
 ) -> CliResult<()> {
-    // Launch delegates to token::handle_create (connects internally).
+    // Launch delegates to token::handle_dao_asset_launch (connects internally).
     if let DaoAction::Launch {
         ref name,
         ref symbol,
         supply,
         decimals,
         ref treasury_recipient,
+        ref manifest_file,
+        ref rewards_policy_file,
+        ref rewards_delegate_keystore,
+        ref governance_signers,
+        governance_threshold,
+        transfer_authority,
+        ref supply_mode,
+        chain_id,
+        ref dao_class,
     } = args.action
     {
         output.header("DAO Launch (AssetLaunch)")?;
         let treasury = treasury_recipient
             .clone()
             .unwrap_or_else(default_protocol_treasury_key_id_hex);
+        let class_hint = dao_class
+            .as_deref()
+            .map(parse_dao_class)
+            .transpose()?;
         output.info(&format!(
             "Launching {} ({}) — 80% creator / 20% treasury ({})",
             name,
             symbol,
             &treasury[..16.min(treasury.len())]
         ))?;
+        if let Some(class) = class_hint {
+            output.info(&format!(
+                "DAO class hint: {} (use with `dao registry-register` after launch)",
+                class.as_str()
+            ))?;
+        }
+        if manifest_file.is_some() {
+            output.info("Using custom manifest file")?;
+        }
+        if rewards_policy_file.is_some() || rewards_delegate_keystore.is_some() {
+            output.info("Rewards policy + delegate keystore wired into launch payload")?;
+        }
+        if governance_signers.is_some() {
+            output.info("Governance multisig wired into launch payload")?;
+        }
+        if transfer_authority {
+            output.info("Transfer authority to governance at launch: enabled")?;
+        }
+        output.info(&format!("Supply mode: {supply_mode}, chain_id: {chain_id}"))?;
+
+        let launch_options = token::DaoLaunchParams {
+            manifest_file: manifest_file.clone(),
+            rewards_policy_file: rewards_policy_file.clone(),
+            rewards_delegate_keystore: rewards_delegate_keystore.clone(),
+            governance_signers: governance_signers.clone(),
+            governance_threshold,
+            transfer_authority,
+            supply_mode: supply_mode.clone(),
+            chain_id,
+            dao_class: dao_class.clone(),
+        };
         token::handle_dao_asset_launch(
             cli,
             output,
@@ -391,11 +435,29 @@ async fn handle_dao_command_impl(
             supply,
             decimals,
             &treasury,
+            &launch_options,
         )
         .await?;
-        output.print(
-            "Next: `reward configure --template`, `asset rewards fund-delegate`, `node configure-rewards` (N3)",
-        )?;
+
+        let mut next: Vec<&str> = Vec::new();
+        if rewards_policy_file.is_none() {
+            next.push("`reward configure --template --asset-id <hex> --out ./policy.json`");
+        }
+        if rewards_policy_file.is_none() || rewards_delegate_keystore.is_none() {
+            next.push("relaunch with `--rewards-policy-file` + `--rewards-delegate-keystore`");
+        } else {
+            next.push("`asset rewards fund-delegate --asset-id <hex> --amount <atoms>`");
+            next.push("`node configure-rewards` (N3)");
+        }
+        if governance_signers.is_none() {
+            next.push("`dao governance propose` for post-launch policy updates (C5)");
+        }
+        if dao_class.is_some() {
+            next.push(
+                "`dao registry-register --token-id <asset_id> --class <np|fp> --metadata-hash <hex>`",
+            );
+        }
+        output.print(&format!("Next: {}", next.join("; ")))?;
         return Ok(());
     }
 

--- a/zhtp-cli/src/commands/identity.rs
+++ b/zhtp-cli/src/commands/identity.rs
@@ -478,7 +478,7 @@ async fn init_creator_identity(
     output.success("Creator identity ready.")?;
     output.print("Next steps:")?;
     output.print(&format!("  1. Keystore: {:?}", keystore))?;
-    output.print("  2. Launch DAO token: zhtp-cli token create (dao launch coming in #2816)")?;
+    output.print("  2. Launch DAO token: zhtp-cli dao launch --name <NAME> --symbol <SYM> --supply <atoms>")?;
     output.print("  3. Operator runbook: docs/ops/dao-launch-bootstrap.md")?;
     output.print("  4. Rewards policy: schemas/zhtp/rewards-policy/examples/bubl-v1.json")?;
     Ok(())

--- a/zhtp-cli/src/commands/token.rs
+++ b/zhtp-cli/src/commands/token.rs
@@ -13,8 +13,7 @@ use crate::commands::rewards::{build_rewards_policy_bundle, load_policy_bytes_fr
 use crate::commands::web4_utils::{connect_default, load_identity_from_keystore};
 use crate::error::{CliError, CliResult};
 use crate::output::Output;
-use lib_blockchain::contracts::sovereign_asset::SupplyMode;
-use lib_blockchain::contracts::sovereign_asset::GovernanceVerifierState;
+use lib_blockchain::contracts::sovereign_asset::{GovernanceVerifierState, SupplyMode};
 use lib_blockchain::rewards_policy::validate_rewards_policy;
 use lib_blockchain::transaction::asset_tx::{
     AssetLaunchPayloadV1, GovernanceLaunchConfig, RewardsLaunchConfig,
@@ -406,7 +405,49 @@ pub async fn handle_create(
     }
 }
 
-fn manifest_cid_hash_from_bytes(bytes: &[u8]) -> CliResult<([u8; 32], [u8; 32])> {
+fn read_manifest_file(path: &Path) -> CliResult<Vec<u8>> {
+    std::fs::read(path).map_err(|e| {
+        CliError::ConfigError(format!("read manifest {}: {e}", path.display()))
+    })
+}
+
+fn validate_manifest_launch_fields(
+    value: &serde_json::Value,
+    name: &str,
+    symbol: &str,
+    decimals: u8,
+) -> CliResult<()> {
+    if let Some(manifest_name) = value.get("name").and_then(|v| v.as_str()) {
+        if manifest_name != name {
+            return Err(CliError::ConfigError(format!(
+                "manifest name '{manifest_name}' does not match --name '{name}'"
+            )));
+        }
+    }
+    if let Some(manifest_symbol) = value.get("symbol").and_then(|v| v.as_str()) {
+        if manifest_symbol != symbol {
+            return Err(CliError::ConfigError(format!(
+                "manifest symbol '{manifest_symbol}' does not match --symbol '{symbol}'"
+            )));
+        }
+    }
+    if let Some(v) = value.get("decimals") {
+        let manifest_decimals = v.as_u64().ok_or_else(|| {
+            CliError::ConfigError("manifest decimals must be a number".to_string())
+        })?;
+        if manifest_decimals != decimals as u64 {
+            return Err(CliError::ConfigError(format!(
+                "manifest decimals {manifest_decimals} does not match --decimals {decimals}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn manifest_cid_hash_from_bytes(
+    bytes: &[u8],
+    launch: Option<(&str, &str, u8)>,
+) -> CliResult<([u8; 32], [u8; 32])> {
     let value: serde_json::Value = serde_json::from_slice(bytes)
         .map_err(|e| CliError::ConfigError(format!("invalid manifest JSON: {e}")))?;
     let schema = value
@@ -417,6 +458,9 @@ fn manifest_cid_hash_from_bytes(bytes: &[u8]) -> CliResult<([u8; 32], [u8; 32])>
         return Err(CliError::ConfigError(format!(
             "manifest schema must be zhtp/asset-manifest/v1, got '{schema}'"
         )));
+    }
+    if let Some((name, symbol, decimals)) = launch {
+        validate_manifest_launch_fields(&value, name, symbol, decimals)?;
     }
     let hash = lib_crypto::hash_blake3(bytes);
     let mut cid = [0u8; 32];
@@ -436,17 +480,44 @@ fn build_dao_launch_manifest(name: &str, symbol: &str, decimals: u8) -> ([u8; 32
         }
     });
     let bytes = serde_json::to_vec(&manifest).expect("manifest json");
-    manifest_cid_hash_from_bytes(&bytes).expect("generated manifest")
+    manifest_cid_hash_from_bytes(&bytes, None).expect("generated manifest")
 }
 
 pub fn parse_supply_mode(value: &str) -> CliResult<SupplyMode> {
     match value.to_ascii_lowercase().as_str() {
         "fixed" => Ok(SupplyMode::Fixed),
-        "elastic" => Ok(SupplyMode::Elastic),
+        "elastic" => Err(CliError::ConfigError(
+            "elastic supply_mode is not supported in dao launch (fixed only)".to_string(),
+        )),
         other => Err(CliError::ConfigError(format!(
-            "supply_mode must be 'fixed' or 'elastic', got '{other}'"
+            "supply_mode must be 'fixed', got '{other}'"
         ))),
     }
+}
+
+pub fn validate_rewards_launch_flags(
+    rewards_policy_file: &Option<String>,
+    rewards_delegate_keystore: &Option<String>,
+) -> CliResult<()> {
+    match (rewards_policy_file, rewards_delegate_keystore) {
+        (Some(_), Some(_)) | (None, None) => Ok(()),
+        _ => Err(CliError::ConfigError(
+            "rewards launch requires both --rewards-policy-file and --rewards-delegate-keystore"
+                .to_string(),
+        )),
+    }
+}
+
+pub fn validate_transfer_authority_flag(
+    transfer_authority: bool,
+    governance_signers: &Option<String>,
+) -> CliResult<()> {
+    if transfer_authority && governance_signers.is_none() {
+        return Err(CliError::ConfigError(
+            "--transfer-authority requires --governance-signers".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 pub fn parse_governance_signers(raw: &str) -> CliResult<Vec<[u8; 32]>> {
@@ -521,25 +592,32 @@ fn build_rewards_launch_config(
     })
 }
 
-fn build_governance_launch_config(
+pub fn build_governance_launch_config(
     signers_raw: &str,
     threshold: Option<u8>,
 ) -> CliResult<GovernanceLaunchConfig> {
     let signers = parse_governance_signers(signers_raw)?;
-    let verifier = if signers.len() == 1 {
-        GovernanceVerifierState::Single {
-            signer_key_id: signers[0],
+    if signers.len() == 1 {
+        if threshold.is_some_and(|t| t > 1) {
+            return Err(CliError::ConfigError(
+                "--governance-threshold > 1 requires multiple --governance-signers".to_string(),
+            ));
         }
+        Ok(GovernanceLaunchConfig {
+            verifier: GovernanceVerifierState::Single {
+                signer_key_id: signers[0],
+            },
+            threshold,
+        })
     } else {
-        GovernanceVerifierState::Multisig {
-            signers,
-            threshold: threshold.unwrap_or(0),
-        }
-    };
-    Ok(GovernanceLaunchConfig {
-        verifier,
-        threshold,
-    })
+        Ok(GovernanceLaunchConfig {
+            verifier: GovernanceVerifierState::Multisig {
+                signers,
+                threshold: threshold.unwrap_or(0),
+            },
+            threshold,
+        })
+    }
 }
 
 /// Submit a signed `AssetLaunch` for the DAO Create New path (M1 / Phase 3).
@@ -567,44 +645,38 @@ pub async fn handle_dao_asset_launch(
     }
 
     let supply_mode = parse_supply_mode(&options.supply_mode)?;
-    if supply_mode == SupplyMode::Elastic {
-        return Err(CliError::ConfigError(
-            "elastic supply_mode requires curve module; not yet supported in dao launch".to_string(),
-        ));
-    }
 
     let (manifest_cid, manifest_hash) = if let Some(path) = &options.manifest_file {
-        let bytes = load_policy_bytes_from_file(Path::new(path))?;
-        manifest_cid_hash_from_bytes(&bytes)?
+        let bytes = read_manifest_file(Path::new(path))?;
+        output.warning(
+            "Custom manifest is committed by hash/CID only — pin or publish the file separately; \
+             AssetLaunch does not carry manifest bytes on chain",
+        )?;
+        manifest_cid_hash_from_bytes(&bytes, Some((name, symbol, decimals)))?
     } else {
         build_dao_launch_manifest(name, symbol, decimals)
     };
 
+    validate_rewards_launch_flags(
+        &options.rewards_policy_file,
+        &options.rewards_delegate_keystore,
+    )?;
     let rewards = match (
         &options.rewards_policy_file,
         &options.rewards_delegate_keystore,
     ) {
         (Some(policy), Some(delegate)) => Some(build_rewards_launch_config(policy, delegate)?),
         (None, None) => None,
-        _ => {
-            return Err(CliError::ConfigError(
-                "rewards launch requires both --rewards-policy-file and --rewards-delegate-keystore"
-                    .to_string(),
-            ));
-        }
+        _ => unreachable!("validated above"),
     };
+
+    validate_transfer_authority_flag(options.transfer_authority, &options.governance_signers)?;
 
     let governance = options
         .governance_signers
         .as_deref()
         .map(|raw| build_governance_launch_config(raw, options.governance_threshold))
         .transpose()?;
-
-    if options.transfer_authority && governance.is_none() {
-        return Err(CliError::ConfigError(
-            "--transfer-authority requires --governance-signers".to_string(),
-        ));
-    }
 
     let payload = AssetLaunchPayloadV1 {
         name: name.to_string(),
@@ -1144,10 +1216,10 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_parse_supply_mode_fixed_and_elastic() {
+    fn test_parse_supply_mode_fixed_only() {
         assert_eq!(parse_supply_mode("fixed").unwrap(), SupplyMode::Fixed);
         assert_eq!(parse_supply_mode("FIXED").unwrap(), SupplyMode::Fixed);
-        assert_eq!(parse_supply_mode("elastic").unwrap(), SupplyMode::Elastic);
+        assert!(parse_supply_mode("elastic").is_err());
         assert!(parse_supply_mode("infinite").is_err());
     }
 
@@ -1181,7 +1253,7 @@ mod tests {
             "decimals": 18
         });
         let bytes = serde_json::to_vec(&manifest).unwrap();
-        let (cid, hash) = manifest_cid_hash_from_bytes(&bytes).unwrap();
+        let (cid, hash) = manifest_cid_hash_from_bytes(&bytes, None).unwrap();
         assert_eq!(cid[..16], hash[..16]);
         assert_eq!(hash, lib_crypto::hash_blake3(&bytes));
     }
@@ -1190,7 +1262,19 @@ mod tests {
     fn test_manifest_cid_hash_from_bytes_rejects_wrong_schema() {
         let manifest = json!({"schema": "other/v1"});
         let bytes = serde_json::to_vec(&manifest).unwrap();
-        assert!(manifest_cid_hash_from_bytes(&bytes).is_err());
+        assert!(manifest_cid_hash_from_bytes(&bytes, None).is_err());
+    }
+
+    #[test]
+    fn test_manifest_cross_validation_rejects_mismatch() {
+        let manifest = json!({
+            "schema": "zhtp/asset-manifest/v1",
+            "name": "Other",
+            "symbol": "TST",
+            "decimals": 18
+        });
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        assert!(manifest_cid_hash_from_bytes(&bytes, Some(("Test", "TST", 18))).is_err());
     }
 
     #[test]
@@ -1198,6 +1282,59 @@ mod tests {
         let (cid, hash) = build_dao_launch_manifest("Bubble", "BUBL", 18);
         assert_ne!(cid, [0u8; 32]);
         assert_ne!(hash, [0u8; 32]);
+        let manifest = json!({
+            "schema": "zhtp/asset-manifest/v1",
+            "name": "Bubble",
+            "symbol": "BUBL",
+            "decimals": 18,
+            "interface": {
+                "version": "1.0.0",
+                "tx_kinds": ["TokenTransfer", "AssetTransfer", "RewardsClaim"]
+            }
+        });
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        assert_eq!(hash, lib_crypto::hash_blake3(&bytes));
+    }
+
+    #[test]
+    fn test_build_governance_launch_config_default_threshold() {
+        let k1 = "aa".repeat(32);
+        let k2 = "bb".repeat(32);
+        let k3 = "cc".repeat(32);
+        let raw = format!("{k1},{k2},{k3}");
+        let cfg = build_governance_launch_config(&raw, None).unwrap();
+        match cfg.resolved_verifier() {
+            GovernanceVerifierState::Multisig { signers, threshold } => {
+                assert_eq!(signers.len(), 3);
+                assert_eq!(threshold, 2);
+            }
+            other => panic!("expected multisig, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_build_governance_rejects_threshold_with_single_signer() {
+        let one = "aa".repeat(32);
+        assert!(build_governance_launch_config(&one, Some(2)).is_err());
+        assert!(build_governance_launch_config(&one, Some(1)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_rewards_launch_flags_one_of_two() {
+        assert!(validate_rewards_launch_flags(&Some("p.json".into()), &None).is_err());
+        assert!(validate_rewards_launch_flags(&None, &Some("ks".into())).is_err());
+        assert!(validate_rewards_launch_flags(&None, &None).is_ok());
+    }
+
+    #[test]
+    fn test_validate_transfer_authority_requires_governance() {
+        assert!(validate_transfer_authority_flag(true, &None).is_err());
+        assert!(validate_transfer_authority_flag(false, &None).is_ok());
+        assert!(validate_transfer_authority_flag(
+            true,
+            &Some("aa".repeat(32))
+        )
+        .is_ok());
     }
 
     #[test]

--- a/zhtp-cli/src/commands/token.rs
+++ b/zhtp-cli/src/commands/token.rs
@@ -8,11 +8,17 @@
 //! - List all tokens
 
 use crate::argument_parsing::{format_output, TokenAction, TokenArgs, ZhtpCli};
+use crate::commands::node::normalize_keystore_path;
+use crate::commands::rewards::{build_rewards_policy_bundle, load_policy_bytes_from_file};
 use crate::commands::web4_utils::{connect_default, load_identity_from_keystore};
 use crate::error::{CliError, CliResult};
 use crate::output::Output;
 use lib_blockchain::contracts::sovereign_asset::SupplyMode;
-use lib_blockchain::transaction::asset_tx::AssetLaunchPayloadV1;
+use lib_blockchain::contracts::sovereign_asset::GovernanceVerifierState;
+use lib_blockchain::rewards_policy::validate_rewards_policy;
+use lib_blockchain::transaction::asset_tx::{
+    AssetLaunchPayloadV1, GovernanceLaunchConfig, RewardsLaunchConfig,
+};
 use lib_blockchain::transaction::{
     TokenCreationPayloadV1, TokenMintData, TokenTransferData, DEFAULT_TOKEN_CREATION_FEE,
 };
@@ -23,7 +29,7 @@ use lib_blockchain::{
 use lib_crypto::keypair::KeyPair;
 use lib_network::client::ZhtpClient;
 use serde_json::json;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 // ============================================================================
 // PURE LOGIC - Path builders and validation
@@ -400,6 +406,24 @@ pub async fn handle_create(
     }
 }
 
+fn manifest_cid_hash_from_bytes(bytes: &[u8]) -> CliResult<([u8; 32], [u8; 32])> {
+    let value: serde_json::Value = serde_json::from_slice(bytes)
+        .map_err(|e| CliError::ConfigError(format!("invalid manifest JSON: {e}")))?;
+    let schema = value
+        .get("schema")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if schema != "zhtp/asset-manifest/v1" {
+        return Err(CliError::ConfigError(format!(
+            "manifest schema must be zhtp/asset-manifest/v1, got '{schema}'"
+        )));
+    }
+    let hash = lib_crypto::hash_blake3(bytes);
+    let mut cid = [0u8; 32];
+    cid[..16].copy_from_slice(&hash[..16]);
+    Ok((cid, hash))
+}
+
 fn build_dao_launch_manifest(name: &str, symbol: &str, decimals: u8) -> ([u8; 32], [u8; 32]) {
     let manifest = json!({
         "schema": "zhtp/asset-manifest/v1",
@@ -408,17 +432,117 @@ fn build_dao_launch_manifest(name: &str, symbol: &str, decimals: u8) -> ([u8; 32
         "decimals": decimals,
         "interface": {
             "version": "1.0.0",
-            "tx_kinds": ["TokenTransfer", "AssetTransfer"]
+            "tx_kinds": ["TokenTransfer", "AssetTransfer", "RewardsClaim"]
         }
     });
     let bytes = serde_json::to_vec(&manifest).expect("manifest json");
-    let hash = lib_crypto::hash_blake3(&bytes);
-    let mut cid = [0u8; 32];
-    cid[..16].copy_from_slice(&hash[..16]);
-    (cid, hash)
+    manifest_cid_hash_from_bytes(&bytes).expect("generated manifest")
 }
 
-/// Submit a signed `AssetLaunch` for the DAO Create New path (M1).
+pub fn parse_supply_mode(value: &str) -> CliResult<SupplyMode> {
+    match value.to_ascii_lowercase().as_str() {
+        "fixed" => Ok(SupplyMode::Fixed),
+        "elastic" => Ok(SupplyMode::Elastic),
+        other => Err(CliError::ConfigError(format!(
+            "supply_mode must be 'fixed' or 'elastic', got '{other}'"
+        ))),
+    }
+}
+
+pub fn parse_governance_signers(raw: &str) -> CliResult<Vec<[u8; 32]>> {
+    let parts: Vec<&str> = raw.split(',').map(str::trim).filter(|s| !s.is_empty()).collect();
+    if parts.is_empty() {
+        return Err(CliError::ConfigError(
+            "governance_signers must list at least one 32-byte hex key_id".to_string(),
+        ));
+    }
+    parts
+        .iter()
+        .map(|part| {
+            let hex_str = part.strip_prefix("0x").unwrap_or(part);
+            let bytes = hex::decode(hex_str)
+                .map_err(|_| CliError::ConfigError(format!("invalid signer hex: {part}")))?;
+            if bytes.len() != 32 {
+                return Err(CliError::ConfigError(format!(
+                    "governance signer must be 32 bytes: {part}"
+                )));
+            }
+            let mut out = [0u8; 32];
+            out.copy_from_slice(&bytes);
+            Ok(out)
+        })
+        .collect()
+}
+
+/// Phase 3 `dao launch` options (C1 #2816).
+#[derive(Debug, Clone, Default)]
+pub struct DaoLaunchParams {
+    pub manifest_file: Option<String>,
+    pub rewards_policy_file: Option<String>,
+    pub rewards_delegate_keystore: Option<String>,
+    pub governance_signers: Option<String>,
+    pub governance_threshold: Option<u8>,
+    pub transfer_authority: bool,
+    pub supply_mode: String,
+    pub chain_id: u8,
+    pub dao_class: Option<String>,
+}
+
+fn build_rewards_launch_config(
+    policy_file: &str,
+    delegate_keystore: &str,
+) -> CliResult<RewardsLaunchConfig> {
+    let policy_bytes = load_policy_bytes_from_file(Path::new(policy_file))?;
+    let policy = validate_rewards_policy(&policy_bytes)
+        .map_err(|e| CliError::ConfigError(format!("rewards policy: {e}")))?;
+    let bundle = build_rewards_policy_bundle(&policy)
+        .map_err(|e| CliError::ConfigError(format!("rewards policy: {e}")))?;
+
+    let delegate_dir = normalize_keystore_path(delegate_keystore)
+        .ok_or_else(|| CliError::ConfigError("invalid rewards_delegate_keystore path".into()))?;
+    if !delegate_dir.is_dir() {
+        return Err(CliError::ConfigError(format!(
+            "rewards_delegate_keystore is not a directory: {}",
+            delegate_dir.display()
+        )));
+    }
+    let delegate = load_identity_from_keystore(&delegate_dir)?;
+    if delegate.keypair.public_key.key_id == [0u8; 32] {
+        return Err(CliError::ConfigError(
+            "rewards delegate key_id must be non-zero".to_string(),
+        ));
+    }
+
+    Ok(RewardsLaunchConfig {
+        spend_delegate_key_id: delegate.keypair.public_key.key_id,
+        policy_cid: bundle.policy_cid,
+        policy_hash: bundle.policy_hash,
+        policy_document: Some(bundle.document_bytes),
+    })
+}
+
+fn build_governance_launch_config(
+    signers_raw: &str,
+    threshold: Option<u8>,
+) -> CliResult<GovernanceLaunchConfig> {
+    let signers = parse_governance_signers(signers_raw)?;
+    let verifier = if signers.len() == 1 {
+        GovernanceVerifierState::Single {
+            signer_key_id: signers[0],
+        }
+    } else {
+        GovernanceVerifierState::Multisig {
+            signers,
+            threshold: threshold.unwrap_or(0),
+        }
+    };
+    Ok(GovernanceLaunchConfig {
+        verifier,
+        threshold,
+    })
+}
+
+/// Submit a signed `AssetLaunch` for the DAO Create New path (M1 / Phase 3).
 pub async fn handle_dao_asset_launch(
     cli: &ZhtpCli,
     output: &dyn Output,
@@ -427,6 +551,7 @@ pub async fn handle_dao_asset_launch(
     supply: u128,
     decimals: u8,
     treasury_recipient: &str,
+    options: &DaoLaunchParams,
 ) -> CliResult<()> {
     validate_decimals(decimals)?;
     output.info(&format!("Launching sovereign asset: {} ({})", name, symbol))?;
@@ -441,7 +566,46 @@ pub async fn handle_dao_asset_launch(
         ));
     }
 
-    let (manifest_cid, manifest_hash) = build_dao_launch_manifest(name, symbol, decimals);
+    let supply_mode = parse_supply_mode(&options.supply_mode)?;
+    if supply_mode == SupplyMode::Elastic {
+        return Err(CliError::ConfigError(
+            "elastic supply_mode requires curve module; not yet supported in dao launch".to_string(),
+        ));
+    }
+
+    let (manifest_cid, manifest_hash) = if let Some(path) = &options.manifest_file {
+        let bytes = load_policy_bytes_from_file(Path::new(path))?;
+        manifest_cid_hash_from_bytes(&bytes)?
+    } else {
+        build_dao_launch_manifest(name, symbol, decimals)
+    };
+
+    let rewards = match (
+        &options.rewards_policy_file,
+        &options.rewards_delegate_keystore,
+    ) {
+        (Some(policy), Some(delegate)) => Some(build_rewards_launch_config(policy, delegate)?),
+        (None, None) => None,
+        _ => {
+            return Err(CliError::ConfigError(
+                "rewards launch requires both --rewards-policy-file and --rewards-delegate-keystore"
+                    .to_string(),
+            ));
+        }
+    };
+
+    let governance = options
+        .governance_signers
+        .as_deref()
+        .map(|raw| build_governance_launch_config(raw, options.governance_threshold))
+        .transpose()?;
+
+    if options.transfer_authority && governance.is_none() {
+        return Err(CliError::ConfigError(
+            "--transfer-authority requires --governance-signers".to_string(),
+        ));
+    }
+
     let payload = AssetLaunchPayloadV1 {
         name: name.to_string(),
         symbol: symbol.to_string(),
@@ -449,13 +613,13 @@ pub async fn handle_dao_asset_launch(
         initial_supply: supply,
         treasury_key_id: treasury_key.key_id,
         treasury_bps: 2_000,
-        supply_mode: SupplyMode::Fixed,
+        supply_mode,
         manifest_cid,
         manifest_hash,
         curve: None,
-        rewards: None,
-        governance: None,
-        transfer_authority: false,
+        rewards,
+        governance,
+        transfer_authority: options.transfer_authority,
     };
     payload.validate_dao_launch_ui_constraints().map_err(|e| {
         CliError::ConfigError(format!("DAO launch validation failed: {e}"))
@@ -465,7 +629,7 @@ pub async fn handle_dao_asset_launch(
         .map_err(|e| CliError::ConfigError(format!("Failed to encode asset launch payload: {e}")))?;
 
     let mut tx = Transaction::new_asset_launch_with_chain_id(
-        0x03,
+        options.chain_id,
         lib_crypto::Signature::default(),
         memo,
     );
@@ -973,6 +1137,67 @@ mod tests {
         assert_eq!(mint_data.token_id, token_id);
         assert_eq!(mint_data.to, to);
         assert_eq!(mint_data.amount, amount as u128);
+    }
+
+    // =========================================================================
+    // dao launch helper tests (C1 #2816 Phase 3)
+    // =========================================================================
+
+    #[test]
+    fn test_parse_supply_mode_fixed_and_elastic() {
+        assert_eq!(parse_supply_mode("fixed").unwrap(), SupplyMode::Fixed);
+        assert_eq!(parse_supply_mode("FIXED").unwrap(), SupplyMode::Fixed);
+        assert_eq!(parse_supply_mode("elastic").unwrap(), SupplyMode::Elastic);
+        assert!(parse_supply_mode("infinite").is_err());
+    }
+
+    #[test]
+    fn test_parse_governance_signers_single_and_multisig() {
+        let one = "aa".repeat(32);
+        let two = "bb".repeat(32);
+        let single = parse_governance_signers(&one).unwrap();
+        assert_eq!(single.len(), 1);
+        assert_eq!(single[0], [0xaa; 32]);
+
+        let multi = parse_governance_signers(&format!("0x{one}, {two}")).unwrap();
+        assert_eq!(multi.len(), 2);
+        assert_eq!(multi[0], [0xaa; 32]);
+        assert_eq!(multi[1], [0xbb; 32]);
+    }
+
+    #[test]
+    fn test_parse_governance_signers_rejects_empty_and_bad_hex() {
+        assert!(parse_governance_signers("").is_err());
+        assert!(parse_governance_signers("not-hex").is_err());
+        assert!(parse_governance_signers("aa").is_err());
+    }
+
+    #[test]
+    fn test_manifest_cid_hash_from_bytes_valid_schema() {
+        let manifest = json!({
+            "schema": "zhtp/asset-manifest/v1",
+            "name": "Test",
+            "symbol": "TST",
+            "decimals": 18
+        });
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        let (cid, hash) = manifest_cid_hash_from_bytes(&bytes).unwrap();
+        assert_eq!(cid[..16], hash[..16]);
+        assert_eq!(hash, lib_crypto::hash_blake3(&bytes));
+    }
+
+    #[test]
+    fn test_manifest_cid_hash_from_bytes_rejects_wrong_schema() {
+        let manifest = json!({"schema": "other/v1"});
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        assert!(manifest_cid_hash_from_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_build_dao_launch_manifest_matches_schema() {
+        let (cid, hash) = build_dao_launch_manifest("Bubble", "BUBL", 18);
+        assert_ne!(cid, [0u8; 32]);
+        assert_ne!(hash, [0u8; 32]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wires Phase 3 acceptance for **C1 #2816** — full `zhtp-cli dao launch` flags into the AssetLaunch transaction path.

- **`dao launch` flags**: `--manifest-file`, `--rewards-policy-file`, `--rewards-delegate-keystore`, `--governance-signers`, `--governance-threshold`, `--transfer-authority`, `--supply-mode`, `--chain-id`, `--dao-class`
- **`DaoLaunchParams`** struct + helpers for manifest CID/hash, supply mode, governance signers, rewards bundle
- **Contextual post-launch next steps** based on which options were provided
- **Stale copy fixes** in `identity init` and `identity init` arg docs

## Test plan

- [x] `cargo check -p zhtp-cli`
- [x] `cargo test -p zhtp-cli --lib` (447 passed)
- [ ] Manual: `zhtp-cli dao launch --name Test --symbol TST --supply 1000000000000000000 --governance-signers <key_id>`

Closes #2816