### PR TITLE
feat(cli): dao governance propose/vote/status (C5 #2820)

### DIFF
--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1374,6 +1374,25 @@ impl Blockchain {
         }
     }
 
+    /// On-chain governance module state (`asset_governance/` sled tree).
+    pub fn get_governance_module_state(
+        &self,
+        asset_id: &[u8; 32],
+    ) -> Option<crate::contracts::sovereign_asset::GovernanceModuleState> {
+        let store = self.get_store()?;
+        match store.get_governance_module_state(asset_id) {
+            Ok(state) => state,
+            Err(e) => {
+                warn!(
+                    "Failed to load governance module state for asset {}: {}",
+                    hex::encode(asset_id),
+                    e
+                );
+                None
+            }
+        }
+    }
+
     pub fn register_web4_contract(
         &mut self,
         contract_id: [u8; 32],

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -991,6 +991,25 @@ impl Transaction {
         }
     }
 
+    /// Create a new rewards policy update transaction (DAO P7 / C5).
+    pub fn new_asset_rewards_policy_update_with_chain_id(
+        chain_id: u8,
+        signature: Signature,
+        memo: Vec<u8>,
+    ) -> Self {
+        Transaction {
+            version: TX_VERSION_V8,
+            chain_id,
+            transaction_type: TransactionType::AssetRewardsPolicyUpdate,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            fee: 0,
+            signature,
+            memo,
+            payload: TransactionPayload::None,
+        }
+    }
+
     /// Create a new token creation transaction with an explicit chain id.
     pub fn new_token_creation_with_chain_id(
         chain_id: u8,

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -9,6 +9,7 @@ use crate::commands;
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde_json::Value;
+use std::path::PathBuf;
 
 /// ZHTP Orchestrator CLI
 #[derive(Parser, Debug, Clone)]
@@ -437,6 +438,56 @@ pub struct DaoArgs {
     pub action: DaoAction,
 }
 
+/// Sovereign asset governance subcommands (C5 #2820).
+#[derive(Args, Debug, Clone)]
+pub struct DaoGovernanceArgs {
+    #[command(subcommand)]
+    pub action: DaoGovernanceAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum DaoGovernanceAction {
+    /// Propose a governance action (currently: rewards_policy_update)
+    Propose {
+        /// Sovereign asset id (64-char hex)
+        #[arg(long)]
+        asset_id: String,
+        /// Proposal type: rewards_policy_update
+        #[arg(long, value_name = "TYPE")]
+        proposal_type: String,
+        /// New rewards policy JSON (`zhtp/rewards-policy/v1`)
+        #[arg(long)]
+        policy_file: String,
+        /// Optional path to write proposal JSON for multisig collection
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+    /// Add a signer approval to a proposal file; optionally submit when threshold met
+    Vote {
+        /// Proposal JSON from `dao governance propose --out`
+        #[arg(long)]
+        proposal_file: PathBuf,
+        /// Signer keystore directory (default: ~/.zhtp/keystore)
+        #[arg(long)]
+        keystore: Option<String>,
+        /// Collected approvals as `<key_id_hex>:<dilithium_sig_hex>` (repeatable)
+        #[arg(long = "approval", value_name = "KEY_ID_HEX:SIG_HEX")]
+        approvals: Vec<String>,
+        /// Broadcast AssetRewardsPolicyUpdate when approvals >= threshold
+        #[arg(long)]
+        submit: bool,
+        /// Chain id byte for signed tx (default: 3)
+        #[arg(long, default_value = "3")]
+        chain_id: u8,
+    },
+    /// Show governance verifier and pending timelocks for an asset
+    Status {
+        /// Sovereign asset id (64-char hex)
+        #[arg(long)]
+        asset_id: String,
+    },
+}
+
 /// Oracle governance commands
 #[derive(Args, Debug, Clone)]
 pub struct OracleArgs {
@@ -561,6 +612,8 @@ pub enum DaoAction {
         #[arg(long)]
         dao_class: Option<String>,
     },
+    /// Sovereign asset governance: propose, vote, status (C5 #2820)
+    Governance(DaoGovernanceArgs),
     /// Get DAO information (orchestrated)
     Info,
     /// Create new proposal (orchestrated)

--- a/zhtp-cli/src/commands/dao.rs
+++ b/zhtp-cli/src/commands/dao.rs
@@ -119,6 +119,7 @@ pub fn action_to_operation(action: &DaoAction) -> Option<DaoOperation> {
         DaoAction::RegistryList => Some(DaoOperation::RegistryList),
         DaoAction::RegistryGet { .. } => Some(DaoOperation::RegistryGet),
         DaoAction::Launch { .. }
+        | DaoAction::Governance { .. }
         | DaoAction::RegistryRegister { .. }
         | DaoAction::FactoryCreate { .. }
         | DaoAction::EntityRegistryInit { .. }
@@ -465,6 +466,14 @@ async fn handle_dao_command_impl(
     let client = connect_default(&cli.server).await?;
     match args.action {
         DaoAction::Launch { .. } => unreachable!("handled above"),
+        DaoAction::Governance(gov_args) => {
+            crate::commands::dao_governance::handle_dao_governance_command(
+                gov_args.action,
+                cli,
+                output,
+            )
+            .await
+        }
         DaoAction::Info => {
             let operation = DaoOperation::Info;
             handle_dao_operation_impl(&client, operation, None, None, None, None, cli, output).await

--- a/zhtp-cli/src/commands/dao_governance.rs
+++ b/zhtp-cli/src/commands/dao_governance.rs
@@ -1,0 +1,469 @@
+//! Sovereign asset governance CLI (DAO C5 #2820).
+//!
+//! - `dao governance propose` — build a rewards policy update proposal (CID/hash)
+//! - `dao governance vote` — collect multisig approvals and optionally submit
+//! - `dao governance status` — pending authority transfer / rewards policy timelocks
+
+use crate::argument_parsing::{format_output, DaoGovernanceAction, ZhtpCli};
+use crate::commands::rewards::{
+    apply_asset_id_to_policy, build_rewards_policy_bundle, load_policy_bytes_from_file,
+    normalize_asset_id_hex,
+};
+use crate::commands::transaction_utils::{broadcast_signed_tx, parse_hex_32};
+use crate::commands::web4_utils::{connect_default, default_keystore_path, load_identity_from_keystore};
+use crate::error::{CliError, CliResult};
+use crate::output::Output;
+use lib_blockchain::contracts::approval_verifier::traits::Signature64;
+use lib_blockchain::contracts::approval_verifier::ApprovalProof;
+use lib_blockchain::transaction::asset_tx::{
+    AssetAuthorityProof, AssetRewardsPolicyUpdatePayloadV1, RewardsPolicyUpdateConfig,
+};
+use lib_blockchain::Transaction;
+use lib_crypto::keypair::KeyPair;
+use lib_network::client::ZhtpClient;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+
+const PROPOSAL_SCHEMA: &str = "zhtp/governance-proposal/v1";
+const PROPOSAL_TYPE_REWARDS_POLICY_UPDATE: &str = "rewards_policy_update";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GovernanceApproval {
+    pub signer_key_id: String,
+    pub signature_hex: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GovernanceProposal {
+    pub schema: String,
+    pub proposal_id: String,
+    pub proposal_type: String,
+    pub asset_id: String,
+    pub policy_cid: String,
+    pub policy_hash: String,
+    pub message_hash: String,
+    pub policy_document_hex: String,
+    pub threshold: u8,
+    #[serde(default)]
+    pub signers: Vec<String>,
+    #[serde(default)]
+    pub approvals: Vec<GovernanceApproval>,
+}
+
+pub fn parse_proposal_type(value: &str) -> CliResult<&'static str> {
+    match value.to_ascii_lowercase().as_str() {
+        "rewards_policy_update" | "rewards-policy-update" => {
+            Ok(PROPOSAL_TYPE_REWARDS_POLICY_UPDATE)
+        }
+        other => Err(CliError::ConfigError(format!(
+            "unsupported proposal type '{other}'; supported: rewards_policy_update"
+        ))),
+    }
+}
+
+pub fn governance_message_hash(
+    asset_id: &[u8; 32],
+    proposal_type: &str,
+    policy_hash: &[u8; 32],
+) -> [u8; 32] {
+    lib_crypto::hash_blake3(
+        &[
+            b"zhtp/governance-proposal/v1\0",
+            proposal_type.as_bytes(),
+            asset_id.as_slice(),
+            policy_hash.as_slice(),
+        ]
+        .concat(),
+    )
+}
+
+pub fn build_rewards_policy_update_proposal(
+    asset_id: &str,
+    policy_file: &Path,
+) -> CliResult<GovernanceProposal> {
+    let asset_id_norm = normalize_asset_id_hex(asset_id).map_err(CliError::ConfigError)?;
+    let asset_id_bytes = parse_hex_32("asset_id", &asset_id_norm)?;
+
+    let policy_bytes = load_policy_bytes_from_file(policy_file)?;
+    let policy = lib_blockchain::rewards_policy::validate_rewards_policy(&policy_bytes)
+        .map_err(|e| CliError::ConfigError(format!("rewards policy: {e}")))?;
+    let policy = apply_asset_id_to_policy(policy, &asset_id_norm)?;
+    let bundle = build_rewards_policy_bundle(&policy)
+        .map_err(|e| CliError::ConfigError(format!("rewards policy: {e}")))?;
+
+    let message_hash = governance_message_hash(
+        &asset_id_bytes,
+        PROPOSAL_TYPE_REWARDS_POLICY_UPDATE,
+        &bundle.policy_hash,
+    );
+
+    Ok(GovernanceProposal {
+        schema: PROPOSAL_SCHEMA.to_string(),
+        proposal_id: hex::encode(message_hash),
+        proposal_type: PROPOSAL_TYPE_REWARDS_POLICY_UPDATE.to_string(),
+        asset_id: asset_id_norm,
+        policy_cid: hex::encode(bundle.policy_cid),
+        policy_hash: hex::encode(bundle.policy_hash),
+        message_hash: hex::encode(message_hash),
+        policy_document_hex: hex::encode(&bundle.document_bytes),
+        threshold: 1,
+        signers: Vec::new(),
+        approvals: Vec::new(),
+    })
+}
+
+fn parse_governance_approval_pairs(raw: &[String]) -> CliResult<Vec<([u8; 32], Vec<u8>)>> {
+    raw.iter()
+        .map(|s| {
+            let (key_hex, sig_hex) = s.split_once(':').ok_or_else(|| {
+                CliError::ConfigError(format!("--approval must be <key_id_hex>:<sig_hex>, got: {s}"))
+            })?;
+            let key_id = parse_hex_32("approval key_id", key_hex)?;
+            let sig = hex::decode(sig_hex.strip_prefix("0x").unwrap_or(sig_hex))
+                .map_err(|_| CliError::ConfigError(format!("invalid approval signature hex: {sig_hex}")))?;
+            Ok((key_id, sig))
+        })
+        .collect()
+}
+
+fn signature64_from_dilithium(sig: &[u8]) -> Signature64 {
+    let h1 = lib_crypto::hash_blake3(sig);
+    let h2 = lib_crypto::hash_blake3(&[h1.as_slice(), b"sig64"].concat());
+    let mut out = [0u8; 64];
+    out[..32].copy_from_slice(&h1);
+    out[32..].copy_from_slice(&h2);
+    Signature64::new(out)
+}
+
+fn merge_approvals(
+    proposal: &mut GovernanceProposal,
+    pairs: Vec<([u8; 32], Vec<u8>)>,
+) -> CliResult<()> {
+    for (key_id, sig) in pairs {
+        let key_hex = hex::encode(key_id);
+        if proposal.approvals.iter().any(|a| a.signer_key_id == key_hex) {
+            return Err(CliError::ConfigError(format!(
+                "duplicate approval for signer {key_hex}"
+            )));
+        }
+        proposal.approvals.push(GovernanceApproval {
+            signer_key_id: key_hex,
+            signature_hex: hex::encode(sig),
+        });
+    }
+    Ok(())
+}
+
+fn sign_proposal_with_keypair(
+    proposal: &mut GovernanceProposal,
+    keypair: &KeyPair,
+) -> CliResult<()> {
+    let message_hash = parse_hex_32("message_hash", &proposal.message_hash)?;
+    let key_hex = hex::encode(keypair.public_key.key_id);
+    if proposal.approvals.iter().any(|a| a.signer_key_id == key_hex) {
+        return Err(CliError::ConfigError(format!(
+            "keystore already approved as {key_hex}"
+        )));
+    }
+    let sig = keypair
+        .sign(&message_hash)
+        .map_err(|e| CliError::ConfigError(format!("failed to sign proposal: {e}")))?;
+    proposal.approvals.push(GovernanceApproval {
+        signer_key_id: key_hex,
+        signature_hex: hex::encode(sig.signature),
+    });
+    Ok(())
+}
+
+fn enrich_proposal_from_asset_detail(proposal: &mut GovernanceProposal, asset: &Value) -> CliResult<()> {
+    let gov_status = asset
+        .get("governance_status")
+        .ok_or_else(|| CliError::ConfigError("asset response missing governance_status".into()))?;
+    if let Some(verifier) = gov_status.get("verifier") {
+        if let Some(threshold) = verifier.get("threshold").and_then(|v| v.as_u64()) {
+            proposal.threshold = threshold as u8;
+        }
+        if let Some(signers) = verifier.get("signers").and_then(|v| v.as_array()) {
+            proposal.signers = signers
+                .iter()
+                .filter_map(|s| s.as_str().map(str::to_string))
+                .collect();
+        }
+    }
+    Ok(())
+}
+
+fn build_policy_update_tx(
+    proposal: &GovernanceProposal,
+    keypair: &KeyPair,
+    chain_id: u8,
+    use_governance_proof: bool,
+) -> CliResult<Transaction> {
+    let asset_id = parse_hex_32("asset_id", &proposal.asset_id)?;
+    let policy_cid = parse_hex_32("policy_cid", &proposal.policy_cid)?;
+    let policy_hash = parse_hex_32("policy_hash", &proposal.policy_hash)?;
+    let message_hash = parse_hex_32("message_hash", &proposal.message_hash)?;
+    let policy_document = hex::decode(&proposal.policy_document_hex)
+        .map_err(|e| CliError::ConfigError(format!("invalid policy_document_hex: {e}")))?;
+
+    let authority_proof = if use_governance_proof {
+        if proposal.approvals.len() < proposal.threshold as usize {
+            return Err(CliError::ConfigError(format!(
+                "need {} approvals, have {}",
+                proposal.threshold,
+                proposal.approvals.len()
+            )));
+        }
+        let mut signers = Vec::new();
+        let mut signatures = Vec::new();
+        for approval in &proposal.approvals {
+            let key_id = parse_hex_32("signer", &approval.signer_key_id)?;
+            let sig_bytes = hex::decode(&approval.signature_hex)
+                .map_err(|e| CliError::ConfigError(format!("invalid approval sig: {e}")))?;
+            signers.push(key_id);
+            signatures.push(signature64_from_dilithium(&sig_bytes));
+        }
+        AssetAuthorityProof::Governance(ApprovalProof::Multisig {
+            signatures,
+            signers,
+            threshold: proposal.threshold,
+            message_hash,
+        })
+    } else {
+        AssetAuthorityProof::CreatorSig
+    };
+
+    let payload = AssetRewardsPolicyUpdatePayloadV1 {
+        asset_id,
+        policy: RewardsPolicyUpdateConfig {
+            policy_cid,
+            policy_hash,
+            policy_document: Some(policy_document),
+        },
+        authority_proof,
+    };
+    let memo = payload
+        .encode_memo()
+        .map_err(|e| CliError::ConfigError(format!("encode policy update payload: {e}")))?;
+
+    let mut tx = Transaction::new_asset_rewards_policy_update_with_chain_id(
+        chain_id,
+        lib_crypto::Signature::default(),
+        memo,
+    );
+    tx.signature = keypair
+        .sign(tx.signing_hash().as_bytes())
+        .map_err(|e| CliError::ConfigError(format!("sign policy update tx: {e}")))?;
+    Ok(tx)
+}
+
+async fn fetch_asset_detail(client: &ZhtpClient, asset_id: &str) -> CliResult<Value> {
+    let endpoint = format!("/api/v1/assets/{}", asset_id.trim_start_matches("0x"));
+    let response = client.get(&endpoint).await.map_err(|e| CliError::ApiCallFailed {
+        endpoint: endpoint.clone(),
+        status: 0,
+        reason: e.to_string(),
+    })?;
+    ZhtpClient::parse_json(&response).map_err(|e| CliError::ApiCallFailed {
+        endpoint,
+        status: 0,
+        reason: format!("Failed to parse asset detail: {e}"),
+    })
+}
+
+pub async fn handle_dao_governance_command(
+    action: DaoGovernanceAction,
+    cli: &ZhtpCli,
+    output: &dyn Output,
+) -> CliResult<()> {
+    match action {
+        DaoGovernanceAction::Propose {
+            asset_id,
+            proposal_type,
+            policy_file,
+            out,
+        } => {
+            let ty = parse_proposal_type(&proposal_type)?;
+            if ty != PROPOSAL_TYPE_REWARDS_POLICY_UPDATE {
+                return Err(CliError::ConfigError(format!(
+                    "proposal type '{ty}' not implemented"
+                )));
+            }
+            output.header("Governance Proposal (rewards_policy_update)")?;
+            let mut proposal =
+                build_rewards_policy_update_proposal(&asset_id, Path::new(&policy_file))?;
+
+            let client = connect_default(&cli.server).await?;
+            if let Ok(asset) = fetch_asset_detail(&client, &proposal.asset_id).await {
+                enrich_proposal_from_asset_detail(&mut proposal, &asset)?;
+            }
+
+            let formatted = format_output(&serde_json::to_value(&proposal)?, &cli.format)?;
+            output.print(&formatted)?;
+
+            if let Some(path) = out {
+                let bytes = serde_json::to_vec_pretty(&proposal)
+                    .map_err(|e| CliError::ConfigError(format!("serialize proposal: {e}")))?;
+                std::fs::write(&path, bytes).map_err(|e| {
+                    CliError::ConfigError(format!("write {}: {e}", path.display()))
+                })?;
+                output.info(&format!("Proposal written to {}", path.display()))?;
+            }
+            output.success("Proposal ready — share message_hash with signers; run `dao governance vote`.")?;
+            Ok(())
+        }
+        DaoGovernanceAction::Vote {
+            proposal_file,
+            keystore,
+            approvals,
+            submit,
+            chain_id,
+        } => {
+            output.header("Governance Vote")?;
+            let bytes = std::fs::read(&proposal_file).map_err(|e| {
+                CliError::ConfigError(format!("read {}: {e}", proposal_file.display()))
+            })?;
+            let mut proposal: GovernanceProposal = serde_json::from_slice(&bytes)
+                .map_err(|e| CliError::ConfigError(format!("invalid proposal file: {e}")))?;
+            if proposal.schema != PROPOSAL_SCHEMA {
+                return Err(CliError::ConfigError(format!(
+                    "proposal schema must be {PROPOSAL_SCHEMA}"
+                )));
+            }
+
+            let client = connect_default(&cli.server).await?;
+            let asset_id = proposal.asset_id.clone();
+            let asset = fetch_asset_detail(&client, &asset_id).await?;
+            enrich_proposal_from_asset_detail(&mut proposal, &asset)?;
+
+            if !approvals.is_empty() {
+                merge_approvals(&mut proposal, parse_governance_approval_pairs(&approvals)?)?;
+            }
+
+            let keystore_dir = match keystore {
+                Some(path) => PathBuf::from(path),
+                None => default_keystore_path()?,
+            };
+            let loaded = load_identity_from_keystore(&keystore_dir)?;
+            sign_proposal_with_keypair(&mut proposal, &loaded.keypair)?;
+
+            output.info(&format!(
+                "Approvals: {}/{} (threshold {})",
+                proposal.approvals.len(),
+                proposal.signers.len().max(proposal.threshold as usize),
+                proposal.threshold
+            ))?;
+
+            if submit {
+                let asset = fetch_asset_detail(&client, &proposal.asset_id).await?;
+                let authority_kind = asset
+                    .get("governance_status")
+                    .and_then(|g| g.get("authority"))
+                    .and_then(|a| a.get("kind"))
+                    .and_then(|k| k.as_str())
+                    .unwrap_or("creator");
+                let use_governance = authority_kind == "governance";
+                let tx = build_policy_update_tx(
+                    &proposal,
+                    &loaded.keypair,
+                    chain_id,
+                    use_governance,
+                )?;
+                let result = broadcast_signed_tx(&client, &tx).await?;
+                output.print(&format!("Signed tx hash: {}", tx.hash()))?;
+                output.print(&format_output(&result, &cli.format)?)?;
+                output.success("Rewards policy update submitted.")?;
+            } else {
+                std::fs::write(
+                    &proposal_file,
+                    serde_json::to_vec_pretty(&proposal)
+                        .map_err(|e| CliError::ConfigError(format!("serialize proposal: {e}")))?,
+                )
+                .map_err(|e| {
+                    CliError::ConfigError(format!("write {}: {e}", proposal_file.display()))
+                })?;
+                output.info(&format!(
+                    "Updated proposal saved to {} (re-run with --submit when threshold met)",
+                    proposal_file.display()
+                ))?;
+            }
+            Ok(())
+        }
+        DaoGovernanceAction::Status { asset_id } => {
+            output.header("Governance Status")?;
+            let client = connect_default(&cli.server).await?;
+            let asset = fetch_asset_detail(&client, &asset_id).await?;
+            let status = asset
+                .get("governance_status")
+                .cloned()
+                .unwrap_or(json!({}));
+            output.print(&format_output(&status, &cli.format)?)?;
+            if let Some(pending) = status.get("pending_authority_transfer") {
+                if let Some(remaining) = pending.get("blocks_remaining").and_then(|v| v.as_u64()) {
+                    output.info(&format!(
+                        "Authority transfer timelock: {remaining} blocks remaining"
+                    ))?;
+                }
+            }
+            if let Some(pending) = status.get("pending_rewards_policy") {
+                if let Some(remaining) = pending.get("blocks_remaining").and_then(|v| v.as_u64()) {
+                    output.info(&format!(
+                        "Rewards policy decrease timelock: {remaining} blocks remaining"
+                    ))?;
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_proposal_type_accepts_aliases() {
+        assert_eq!(
+            parse_proposal_type("rewards_policy_update").unwrap(),
+            PROPOSAL_TYPE_REWARDS_POLICY_UPDATE
+        );
+        assert_eq!(
+            parse_proposal_type("rewards-policy-update").unwrap(),
+            PROPOSAL_TYPE_REWARDS_POLICY_UPDATE
+        );
+        assert!(parse_proposal_type("manifest_update").is_err());
+    }
+
+    #[test]
+    fn governance_message_hash_is_deterministic() {
+        let asset_id = [0xab; 32];
+        let policy_hash = [0xcd; 32];
+        let h1 = governance_message_hash(&asset_id, PROPOSAL_TYPE_REWARDS_POLICY_UPDATE, &policy_hash);
+        let h2 = governance_message_hash(&asset_id, PROPOSAL_TYPE_REWARDS_POLICY_UPDATE, &policy_hash);
+        assert_eq!(h1, h2);
+        assert_ne!(h1, [0u8; 32]);
+    }
+
+    #[test]
+    fn merge_approvals_rejects_duplicate_signer() {
+        let mut proposal = GovernanceProposal {
+            schema: PROPOSAL_SCHEMA.to_string(),
+            proposal_id: "00".repeat(32),
+            proposal_type: PROPOSAL_TYPE_REWARDS_POLICY_UPDATE.to_string(),
+            asset_id: "11".repeat(32),
+            policy_cid: "22".repeat(32),
+            policy_hash: "33".repeat(32),
+            message_hash: "44".repeat(32),
+            policy_document_hex: "7b7d".to_string(),
+            threshold: 2,
+            signers: vec![],
+            approvals: vec![GovernanceApproval {
+                signer_key_id: "aa".repeat(32),
+                signature_hex: "bb".to_string(),
+            }],
+        };
+        let key = parse_hex_32("k", &"aa".repeat(32)).unwrap();
+        assert!(merge_approvals(&mut proposal, vec![(key, vec![1, 2])]).is_err());
+    }
+}

--- a/zhtp-cli/src/commands/mod.rs
+++ b/zhtp-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod component;
 pub mod config;
 pub mod curve;
 pub mod dao;
+pub mod dao_governance;
 pub mod deploy;
 pub mod diagnostics;
 pub mod domain;

--- a/zhtp/src/api/handlers/assets/mod.rs
+++ b/zhtp/src/api/handlers/assets/mod.rs
@@ -2,7 +2,8 @@
 
 use anyhow::Result;
 use lib_blockchain::contracts::sovereign_asset::{
-    AssetIdSource, RewardsModuleState, SovereignAsset, SupplyMode,
+    AssetAuthority, AssetIdSource, GovernanceModuleState, GovernanceVerifierState,
+    RewardsModuleState, SovereignAsset, SupplyMode,
 };
 use lib_blockchain::transaction::asset_tx::AssetLaunchPayloadV1;
 use lib_blockchain::transaction::{hash_transaction, Transaction};
@@ -90,6 +91,7 @@ struct AssetDetailResponse {
     manifest_resolved: bool,
     manifest: Option<serde_json::Value>,
     dao_registry: Option<serde_json::Value>,
+    governance_status: serde_json::Value,
 }
 
 fn id_source_label(s: AssetIdSource) -> &'static str {
@@ -217,6 +219,79 @@ async fn resolve_asset_manifest(asset: &SovereignAsset) -> (Option<serde_json::V
     }
 }
 
+fn governance_status_detail(
+    asset: &SovereignAsset,
+    gov_state: Option<&GovernanceModuleState>,
+    rewards_state: Option<&RewardsModuleState>,
+    tip_height: u64,
+) -> serde_json::Value {
+    let authority = match &asset.authority {
+        AssetAuthority::Creator { key_id } => json!({
+            "kind": "creator",
+            "key_id": hex::encode(key_id),
+        }),
+        AssetAuthority::Governance { module_ref } => json!({
+            "kind": "governance",
+            "module_ref": hex::encode(module_ref),
+        }),
+    };
+
+    let verifier = gov_state.and_then(|g| g.verifier.as_ref()).map(|v| match v {
+        GovernanceVerifierState::Single { signer_key_id } => json!({
+            "kind": "single",
+            "signers": [hex::encode(signer_key_id)],
+            "threshold": 1,
+        }),
+        GovernanceVerifierState::Multisig { signers, threshold } => json!({
+            "kind": "multisig",
+            "signers": signers.iter().map(hex::encode).collect::<Vec<_>>(),
+            "threshold": threshold,
+        }),
+    });
+
+    let pending_authority_transfer = gov_state
+        .and_then(|g| g.pending_transfer.as_ref())
+        .map(|p| {
+            let blocks_remaining = p.effective_height.saturating_sub(tip_height);
+            json!({
+                "new_verifier": match &p.new_verifier {
+                    GovernanceVerifierState::Single { signer_key_id } => json!({
+                        "kind": "single",
+                        "signers": [hex::encode(signer_key_id)],
+                        "threshold": 1,
+                    }),
+                    GovernanceVerifierState::Multisig { signers, threshold } => json!({
+                        "kind": "multisig",
+                        "signers": signers.iter().map(hex::encode).collect::<Vec<_>>(),
+                        "threshold": threshold,
+                    }),
+                },
+                "effective_height": p.effective_height,
+                "blocks_remaining": blocks_remaining,
+            })
+        });
+
+    let pending_rewards_policy = rewards_state
+        .and_then(|r| r.pending_policy.as_ref())
+        .map(|p| {
+            let blocks_remaining = p.effective_height.saturating_sub(tip_height);
+            json!({
+                "policy_cid": hex::encode(p.policy_cid),
+                "policy_hash": hex::encode(p.policy_hash),
+                "effective_height": p.effective_height,
+                "blocks_remaining": blocks_remaining,
+            })
+        });
+
+    json!({
+        "authority": authority,
+        "verifier": verifier,
+        "pending_authority_transfer": pending_authority_transfer,
+        "pending_rewards_policy": pending_rewards_policy,
+        "chain_tip_height": tip_height,
+    })
+}
+
 fn rewards_detail(
     asset: &SovereignAsset,
     state: Option<&RewardsModuleState>,
@@ -238,6 +313,8 @@ fn rewards_detail(
 fn to_detail(
     asset: &SovereignAsset,
     rewards_state: Option<&RewardsModuleState>,
+    gov_state: Option<&GovernanceModuleState>,
+    tip_height: u64,
     manifest: Option<&serde_json::Value>,
     manifest_resolved: bool,
     dao_registry: Option<serde_json::Value>,
@@ -281,6 +358,12 @@ fn to_detail(
         manifest_resolved,
         manifest: manifest.cloned(),
         dao_registry,
+        governance_status: governance_status_detail(
+            asset,
+            gov_state,
+            rewards_state,
+            tip_height,
+        ),
     }
 }
 
@@ -408,11 +491,15 @@ impl AssetsHandler {
         if asset.module_flags.has_rewards() && rewards_state.is_none() {
             anyhow::bail!("rewards module state unavailable for asset {}", asset_id_hex);
         }
+        let gov_state = bc.get_governance_module_state(&asset_id);
+        let tip_height = bc.height;
         let (manifest, manifest_resolved) = resolve_asset_manifest(&asset).await;
         let dao_registry = dao_registry_linkage(&bc, &asset_id);
         create_json_response(serde_json::to_value(to_detail(
             &asset,
             rewards_state.as_ref(),
+            gov_state.as_ref(),
+            tip_height,
             manifest.as_ref(),
             manifest_resolved,
             dao_registry,


### PR DESCRIPTION
## Summary

Implements **C5 #2820** — sovereign asset governance CLI for post-launch `rewards_policy_update`.

### Commands

```bash
# Propose policy update → proposal_id, policy_cid, policy_hash, message_hash
zhtp-cli dao governance propose \
  --asset-id <hex> --proposal-type rewards_policy_update \
  --policy-file ./policy.json [--out ./proposal.json]

# Collect signer approval; submit when threshold met
zhtp-cli dao governance vote \
  --proposal-file ./proposal.json [--approval KEY:SIG ...] [--submit]

# Pending authority transfer + rewards policy timelocks
zhtp-cli dao governance status --asset-id <hex>
```

### Protocol / API

- `GET /api/v1/assets/{id}` now includes `governance_status` (authority, verifier, pending timelocks, chain tip)
- `Transaction::new_asset_rewards_policy_update_with_chain_id`
- `Blockchain::get_governance_module_state`

## Test plan

- [x] `cargo check -p zhtp-cli -p zhtp`
- [x] `cargo test -p zhtp-cli --lib dao_governance` (3 passed)

Closes #2820