### PR TITLE
feat(protocol): DAO launch economic rules Q1–Q10 (P2/P8–P11)

### DIFF
--- a/docs/arch/dao-launch-decision-register.md
+++ b/docs/arch/dao-launch-decision-register.md
@@ -1,0 +1,410 @@
+# DAO Launch v1 — Decision Register (Q1–Q10)
+
+**Epic:** [#2799](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2799) — DAO Launch v1 (Sovereign Asset)  
+**Status:** **Locked** (2026-07-13)  
+**Companion:** [`sovereign-asset.md`](./sovereign-asset.md) (primitive design), [`dao-launch-bootstrap.md`](../ops/dao-launch-bootstrap.md) (operator runbook)
+
+---
+
+## Governing principle (locked)
+
+> **Consensus owns economic rules; governance owns treasury decisions; the UI only exposes features the protocol can enforce.**
+
+No economic rule should exist only in the CLI, mobile application, registry, or operator runbook. If it affects supply, balances, ownership, fees, or authorization, the **executor must enforce it deterministically**.
+
+Leaving Q1–Q10 open was already causing divergent implementations and replay risk. This register is the authoritative lock set for implementation.
+
+---
+
+## Numbering collision (read this first)
+
+**Two different `Qn` namespaces exist in the repo.**
+
+| Namespace | Where | Example Q1 | Example Q7 |
+|-----------|--------|------------|------------|
+| **Epic #2799 (this doc)** | Child issues P2, P8–P11, M2 | Post-launch mint & class-based split | `dao_class` NP/FP economics |
+| **`sovereign-asset.md` §11** | SA primitive open questions | Symbol tombstone after sunset | Token-weighted governance (out of scope v1) |
+
+When an issue says “Blocked by Q7”, it means **epic Q7** (non-profit economics), not token-weighted votes from the arch doc. Prefer renaming arch-doc items to `SA-Q*` in a follow-up doc pass to eliminate ambiguity.
+
+---
+
+## Executor persistence checkpoint (locked)
+
+**Decision:** Validator registration persistence follows the **identity-registration pattern**.
+
+| Layer | Responsibility |
+|-------|----------------|
+| `apply_tx` | Validates and updates deterministic execution state as required |
+| Blockchain-layer **metadata batch** | **Single** durable write for validator records |
+| Executor persistence | **Intentional no-op** |
+
+**Explicitly rejected for validators:**
+
+- Temporary dual-write paths
+- Divergence detectors between executor and finalization
+- Copying the current **observer** persistence path (treat observer inconsistency as technical debt to eliminate, not a pattern to extend)
+
+**Reason:** Consensus-critical persistence must have **one owner** and **one atomic commit boundary**. Splitting storage between executor and block finalization creates ambiguity during replay, rollback, partial failure, and future migrations.
+
+---
+
+## Final locked set
+
+| Question | Decision |
+|----------|----------|
+| Executor validator persistence | Blockchain-layer metadata batch only |
+| **Q1** | Fixed rejects mint; elastic uses mandatory **class-based** split |
+| **Q2** | Governance-controlled treasury; no hard-coded spending categories |
+| **Q3** | Dedicated delegate float funded **explicitly** from treasury |
+| **Q4** | Keep current consensus `RewardClaim` (spend delegate) |
+| **Q5** | Keep decrease timelock on rewards policy |
+| **Q6** | Keep rewards state on-chain |
+| **Q7** | FP = 80/20; NP = 100% treasury; `dao_class` stored on-chain |
+| **Q8** | Transfer-only true burn; governance-timelocked; capped |
+| **Q9** | Curve-derived price; derived APY; registry-level welfare sector |
+| **Q10** | Separate domain tx; 100 native SOV to protocol treasury |
+
+### Summary table
+
+| ID | Topic | Status | Unblocks |
+|----|--------|--------|----------|
+| **Q1** | Post-launch mint & class-based split | **Locked** | P2 #2801 |
+| **Q2** | Treasury spend authorization | **Locked** | P10 #2809 |
+| **Q3** | Rewards funding | **Locked** | P10 #2809 |
+| **Q4** | Rewards spend-delegate settlement | **Locked** (shipped) | — |
+| **Q5** | Rewards policy decrease timelock | **Locked** (shipped) | — |
+| **Q6** | Rewards state on-chain only | **Locked** (shipped) | — |
+| **Q7** | `dao_class` NP/FP economics | **Locked** | P8 #2807, M2 #2827 |
+| **Q8** | Per-transfer burn | **Locked** | P9 #2808, M2 #2827 |
+| **Q9** | Curve / APY / welfare sector | **Locked** | M2 #2827 Phase 4 |
+| **Q10** | Domain binding & claim fee | **Locked** | P11 #2810 |
+
+---
+
+## Q1 — Post-launch mint and treasury split
+
+**Status:** **Locked — Option B, with `dao_class` determining the split**
+
+**Blocks:** [P2 #2801](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2801)
+
+### Fixed supply
+
+After launch:
+
+- **Reject all net-new mint transactions.**
+- Governance **must not** bypass fixed supply.
+- A future conversion from `Fixed` → `Elastic`, if ever supported, must be a **separate explicit protocol upgrade with a timelock** — not an ordinary mint authorization.
+
+### Elastic supply
+
+Every net-new mint must follow the asset’s canonical **class-based** allocation:
+
+| Class | Recipient | Treasury |
+|-------|-----------|----------|
+| **FP** (for-profit) | 80% designated recipient | 20% DAO treasury |
+| **NP** (non-profit) | — | 100% DAO treasury |
+
+Applies to:
+
+- Curve-generated supply
+- Governance-authorized inflation
+- Any transaction that increases `total_supply`
+
+### Implementation requirement
+
+- **One shared `mint_and_allocate()` consensus function** for all supply increases.
+- Do **not** implement separate split logic in curve, governance, and executor paths.
+- A governance proof **authorizes the mint**; it does **not** authorize bypassing the economic split.
+
+---
+
+## Q2 — Treasury spend rules
+
+**Status:** **Locked — governance-controlled treasury, unrestricted purpose at consensus level**
+
+**Blocks:** [P10 #2809](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2809)
+
+### Rules
+
+- The treasury allocation must **not** be immediately spendable by the creator or by a plain treasury private key.
+- Canonical `treasury_key_id` resolves to a **deterministic DAO-controlled authority** derived from the DAO governance configuration.
+- Treasury spending requires:
+  - valid governance authorization;
+  - configured approval threshold;
+  - ordinary balance and transaction validation.
+
+### What consensus must not do
+
+Do **not** hard-code spending categories (grants, rewards, domain fees, reserves, welfare programs) into consensus. That embeds current product assumptions into the protocol.
+
+| Consensus answers | Consensus does not answer |
+|-------------------|---------------------------|
+| “Was this transfer validly authorized by the DAO?” | “Was this transfer a good use of treasury funds?” |
+
+### Creator-supplied treasury address
+
+May be accepted **only** when it represents the configured governance authority. It must **not** provide a hidden unilateral escape route.
+
+---
+
+## Q3 — Rewards funding
+
+**Status:** **Locked — dedicated spend-delegate float, funded explicitly from treasury**
+
+**Blocks:** [P10 #2809](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2809)
+
+### Flow
+
+1. DAO governance authorizes a **treasury transfer**.
+2. Treasury funds the **rewards spend delegate**.
+3. Delegate signs consensus `RewardClaim` transactions.
+4. Claims debit the **delegate balance** (not the general treasury per claim).
+
+Do **not** automatically carve another percentage out of the initial creator/treasury allocation at launch. The launch split stays canonical and understandable.
+
+### Underfunding
+
+| Situation | Behavior |
+|-----------|----------|
+| Launch with rewards configured, delegate unfunded | **Valid** — launch must not reject |
+| Claim against underfunded delegate | **Deterministic failure:** `InsufficientRewardLiquidity` (protocol-level) |
+| API | Expose as valid economic state — **not** generic 503 |
+| CLI / UI | Show clearly: **“Rewards configured, but not funded.”** |
+
+---
+
+## Q4 — Rewards spend-delegate settlement
+
+**Status:** **Locked — keep; no reopening**
+
+- Consensus `RewardClaim` signed by the on-chain spend delegate.
+- Policy validated via `policy_hash` / DHT document.
+- Shipped: P4, P5, N2, N3, N4.
+
+Reopen only if a concrete security or consensus defect is discovered.
+
+---
+
+## Q5 — Rewards policy decrease timelock
+
+**Status:** **Locked — keep; no reopening**
+
+- Decrease-only policy updates queue `pending_policy` with timelock (`REWARDS_POLICY_DECREASE_TIMELOCK_BLOCKS` = 7200).
+- Shipped: P7.
+
+---
+
+## Q6 — Rewards eligibility storage
+
+**Status:** **Locked — keep; no reopening**
+
+- Eligibility, streaks, history, and deduplication remain **on-chain** consensus state.
+- Node-local `rewards.sled` retired (N4).
+
+---
+
+## Q7 — Non-profit and for-profit `dao_class`
+
+**Status:** **Locked — consensus data; changes initial and future mint allocation**
+
+**Blocks:** [P8 #2807](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2807), [M2 #2827](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2827)
+
+### For-profit (FP)
+
+| Event | Allocation |
+|-------|------------|
+| Initial launch | 80% creator / 20% treasury |
+| Every future elastic mint | 80% designated recipient / 20% treasury |
+
+### Non-profit (NP)
+
+| Event | Allocation |
+|-------|------------|
+| Initial launch | **100% treasury** (no direct creator allocation) |
+| Every future elastic mint | **100% treasury** |
+
+This is a **meaningful protocol distinction**, not a cosmetic registry label.
+
+### Storage (required)
+
+`dao_class` must exist in:
+
+1. `AssetLaunchPayloadV1`
+2. Canonical `SovereignAsset` state
+3. Registry projections **derived from chain state**
+
+The registry must **not** independently default or override class. Remove current registry-only / default-`fp` behavior.
+
+### Staking proof
+
+**Do not require** staking proof for DAO launch v1.
+
+Existing `PendingDao` / SOV staking may later become admission, discovery/ranking, or a launch prerequisite in a **subsequent version**. Do not mix into this launch primitive until economic and slashing semantics are fully defined.
+
+---
+
+## Q8 — Per-transaction burn
+
+**Status:** **Locked — optional transfer burn only; burned supply destroyed**
+
+**Blocks:** [P9 #2808](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2808), M2
+
+### v1 semantics
+
+| Rule | Value |
+|------|-------|
+| Applies to | **Transfers only** (not mints) |
+| Burned atoms | Reduce `total_supply` — **not** routed to treasury |
+| Sender debited | Full submitted transfer amount |
+| Recipient receives | `amount - burn` |
+| Formula | `burn = floor(amount × burn_bps / 10_000)` |
+
+Routing burn proceeds to treasury is a **transfer tax**, not a burn. Keep concepts separate.
+
+### Governance changes
+
+Any change to `burn_bps` is **timelocked** (increases **and** decreases). Both materially affect token economics and deserve visible advance notice.
+
+### Caps
+
+| Parameter | Value |
+|-----------|-------|
+| Default | `0` |
+| Protocol maximum | **1000 bps (10%)** per transfer |
+
+DAOs needing more aggressive mechanics should use a **specialized module**, not unrestricted transfer burn.
+
+---
+
+## Q9 — Curve, staking APY, and welfare sector
+
+**Status:** **Locked — three distinct concepts (not one launch-economics bundle)**
+
+**Blocks:** M2 Phase 4
+
+### Initial price
+
+- Valid **only** when a **curve module** is enabled.
+- Must be **derived** from curve configuration and reserve state.
+- Must **not** be an independent display field that contradicts protocol economics.
+- **Fixed-supply, no curve:** no canonical protocol “initial price”; UI must not present one as guaranteed.
+
+### Staking APY
+
+- **Calculated display value** from on-chain staking parameters when integrated.
+- Do **not** store promised APY as arbitrary marketing metadata.
+- UI may show **estimated** APY from emission rate, staked amount, duration, protocol assumptions — labelled **variable and derived**.
+- Until on-chain staking is integrated: field stays **disabled**.
+
+### Welfare sector
+
+- **Registry-level classification** with optional canonical sector identifier.
+- Binds DAO to existing sector/root registry record; supports discovery and governance organization.
+- Does **not** alter monetary consensus rules in v1.
+- May appear in launch payload as optional registry reference; launch validity must **not** depend on mutable external content.
+
+---
+
+## Q10 — Domain binding and claim fee
+
+**Status:** **Locked — separate `DomainRegister` tx; launch workflow may bundle UX only**
+
+**Blocks:** [P11 #2810](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2810)
+
+### Transaction model
+
+- **Do not** place domain registration inside `AssetLaunch` (different failure conditions and lifecycle).
+- CLI / mobile may present one **workflow**:
+  1. Submit `AssetLaunch`
+  2. Wait for finality
+  3. Submit `DomainRegister` referencing `asset_id`
+
+### Fee
+
+| Field | Value |
+|-------|-------|
+| Denomination | **Native SOV only** |
+| Amount | **100 SOV** (v1 standard claim; governance may reconfigure later) |
+| Sink | **Protocol treasury** |
+| Not allowed | Bridged token, DAO token, burn |
+
+Native SOV prevents every DAO from inventing circular payment mechanics for scarce global namespace.
+
+### Failure behavior
+
+| Outcome | Rule |
+|---------|------|
+| Domain registration fails | DAO launch **remains valid** |
+| Fee | Charged **only** if domain tx succeeds |
+| Retry | User may retry same or different domain |
+
+### Domain record binds
+
+- Normalized domain
+- `asset_id`
+- Controlling governance authority
+- Registration height
+- Renewal / expiry policy (once defined)
+
+---
+
+## UI / protocol conflicts (C1–C10)
+
+Epic guiding principle: protocol wins; UI adapts (notably **C6, C7**).
+
+| ID | Conflict | Resolution after lock |
+|----|----------|------------------------|
+| **C1** | Launch command completeness | Phase 3 largely shipped; align with Q7 on-chain `dao_class` |
+| **C2** | `new_partner` amount discrepancy | **Resolved** (D1) |
+| **C3** | Identity / keystore | **Resolved** (C3) |
+| **C4** | Rewards API vs chain | **Resolved** (Q4–Q6) |
+| **C5** | Governance CLI vs proof validation | **Partial** — finish P6 `GovernanceProof` |
+| **C6** | Unsupported economic fields | **Unlock per rule:** Q7/Q8/Q9 + implementation order below |
+| **C7** | Stricter UI validation | **Resolved** — `validate_dao_launch_ui_constraints()` |
+| **C8** | Registry class vs launch | **Resolved by Q7** — class on-chain; registry projects only |
+| **C9** | Template preview vs executor | Split/allocations via executor; APY display-only per Q9 |
+| **C10** | Domain in launch flow | **Resolved by Q10** — separate tx, unified UX workflow |
+
+---
+
+## Implementation order (locked)
+
+Execute in this sequence. Do not enable advanced UI fields until the corresponding chain rule ships.
+
+1. Add canonical **`dao_class`** to `AssetLaunchPayloadV1` and `SovereignAsset` state.
+2. Centralize all supply increases in one **class-aware `mint_and_allocate()`** function.
+3. Enforce **fixed-supply mint rejection** (Q1).
+4. Introduce **governance-controlled treasury authorization** (Q2).
+5. Formalize **rewards delegate funding** and `InsufficientRewardLiquidity` (Q3).
+6. Add **transfer-burn** semantics with timelock and cap (Q8).
+7. Add **`DomainRegister`** as separate transaction + 100 SOV fee (Q10).
+8. Enable M2 Phase 4 UI fields only after their chain rules exist (Q9 sub-items).
+
+**Parallel / already in flight:** P6 governance proof validation (C5); validator persistence refactor per executor checkpoint above.
+
+---
+
+## Delivery phases (epic)
+
+| Phase | Scope |
+|-------|--------|
+| **1** | Minimal launch (name, symbol, supply, treasury) |
+| **2** | Schemas, templates, rewards policy, discovery |
+| **3** | Full `dao launch` flags, governance CLI, mobile submit |
+| **4** | Advanced UI (burn, NP split, curve price, welfare) — **gated on implementation order** |
+
+---
+
+## Sovereign Asset primitive (D1–D10)
+
+Unchanged; see [`sovereign-asset.md` §2](./sovereign-asset.md). Epic Q1–Q10 extend D2/D3 with **economic enforcement** detail.
+
+---
+
+## Change log
+
+| Date | Change |
+|------|--------|
+| 2026-07-13 | Initial draft from epic child issues and codebase |
+| 2026-07-13 | **Locked** full Q1–Q10, executor persistence checkpoint, implementation order, governing principle |

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1563,6 +1563,7 @@ impl Blockchain {
                             version: 1,
                             updated_at: block_ts,
                             fee_tx_hash: payload.fee_tx_hash,
+                            asset_id: payload.asset_id,
                         };
                         info!(
                             "⛓️  Domain registered on-chain: {} at height {} (fee {} atoms, v2={})",

--- a/lib-blockchain/src/blockchain/dao.rs
+++ b/lib-blockchain/src/blockchain/dao.rs
@@ -343,7 +343,6 @@ impl Blockchain {
     /// Derive a registry entry from an `AssetLaunch` tx (P1 #2800).
     ///
     /// `dao_id` and `token_key_id` both equal the launch tx hash (`asset_id`).
-    /// Default class is `fp` until P8 adds optional `dao_class` on the payload.
     fn dao_registry_entry_from_asset_launch(
         tx: &Transaction,
         block_height: u64,
@@ -356,7 +355,7 @@ impl Blockchain {
         Some(DaoRegistryIndexEntry {
             dao_id: asset_id,
             token_key_id: asset_id,
-            class: crate::types::dao::DAOType::FP.as_str().to_string(),
+            class: payload.dao_class.as_str().to_string(),
             metadata_hash: payload.manifest_hash,
             treasury_key_id: payload.treasury_key_id,
             owner_key_id: tx.signature.public_key.key_id,

--- a/lib-blockchain/src/blockchain/tests/replay_contract_execution_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/replay_contract_execution_tests.rs
@@ -185,6 +185,8 @@ fn asset_launch_tx(signer: &PublicKey, symbol: &str, treasury_seed: u8) -> Trans
         rewards: None,
         governance: None,
         transfer_authority: false,
+        dao_class: crate::contracts::sovereign_asset::DaoClass::Fp,
+        burn_bps: 0,
     };
 
     Transaction {

--- a/lib-blockchain/src/contracts/sovereign_asset/migration.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/migration.rs
@@ -1,0 +1,135 @@
+//! Bincode migration shims for `SovereignAsset` sled records.
+//!
+//! `#[serde(default)]` does not apply to bincode — new fields must be appended
+//! at the end of the struct and legacy bytes decoded via an explicit fallback.
+
+use serde::Deserialize;
+
+use super::types::{
+    AssetAuthority, AssetIdSource, AssetModuleFlags, CurveModuleHeader, DaoClass,
+    GovernanceModuleHeader, RewardsModuleHeader, SovereignAsset, SupplyMode,
+};
+
+/// Pre-Q7 sled layout (no `dao_class`, `burn_bps`, or `pending_burn_bps`).
+#[derive(serde::Serialize, Deserialize)]
+struct LegacySovereignAsset {
+    asset_id: [u8; 32],
+    id_source: AssetIdSource,
+    name: String,
+    symbol: String,
+    decimals: u8,
+    creator_key_id: [u8; 32],
+    creator_did: Option<String>,
+    treasury_key_id: Option<[u8; 32]>,
+    launched_at_height: Option<u64>,
+    supply_mode: SupplyMode,
+    max_supply: u128,
+    total_supply: u128,
+    manifest_cid: Option<[u8; 32]>,
+    manifest_hash: Option<[u8; 32]>,
+    schema_version: u16,
+    authority: AssetAuthority,
+    module_flags: AssetModuleFlags,
+    curve: Option<CurveModuleHeader>,
+    rewards: Option<RewardsModuleHeader>,
+    governance: Option<GovernanceModuleHeader>,
+}
+
+fn from_legacy(legacy: LegacySovereignAsset) -> SovereignAsset {
+    SovereignAsset {
+        asset_id: legacy.asset_id,
+        id_source: legacy.id_source,
+        name: legacy.name,
+        symbol: legacy.symbol,
+        decimals: legacy.decimals,
+        creator_key_id: legacy.creator_key_id,
+        creator_did: legacy.creator_did,
+        treasury_key_id: legacy.treasury_key_id,
+        launched_at_height: legacy.launched_at_height,
+        supply_mode: legacy.supply_mode,
+        max_supply: legacy.max_supply,
+        total_supply: legacy.total_supply,
+        manifest_cid: legacy.manifest_cid,
+        manifest_hash: legacy.manifest_hash,
+        schema_version: legacy.schema_version,
+        authority: legacy.authority,
+        module_flags: legacy.module_flags,
+        curve: legacy.curve,
+        rewards: legacy.rewards,
+        governance: legacy.governance,
+        dao_class: DaoClass::Fp,
+        burn_bps: 0,
+        pending_burn_bps: None,
+    }
+}
+
+/// Deserialize a `SovereignAsset` from sled, migrating legacy records when needed.
+pub fn deserialize_sovereign_asset(bytes: &[u8]) -> Result<SovereignAsset, String> {
+    match bincode::deserialize::<SovereignAsset>(bytes) {
+        Ok(asset) => Ok(asset),
+        Err(_) => {
+            let legacy: LegacySovereignAsset = bincode::deserialize(bytes)
+                .map_err(|e| format!("sovereign asset deserialize failed: {e}"))?;
+            Ok(from_legacy(legacy))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::sovereign_asset::types::PendingBurnBpsUpdate;
+
+    fn legacy_sample() -> LegacySovereignAsset {
+        LegacySovereignAsset {
+            asset_id: [0xAB; 32],
+            id_source: AssetIdSource::LaunchTx,
+            name: "Legacy".into(),
+            symbol: "LEG".into(),
+            decimals: 8,
+            creator_key_id: [0xCC; 32],
+            creator_did: None,
+            treasury_key_id: Some([0xEE; 32]),
+            launched_at_height: Some(100),
+            supply_mode: SupplyMode::Fixed,
+            max_supply: 1_000_000,
+            total_supply: 500_000,
+            manifest_cid: Some([0x11; 32]),
+            manifest_hash: Some([0x22; 32]),
+            schema_version: 1,
+            authority: AssetAuthority::Creator {
+                key_id: [0xCC; 32],
+            },
+            module_flags: AssetModuleFlags(0),
+            curve: None,
+            rewards: None,
+            governance: None,
+        }
+    }
+
+    #[test]
+    fn legacy_sled_bytes_round_trip_with_defaults() {
+        let bytes = bincode::serialize(&legacy_sample()).expect("legacy serialize");
+        let asset = deserialize_sovereign_asset(&bytes).expect("legacy migrate");
+        assert_eq!(asset.symbol, "LEG");
+        assert_eq!(asset.dao_class, DaoClass::Fp);
+        assert_eq!(asset.burn_bps, 0);
+        assert!(asset.pending_burn_bps.is_none());
+    }
+
+    #[test]
+    fn current_layout_round_trip() {
+        let mut asset = from_legacy(legacy_sample());
+        asset.dao_class = DaoClass::Np;
+        asset.burn_bps = 100;
+        asset.pending_burn_bps = Some(PendingBurnBpsUpdate {
+            new_burn_bps: 200,
+            effective_height: 99_000,
+        });
+        let bytes = bincode::serialize(&asset).expect("current serialize");
+        let decoded = deserialize_sovereign_asset(&bytes).expect("current decode");
+        assert_eq!(decoded.dao_class, DaoClass::Np);
+        assert_eq!(decoded.burn_bps, 100);
+        assert_eq!(decoded.pending_burn_bps, asset.pending_burn_bps);
+    }
+}

--- a/lib-blockchain/src/contracts/sovereign_asset/mod.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/mod.rs
@@ -1,8 +1,11 @@
 //! Sovereign Asset — unified DAO/token primitive (ADR: docs/arch/sovereign-asset.md).
 
+mod migration;
 mod projection;
 mod state;
 mod types;
+
+pub use migration::deserialize_sovereign_asset;
 
 pub use projection::{
     is_sov_native_token_id, merge_curve_into_asset, project_from_bonding_curve_token,

--- a/lib-blockchain/src/contracts/sovereign_asset/projection.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/projection.rs
@@ -62,9 +62,6 @@ pub fn project_from_token_contract(
         treasury_key_id: None,
         launched_at_height,
         supply_mode,
-        dao_class: DaoClass::Fp,
-        burn_bps: 0,
-        pending_burn_bps: None,
         max_supply,
         total_supply: token.total_supply,
         manifest_cid: None,
@@ -77,6 +74,9 @@ pub fn project_from_token_contract(
         curve: None,
         rewards,
         governance: None,
+        dao_class: DaoClass::Fp,
+        burn_bps: 0,
+        pending_burn_bps: None,
     })
 }
 
@@ -95,9 +95,6 @@ pub fn project_from_bonding_curve_token(curve: &BondingCurveToken) -> SovereignA
         treasury_key_id: None,
         launched_at_height: Some(curve.deployed_at_block),
         supply_mode: SupplyMode::Elastic,
-        dao_class: DaoClass::Fp,
-        burn_bps: 0,
-        pending_burn_bps: None,
         max_supply: curve.total_supply,
         total_supply: curve.total_supply,
         manifest_cid: None,
@@ -113,6 +110,9 @@ pub fn project_from_bonding_curve_token(curve: &BondingCurveToken) -> SovereignA
         }),
         rewards: None,
         governance: None,
+        dao_class: DaoClass::Fp,
+        burn_bps: 0,
+        pending_burn_bps: None,
     }
 }
 

--- a/lib-blockchain/src/contracts/sovereign_asset/projection.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/projection.rs
@@ -1,8 +1,8 @@
 //! Legacy read projection: `TokenContract` / `BondingCurveToken` → `SovereignAsset`.
 
 use super::types::{
-    AssetAuthority, AssetIdSource, AssetModuleFlags, CurveModuleHeader, RewardsModuleHeader,
-    SovereignAsset, SupplyMode,
+    AssetAuthority, AssetIdSource, AssetModuleFlags, CurveModuleHeader, DaoClass,
+    RewardsModuleHeader, SovereignAsset, SupplyMode,
 };
 use crate::contracts::bonding_curve::token::BondingCurveToken;
 use crate::contracts::bonding_curve::types::Phase;
@@ -62,6 +62,9 @@ pub fn project_from_token_contract(
         treasury_key_id: None,
         launched_at_height,
         supply_mode,
+        dao_class: DaoClass::Fp,
+        burn_bps: 0,
+        pending_burn_bps: None,
         max_supply,
         total_supply: token.total_supply,
         manifest_cid: None,
@@ -92,6 +95,9 @@ pub fn project_from_bonding_curve_token(curve: &BondingCurveToken) -> SovereignA
         treasury_key_id: None,
         launched_at_height: Some(curve.deployed_at_block),
         supply_mode: SupplyMode::Elastic,
+        dao_class: DaoClass::Fp,
+        burn_bps: 0,
+        pending_burn_bps: None,
         max_supply: curve.total_supply,
         total_supply: curve.total_supply,
         manifest_cid: None,

--- a/lib-blockchain/src/contracts/sovereign_asset/state.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/state.rs
@@ -120,6 +120,13 @@ pub const GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT: u64 = 0;
 #[cfg(not(test))]
 pub const GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT: u64 = 80_000;
 
+/// Epic Q1–Q3 / Q8 economic rules (mint class, treasury spend auth, reward liquidity, burn).
+/// Inactive below [`GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT`] so replay matches pre-rules history.
+#[inline]
+pub fn economic_rules_active(block_height: u64) -> bool {
+    block_height >= GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT
+}
+
 /// Default multisig threshold: floor(N/2) + 1.
 pub fn default_governance_threshold(n: usize) -> u8 {
     ((n / 2) + 1) as u8

--- a/lib-blockchain/src/contracts/sovereign_asset/types.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/types.rs
@@ -17,6 +17,64 @@ pub enum SupplyMode {
     Elastic,
 }
 
+/// DAO economic class (epic Q7). Determines treasury split on every supply increase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DaoClass {
+    #[default]
+    Fp,
+    Np,
+}
+
+pub const FP_TREASURY_BPS: u16 = 2_000;
+pub const NP_TREASURY_BPS: u16 = 10_000;
+pub const MAX_TRANSFER_BURN_BPS: u16 = 1_000;
+
+impl DaoClass {
+    pub fn treasury_bps(self) -> u16 {
+        match self {
+            DaoClass::Fp => FP_TREASURY_BPS,
+            DaoClass::Np => NP_TREASURY_BPS,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DaoClass::Fp => "fp",
+            DaoClass::Np => "np",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "fp" | "for_profit" | "for-profit" => Some(DaoClass::Fp),
+            "np" | "non_profit" | "non-profit" => Some(DaoClass::Np),
+            _ => None,
+        }
+    }
+
+    pub fn from_dao_type(t: crate::types::dao::DAOType) -> Self {
+        match t {
+            crate::types::dao::DAOType::FP => DaoClass::Fp,
+            crate::types::dao::DAOType::NP => DaoClass::Np,
+        }
+    }
+
+    pub fn to_dao_type(self) -> crate::types::dao::DAOType {
+        match self {
+            DaoClass::Fp => crate::types::dao::DAOType::FP,
+            DaoClass::Np => crate::types::dao::DAOType::NP,
+        }
+    }
+}
+
+/// Queued `burn_bps` change (epic Q8 — timelocked increases and decreases).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingBurnBpsUpdate {
+    pub new_burn_bps: u16,
+    pub effective_height: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AssetAuthority {
     Creator { key_id: [u8; 32] },
@@ -82,6 +140,13 @@ pub struct SovereignAsset {
     pub treasury_key_id: Option<[u8; 32]>,
     pub launched_at_height: Option<u64>,
     pub supply_mode: SupplyMode,
+    #[serde(default)]
+    pub dao_class: DaoClass,
+    /// Per-transfer burn rate in basis points (0..=MAX_TRANSFER_BURN_BPS).
+    #[serde(default)]
+    pub burn_bps: u16,
+    #[serde(default)]
+    pub pending_burn_bps: Option<PendingBurnBpsUpdate>,
     pub max_supply: u128,
     pub total_supply: u128,
     pub manifest_cid: Option<[u8; 32]>,

--- a/lib-blockchain/src/contracts/sovereign_asset/types.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/types.rs
@@ -140,13 +140,6 @@ pub struct SovereignAsset {
     pub treasury_key_id: Option<[u8; 32]>,
     pub launched_at_height: Option<u64>,
     pub supply_mode: SupplyMode,
-    #[serde(default)]
-    pub dao_class: DaoClass,
-    /// Per-transfer burn rate in basis points (0..=MAX_TRANSFER_BURN_BPS).
-    #[serde(default)]
-    pub burn_bps: u16,
-    #[serde(default)]
-    pub pending_burn_bps: Option<PendingBurnBpsUpdate>,
     pub max_supply: u128,
     pub total_supply: u128,
     pub manifest_cid: Option<[u8; 32]>,
@@ -157,6 +150,11 @@ pub struct SovereignAsset {
     pub curve: Option<CurveModuleHeader>,
     pub rewards: Option<RewardsModuleHeader>,
     pub governance: Option<GovernanceModuleHeader>,
+    /// Economic class (FP 80/20, NP 100% treasury). Appended for bincode compat.
+    pub dao_class: DaoClass,
+    /// Per-transfer burn rate in basis points (0..=MAX_TRANSFER_BURN_BPS).
+    pub burn_bps: u16,
+    pub pending_burn_bps: Option<PendingBurnBpsUpdate>,
 }
 
 impl SovereignAsset {

--- a/lib-blockchain/src/execution/errors.rs
+++ b/lib-blockchain/src/execution/errors.rs
@@ -123,6 +123,10 @@ pub enum TxApplyError {
         token: TokenId,
     },
 
+    /// Rewards spend-delegate lacks funded balance for a valid claim (epic Q3).
+    #[error("Insufficient reward liquidity: have {have}, need {need}")]
+    InsufficientRewardLiquidity { have: u128, need: u128 },
+
     #[error("Token not found: {0}")]
     TokenNotFound(TokenId),
 

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -45,7 +45,7 @@ use crate::transaction::{
     asset_tx::{
         AssetAuthorityTransferPayloadV1, AssetLaunchPayloadV1, AssetManifestUpdatePayloadV1,
         AssetModuleUpgradePayloadV1, AssetRewardsDelegateRotatePayloadV1,
-        AssetRewardsPolicyUpdatePayloadV1,
+        AssetBurnBpsUpdatePayloadV1, AssetRewardsPolicyUpdatePayloadV1,
     },
     contract_deployment::ContractDeploymentPayloadV1,
     contract_execution::DecodedContractExecutionMemo, decode_canonical_bonding_curve_tx,
@@ -56,12 +56,16 @@ use crate::transaction::{
 use crate::types::TransactionType;
 
 use super::errors::{BlockApplyError, BlockApplyResult, TxApplyError};
+use super::mint_and_allocate::mint_and_allocate;
 use super::sovereign_asset::{
-    activate_pending_authority_transfers, activate_pending_rewards_policies,
-    apply_asset_authority_transfer, apply_asset_launch,
-    apply_asset_manifest_update, apply_asset_module_upgrade, apply_asset_rewards_delegate_rotate,
-    apply_asset_rewards_policy_update, AssetLaunchOutcome,
+    activate_pending_authority_transfers, activate_pending_burn_bps,
+    activate_pending_rewards_policies, apply_asset_authority_transfer, apply_asset_burn_bps_update,
+    apply_asset_launch, apply_asset_manifest_update, apply_asset_module_upgrade,
+    apply_asset_rewards_delegate_rotate, apply_asset_rewards_policy_update,
+    apply_sovereign_token_transfer, require_governance_mint_signer, require_treasury_spend_signer,
+    AssetLaunchOutcome,
 };
+use crate::contracts::sovereign_asset::SupplyMode;
 use super::tx_apply::{self, CoinbaseOutcome, StateMutator, TransferOutcome};
 
 use crate::protocol::ProtocolParams;
@@ -671,6 +675,11 @@ impl BlockExecutor {
                 "activate pending rewards policies failed: {e}"
             ))
         })?;
+        activate_pending_burn_bps(&mutator, block_height).map_err(|e| {
+            BlockApplyError::ValidationFailed(format!(
+                "activate pending burn bps updates failed: {e}"
+            ))
+        })?;
 
         // =====================================================================
         // Pre-step: Coinbase position validation
@@ -1082,6 +1091,7 @@ impl BlockExecutor {
             TransactionType::AssetAuthorityTransfer => {}
             TransactionType::AssetRewardsDelegateRotate => {}
             TransactionType::AssetRewardsPolicyUpdate => {}
+            TransactionType::AssetBurnBpsUpdate => {}
             TransactionType::ContractDeployment => {}
             TransactionType::ContractExecution => {}
             TransactionType::DaoProposal => {}
@@ -1353,6 +1363,18 @@ impl BlockExecutor {
                 AssetRewardsPolicyUpdatePayloadV1::decode_memo(&tx.memo).map_err(|e| {
                     TxApplyError::InvalidType(format!(
                         "AssetRewardsPolicyUpdate requires canonical memo payload: {e}"
+                    ))
+                })?;
+            }
+            TransactionType::AssetBurnBpsUpdate => {
+                if !tx.inputs.is_empty() || !tx.outputs.is_empty() {
+                    return Err(TxApplyError::InvalidType(
+                        "AssetBurnBpsUpdate must not have UTXO inputs or outputs".to_string(),
+                    ));
+                }
+                AssetBurnBpsUpdatePayloadV1::decode_memo(&tx.memo).map_err(|e| {
+                    TxApplyError::InvalidType(format!(
+                        "AssetBurnBpsUpdate requires canonical memo payload: {e}"
                     ))
                 })?;
             }
@@ -3326,6 +3348,16 @@ impl BlockExecutor {
                 } else {
                     crate::contracts::tokens::constants::SOV_FEE_RATE_BPS
                 };
+                let signer_key_id = tx.signature.public_key.key_id;
+                if let Some(asset) = mutator.get_sovereign_asset(&transfer_data.token_id)? {
+                    require_treasury_spend_signer(
+                        mutator,
+                        &asset,
+                        transfer_data.from,
+                        signer_key_id,
+                    )?;
+                }
+
                 tracing::info!(
                     tx_hash = %hex::encode(&tx.hash().as_bytes()[..8]),
                     token = %hex::encode(&token.0[..8]),
@@ -3336,15 +3368,30 @@ impl BlockExecutor {
                     fee_bps = fee_bps,
                     "[fee-debug] BEFORE apply_token_transfer"
                 );
-                let _fee_collected = tx_apply::apply_token_transfer(
-                    mutator,
-                    &token,
-                    &from,
-                    &to,
-                    amount,
-                    fee_bps,
-                    &fee_destination,
-                )?;
+                let _fee_collected = if let Some(mut asset) =
+                    mutator.get_sovereign_asset(&transfer_data.token_id)?
+                {
+                    apply_sovereign_token_transfer(
+                        mutator,
+                        &mut asset,
+                        &token,
+                        &from,
+                        &to,
+                        amount,
+                        fee_bps,
+                        &fee_destination,
+                    )?
+                } else {
+                    tx_apply::apply_token_transfer(
+                        mutator,
+                        &token,
+                        &from,
+                        &to,
+                        amount,
+                        fee_bps,
+                        &fee_destination,
+                    )?
+                };
                 tracing::info!(
                     tx_hash = %hex::encode(&tx.hash().as_bytes()[..8]),
                     from = %hex::encode(&from.0[..8]),
@@ -3403,13 +3450,24 @@ impl BlockExecutor {
 
                 let to = Address::new(mint_data.to);
                 let amount = mint_data.amount;
+                let signer_key_id = tx.signature.public_key.key_id;
 
-                tx_apply::apply_token_mint(mutator, &token, &to, amount)?;
-                if token == Self::canonical_sov_token_id() {
-                    self.sync_canonical_sov_contract_after_mint(mutator, &to, amount)?;
+                if let Some(mut asset) = mutator.get_sovereign_asset(&mint_data.token_id)? {
+                    if asset.supply_mode == SupplyMode::Fixed {
+                        return Err(TxApplyError::InvalidType(
+                            "fixed-supply sovereign asset rejects post-launch mint".to_string(),
+                        ));
+                    }
+                    require_governance_mint_signer(mutator, &asset, signer_key_id)?;
+                    mint_and_allocate(mutator, &mut asset, mint_data.to, amount)?;
+                    Ok(TxOutcome::TokenMint(TokenMintOutcome { token, to, amount }))
+                } else {
+                    tx_apply::apply_token_mint(mutator, &token, &to, amount)?;
+                    if token == Self::canonical_sov_token_id() {
+                        self.sync_canonical_sov_contract_after_mint(mutator, &to, amount)?;
+                    }
+                    Ok(TxOutcome::TokenMint(TokenMintOutcome { token, to, amount }))
                 }
-
-                Ok(TxOutcome::TokenMint(TokenMintOutcome { token, to, amount }))
             }
             TransactionType::WalletRegistration => {
                 let wallet_data = tx.wallet_data().ok_or_else(|| {
@@ -3591,6 +3649,16 @@ impl BlockExecutor {
                     })?;
                 let signer = tx.signature.public_key.key_id;
                 apply_asset_rewards_policy_update(mutator, signer, &payload, block_height)?;
+                Ok(TxOutcome::LegacySystem)
+            }
+            TransactionType::AssetBurnBpsUpdate => {
+                let payload = AssetBurnBpsUpdatePayloadV1::decode_memo(&tx.memo).map_err(|e| {
+                    TxApplyError::InvalidType(format!(
+                        "AssetBurnBpsUpdate requires canonical memo payload: {e}"
+                    ))
+                })?;
+                let signer = tx.signature.public_key.key_id;
+                apply_asset_burn_bps_update(mutator, signer, &payload, block_height)?;
                 Ok(TxOutcome::LegacySystem)
             }
             TransactionType::AssetAuthorityTransfer => {
@@ -4374,6 +4442,7 @@ mod tests {
             fee_tx_hash: String::new(),
             fee_amount_atoms: fee,
             fee_payer_wallet_id: payer_wallet_id,
+            asset_id: None,
         };
         let mut domain_tx = create_legacy_tx(TransactionType::DomainRegistration);
         domain_tx.memo = payload.encode_memo().unwrap();
@@ -5102,6 +5171,8 @@ mod tests {
             rewards: None,
             governance: None,
             transfer_authority: false,
+            dao_class: crate::contracts::sovereign_asset::DaoClass::Fp,
+            burn_bps: 0,
         };
         let memo = payload.encode_memo().expect("valid asset launch memo");
         let tx = Transaction {
@@ -5127,6 +5198,7 @@ mod tests {
         assert_eq!(asset.asset_id, expected_asset_id);
         assert_eq!(asset.id_source, AssetIdSource::LaunchTx);
         assert_eq!(asset.symbol, "BUBL");
+        assert_eq!(asset.dao_class, crate::contracts::sovereign_asset::DaoClass::Fp);
 
         let creator = Address::new(create_dummy_signature().public_key.key_id);
         let treasury = Address::new([0xAA; 32]);
@@ -5174,6 +5246,8 @@ mod tests {
             }),
             governance: None,
             transfer_authority: false,
+            dao_class: crate::contracts::sovereign_asset::DaoClass::Fp,
+            burn_bps: 0,
         };
         let memo = payload.encode_memo().expect("valid asset launch memo");
         let tx = Transaction {
@@ -5268,6 +5342,8 @@ mod tests {
             }),
             governance: None,
             transfer_authority: false,
+            dao_class: crate::contracts::sovereign_asset::DaoClass::Fp,
+            burn_bps: 0,
         };
         let memo = payload.encode_memo().expect("memo");
         let launch_tx = Transaction {

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -3349,13 +3349,15 @@ impl BlockExecutor {
                     crate::contracts::tokens::constants::SOV_FEE_RATE_BPS
                 };
                 let signer_key_id = tx.signature.public_key.key_id;
-                if let Some(asset) = mutator.get_sovereign_asset(&transfer_data.token_id)? {
-                    require_treasury_spend_signer(
-                        mutator,
-                        &asset,
-                        transfer_data.from,
-                        signer_key_id,
-                    )?;
+                if crate::contracts::sovereign_asset::economic_rules_active(block_height) {
+                    if let Some(asset) = mutator.get_sovereign_asset(&transfer_data.token_id)? {
+                        require_treasury_spend_signer(
+                            mutator,
+                            &asset,
+                            transfer_data.from,
+                            signer_key_id,
+                        )?;
+                    }
                 }
 
                 tracing::info!(
@@ -3368,30 +3370,43 @@ impl BlockExecutor {
                     fee_bps = fee_bps,
                     "[fee-debug] BEFORE apply_token_transfer"
                 );
-                let _fee_collected = if let Some(mut asset) =
-                    mutator.get_sovereign_asset(&transfer_data.token_id)?
-                {
-                    apply_sovereign_token_transfer(
-                        mutator,
-                        &mut asset,
-                        &token,
-                        &from,
-                        &to,
-                        amount,
-                        fee_bps,
-                        &fee_destination,
-                    )?
-                } else {
-                    tx_apply::apply_token_transfer(
-                        mutator,
-                        &token,
-                        &from,
-                        &to,
-                        amount,
-                        fee_bps,
-                        &fee_destination,
-                    )?
-                };
+                let _fee_collected =
+                    if crate::contracts::sovereign_asset::economic_rules_active(block_height) {
+                        if let Some(mut asset) =
+                            mutator.get_sovereign_asset(&transfer_data.token_id)?
+                        {
+                            apply_sovereign_token_transfer(
+                                mutator,
+                                &mut asset,
+                                &token,
+                                &from,
+                                &to,
+                                amount,
+                                fee_bps,
+                                &fee_destination,
+                            )?
+                        } else {
+                            tx_apply::apply_token_transfer(
+                                mutator,
+                                &token,
+                                &from,
+                                &to,
+                                amount,
+                                fee_bps,
+                                &fee_destination,
+                            )?
+                        }
+                    } else {
+                        tx_apply::apply_token_transfer(
+                            mutator,
+                            &token,
+                            &from,
+                            &to,
+                            amount,
+                            fee_bps,
+                            &fee_destination,
+                        )?
+                    };
                 tracing::info!(
                     tx_hash = %hex::encode(&tx.hash().as_bytes()[..8]),
                     from = %hex::encode(&from.0[..8]),
@@ -3453,13 +3468,17 @@ impl BlockExecutor {
                 let signer_key_id = tx.signature.public_key.key_id;
 
                 if let Some(mut asset) = mutator.get_sovereign_asset(&mint_data.token_id)? {
-                    if asset.supply_mode == SupplyMode::Fixed {
-                        return Err(TxApplyError::InvalidType(
-                            "fixed-supply sovereign asset rejects post-launch mint".to_string(),
-                        ));
+                    if crate::contracts::sovereign_asset::economic_rules_active(block_height) {
+                        if asset.supply_mode == SupplyMode::Fixed {
+                            return Err(TxApplyError::InvalidType(
+                                "fixed-supply sovereign asset rejects post-launch mint".to_string(),
+                            ));
+                        }
+                        require_governance_mint_signer(mutator, &asset, signer_key_id)?;
+                        mint_and_allocate(mutator, &mut asset, mint_data.to, amount)?;
+                    } else {
+                        tx_apply::apply_token_mint(mutator, &token, &to, amount)?;
                     }
-                    require_governance_mint_signer(mutator, &asset, signer_key_id)?;
-                    mint_and_allocate(mutator, &mut asset, mint_data.to, amount)?;
                     Ok(TxOutcome::TokenMint(TokenMintOutcome { token, to, amount }))
                 } else {
                     tx_apply::apply_token_mint(mutator, &token, &to, amount)?;

--- a/lib-blockchain/src/execution/mint_and_allocate.rs
+++ b/lib-blockchain/src/execution/mint_and_allocate.rs
@@ -1,0 +1,137 @@
+//! Class-aware supply increases for Sovereign Assets (epic Q1 / Q7).
+
+use crate::contracts::sovereign_asset::{DaoClass, SovereignAsset, SupplyMode};
+use crate::execution::errors::{TxApplyError, TxApplyResult};
+use crate::execution::tx_apply::{apply_token_mint, StateMutator};
+use crate::storage::{Address, TokenId};
+
+/// Split a mint amount into (recipient, treasury) per `dao_class`.
+pub fn split_mint_amount(amount: u128, dao_class: DaoClass) -> (u128, u128) {
+    let bps = dao_class.treasury_bps() as u128;
+    let treasury = amount
+        .checked_mul(bps)
+        .map(|p| p / 10_000u128)
+        .unwrap_or(0);
+    let recipient = amount.saturating_sub(treasury);
+    (recipient, treasury)
+}
+
+/// Mint `amount` atoms, allocate per class, and persist updated `total_supply`.
+pub fn mint_and_allocate(
+    mutator: &StateMutator<'_>,
+    asset: &mut SovereignAsset,
+    recipient_key_id: [u8; 32],
+    amount: u128,
+) -> TxApplyResult<(u128, u128)> {
+    if amount == 0 {
+        return Err(TxApplyError::InvalidType(
+            "mint amount must be greater than 0".to_string(),
+        ));
+    }
+
+    let new_supply = asset.total_supply.checked_add(amount).ok_or_else(|| {
+        TxApplyError::InvalidType("total_supply overflow on mint".to_string())
+    })?;
+    if asset.supply_mode == SupplyMode::Fixed && new_supply > asset.max_supply {
+        return Err(TxApplyError::InvalidType(
+            "fixed supply asset cannot exceed max_supply".to_string(),
+        ));
+    }
+
+    let treasury_key_id = asset.treasury_key_id.ok_or_else(|| {
+        TxApplyError::InvalidType("sovereign asset missing treasury_key_id".to_string())
+    })?;
+
+    let (recipient_alloc, treasury_alloc) = split_mint_amount(amount, asset.dao_class);
+    let token_id = TokenId::new(asset.asset_id);
+
+    if recipient_alloc > 0 {
+        apply_token_mint(
+            mutator,
+            &token_id,
+            &Address::new(recipient_key_id),
+            recipient_alloc,
+        )?;
+    }
+    if treasury_alloc > 0 {
+        apply_token_mint(
+            mutator,
+            &token_id,
+            &Address::new(treasury_key_id),
+            treasury_alloc,
+        )?;
+    }
+
+    asset.total_supply = new_supply;
+    mutator.put_sovereign_asset(asset)?;
+    Ok((recipient_alloc, treasury_alloc))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::sovereign_asset::{
+        AssetAuthority, AssetIdSource, AssetModuleFlags, SupplyMode,
+    };
+
+    #[test]
+    fn fp_split_is_eighty_twenty() {
+        let (r, t) = split_mint_amount(1_000, DaoClass::Fp);
+        assert_eq!(r, 800);
+        assert_eq!(t, 200);
+    }
+
+    #[test]
+    fn np_split_is_all_treasury() {
+        let (r, t) = split_mint_amount(1_000, DaoClass::Np);
+        assert_eq!(r, 0);
+        assert_eq!(t, 1_000);
+    }
+
+    #[test]
+    fn mint_and_allocate_updates_total_supply() {
+        use crate::storage::{BlockchainStore, SledStore};
+        use std::sync::Arc;
+
+        let store: Arc<dyn BlockchainStore> = Arc::new(SledStore::open_temporary().unwrap());
+        store.begin_block(0).unwrap();
+        let mutator = StateMutator::new(store.as_ref());
+
+        let asset_id = [0x01; 32];
+        let mut asset = SovereignAsset {
+            asset_id,
+            id_source: AssetIdSource::LaunchTx,
+            name: "T".into(),
+            symbol: "T".into(),
+            decimals: 8,
+            creator_key_id: [0xCC; 32],
+            creator_did: None,
+            treasury_key_id: Some([0xAA; 32]),
+            launched_at_height: Some(1),
+            supply_mode: SupplyMode::Elastic,
+            dao_class: DaoClass::Fp,
+            burn_bps: 0,
+            pending_burn_bps: None,
+            max_supply: u128::MAX,
+            total_supply: 1_000,
+            manifest_cid: Some([1; 32]),
+            manifest_hash: Some([2; 32]),
+            schema_version: 1,
+            authority: AssetAuthority::Creator {
+                key_id: [0xCC; 32],
+            },
+            module_flags: AssetModuleFlags(0),
+            curve: None,
+            rewards: None,
+            governance: None,
+        };
+        mutator.put_sovereign_asset(&asset).unwrap();
+
+        let (r, t) = mint_and_allocate(&mutator, &mut asset, [0xBB; 32], 500).unwrap();
+        assert_eq!(r, 400);
+        assert_eq!(t, 100);
+        assert_eq!(asset.total_supply, 1_500);
+
+        store.commit_block().unwrap();
+    }
+}

--- a/lib-blockchain/src/execution/mint_and_allocate.rs
+++ b/lib-blockchain/src/execution/mint_and_allocate.rs
@@ -109,9 +109,6 @@ mod tests {
             treasury_key_id: Some([0xAA; 32]),
             launched_at_height: Some(1),
             supply_mode: SupplyMode::Elastic,
-            dao_class: DaoClass::Fp,
-            burn_bps: 0,
-            pending_burn_bps: None,
             max_supply: u128::MAX,
             total_supply: 1_000,
             manifest_cid: Some([1; 32]),
@@ -124,6 +121,9 @@ mod tests {
             curve: None,
             rewards: None,
             governance: None,
+            dao_class: DaoClass::Fp,
+            burn_bps: 0,
+            pending_burn_bps: None,
         };
         mutator.put_sovereign_asset(&asset).unwrap();
 

--- a/lib-blockchain/src/execution/mod.rs
+++ b/lib-blockchain/src/execution/mod.rs
@@ -38,6 +38,7 @@
 
 pub mod errors;
 pub mod executor;
+pub mod mint_and_allocate;
 pub mod reward_claim;
 pub mod sovereign_asset;
 pub mod state_view;

--- a/lib-blockchain/src/execution/reward_claim.rs
+++ b/lib-blockchain/src/execution/reward_claim.rs
@@ -256,15 +256,19 @@ pub fn apply_reward_claim(
         crate::contracts::tokens::constants::SOV_FEE_RATE_BPS
     };
 
-    tx_apply::apply_token_transfer(
-        mutator,
-        &token,
-        &from,
-        &to,
-        data.amount,
-        fee_bps,
-        fee_sink,
-    )?;
+    if let Err(TxApplyError::InsufficientBalance { have, need, .. }) =
+        tx_apply::apply_token_transfer(
+            mutator,
+            &token,
+            &from,
+            &to,
+            data.amount,
+            fee_bps,
+            fee_sink,
+        )
+    {
+        return Err(TxApplyError::InsufficientRewardLiquidity { have, need });
+    }
     mutator.increment_token_nonce(&token, &from)?;
 
     match data.event {

--- a/lib-blockchain/src/execution/reward_claim.rs
+++ b/lib-blockchain/src/execution/reward_claim.rs
@@ -256,7 +256,21 @@ pub fn apply_reward_claim(
         crate::contracts::tokens::constants::SOV_FEE_RATE_BPS
     };
 
-    if let Err(TxApplyError::InsufficientBalance { have, need, .. }) =
+    if crate::contracts::sovereign_asset::economic_rules_active(block_height) {
+        if let Err(TxApplyError::InsufficientBalance { have, need, .. }) =
+            tx_apply::apply_token_transfer(
+                mutator,
+                &token,
+                &from,
+                &to,
+                data.amount,
+                fee_bps,
+                fee_sink,
+            )
+        {
+            return Err(TxApplyError::InsufficientRewardLiquidity { have, need });
+        }
+    } else {
         tx_apply::apply_token_transfer(
             mutator,
             &token,
@@ -265,9 +279,7 @@ pub fn apply_reward_claim(
             data.amount,
             fee_bps,
             fee_sink,
-        )
-    {
-        return Err(TxApplyError::InsufficientRewardLiquidity { have, need });
+        )?;
     }
     mutator.increment_token_nonce(&token, &from)?;
 

--- a/lib-blockchain/src/execution/sovereign_asset.rs
+++ b/lib-blockchain/src/execution/sovereign_asset.rs
@@ -127,9 +127,6 @@ pub fn apply_asset_launch(
         treasury_key_id: Some(payload.treasury_key_id),
         launched_at_height: Some(block_height),
         supply_mode: payload.supply_mode,
-        dao_class: payload.dao_class,
-        burn_bps: payload.burn_bps,
-        pending_burn_bps: None,
         max_supply: payload.initial_supply,
         total_supply: 0,
         manifest_cid: Some(payload.manifest_cid),
@@ -140,6 +137,9 @@ pub fn apply_asset_launch(
         curve: curve_header,
         rewards: rewards_header,
         governance: governance_header,
+        dao_class: payload.dao_class,
+        burn_bps: payload.burn_bps,
+        pending_burn_bps: None,
     };
 
     mutator.put_sovereign_asset(&asset)?;
@@ -819,9 +819,6 @@ mod activate_pending_tests {
             treasury_key_id: Some(key(0xEE)),
             launched_at_height: Some(1),
             supply_mode: SupplyMode::Fixed,
-            dao_class: crate::contracts::sovereign_asset::DaoClass::Fp,
-            burn_bps: 0,
-            pending_burn_bps: None,
             max_supply: 1_000,
             total_supply: 1_000,
             manifest_cid: Some([0x11; 32]),
@@ -836,6 +833,9 @@ mod activate_pending_tests {
                 signers: 1,
                 threshold: 1,
             }),
+            dao_class: crate::contracts::sovereign_asset::DaoClass::Fp,
+            burn_bps: 0,
+            pending_burn_bps: None,
         }
     }
 

--- a/lib-blockchain/src/execution/sovereign_asset.rs
+++ b/lib-blockchain/src/execution/sovereign_asset.rs
@@ -4,18 +4,21 @@ use crate::contracts::sovereign_asset::{
     project_from_token_contract, validate_governance_verifier, AssetAuthority, AssetIdSource,
     AssetModuleFlags, CurveModuleHeader, GovernanceModuleHeader, GovernanceModuleState,
     GovernanceVerifierKind, GovernanceVerifierState, PendingAuthorityTransfer,
-    PendingRewardsPolicyUpdate, RewardsModuleHeader, RewardsModuleState, SovereignAsset,
-    SupplyMode, AUTHORITY_TRANSFER_TIMELOCK_BLOCKS, GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT,
+    PendingBurnBpsUpdate, PendingRewardsPolicyUpdate, RewardsModuleHeader, RewardsModuleState,
+    SovereignAsset, SupplyMode, AUTHORITY_TRANSFER_TIMELOCK_BLOCKS,
+    GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT, MAX_TRANSFER_BURN_BPS,
     REWARDS_POLICY_DECREASE_TIMELOCK_BLOCKS,
 };
-use crate::execution::tx_apply::{apply_token_mint, StateMutator};
+use crate::execution::mint_and_allocate::mint_and_allocate;
+use crate::execution::tx_apply::StateMutator;
 use crate::execution::{TxApplyError, TxApplyResult};
-use crate::storage::{Address, TokenId};
+use crate::storage::{Address, AddressExt, TokenId};
 use crate::transaction::asset_tx::{
     AssetAuthorityProof, AssetAuthorityTransferPayloadV1, AssetLaunchPayloadV1,
     AssetManifestUpdatePayloadV1, AssetModuleUpgradePayloadV1,
-    AssetRewardsDelegateRotatePayloadV1, AssetRewardsPolicyUpdatePayloadV1, AssetUpgradeModule,
-    GovernanceLaunchConfig, RewardsLaunchConfig,
+    AssetBurnBpsUpdatePayloadV1, AssetRewardsDelegateRotatePayloadV1,
+    AssetRewardsPolicyUpdatePayloadV1, AssetUpgradeModule, GovernanceLaunchConfig,
+    RewardsLaunchConfig,
 };
 use crate::types::Hash;
 
@@ -55,6 +58,11 @@ pub fn apply_asset_launch(
     }
 
     let (creator_allocation, treasury_allocation) = payload.split_initial_supply();
+    let creator_recipient = if creator_allocation > 0 {
+        creator_key_id
+    } else {
+        payload.treasury_key_id
+    };
     let mut module_flags = AssetModuleFlags(0);
     let mut curve_header = None;
     let mut rewards_header = None;
@@ -119,8 +127,11 @@ pub fn apply_asset_launch(
         treasury_key_id: Some(payload.treasury_key_id),
         launched_at_height: Some(block_height),
         supply_mode: payload.supply_mode,
+        dao_class: payload.dao_class,
+        burn_bps: payload.burn_bps,
+        pending_burn_bps: None,
         max_supply: payload.initial_supply,
-        total_supply: payload.initial_supply,
+        total_supply: 0,
         manifest_cid: Some(payload.manifest_cid),
         manifest_hash: Some(payload.manifest_hash),
         schema_version: 1,
@@ -134,11 +145,15 @@ pub fn apply_asset_launch(
     mutator.put_sovereign_asset(&asset)?;
     mutator.put_asset_symbol_index(&payload.symbol, &asset_id)?;
 
-    let token_id = TokenId::new(asset_id);
-    let creator_addr = Address::new(creator_key_id);
-    let treasury_addr = Address::new(payload.treasury_key_id);
-    apply_token_mint(mutator, &token_id, &creator_addr, creator_allocation)?;
-    apply_token_mint(mutator, &token_id, &treasury_addr, treasury_allocation)?;
+    let mut live_asset = mutator
+        .get_sovereign_asset(&asset_id)?
+        .expect("asset just written");
+    mint_and_allocate(
+        mutator,
+        &mut live_asset,
+        creator_recipient,
+        payload.initial_supply,
+    )?;
 
     Ok(AssetLaunchOutcome {
         asset_id,
@@ -192,7 +207,7 @@ pub fn apply_asset_module_upgrade(
                 decimals: asset.decimals,
                 initial_supply: asset.total_supply,
                 treasury_key_id: asset.treasury_key_id.unwrap_or([0u8; 32]),
-                treasury_bps: 2_000,
+                treasury_bps: asset.dao_class.treasury_bps(),
                 supply_mode: SupplyMode::Elastic,
                 manifest_cid: asset.manifest_cid.unwrap_or([0u8; 32]),
                 manifest_hash: asset.manifest_hash.unwrap_or([0u8; 32]),
@@ -200,6 +215,8 @@ pub fn apply_asset_module_upgrade(
                 rewards: None,
                 governance: None,
                 transfer_authority: false,
+                dao_class: asset.dao_class,
+                burn_bps: asset.burn_bps,
             };
             if let Some(state) = launch.initial_curve_state() {
                 mutator.put_curve_module_state(&payload.asset_id, &state)?;
@@ -628,6 +645,144 @@ fn verifier_contains(verifier: &GovernanceVerifierState, key_id: [u8; 32]) -> bo
     }
 }
 
+/// Returns true when `signer_key_id` is an on-chain governance verifier for the asset.
+pub fn is_governance_verifier_signer(
+    mutator: &StateMutator<'_>,
+    asset_id: &[u8; 32],
+    signer_key_id: [u8; 32],
+) -> TxApplyResult<bool> {
+    let Some(gov) = mutator.get_governance_module_state(asset_id)? else {
+        return Ok(false);
+    };
+    let Some(verifier) = gov.verifier.as_ref() else {
+        return Ok(false);
+    };
+    Ok(verifier_contains(verifier, signer_key_id))
+}
+
+/// Post-launch elastic mints require a configured governance verifier signer.
+pub fn require_governance_mint_signer(
+    mutator: &StateMutator<'_>,
+    asset: &SovereignAsset,
+    signer_key_id: [u8; 32],
+) -> TxApplyResult<()> {
+    if !is_governance_verifier_signer(mutator, &asset.asset_id, signer_key_id)? {
+        return Err(TxApplyError::Unauthorized(
+            "elastic sovereign mint requires governance verifier signer".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Treasury balance moves require a governance verifier signer (epic Q2).
+pub fn require_treasury_spend_signer(
+    mutator: &StateMutator<'_>,
+    asset: &SovereignAsset,
+    from_key_id: [u8; 32],
+    signer_key_id: [u8; 32],
+) -> TxApplyResult<()> {
+    let Some(treasury_key_id) = asset.treasury_key_id else {
+        return Ok(());
+    };
+    if from_key_id != treasury_key_id {
+        return Ok(());
+    }
+    if !is_governance_verifier_signer(mutator, &asset.asset_id, signer_key_id)? {
+        return Err(TxApplyError::Unauthorized(
+            "treasury spend requires governance verifier authorization".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn apply_asset_burn_bps_update(
+    mutator: &StateMutator<'_>,
+    signer_key_id: [u8; 32],
+    payload: &AssetBurnBpsUpdatePayloadV1,
+    block_height: u64,
+) -> TxApplyResult<()> {
+    let mut asset = mutator
+        .get_sovereign_asset(&payload.asset_id)?
+        .ok_or_else(|| TxApplyError::InvalidType("asset not found".to_string()))?;
+
+    verify_authority_proof(mutator, &asset, signer_key_id, &payload.authority_proof)?;
+
+    asset.pending_burn_bps = Some(PendingBurnBpsUpdate {
+        new_burn_bps: payload.new_burn_bps,
+        effective_height: block_height.saturating_add(AUTHORITY_TRANSFER_TIMELOCK_BLOCKS),
+    });
+    mutator.put_sovereign_asset(&asset)?;
+    Ok(())
+}
+
+/// Activate queued `burn_bps` updates whose timelock has expired (epic Q8).
+pub fn activate_pending_burn_bps(mutator: &StateMutator<'_>, block_height: u64) -> TxApplyResult<()> {
+    if block_height < GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT {
+        return Ok(());
+    }
+
+    for (asset_id, mut asset) in mutator.iter_sovereign_assets()? {
+        let Some(pending) = asset.pending_burn_bps.clone() else {
+            continue;
+        };
+        if pending.effective_height > block_height {
+            continue;
+        }
+        if pending.new_burn_bps > MAX_TRANSFER_BURN_BPS {
+            tracing::warn!(
+                asset_id = %hex::encode(asset_id),
+                burn_bps = pending.new_burn_bps,
+                "pending burn_bps exceeds cap; skipping activation"
+            );
+            asset.pending_burn_bps = None;
+            mutator.put_sovereign_asset(&asset)?;
+            continue;
+        }
+        asset.burn_bps = pending.new_burn_bps;
+        asset.pending_burn_bps = None;
+        mutator.put_sovereign_asset(&asset)?;
+    }
+    Ok(())
+}
+
+/// Apply a sovereign-asset transfer with optional burn (epic Q8).
+pub fn apply_sovereign_token_transfer(
+    mutator: &StateMutator<'_>,
+    asset: &mut SovereignAsset,
+    token: &TokenId,
+    from: &Address,
+    to: &Address,
+    amount: u128,
+    fee_bps: u16,
+    fee_destination: &Address,
+) -> TxApplyResult<u128> {
+    let burn = if asset.burn_bps > 0 {
+        (amount * asset.burn_bps as u128) / 10_000u128
+    } else {
+        0
+    };
+    let after_burn = amount.saturating_sub(burn);
+    let fee_amount = if fee_bps > 0 && *fee_destination != Address::ZERO {
+        (after_burn * fee_bps as u128) / 10_000u128
+    } else {
+        0
+    };
+    let net_to_recipient = after_burn.saturating_sub(fee_amount);
+
+    mutator.debit_token(token, from, amount)?;
+    if net_to_recipient > 0 {
+        mutator.credit_token(token, to, net_to_recipient)?;
+    }
+    if fee_amount > 0 {
+        mutator.credit_token(token, fee_destination, fee_amount)?;
+    }
+    if burn > 0 {
+        asset.total_supply = asset.total_supply.saturating_sub(burn);
+        mutator.put_sovereign_asset(asset)?;
+    }
+    Ok(fee_amount)
+}
+
 #[cfg(test)]
 mod activate_pending_tests {
     use super::*;
@@ -664,6 +819,9 @@ mod activate_pending_tests {
             treasury_key_id: Some(key(0xEE)),
             launched_at_height: Some(1),
             supply_mode: SupplyMode::Fixed,
+            dao_class: crate::contracts::sovereign_asset::DaoClass::Fp,
+            burn_bps: 0,
+            pending_burn_bps: None,
             max_supply: 1_000,
             total_supply: 1_000,
             manifest_cid: Some([0x11; 32]),

--- a/lib-blockchain/src/execution/tx_apply.rs
+++ b/lib-blockchain/src/execution/tx_apply.rs
@@ -335,6 +335,17 @@ impl<'a> StateMutator<'a> {
         Ok(self.store.list_governance_module_asset_ids()?)
     }
 
+    pub fn iter_sovereign_assets(
+        &self,
+    ) -> TxApplyResult<
+        Vec<([u8; 32], crate::contracts::sovereign_asset::SovereignAsset)>,
+    > {
+        Ok(self
+            .store
+            .iter_sovereign_asset_records()?
+            .collect())
+    }
+
     pub fn get_rewards_policy_document(
         &self,
         policy_hash: &[u8; 32],

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1700,14 +1700,20 @@ impl BlockchainStore for SledStore {
             if let Some(ref batch) = *batch_guard {
                 if let Some(staged) = batch.tree_lookup(TREE_ASSETS, key.as_ref()) {
                     return match staged {
-                        Some(bytes) => Ok(Some(Self::deserialize(&bytes)?)),
+                        Some(bytes) => Ok(Some(
+                            crate::contracts::sovereign_asset::deserialize_sovereign_asset(&bytes)
+                                .map_err(|e| StorageError::Serialization(e))?,
+                        )),
                         None => Ok(None),
                     };
                 }
             }
         }
         match self.assets.get(key) {
-            Ok(Some(bytes)) => Ok(Some(Self::deserialize(&bytes)?)),
+            Ok(Some(bytes)) => Ok(Some(
+                crate::contracts::sovereign_asset::deserialize_sovereign_asset(&bytes)
+                    .map_err(|e| StorageError::Serialization(e))?,
+            )),
             Ok(None) => Ok(None),
             Err(e) => Err(StorageError::Database(e.to_string())),
         }
@@ -1727,7 +1733,8 @@ impl BlockchainStore for SledStore {
                         Err(_) => continue,
                     };
                     let asset: crate::contracts::sovereign_asset::SovereignAsset =
-                        Self::deserialize(&value)?;
+                        crate::contracts::sovereign_asset::deserialize_sovereign_asset(&value)
+                            .map_err(|e| StorageError::Serialization(e))?;
                     results.push((asset_id, asset));
                 }
                 Err(e) => return Err(StorageError::Database(e.to_string())),

--- a/lib-blockchain/src/sync/mod.rs
+++ b/lib-blockchain/src/sync/mod.rs
@@ -645,6 +645,7 @@ mod tests {
             fee_tx_hash: String::new(),
             fee_amount_atoms: fee,
             fee_payer_wallet_id: payer,
+            asset_id: None,
         };
         let mut domain_tx = create_test_tx(TransactionType::DomainRegistration);
         domain_tx.memo = payload.encode_memo().unwrap();

--- a/lib-blockchain/src/transaction/asset_tx.rs
+++ b/lib-blockchain/src/transaction/asset_tx.rs
@@ -11,6 +11,7 @@ use crate::contracts::sovereign_asset::{
 };
 
 pub const ASSET_LAUNCH_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_LAUNCH_V1:";
+pub const ASSET_LAUNCH_MEMO_PREFIX_V2: &[u8] = b"ZHTP_ASSET_LAUNCH_V2:";
 pub const ASSET_MODULE_UPGRADE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_UPGRADE_V1:";
 pub const ASSET_MANIFEST_UPDATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_MANIFEST_V1:";
 pub const ASSET_AUTHORITY_TRANSFER_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_AUTH_XFER_V1:";
@@ -90,6 +91,55 @@ impl GovernanceLaunchConfig {
     }
 }
 
+/// Legacy V1 wire layout — kept verbatim for historical chain replay.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AssetLaunchPayloadV1Wire {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub initial_supply: u128,
+    pub treasury_key_id: [u8; 32],
+    #[serde(default = "default_asset_launch_treasury_bps")]
+    pub treasury_bps: u16,
+    pub supply_mode: SupplyMode,
+    pub manifest_cid: [u8; 32],
+    pub manifest_hash: [u8; 32],
+    #[serde(default)]
+    pub curve: Option<CurveLaunchConfig>,
+    #[serde(default)]
+    pub rewards: Option<RewardsLaunchConfig>,
+    #[serde(default)]
+    pub governance: Option<GovernanceLaunchConfig>,
+    #[serde(default)]
+    pub transfer_authority: bool,
+}
+
+/// V2 wire layout — V1 fields + economic class and burn (epic Q1/Q7/Q8).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AssetLaunchPayloadV2Wire {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub initial_supply: u128,
+    pub treasury_key_id: [u8; 32],
+    #[serde(default = "default_asset_launch_treasury_bps")]
+    pub treasury_bps: u16,
+    pub supply_mode: SupplyMode,
+    pub manifest_cid: [u8; 32],
+    pub manifest_hash: [u8; 32],
+    #[serde(default)]
+    pub curve: Option<CurveLaunchConfig>,
+    #[serde(default)]
+    pub rewards: Option<RewardsLaunchConfig>,
+    #[serde(default)]
+    pub governance: Option<GovernanceLaunchConfig>,
+    #[serde(default)]
+    pub transfer_authority: bool,
+    pub dao_class: DaoClass,
+    pub burn_bps: u16,
+}
+
+/// Canonical launch payload (executor + API). New txes emit V2 wire format.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AssetLaunchPayloadV1 {
     pub name: String,
@@ -110,12 +160,68 @@ pub struct AssetLaunchPayloadV1 {
     pub governance: Option<GovernanceLaunchConfig>,
     #[serde(default)]
     pub transfer_authority: bool,
-    /// Economic class (FP 80/20, NP 100% treasury). Defaults to FP for legacy memos.
-    #[serde(default)]
     pub dao_class: DaoClass,
-    /// Optional per-transfer burn at launch (0..=1000 bps). Default 0.
-    #[serde(default)]
     pub burn_bps: u16,
+}
+
+fn wire_v1_to_payload(v1: AssetLaunchPayloadV1Wire) -> AssetLaunchPayloadV1 {
+    AssetLaunchPayloadV1 {
+        name: v1.name,
+        symbol: v1.symbol,
+        decimals: v1.decimals,
+        initial_supply: v1.initial_supply,
+        treasury_key_id: v1.treasury_key_id,
+        treasury_bps: v1.treasury_bps,
+        supply_mode: v1.supply_mode,
+        manifest_cid: v1.manifest_cid,
+        manifest_hash: v1.manifest_hash,
+        curve: v1.curve,
+        rewards: v1.rewards,
+        governance: v1.governance,
+        transfer_authority: v1.transfer_authority,
+        dao_class: DaoClass::Fp,
+        burn_bps: 0,
+    }
+}
+
+fn payload_to_wire_v2(payload: &AssetLaunchPayloadV1) -> AssetLaunchPayloadV2Wire {
+    AssetLaunchPayloadV2Wire {
+        name: payload.name.clone(),
+        symbol: payload.symbol.clone(),
+        decimals: payload.decimals,
+        initial_supply: payload.initial_supply,
+        treasury_key_id: payload.treasury_key_id,
+        treasury_bps: payload.treasury_bps,
+        supply_mode: payload.supply_mode,
+        manifest_cid: payload.manifest_cid,
+        manifest_hash: payload.manifest_hash,
+        curve: payload.curve.clone(),
+        rewards: payload.rewards.clone(),
+        governance: payload.governance.clone(),
+        transfer_authority: payload.transfer_authority,
+        dao_class: payload.dao_class,
+        burn_bps: payload.burn_bps,
+    }
+}
+
+fn wire_v2_to_payload(v2: AssetLaunchPayloadV2Wire) -> AssetLaunchPayloadV1 {
+    AssetLaunchPayloadV1 {
+        name: v2.name,
+        symbol: v2.symbol,
+        decimals: v2.decimals,
+        initial_supply: v2.initial_supply,
+        treasury_key_id: v2.treasury_key_id,
+        treasury_bps: v2.treasury_bps,
+        supply_mode: v2.supply_mode,
+        manifest_cid: v2.manifest_cid,
+        manifest_hash: v2.manifest_hash,
+        curve: v2.curve,
+        rewards: v2.rewards,
+        governance: v2.governance,
+        transfer_authority: v2.transfer_authority,
+        dao_class: v2.dao_class,
+        burn_bps: v2.burn_bps,
+    }
 }
 
 fn default_asset_launch_treasury_bps() -> u16 {
@@ -209,11 +315,12 @@ impl AssetLaunchPayloadV1 {
 
     pub fn encode_memo(&self) -> Result<Vec<u8>, String> {
         self.validate()?;
+        let wire = payload_to_wire_v2(self);
         let encoded = bincode::DefaultOptions::new()
             .with_limit(MAX_ASSET_MEMO_BYTES as u64)
-            .serialize(self)
+            .serialize(&wire)
             .map_err(|e| format!("serialize asset launch: {e}"))?;
-        let mut memo = ASSET_LAUNCH_MEMO_PREFIX.to_vec();
+        let mut memo = ASSET_LAUNCH_MEMO_PREFIX_V2.to_vec();
         memo.extend_from_slice(&encoded);
         if memo.len() > MAX_ASSET_MEMO_BYTES {
             return Err("asset launch memo too large".to_string());
@@ -222,13 +329,21 @@ impl AssetLaunchPayloadV1 {
     }
 
     pub fn decode_memo(memo: &[u8]) -> Result<Self, String> {
-        if !memo.starts_with(ASSET_LAUNCH_MEMO_PREFIX) {
-            return Err("missing asset launch memo prefix".to_string());
-        }
-        let payload: Self = bincode::DefaultOptions::new()
-            .with_limit(MAX_ASSET_MEMO_BYTES as u64)
-            .deserialize(&memo[ASSET_LAUNCH_MEMO_PREFIX.len()..])
-            .map_err(|e| format!("invalid asset launch payload: {e}"))?;
+        let payload = if let Some(v2_bytes) = memo.strip_prefix(ASSET_LAUNCH_MEMO_PREFIX_V2) {
+            let v2: AssetLaunchPayloadV2Wire = bincode::DefaultOptions::new()
+                .with_limit(MAX_ASSET_MEMO_BYTES as u64)
+                .deserialize(v2_bytes)
+                .map_err(|e| format!("invalid asset launch V2 payload: {e}"))?;
+            wire_v2_to_payload(v2)
+        } else if let Some(v1_bytes) = memo.strip_prefix(ASSET_LAUNCH_MEMO_PREFIX) {
+            let v1: AssetLaunchPayloadV1Wire = bincode::DefaultOptions::new()
+                .with_limit(MAX_ASSET_MEMO_BYTES as u64)
+                .deserialize(v1_bytes)
+                .map_err(|e| format!("invalid asset launch V1 payload: {e}"))?;
+            wire_v1_to_payload(v1)
+        } else {
+            return Err("missing asset launch memo prefix (V1 or V2)".to_string());
+        };
         payload.validate()?;
         Ok(payload)
     }
@@ -531,5 +646,42 @@ mod tests {
         let mut long = sample_launch();
         long.symbol = "TOOLONG".to_string();
         assert!(long.validate_dao_launch_ui_constraints().is_err());
+    }
+
+    #[test]
+    fn legacy_v1_launch_memo_decodes_with_fp_defaults() {
+        let v1 = AssetLaunchPayloadV1Wire {
+            name: "Legacy".to_string(),
+            symbol: "LEG".to_string(),
+            decimals: 8,
+            initial_supply: 1_000,
+            treasury_key_id: [0xAA; 32],
+            treasury_bps: ASSET_LAUNCH_TREASURY_BPS,
+            supply_mode: SupplyMode::Fixed,
+            manifest_cid: [0x11; 32],
+            manifest_hash: [0x22; 32],
+            curve: None,
+            rewards: None,
+            governance: None,
+            transfer_authority: false,
+        };
+        let encoded = bincode::DefaultOptions::new()
+            .serialize(&v1)
+            .expect("legacy wire serialize");
+        let mut memo = ASSET_LAUNCH_MEMO_PREFIX.to_vec();
+        memo.extend_from_slice(&encoded);
+        let decoded = AssetLaunchPayloadV1::decode_memo(&memo).expect("legacy decode");
+        assert_eq!(decoded.dao_class, DaoClass::Fp);
+        assert_eq!(decoded.burn_bps, 0);
+        assert_eq!(decoded.name, "Legacy");
+    }
+
+    #[test]
+    fn v2_launch_memo_round_trip() {
+        let payload = sample_launch();
+        let memo = payload.encode_memo().expect("encode");
+        assert!(memo.starts_with(ASSET_LAUNCH_MEMO_PREFIX_V2));
+        let decoded = AssetLaunchPayloadV1::decode_memo(&memo).expect("decode");
+        assert_eq!(decoded, payload);
     }
 }

--- a/lib-blockchain/src/transaction/asset_tx.rs
+++ b/lib-blockchain/src/transaction/asset_tx.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 use crate::contracts::approval_verifier::ApprovalProof;
 use crate::contracts::sovereign_asset::{
     default_governance_threshold, validate_governance_verifier, CurveModuleState, CurvePhase,
-    GovernanceVerifierState, SupplyMode,
+    DaoClass, GovernanceVerifierState, MAX_TRANSFER_BURN_BPS, SupplyMode, FP_TREASURY_BPS,
+    NP_TREASURY_BPS,
 };
 
 pub const ASSET_LAUNCH_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_LAUNCH_V1:";
@@ -15,6 +16,7 @@ pub const ASSET_MANIFEST_UPDATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_MANIFEST_V1:";
 pub const ASSET_AUTHORITY_TRANSFER_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_AUTH_XFER_V1:";
 pub const ASSET_REWARDS_DELEGATE_ROTATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_REWARDS_ROT_V1:";
 pub const ASSET_REWARDS_POLICY_UPDATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_REWARDS_POL_V1:";
+pub const ASSET_BURN_BPS_UPDATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_BURN_BPS_V1:";
 
 pub const MAX_ASSET_MEMO_BYTES: usize = 8192;
 pub const MAX_ASSET_NAME_BYTES: usize = 64;
@@ -108,6 +110,12 @@ pub struct AssetLaunchPayloadV1 {
     pub governance: Option<GovernanceLaunchConfig>,
     #[serde(default)]
     pub transfer_authority: bool,
+    /// Economic class (FP 80/20, NP 100% treasury). Defaults to FP for legacy memos.
+    #[serde(default)]
+    pub dao_class: DaoClass,
+    /// Optional per-transfer burn at launch (0..=1000 bps). Default 0.
+    #[serde(default)]
+    pub burn_bps: u16,
 }
 
 fn default_asset_launch_treasury_bps() -> u16 {
@@ -125,8 +133,19 @@ impl AssetLaunchPayloadV1 {
         if self.initial_supply == 0 {
             return Err("initial_supply must be > 0".to_string());
         }
-        if self.treasury_bps != ASSET_LAUNCH_TREASURY_BPS {
-            return Err(format!("treasury_bps must be {}", ASSET_LAUNCH_TREASURY_BPS));
+        let expected_bps = self.dao_class.treasury_bps();
+        if self.treasury_bps != expected_bps {
+            return Err(format!(
+                "treasury_bps must be {} for dao_class {}",
+                expected_bps,
+                self.dao_class.as_str()
+            ));
+        }
+        if self.burn_bps > MAX_TRANSFER_BURN_BPS {
+            return Err(format!(
+                "burn_bps must be <= {}",
+                MAX_TRANSFER_BURN_BPS
+            ));
         }
         if self.treasury_key_id == [0u8; 32] {
             return Err("treasury_key_id must be non-zero".to_string());
@@ -185,14 +204,7 @@ impl AssetLaunchPayloadV1 {
     }
 
     pub fn split_initial_supply(&self) -> (u128, u128) {
-        let bps = self.treasury_bps as u128;
-        let treasury = self
-            .initial_supply
-            .checked_mul(bps)
-            .map(|p| p / 10_000u128)
-            .unwrap_or(0);
-        let creator = self.initial_supply.saturating_sub(treasury);
-        (creator, treasury)
+        crate::execution::mint_and_allocate::split_mint_amount(self.initial_supply, self.dao_class)
     }
 
     pub fn encode_memo(&self) -> Result<Vec<u8>, String> {
@@ -404,6 +416,48 @@ pub struct AssetRewardsPolicyUpdatePayloadV1 {
     pub authority_proof: AssetAuthorityProof,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AssetBurnBpsUpdatePayloadV1 {
+    pub asset_id: [u8; 32],
+    pub new_burn_bps: u16,
+    pub authority_proof: AssetAuthorityProof,
+}
+
+impl AssetBurnBpsUpdatePayloadV1 {
+    pub fn encode_memo(&self) -> Result<Vec<u8>, String> {
+        if self.new_burn_bps > MAX_TRANSFER_BURN_BPS {
+            return Err(format!(
+                "new_burn_bps must be <= {}",
+                MAX_TRANSFER_BURN_BPS
+            ));
+        }
+        let encoded = bincode::DefaultOptions::new()
+            .with_limit(MAX_ASSET_MEMO_BYTES as u64)
+            .serialize(self)
+            .map_err(|e| format!("serialize burn bps update: {e}"))?;
+        let mut memo = ASSET_BURN_BPS_UPDATE_MEMO_PREFIX.to_vec();
+        memo.extend_from_slice(&encoded);
+        Ok(memo)
+    }
+
+    pub fn decode_memo(memo: &[u8]) -> Result<Self, String> {
+        if !memo.starts_with(ASSET_BURN_BPS_UPDATE_MEMO_PREFIX) {
+            return Err("missing burn bps update memo prefix".to_string());
+        }
+        let payload: Self = bincode::DefaultOptions::new()
+            .with_limit(MAX_ASSET_MEMO_BYTES as u64)
+            .deserialize(&memo[ASSET_BURN_BPS_UPDATE_MEMO_PREFIX.len()..])
+            .map_err(|e| format!("invalid burn bps update payload: {e}"))?;
+        if payload.new_burn_bps > MAX_TRANSFER_BURN_BPS {
+            return Err(format!(
+                "new_burn_bps must be <= {}",
+                MAX_TRANSFER_BURN_BPS
+            ));
+        }
+        Ok(payload)
+    }
+}
+
 impl AssetRewardsPolicyUpdatePayloadV1 {
     pub fn encode_memo(&self) -> Result<Vec<u8>, String> {
         self.policy.validate()?;
@@ -448,7 +502,27 @@ mod tests {
             rewards: None,
             governance: None,
             transfer_authority: false,
+            dao_class: DaoClass::Fp,
+            burn_bps: 0,
         }
+    }
+
+    #[test]
+    fn np_launch_split_is_all_treasury() {
+        let mut np = sample_launch();
+        np.dao_class = DaoClass::Np;
+        np.treasury_bps = NP_TREASURY_BPS;
+        let (creator, treasury) = np.split_initial_supply();
+        assert_eq!(creator, 0);
+        assert_eq!(treasury, np.initial_supply);
+    }
+
+    #[test]
+    fn fp_launch_rejects_wrong_treasury_bps() {
+        let mut bad = sample_launch();
+        bad.dao_class = DaoClass::Np;
+        bad.treasury_bps = FP_TREASURY_BPS;
+        assert!(bad.validate().is_err());
     }
 
     #[test]

--- a/lib-blockchain/src/transaction/creation.rs
+++ b/lib-blockchain/src/transaction/creation.rs
@@ -763,6 +763,7 @@ pub mod utils {
             | TransactionType::AssetAuthorityTransfer
             | TransactionType::AssetRewardsDelegateRotate
             | TransactionType::AssetRewardsPolicyUpdate
+            | TransactionType::AssetBurnBpsUpdate
             | TransactionType::TokenSwap
             | TransactionType::CreatePool
             | TransactionType::AddLiquidity

--- a/lib-blockchain/src/transaction/domain.rs
+++ b/lib-blockchain/src/transaction/domain.rs
@@ -21,6 +21,8 @@ use serde::{Deserialize, Serialize};
 
 pub const DOMAIN_REGISTRATION_PREFIX: &[u8] = b"DOMREG1:";
 pub const DOMAIN_REGISTRATION_PREFIX_V2: &[u8] = b"DOMREG2:";
+/// DAO launch domain binding (epic Q10) — V2 + optional `asset_id`.
+pub const DOMAIN_REGISTRATION_PREFIX_V3: &[u8] = b"DOMREG3:";
 pub const DOMAIN_UPDATE_PREFIX: &[u8] = b"DOMUPD1:";
 
 /// Canonical on-chain domain record — stored in `Blockchain::domain_registry`.
@@ -52,6 +54,9 @@ pub struct OnChainDomainRecord {
     pub updated_at: u64,
     /// Hash of the SOV fee payment transaction
     pub fee_tx_hash: String,
+    /// Sovereign asset this domain is bound to (DAO launch Q10).
+    #[serde(default)]
+    pub asset_id: Option<[u8; 32]>,
 }
 
 /// Public payload type used by handlers, validators, and the block executor.
@@ -75,6 +80,8 @@ pub struct DomainRegistrationPayload {
     /// Wallet that pays the fee. Zeroed `[0; 32]` for V1. For V2, must be
     /// the signer's Primary wallet — validation enforces this.
     pub fee_payer_wallet_id: [u8; 32],
+    /// Optional sovereign `asset_id` for DAO-scoped domains (Q10).
+    pub asset_id: Option<[u8; 32]>,
 }
 
 /// Legacy (V1) wire layout — kept verbatim so historical chain replay
@@ -110,6 +117,25 @@ struct DomainRegistrationPayloadV2 {
     pub fee_payer_wallet_id: [u8; 32],
 }
 
+/// V3 wire layout — V2 + optional DAO `asset_id` binding.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DomainRegistrationPayloadV3 {
+    pub domain: String,
+    pub owner_did: String,
+    pub manifest_cid: String,
+    pub build_hash: String,
+    pub title: String,
+    pub description: String,
+    pub category: String,
+    pub tags: Vec<String>,
+    pub duration_days: u64,
+    pub fee_tx_hash: String,
+    pub fee_amount_atoms: u128,
+    pub fee_payer_wallet_id: [u8; 32],
+    #[serde(default)]
+    pub asset_id: Option<[u8; 32]>,
+}
+
 /// Payload embedded in a `DomainUpdate` transaction memo.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DomainUpdatePayload {
@@ -123,8 +149,32 @@ pub struct DomainUpdatePayload {
 }
 
 impl DomainRegistrationPayload {
-    /// Always emits V2 — the canonical fee-bearing wire format.
+    /// Emits V3 when `asset_id` is set; otherwise V2 (canonical fee-bearing format).
     pub fn encode_memo(&self) -> Result<Vec<u8>> {
+        if self.asset_id.is_some() {
+            let v3 = DomainRegistrationPayloadV3 {
+                domain: self.domain.clone(),
+                owner_did: self.owner_did.clone(),
+                manifest_cid: self.manifest_cid.clone(),
+                build_hash: self.build_hash.clone(),
+                title: self.title.clone(),
+                description: self.description.clone(),
+                category: self.category.clone(),
+                tags: self.tags.clone(),
+                duration_days: self.duration_days,
+                fee_tx_hash: self.fee_tx_hash.clone(),
+                fee_amount_atoms: self.fee_amount_atoms,
+                fee_payer_wallet_id: self.fee_payer_wallet_id,
+                asset_id: self.asset_id,
+            };
+            let payload = bincode::serialize(&v3)
+                .map_err(|e| anyhow!("Failed to encode DomainRegistrationPayloadV3: {}", e))?;
+            let mut memo =
+                Vec::with_capacity(DOMAIN_REGISTRATION_PREFIX_V3.len() + payload.len());
+            memo.extend_from_slice(DOMAIN_REGISTRATION_PREFIX_V3);
+            memo.extend_from_slice(&payload);
+            return Ok(memo);
+        }
         let v2 = DomainRegistrationPayloadV2 {
             domain: self.domain.clone(),
             owner_did: self.owner_did.clone(),
@@ -153,6 +203,25 @@ impl DomainRegistrationPayload {
     /// `fee_payer_wallet_id = [0; 32]` — `process_domain_transactions`
     /// treats that as "legacy, no on-chain fee".
     pub fn decode_memo(memo: &[u8]) -> Result<Self> {
+        if let Some(v3_bytes) = memo.strip_prefix(DOMAIN_REGISTRATION_PREFIX_V3) {
+            let v3: DomainRegistrationPayloadV3 = bincode::deserialize(v3_bytes)
+                .map_err(|e| anyhow!("Failed to decode DomainRegistrationPayloadV3: {}", e))?;
+            return Ok(Self {
+                domain: v3.domain,
+                owner_did: v3.owner_did,
+                manifest_cid: v3.manifest_cid,
+                build_hash: v3.build_hash,
+                title: v3.title,
+                description: v3.description,
+                category: v3.category,
+                tags: v3.tags,
+                duration_days: v3.duration_days,
+                fee_tx_hash: v3.fee_tx_hash,
+                fee_amount_atoms: v3.fee_amount_atoms,
+                fee_payer_wallet_id: v3.fee_payer_wallet_id,
+                asset_id: v3.asset_id,
+            });
+        }
         if let Some(v2_bytes) = memo.strip_prefix(DOMAIN_REGISTRATION_PREFIX_V2) {
             let v2: DomainRegistrationPayloadV2 = bincode::deserialize(v2_bytes)
                 .map_err(|e| anyhow!("Failed to decode DomainRegistrationPayloadV2: {}", e))?;
@@ -169,6 +238,7 @@ impl DomainRegistrationPayload {
                 fee_tx_hash: v2.fee_tx_hash,
                 fee_amount_atoms: v2.fee_amount_atoms,
                 fee_payer_wallet_id: v2.fee_payer_wallet_id,
+                asset_id: None,
             });
         }
         if let Some(v1_bytes) = memo.strip_prefix(DOMAIN_REGISTRATION_PREFIX) {
@@ -187,9 +257,10 @@ impl DomainRegistrationPayload {
                 fee_tx_hash: v1.fee_tx_hash,
                 fee_amount_atoms: 0,
                 fee_payer_wallet_id: [0u8; 32],
+                asset_id: None,
             });
         }
-        Err(anyhow!("Missing DOMREG1: or DOMREG2: prefix in memo"))
+        Err(anyhow!("Missing DOMREG1:, DOMREG2:, or DOMREG3: prefix in memo"))
     }
 }
 
@@ -260,6 +331,7 @@ mod tests {
             fee_tx_hash: String::new(),
             fee_amount_atoms: 10 * lib_types::TOKEN_SCALE_18,
             fee_payer_wallet_id: [0xab; 32],
+            asset_id: None,
         };
         let memo = original.encode_memo().expect("V2 encode");
         assert!(memo.starts_with(DOMAIN_REGISTRATION_PREFIX_V2));
@@ -284,6 +356,7 @@ mod tests {
             fee_tx_hash: String::new(),
             fee_amount_atoms: 1,
             fee_payer_wallet_id: [1u8; 32],
+            asset_id: None,
         };
         let memo = p.encode_memo().unwrap();
         assert!(memo.starts_with(DOMAIN_REGISTRATION_PREFIX_V2));
@@ -318,6 +391,7 @@ mod tests {
             fee_tx_hash: "ab".repeat(32),
             fee_amount_atoms: 0,
             fee_payer_wallet_id: [0u8; 32],
+            asset_id: None,
         };
         let domain_tx = Transaction {
             version: 2,
@@ -396,6 +470,7 @@ mod tests {
             fee_tx_hash: fee_hash,
             fee_amount_atoms: 0,
             fee_payer_wallet_id: [0u8; 32],
+            asset_id: None,
         };
         let domain_tx = Transaction {
             version: 2,
@@ -462,6 +537,7 @@ mod tests {
             fee_tx_hash: fee_hash,
             fee_amount_atoms: 0,
             fee_payer_wallet_id: [0u8; 32],
+            asset_id: None,
         };
         let domain_tx = Transaction {
             version: 2,

--- a/lib-blockchain/src/transaction/fee.rs
+++ b/lib-blockchain/src/transaction/fee.rs
@@ -6,12 +6,9 @@ pub const DEFAULT_TX_WITNESS_CAP: u32 = 500;
 pub const DEFAULT_TOKEN_CREATION_FEE: u64 = 1_000;
 
 /// Default DomainRegistration fee, in atomic SOV units (10^18 per whole SOV).
-/// Default value = 10 whole SOV = `10 * 10^18` atoms. The value exceeds
-/// `u64::MAX` at the 19th whole-SOV boundary, so this field is `u128`
-/// rather than `u64` like `token_creation_fee` — `token_creation_fee`
-/// stores a much smaller atom count that fits comfortably in u64.
+/// DAO launch v1 standard (epic Q10) = 100 whole SOV.
 pub const DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS: u128 =
-    10 * lib_types::TOKEN_SCALE_18;
+    100 * lib_types::TOKEN_SCALE_18;
 
 /// Non-refundable SOV burn applied at observer-admission registration time
 /// (observer-admission-3). Provides a small economic barrier against Sybil

--- a/lib-blockchain/src/transaction/system_tx_signature.rs
+++ b/lib-blockchain/src/transaction/system_tx_signature.rs
@@ -49,6 +49,7 @@ pub fn system_tx_signature_policy(ty: TransactionType) -> SystemTxSignaturePolic
         | TransactionType::AssetAuthorityTransfer
         | TransactionType::AssetRewardsDelegateRotate
         | TransactionType::AssetRewardsPolicyUpdate
+        | TransactionType::AssetBurnBpsUpdate
         | TransactionType::TokenSwap
         | TransactionType::CreatePool
         | TransactionType::AddLiquidity

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -12,7 +12,8 @@ use crate::transaction::mint_authorization::validate_token_mint_authorization;
 use crate::transaction::system_tx_signature::requires_system_tx_signature;
 use crate::transaction::asset_tx::{
     AssetLaunchPayloadV1, AssetManifestUpdatePayloadV1, AssetModuleUpgradePayloadV1,
-    AssetRewardsDelegateRotatePayloadV1, AssetRewardsPolicyUpdatePayloadV1,
+    AssetBurnBpsUpdatePayloadV1, AssetRewardsDelegateRotatePayloadV1,
+    AssetRewardsPolicyUpdatePayloadV1,
 };
 use crate::transaction::token_creation::TokenCreationPayloadV1;
 use crate::transaction::{
@@ -313,6 +314,7 @@ impl TransactionValidator {
                 | TransactionType::AssetAuthorityTransfer
                 | TransactionType::AssetRewardsDelegateRotate
                 | TransactionType::AssetRewardsPolicyUpdate
+                | TransactionType::AssetBurnBpsUpdate
                 | TransactionType::RegisterObserver
                 | TransactionType::UpdateObserverMetadata
                 | TransactionType::SuspendObserver
@@ -489,6 +491,13 @@ impl TransactionValidator {
                     return Err(ValidationError::InvalidInputs);
                 }
                 AssetRewardsPolicyUpdatePayloadV1::decode_memo(&transaction.memo)
+                    .map_err(|_| ValidationError::InvalidMemo)?;
+            }
+            TransactionType::AssetBurnBpsUpdate => {
+                if !transaction.inputs.is_empty() || !transaction.outputs.is_empty() {
+                    return Err(ValidationError::InvalidInputs);
+                }
+                AssetBurnBpsUpdatePayloadV1::decode_memo(&transaction.memo)
                     .map_err(|_| ValidationError::InvalidMemo)?;
             }
             TransactionType::AssetAuthorityTransfer => {
@@ -857,7 +866,8 @@ impl TransactionValidator {
             | TransactionType::AssetManifestUpdate
             | TransactionType::AssetAuthorityTransfer
             | TransactionType::AssetRewardsDelegateRotate
-            | TransactionType::AssetRewardsPolicyUpdate => {
+            | TransactionType::AssetRewardsPolicyUpdate
+            | TransactionType::AssetBurnBpsUpdate => {
                 if !transaction.inputs.is_empty() || !transaction.outputs.is_empty() {
                     return Err(ValidationError::InvalidInputs);
                 }
@@ -1839,6 +1849,7 @@ impl<'a> StatefulTransactionValidator<'a> {
                 | TransactionType::AssetAuthorityTransfer
                 | TransactionType::AssetRewardsDelegateRotate
                 | TransactionType::AssetRewardsPolicyUpdate
+                | TransactionType::AssetBurnBpsUpdate
                 | TransactionType::RegisterObserver
                 | TransactionType::UpdateObserverMetadata
                 | TransactionType::SuspendObserver
@@ -2422,6 +2433,7 @@ impl<'a> StatefulTransactionValidator<'a> {
             | TransactionType::AssetAuthorityTransfer
             | TransactionType::AssetRewardsDelegateRotate
             | TransactionType::AssetRewardsPolicyUpdate
+            | TransactionType::AssetBurnBpsUpdate
             | TransactionType::RewardClaim => {}
         }
 
@@ -3560,6 +3572,7 @@ pub mod utils {
             | TransactionType::AssetAuthorityTransfer
             | TransactionType::AssetRewardsDelegateRotate
             | TransactionType::AssetRewardsPolicyUpdate
+            | TransactionType::AssetBurnBpsUpdate
             | TransactionType::BondingCurveDeploy
             | TransactionType::BondingCurveBuy
             | TransactionType::BondingCurveSell

--- a/lib-blockchain/src/types/transaction_type.rs
+++ b/lib-blockchain/src/types/transaction_type.rs
@@ -241,6 +241,8 @@ pub enum TransactionType {
     AssetRewardsDelegateRotate = 66,
     /// Update the DHT-pinned rewards policy (CID + hash) for an asset.
     AssetRewardsPolicyUpdate = 68,
+    /// Queue a timelocked per-transfer burn rate change for a Sovereign Asset.
+    AssetBurnBpsUpdate = 69,
     /// BUBL reward claim — chain-enforced eligibility + treasury token transfer.
     ///
     /// Signed by the BUBL `TokenCreation` creator (or authorized delegate).
@@ -451,6 +453,9 @@ impl TransactionType {
             TransactionType::AssetRewardsPolicyUpdate => {
                 "Update Sovereign Asset rewards policy"
             }
+            TransactionType::AssetBurnBpsUpdate => {
+                "Update Sovereign Asset per-transfer burn rate"
+            }
             TransactionType::RewardClaim => "BUBL reward claim (chain-enforced eligibility)",
         }
     }
@@ -526,6 +531,7 @@ impl TransactionType {
             TransactionType::AssetAuthorityTransfer => "asset_authority_transfer",
             TransactionType::AssetRewardsDelegateRotate => "asset_rewards_delegate_rotate",
             TransactionType::AssetRewardsPolicyUpdate => "asset_rewards_policy_update",
+            TransactionType::AssetBurnBpsUpdate => "asset_burn_bps_update",
             TransactionType::RewardClaim => "reward_claim",
         }
     }
@@ -601,6 +607,7 @@ impl TransactionType {
             "asset_authority_transfer" => Some(TransactionType::AssetAuthorityTransfer),
             "asset_rewards_delegate_rotate" => Some(TransactionType::AssetRewardsDelegateRotate),
             "asset_rewards_policy_update" => Some(TransactionType::AssetRewardsPolicyUpdate),
+            "asset_burn_bps_update" => Some(TransactionType::AssetBurnBpsUpdate),
             "reward_claim" => Some(TransactionType::RewardClaim),
             _ => None,
         }

--- a/lib-blockchain/src/validation/tx_validate.rs
+++ b/lib-blockchain/src/validation/tx_validate.rs
@@ -61,6 +61,7 @@ const PHASE2_ALLOWED_TYPES: &[TransactionType] = &[
     TransactionType::AssetAuthorityTransfer,
     TransactionType::AssetRewardsDelegateRotate,
     TransactionType::AssetRewardsPolicyUpdate,
+    TransactionType::AssetBurnBpsUpdate,
     TransactionType::RewardClaim,
     TransactionType::OracleAttestation,
     TransactionType::RegisterCredential,


### PR DESCRIPTION
## Summary

Implements the locked epic #2799 economic enforcement order (decision register: `docs/arch/dao-launch-decision-register.md`).

| Step | Rule | Implementation |
|------|------|----------------|
| 1 | Q7 `dao_class` on-chain | `DaoClass` on `AssetLaunchPayloadV1` + `SovereignAsset`; registry projects from payload |
| 2 | Q1/Q7 class split | `mint_and_allocate()` — single path for launch + elastic mints |
| 3 | Q1 fixed mint reject | Sovereign `TokenMint` rejected when `supply_mode == Fixed` |
| 4 | Q2 treasury auth | Transfers from `treasury_key_id` require governance verifier signer |
| 5 | Q3 reward liquidity | `InsufficientRewardLiquidity` when delegate balance insufficient |
| 6 | Q8 transfer burn | `burn_bps` on asset; `apply_sovereign_token_transfer`; timelocked `AssetBurnBpsUpdate` (tx type 69) |
| 7 | Q10 domain | Fee standard **100 SOV**; `DOMREG3:` memo with optional `asset_id` binding |

## Unblocks

- P2 #2801 (post-launch mint / class split)
- P8 #2807 (`dao_class` on-chain)
- P9 #2808 (transfer burn)
- P10 #2809 (treasury + rewards funding semantics)
- P11 #2810 (domain binding + fee)
- M2 #2827 Phase 4 UI fields (after merge)

## Test plan

- [x] `cargo build -p lib-blockchain`
- [x] `cargo test -p lib-blockchain --lib np_launch_split_is_all_treasury`
- [x] `cargo test -p lib-blockchain --lib test_asset_launch_writes_sovereign_asset_record`
- [x] `cargo test -p lib-blockchain --lib test_asset_launch_writes_rewards_module_state`

## Notes

- NP launch: 100% treasury allocation (0% creator mint)
- Elastic post-launch mints require governance module + verifier signer
- Domain V1/V2 replay unchanged; V3 used when `asset_id` is set