### PR TITLE
feat(consensus): reject peers with mismatched build id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9531,6 +9531,7 @@ dependencies = [
  "hex",
  "lib-blockchain",
  "lib-client",
+ "lib-consensus-core",
  "lib-crypto",
  "lib-economy",
  "lib-governance",

--- a/lib-consensus-core/Cargo.toml
+++ b/lib-consensus-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lib-consensus-core"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 authors = ["Sovereign Network Team"]
 license = "MIT OR Apache-2.0"
 description = "Pure BFT consensus FSM. No IO. No domain leak."

--- a/lib-consensus-core/build.rs
+++ b/lib-consensus-core/build.rs
@@ -3,14 +3,14 @@ use std::process::Command;
 fn main() {
     let hash = git_head_hash();
     let dirty = git_is_dirty();
-    let build_id = if dirty {
+    let revision = if dirty {
         format!("{hash}-dirty")
     } else {
         hash
     };
-    println!("cargo:rustc-env=CONSENSUS_BUILD_ID={build_id}");
-    println!("cargo:rerun-if-changed=../.git/HEAD");
-    println!("cargo:rerun-if-changed=../.git/index");
+    println!("cargo:rustc-env=BUILD_REVISION={revision}");
+    // Re-run on every build so dirty-tree detection stays accurate.
+    println!("cargo:rerun-if-changed=build.rs");
 }
 
 fn git_head_hash() -> String {
@@ -20,15 +20,19 @@ fn git_head_hash() -> String {
         .ok()
         .filter(|output| output.status.success())
         .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
-        .filter(|hash| !hash.is_empty())
-        .unwrap_or_else(|| "unknown".to_string())
+        .filter(|hash| !hash.is_empty() && *hash != "unknown")
+        .unwrap_or_else(|| {
+            panic!(
+                "CONSENSUS build requires a git checkout — cannot embed BUILD_REVISION"
+            );
+        })
 }
 
 fn git_is_dirty() -> bool {
+    // diff-index compares the working tree AND index against HEAD.
     Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .map(|output| !String::from_utf8_lossy(&output.stdout).is_empty())
-        .unwrap_or(false)
+        .args(["diff-index", "--quiet", "HEAD", "--"])
+        .status()
+        .map(|status| !status.success())
+        .unwrap_or(true)
 }

--- a/lib-consensus-core/build.rs
+++ b/lib-consensus-core/build.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+fn main() {
+    let hash = git_head_hash();
+    let dirty = git_is_dirty();
+    let build_id = if dirty {
+        format!("{hash}-dirty")
+    } else {
+        hash
+    };
+    println!("cargo:rustc-env=CONSENSUS_BUILD_ID={build_id}");
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/index");
+}
+
+fn git_head_hash() -> String {
+    Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|hash| !hash.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn git_is_dirty() -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .map(|output| !String::from_utf8_lossy(&output.stdout).is_empty())
+        .unwrap_or(false)
+}

--- a/lib-consensus-core/src/build_id.rs
+++ b/lib-consensus-core/src/build_id.rs
@@ -1,29 +1,69 @@
-//! Compile-time validator build identity for mixed-binary detection.
+//! Binary epoch + build revision for mixed-binary detection.
 //!
-//! Every validator binary embeds the git short hash it was built from.
-//! Consensus messages carry this value so peers can reject traffic from
-//! nodes running a different build before it affects quorum.
+//! **Gated (consensus admission):** [`CONSENSUS_BUILD_ID`] — a human-bumped
+//! binary epoch. Bump it when validator wire format or consensus rules require
+//! a homogeneous cluster. Stable across ordinary commits that do not touch
+//! consensus.
+//!
+//! **Advisory (telemetry only):** [`BUILD_REVISION`] — git short hash embedded at
+//! compile time. Surfaced on heartbeats, API, and CLI for ops visibility. Never
+//! used to reject peer messages.
+//!
+//! **Safety net, not security:** `build_id` on proposals/votes is outside the
+//! inner signature. It stops accidental mixed-binary deploys, not adversarial
+//! peers claiming a false epoch.
 
-/// Git short hash (12 hex chars) of the commit this binary was built from.
-/// Appends `-dirty` when the working tree had uncommitted changes at build time.
-pub const CONSENSUS_BUILD_ID: &str = env!("CONSENSUS_BUILD_ID");
+/// Human-bumped binary epoch. All validators in a cluster must match.
+///
+/// Bump when:
+/// - Consensus wire codec version changes (see `CONSENSUS_CODEC_VERSION`)
+/// - Consensus admission rules change in a way that requires homogeneous binaries
+///
+/// Do **not** bump for docs-only, CLI-only, or unrelated crate changes.
+pub const CONSENSUS_BUILD_ID: &str = "1";
 
-/// Local build id for outbound consensus messages.
+/// Marker assigned when decoding codec v1 frames (no epoch field on wire).
+pub const LEGACY_BUILD_ID: &str = "";
+
+/// Git short hash (+ `-dirty`) compiled into this binary. Advisory only.
+pub const BUILD_REVISION: &str = env!("BUILD_REVISION");
+
+/// Gated epoch carried on outbound consensus messages.
 #[inline]
 pub fn local_build_id() -> &'static str {
     CONSENSUS_BUILD_ID
 }
 
-/// Returns `Ok(())` when `peer_build_id` matches this binary.
-///
-/// Empty peer ids are rejected — pre-build-id nodes must upgrade before
-/// joining a cluster that enforces homogeneous builds.
-pub fn validate_peer_build_id(peer_build_id: &str) -> Result<(), &'static str> {
+/// Advisory git revision for heartbeats / API / CLI.
+#[inline]
+pub fn local_build_revision() -> &'static str {
+    BUILD_REVISION
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildIdRejectReason {
+    /// Peer sent codec v1 / pre-epoch wire (empty epoch).
+    LegacyPeer,
+    /// Peer epoch does not match our [`CONSENSUS_BUILD_ID`].
+    EpochMismatch,
+}
+
+impl BuildIdRejectReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyPeer => "legacy peer (codec v1, no binary epoch)",
+            Self::EpochMismatch => "binary epoch mismatch",
+        }
+    }
+}
+
+/// Returns `Ok(())` when `peer_build_id` matches [`CONSENSUS_BUILD_ID`].
+pub fn validate_peer_build_id(peer_build_id: &str) -> Result<(), BuildIdRejectReason> {
     if peer_build_id.is_empty() {
-        return Err("missing build_id");
+        return Err(BuildIdRejectReason::LegacyPeer);
     }
     if peer_build_id != CONSENSUS_BUILD_ID {
-        return Err("build_id mismatch");
+        return Err(BuildIdRejectReason::EpochMismatch);
     }
     Ok(())
 }
@@ -33,25 +73,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn local_build_id_matches_constant() {
-        assert_eq!(local_build_id(), CONSENSUS_BUILD_ID);
+    fn local_build_id_is_stable_epoch() {
+        assert_eq!(local_build_id(), "1");
     }
 
     #[test]
-    fn validate_peer_build_id_accepts_local() {
+    fn build_revision_is_nonempty() {
+        assert!(!BUILD_REVISION.is_empty());
+        assert_ne!(BUILD_REVISION, "unknown");
+    }
+
+    #[test]
+    fn validate_peer_build_id_accepts_local_epoch() {
         assert!(validate_peer_build_id(CONSENSUS_BUILD_ID).is_ok());
     }
 
     #[test]
-    fn validate_peer_build_id_rejects_empty() {
-        assert_eq!(validate_peer_build_id(""), Err("missing build_id"));
+    fn validate_peer_build_id_rejects_legacy_empty() {
+        assert_eq!(
+            validate_peer_build_id(LEGACY_BUILD_ID),
+            Err(BuildIdRejectReason::LegacyPeer)
+        );
     }
 
     #[test]
-    fn validate_peer_build_id_rejects_mismatch() {
+    fn validate_peer_build_id_rejects_epoch_mismatch() {
         assert_eq!(
-            validate_peer_build_id("deadbeef0000"),
-            Err("build_id mismatch")
+            validate_peer_build_id("99"),
+            Err(BuildIdRejectReason::EpochMismatch)
         );
     }
 }

--- a/lib-consensus-core/src/build_id.rs
+++ b/lib-consensus-core/src/build_id.rs
@@ -1,0 +1,57 @@
+//! Compile-time validator build identity for mixed-binary detection.
+//!
+//! Every validator binary embeds the git short hash it was built from.
+//! Consensus messages carry this value so peers can reject traffic from
+//! nodes running a different build before it affects quorum.
+
+/// Git short hash (12 hex chars) of the commit this binary was built from.
+/// Appends `-dirty` when the working tree had uncommitted changes at build time.
+pub const CONSENSUS_BUILD_ID: &str = env!("CONSENSUS_BUILD_ID");
+
+/// Local build id for outbound consensus messages.
+#[inline]
+pub fn local_build_id() -> &'static str {
+    CONSENSUS_BUILD_ID
+}
+
+/// Returns `Ok(())` when `peer_build_id` matches this binary.
+///
+/// Empty peer ids are rejected — pre-build-id nodes must upgrade before
+/// joining a cluster that enforces homogeneous builds.
+pub fn validate_peer_build_id(peer_build_id: &str) -> Result<(), &'static str> {
+    if peer_build_id.is_empty() {
+        return Err("missing build_id");
+    }
+    if peer_build_id != CONSENSUS_BUILD_ID {
+        return Err("build_id mismatch");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_build_id_matches_constant() {
+        assert_eq!(local_build_id(), CONSENSUS_BUILD_ID);
+    }
+
+    #[test]
+    fn validate_peer_build_id_accepts_local() {
+        assert!(validate_peer_build_id(CONSENSUS_BUILD_ID).is_ok());
+    }
+
+    #[test]
+    fn validate_peer_build_id_rejects_empty() {
+        assert_eq!(validate_peer_build_id(""), Err("missing build_id"));
+    }
+
+    #[test]
+    fn validate_peer_build_id_rejects_mismatch() {
+        assert_eq!(
+            validate_peer_build_id("deadbeef0000"),
+            Err("build_id mismatch")
+        );
+    }
+}

--- a/lib-consensus-core/src/lib.rs
+++ b/lib-consensus-core/src/lib.rs
@@ -31,6 +31,8 @@
 #![forbid(unsafe_code)]
 
 pub mod budget;
+pub mod build_id;
+pub use build_id::{local_build_id, validate_peer_build_id, CONSENSUS_BUILD_ID};
 pub mod byzantine;
 pub mod engine;
 pub mod fsm;

--- a/lib-consensus-core/src/lib.rs
+++ b/lib-consensus-core/src/lib.rs
@@ -32,7 +32,10 @@
 
 pub mod budget;
 pub mod build_id;
-pub use build_id::{local_build_id, validate_peer_build_id, CONSENSUS_BUILD_ID};
+pub use build_id::{
+    local_build_id, local_build_revision, validate_peer_build_id, BuildIdRejectReason,
+    BUILD_REVISION, CONSENSUS_BUILD_ID, LEGACY_BUILD_ID,
+};
 pub mod byzantine;
 pub mod engine;
 pub mod fsm;

--- a/lib-consensus-core/src/ports/finalization.rs
+++ b/lib-consensus-core/src/ports/finalization.rs
@@ -129,6 +129,7 @@ mod tests {
             signature: PostQuantumSignature::default(),
             consensus_proof: ConsensusProof::empty(ConsensusType::ByzantineFaultTolerance, 0),
             valid_round: None,
+            build_id: String::new(),
         }
     }
 

--- a/lib-consensus-core/src/types/messages.rs
+++ b/lib-consensus-core/src/types/messages.rs
@@ -99,9 +99,12 @@ pub struct HeartbeatMessage {
     pub network_summary: NetworkSummary,
     pub timestamp: u64,
     pub signature: PostQuantumSignature,
-    /// Build identity of the sender's binary (advisory telemetry).
+    /// Binary epoch (gated at admission on proposals/votes; advisory here).
     #[serde(default)]
     pub build_id: String,
+    /// Git revision compiled into this binary (advisory telemetry only).
+    #[serde(default)]
+    pub build_revision: String,
 }
 
 /// Snapshot of a voter's local view of the round, included on every

--- a/lib-consensus-core/src/types/messages.rs
+++ b/lib-consensus-core/src/types/messages.rs
@@ -80,6 +80,10 @@ pub struct VoteMessage {
     pub consensus_state: ConsensusStateView,
     pub timestamp: u64,
     pub signature: PostQuantumSignature,
+    /// Build identity of the voter's binary. Peers reject votes when
+    /// this does not match their own `CONSENSUS_BUILD_ID`.
+    #[serde(default)]
+    pub build_id: String,
 }
 
 /// Heartbeat envelope — advisory liveness telemetry. Per the original
@@ -95,6 +99,9 @@ pub struct HeartbeatMessage {
     pub network_summary: NetworkSummary,
     pub timestamp: u64,
     pub signature: PostQuantumSignature,
+    /// Build identity of the sender's binary (advisory telemetry).
+    #[serde(default)]
+    pub build_id: String,
 }
 
 /// Snapshot of a voter's local view of the round, included on every

--- a/lib-consensus-core/src/types/proposal.rs
+++ b/lib-consensus-core/src/types/proposal.rs
@@ -135,4 +135,11 @@ pub struct ConsensusProposal {
     /// proposals as `None`.
     #[serde(default)]
     pub valid_round: Option<u32>,
+    /// Git short hash identifying the validator binary that produced
+    /// this proposal. Peers reject proposals whose `build_id` does not
+    /// match their own `CONSENSUS_BUILD_ID`, preventing mixed-binary
+    /// clusters from silently diverging. Not part of the inner proposal
+    /// signature — admission-time metadata only.
+    #[serde(default)]
+    pub build_id: String,
 }

--- a/lib-consensus-core/src/types/proposal.rs
+++ b/lib-consensus-core/src/types/proposal.rs
@@ -135,11 +135,10 @@ pub struct ConsensusProposal {
     /// proposals as `None`.
     #[serde(default)]
     pub valid_round: Option<u32>,
-    /// Git short hash identifying the validator binary that produced
-    /// this proposal. Peers reject proposals whose `build_id` does not
-    /// match their own `CONSENSUS_BUILD_ID`, preventing mixed-binary
-    /// clusters from silently diverging. Not part of the inner proposal
-    /// signature — admission-time metadata only.
+    /// Human-bumped binary epoch. Peers reject proposals whose epoch
+    /// does not match [`CONSENSUS_BUILD_ID`](crate::build_id::CONSENSUS_BUILD_ID).
+    /// Not part of the inner proposal signature — admission-time safety
+    /// net only, not a cryptographic identity binding.
     #[serde(default)]
     pub build_id: String,
 }

--- a/lib-consensus-net/src/codec/legacy.rs
+++ b/lib-consensus-net/src/codec/legacy.rs
@@ -1,0 +1,210 @@
+//! Codec v1 wire types — exact bincode layout before binary-epoch fields.
+//!
+//! Decoding v1 frames through these types and upgrading to current
+//! [`ValidatorMessage`] assigns [`LEGACY_BUILD_ID`] so admission can
+//! reject with an explicit reason instead of a bincode failure.
+
+use std::collections::BTreeMap;
+
+use lib_consensus_core::build_id::LEGACY_BUILD_ID;
+use lib_consensus_core::types::{
+    ConsensusProof, ConsensusProposal, ConsensusStateView, ConsensusVote, HaltMessage,
+    HeartbeatMessage, Justification, NetworkSummary, ProposeMessage, ValidatorMessage,
+    VoteMessage,
+};
+use lib_crypto::{Hash, PostQuantumSignature};
+use lib_identity::IdentityId;
+use lib_types::consensus::ConsensusStep;
+use serde::{Deserialize, Serialize};
+
+use super::CodecError;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) enum ValidatorMessageV1 {
+    Propose(ProposeMessageV1),
+    Vote(VoteMessageV1),
+    Heartbeat(HeartbeatMessageV1),
+    Halt(HaltMessage),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct ProposeMessageV1 {
+    pub message_id: Hash,
+    pub proposer: IdentityId,
+    pub proposal: ConsensusProposalV1,
+    pub justification: Option<Justification>,
+    pub timestamp: u64,
+    pub signature: PostQuantumSignature,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct VoteMessageV1 {
+    pub message_id: Hash,
+    pub voter: IdentityId,
+    pub vote: ConsensusVote,
+    pub consensus_state: ConsensusStateView,
+    pub timestamp: u64,
+    pub signature: PostQuantumSignature,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct HeartbeatMessageV1 {
+    pub message_id: Hash,
+    pub validator: IdentityId,
+    pub height: u64,
+    pub round: u32,
+    pub step: ConsensusStep,
+    pub network_summary: NetworkSummary,
+    pub timestamp: u64,
+    pub signature: PostQuantumSignature,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct ConsensusProposalV1 {
+    pub id: Hash,
+    pub proposer: IdentityId,
+    pub height: u64,
+    #[serde(default)]
+    pub round: u32,
+    #[serde(default)]
+    pub protocol_version: u32,
+    pub previous_hash: Hash,
+    pub block_data: Vec<u8>,
+    pub timestamp: u64,
+    pub signature: PostQuantumSignature,
+    pub consensus_proof: ConsensusProof,
+    #[serde(default)]
+    pub valid_round: Option<u32>,
+}
+
+pub(super) fn decode_v1(bytes: &[u8]) -> Result<ValidatorMessage, CodecError> {
+    let msg: ValidatorMessageV1 = bincode::deserialize(bytes)
+        .map_err(|e| CodecError::DeserializationFailed(e.to_string()))?;
+    Ok(upgrade_v1(msg))
+}
+
+fn upgrade_v1(msg: ValidatorMessageV1) -> ValidatorMessage {
+    match msg {
+        ValidatorMessageV1::Propose(m) => ValidatorMessage::Propose(ProposeMessage {
+            message_id: m.message_id,
+            proposer: m.proposer,
+            proposal: ConsensusProposal {
+                id: m.proposal.id,
+                proposer: m.proposal.proposer,
+                height: m.proposal.height,
+                round: m.proposal.round,
+                protocol_version: m.proposal.protocol_version,
+                previous_hash: m.proposal.previous_hash,
+                block_data: m.proposal.block_data,
+                timestamp: m.proposal.timestamp,
+                signature: m.proposal.signature,
+                consensus_proof: m.proposal.consensus_proof,
+                valid_round: m.proposal.valid_round,
+                build_id: LEGACY_BUILD_ID.to_string(),
+            },
+            justification: m.justification,
+            timestamp: m.timestamp,
+            signature: m.signature,
+        }),
+        ValidatorMessageV1::Vote(m) => ValidatorMessage::Vote(VoteMessage {
+            message_id: m.message_id,
+            voter: m.voter,
+            vote: m.vote,
+            consensus_state: m.consensus_state,
+            timestamp: m.timestamp,
+            signature: m.signature,
+            build_id: LEGACY_BUILD_ID.to_string(),
+        }),
+        ValidatorMessageV1::Heartbeat(m) => ValidatorMessage::Heartbeat(HeartbeatMessage {
+            message_id: m.message_id,
+            validator: m.validator,
+            height: m.height,
+            round: m.round,
+            step: m.step,
+            network_summary: m.network_summary,
+            timestamp: m.timestamp,
+            signature: m.signature,
+            build_id: LEGACY_BUILD_ID.to_string(),
+            build_revision: String::new(),
+        }),
+        ValidatorMessageV1::Halt(m) => ValidatorMessage::Halt(m),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lib_consensus_core::types::ConsensusProof;
+    use lib_types::consensus::{ConsensusType, VoteType};
+
+    fn zero_proposal_v1() -> ConsensusProposalV1 {
+        ConsensusProposalV1 {
+            id: Hash::default(),
+            proposer: IdentityId::default(),
+            height: 0,
+            round: 0,
+            protocol_version: 0,
+            previous_hash: Hash::default(),
+            block_data: vec![],
+            timestamp: 0,
+            signature: PostQuantumSignature::default(),
+            consensus_proof: ConsensusProof::empty(ConsensusType::ByzantineFaultTolerance, 0),
+            valid_round: None,
+        }
+    }
+
+    #[test]
+    fn v1_vote_round_trip_assigns_legacy_build_id() {
+        let v1 = ValidatorMessageV1::Vote(VoteMessageV1 {
+            message_id: Hash::default(),
+            voter: IdentityId::default(),
+            vote: ConsensusVote {
+                id: Hash::default(),
+                voter: IdentityId::default(),
+                proposal_id: Hash::default(),
+                vote_type: VoteType::PreVote,
+                height: 0,
+                round: 0,
+                timestamp: 0,
+                signature: PostQuantumSignature::default(),
+            },
+            consensus_state: ConsensusStateView {
+                height: 0,
+                round: 0,
+                step: ConsensusStep::Propose,
+                known_proposals: vec![],
+                vote_counts: BTreeMap::new(),
+            },
+            timestamp: 0,
+            signature: PostQuantumSignature::default(),
+        });
+        let bytes = bincode::serialize(&v1).expect("encode v1");
+        let upgraded = decode_v1(&bytes).expect("decode v1");
+        match upgraded {
+            ValidatorMessage::Vote(m) => {
+                assert_eq!(m.build_id, LEGACY_BUILD_ID);
+            }
+            other => panic!("expected vote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn v1_propose_round_trip_assigns_legacy_build_id() {
+        let v1 = ValidatorMessageV1::Propose(ProposeMessageV1 {
+            message_id: Hash::default(),
+            proposer: IdentityId::default(),
+            proposal: zero_proposal_v1(),
+            justification: None,
+            timestamp: 0,
+            signature: PostQuantumSignature::default(),
+        });
+        let bytes = bincode::serialize(&v1).expect("encode v1");
+        let upgraded = decode_v1(&bytes).expect("decode v1");
+        match upgraded {
+            ValidatorMessage::Propose(m) => {
+                assert_eq!(m.proposal.build_id, LEGACY_BUILD_ID);
+            }
+            other => panic!("expected propose, got {other:?}"),
+        }
+    }
+}

--- a/lib-consensus-net/src/codec/mod.rs
+++ b/lib-consensus-net/src/codec/mod.rs
@@ -85,6 +85,8 @@
 //! let decoded = codec.decode_framed(&framed)?;
 //! ```
 
+mod legacy;
+
 use crate::validator_protocol::ValidatorMessage;
 use thiserror::Error;
 
@@ -97,12 +99,14 @@ use thiserror::Error;
 /// - ProposeMessage with 500 votes × (64B hash + 3KB sig) ≈ 1.5 MB
 pub const MAX_CONSENSUS_MESSAGE_SIZE: usize = 8 * 1024 * 1024; // 8 MB
 
-/// Codec version (v1: bincode serialization, 4-byte BE length prefix)
-///
-/// Version evolution path:
-/// - v1: bincode serialization, 4-byte BE length prefix
-/// - v2+: Future extensions (compression, alternate serialization, new message types)
-pub const CONSENSUS_CODEC_VERSION: u8 = 1;
+/// Current codec version written on encode (binary epoch + revision fields).
+pub const CONSENSUS_CODEC_VERSION: u8 = 2;
+
+/// Legacy codec version (pre-binary-epoch wire). Still accepted on decode.
+pub const CONSENSUS_CODEC_VERSION_LEGACY: u8 = 1;
+
+/// Supported codec versions on decode (v1 upgraded in-place).
+pub const SUPPORTED_CODEC_VERSIONS: &[u8] = &[CONSENSUS_CODEC_VERSION_LEGACY, CONSENSUS_CODEC_VERSION];
 
 // Internal constants
 const LENGTH_PREFIX_SIZE: usize = 4;
@@ -266,6 +270,19 @@ impl BincodeConsensusCodec {
     pub fn new() -> Self {
         Self
     }
+
+    /// Decode a payload for a specific wire codec version.
+    pub fn decode_versioned(
+        &self,
+        version: u8,
+        bytes: &[u8],
+    ) -> Result<ValidatorMessage, CodecError> {
+        match version {
+            CONSENSUS_CODEC_VERSION_LEGACY => legacy::decode_v1(bytes),
+            CONSENSUS_CODEC_VERSION => self.decode(bytes),
+            other => Err(CodecError::UnsupportedVersion(other, CONSENSUS_CODEC_VERSION)),
+        }
+    }
 }
 
 impl ConsensusMessageCodec for BincodeConsensusCodec {
@@ -346,8 +363,8 @@ impl ConsensusMessageCodec for BincodeConsensusCodec {
         // Read version byte
         let version = framed[4];
 
-        // CM-9: Version validation (strict checking, no fallback)
-        if version != CONSENSUS_CODEC_VERSION {
+        // CM-9: Version validation — accept legacy v1 and current v2.
+        if !SUPPORTED_CODEC_VERSIONS.contains(&version) {
             return Err(CodecError::UnsupportedVersion(
                 version,
                 CONSENSUS_CODEC_VERSION,
@@ -367,6 +384,11 @@ impl ConsensusMessageCodec for BincodeConsensusCodec {
         let payload = framed[FRAME_HEADER_SIZE..expected_total].to_vec();
 
         Ok((version, payload))
+    }
+
+    fn decode_framed(&self, framed: &[u8]) -> Result<ValidatorMessage, CodecError> {
+        let (version, payload) = self.unframe(framed)?;
+        self.decode_versioned(version, &payload)
     }
 }
 
@@ -420,6 +442,7 @@ mod tests {
                     timestamp: 1234567890,
                     signature: PostQuantumSignature::default(),
                     build_id: String::new(),
+                    build_revision: String::new(),
                 })
             }
             _ => panic!("Invalid variant"),
@@ -796,6 +819,40 @@ mod tests {
     // ===== FULL INTEGRATION TESTS =====
 
     #[test]
+    fn test_codec_v1_frame_decodes_with_legacy_epoch() {
+        use super::legacy::{decode_v1, ValidatorMessageV1, VoteMessageV1};
+        use lib_consensus_core::build_id::LEGACY_BUILD_ID;
+
+        let v1 = ValidatorMessageV1::Vote(VoteMessageV1 {
+            message_id: Hash::default(),
+            voter: IdentityId::default(),
+            vote: create_test_vote(),
+            consensus_state: create_test_consensus_state(),
+            timestamp: 0,
+            signature: PostQuantumSignature::default(),
+        });
+        let payload = bincode::serialize(&v1).expect("v1 payload");
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        framed.push(CONSENSUS_CODEC_VERSION_LEGACY);
+        framed.extend_from_slice(&payload);
+
+        let codec = BincodeConsensusCodec::new();
+        let decoded = codec.decode_framed(&framed).expect("v1 framed decode");
+        match decoded {
+            ValidatorMessage::Vote(m) => assert_eq!(m.build_id, LEGACY_BUILD_ID),
+            other => panic!("expected vote, got {other:?}"),
+        }
+
+        // Direct legacy decode matches framed path.
+        let direct = decode_v1(&payload).expect("direct v1");
+        match direct {
+            ValidatorMessage::Vote(m) => assert_eq!(m.build_id, LEGACY_BUILD_ID),
+            other => panic!("expected vote, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_full_codec_roundtrip_all_variants() {
         let codec = BincodeConsensusCodec::new();
 
@@ -916,6 +973,7 @@ mod tests {
                     timestamp: 0,
                     signature: zero_sig,
                     build_id: String::new(),
+                    build_revision: String::new(),
                 }),
                 _ => panic!("invalid variant"),
             }
@@ -962,7 +1020,7 @@ mod tests {
             let encoded = codec.encode(&zero_message(2)).expect("encode");
             assert_eq!(
                 encoded.len(),
-                4_348,
+                4_356,
                 "HeartbeatMessage encoded length changed — wire format \
                  drifted. Bump CONSENSUS_PROTOCOL_VERSION (CONS-203)."
             );

--- a/lib-consensus-net/src/codec/mod.rs
+++ b/lib-consensus-net/src/codec/mod.rs
@@ -405,6 +405,7 @@ mod tests {
                     consensus_state: create_test_consensus_state(),
                     timestamp: 1234567890,
                     signature: PostQuantumSignature::default(),
+                    build_id: String::new(),
                 })
             }
             2 => {
@@ -418,6 +419,7 @@ mod tests {
                     network_summary: create_test_network_summary(),
                     timestamp: 1234567890,
                     signature: PostQuantumSignature::default(),
+                    build_id: String::new(),
                 })
             }
             _ => panic!("Invalid variant"),
@@ -441,6 +443,8 @@ mod tests {
             timestamp: 1234567890,
             signature: PostQuantumSignature::default(),
             consensus_proof: create_test_consensus_proof(),
+            valid_round: None,
+            build_id: String::new(),
         }
     }
 
@@ -861,6 +865,8 @@ mod tests {
                 timestamp: 0,
                 signature: zero_sig.clone(),
                 consensus_proof: zero_proof,
+                valid_round: None,
+                build_id: String::new(),
             };
             let zero_vote = ConsensusVote {
                 id: zero_hash.clone(),
@@ -879,7 +885,7 @@ mod tests {
                     proposal: zero_proposal,
                     justification: None,
                     timestamp: 0,
-                    signature: zero_sig,
+                    signature: zero_sig.clone(),
                 }),
                 1 => ValidatorMessage::Vote(VoteMessage {
                     message_id: zero_hash.clone(),
@@ -893,7 +899,8 @@ mod tests {
                         vote_counts: std::collections::BTreeMap::new(),
                     },
                     timestamp: 0,
-                    signature: zero_sig,
+                    signature: zero_sig.clone(),
+                    build_id: String::new(),
                 }),
                 2 => ValidatorMessage::Heartbeat(HeartbeatMessage {
                     message_id: zero_hash.clone(),
@@ -908,6 +915,7 @@ mod tests {
                     },
                     timestamp: 0,
                     signature: zero_sig,
+                    build_id: String::new(),
                 }),
                 _ => panic!("invalid variant"),
             }
@@ -930,7 +938,7 @@ mod tests {
             // bump CONSENSUS_PROTOCOL_VERSION.
             assert_eq!(
                 encoded.len(),
-                8_677,
+                8_686,
                 "ProposeMessage encoded length changed — wire format \
                  drifted. Bump CONSENSUS_PROTOCOL_VERSION (CONS-203)."
             );
@@ -942,7 +950,7 @@ mod tests {
             let encoded = codec.encode(&zero_message(1)).expect("encode");
             assert_eq!(
                 encoded.len(),
-                8_684,
+                8_692,
                 "VoteMessage encoded length changed — wire format \
                  drifted. Bump CONSENSUS_PROTOCOL_VERSION (CONS-203)."
             );
@@ -954,7 +962,7 @@ mod tests {
             let encoded = codec.encode(&zero_message(2)).expect("encode");
             assert_eq!(
                 encoded.len(),
-                4_340,
+                4_348,
                 "HeartbeatMessage encoded length changed — wire format \
                  drifted. Bump CONSENSUS_PROTOCOL_VERSION (CONS-203)."
             );

--- a/lib-consensus-net/src/heartbeat/mod.rs
+++ b/lib-consensus-net/src/heartbeat/mod.rs
@@ -447,6 +447,7 @@ impl HeartbeatTracker {
                 timestamp,
             },
             build_id: lib_consensus_core::build_id::local_build_id().to_string(),
+            build_revision: lib_consensus_core::build_id::local_build_revision().to_string(),
         }
     }
 
@@ -731,6 +732,7 @@ mod tests {
             timestamp: now,
             signature: create_test_signature(now),
             build_id: String::new(),
+            build_revision: String::new(),
         };
 
         let is_validator = |vid: &IdentityId| vid == &validator_id;
@@ -758,6 +760,7 @@ mod tests {
             timestamp: now,
             signature: create_test_signature(now),
             build_id: String::new(),
+            build_revision: String::new(),
         };
 
         let is_validator = |_: &IdentityId| false; // Always reject
@@ -785,6 +788,7 @@ mod tests {
             timestamp: now,
             signature: create_test_signature(now),
             build_id: String::new(),
+            build_revision: String::new(),
         };
 
         let is_validator = |vid: &IdentityId| vid == &validator_id;
@@ -815,6 +819,7 @@ mod tests {
             timestamp: now,
             signature: create_test_signature(now),
             build_id: String::new(),
+            build_revision: String::new(),
         };
 
         let is_validator = |vid: &IdentityId| vid == &validator_id;
@@ -844,6 +849,7 @@ mod tests {
             timestamp: now,
             signature: create_test_signature(now),
             build_id: String::new(),
+            build_revision: String::new(),
         };
 
         let is_validator = |_: &IdentityId| false; // Always reject

--- a/lib-consensus-net/src/heartbeat/mod.rs
+++ b/lib-consensus-net/src/heartbeat/mod.rs
@@ -446,6 +446,7 @@ impl HeartbeatTracker {
                 algorithm: SignatureAlgorithm::DEFAULT,
                 timestamp,
             },
+            build_id: lib_consensus_core::build_id::local_build_id().to_string(),
         }
     }
 
@@ -729,6 +730,7 @@ mod tests {
             },
             timestamp: now,
             signature: create_test_signature(now),
+            build_id: String::new(),
         };
 
         let is_validator = |vid: &IdentityId| vid == &validator_id;
@@ -755,6 +757,7 @@ mod tests {
             },
             timestamp: now,
             signature: create_test_signature(now),
+            build_id: String::new(),
         };
 
         let is_validator = |_: &IdentityId| false; // Always reject
@@ -781,6 +784,7 @@ mod tests {
             },
             timestamp: now,
             signature: create_test_signature(now),
+            build_id: String::new(),
         };
 
         let is_validator = |vid: &IdentityId| vid == &validator_id;
@@ -810,6 +814,7 @@ mod tests {
             },
             timestamp: now,
             signature: create_test_signature(now),
+            build_id: String::new(),
         };
 
         let is_validator = |vid: &IdentityId| vid == &validator_id;
@@ -838,6 +843,7 @@ mod tests {
             },
             timestamp: now,
             signature: create_test_signature(now),
+            build_id: String::new(),
         };
 
         let is_validator = |_: &IdentityId| false; // Always reject

--- a/lib-consensus-net/src/validator_protocol/mod.rs
+++ b/lib-consensus-net/src/validator_protocol/mod.rs
@@ -360,6 +360,7 @@ impl ValidatorProtocol {
             consensus_state,
             timestamp: self.current_timestamp(),
             signature: PostQuantumSignature::default(),
+            build_id: lib_consensus_core::build_id::local_build_id().to_string(),
         };
 
         message.signature = self.sign_vote_message(&message)?;
@@ -407,6 +408,7 @@ impl ValidatorProtocol {
             network_summary,
             timestamp: self.current_timestamp(),
             signature: PostQuantumSignature::default(),
+            build_id: lib_consensus_core::build_id::local_build_id().to_string(),
         };
 
         message.signature = self.sign_heartbeat_message(&message)?;
@@ -976,6 +978,8 @@ mod tests {
                     zk_did_proof: None,
                     timestamp: now,
                 },
+                valid_round: None,
+                build_id: String::new(),
             },
             justification: None,
             timestamp: now,
@@ -1019,6 +1023,7 @@ mod tests {
             },
             timestamp: now,
             signature: PostQuantumSignature::default(),
+            build_id: String::new(),
         };
         msg.signature = sign_heartbeat_envelope(&msg, &kp)?;
 
@@ -1058,6 +1063,7 @@ mod tests {
             },
             timestamp: now,
             signature: PostQuantumSignature::default(),
+            build_id: String::new(),
         };
         msg.signature = sign_vote_envelope(&msg, &kp)?;
 
@@ -1120,6 +1126,8 @@ mod tests {
                     zk_did_proof: None,
                     timestamp: now,
                 },
+                valid_round: None,
+                build_id: String::new(),
             },
             justification: None,
             timestamp: now,
@@ -1194,6 +1202,7 @@ mod tests {
             },
             timestamp: protocol.current_timestamp(),
             signature: PostQuantumSignature::default(),
+            build_id: String::new(),
         };
 
         protocol
@@ -1232,6 +1241,8 @@ mod tests {
                     zk_did_proof: None,
                     timestamp: now,
                 },
+                valid_round: None,
+                build_id: String::new(),
             },
             justification: None,
             timestamp: now,
@@ -1286,6 +1297,7 @@ mod tests {
             consensus_state: state_view,
             timestamp: now,
             signature: PostQuantumSignature::default(),
+            build_id: String::new(),
         };
         msg.signature = protocol.sign_vote_message(&msg)?;
 
@@ -1329,6 +1341,8 @@ mod tests {
                     zk_did_proof: None,
                     timestamp: now,
                 },
+                valid_round: None,
+                build_id: String::new(),
             },
             justification: None,
             timestamp: now,

--- a/lib-consensus-net/src/validator_protocol/mod.rs
+++ b/lib-consensus-net/src/validator_protocol/mod.rs
@@ -409,6 +409,7 @@ impl ValidatorProtocol {
             timestamp: self.current_timestamp(),
             signature: PostQuantumSignature::default(),
             build_id: lib_consensus_core::build_id::local_build_id().to_string(),
+            build_revision: lib_consensus_core::build_id::local_build_revision().to_string(),
         };
 
         message.signature = self.sign_heartbeat_message(&message)?;
@@ -1024,6 +1025,7 @@ mod tests {
             timestamp: now,
             signature: PostQuantumSignature::default(),
             build_id: String::new(),
+            build_revision: String::new(),
         };
         msg.signature = sign_heartbeat_envelope(&msg, &kp)?;
 
@@ -1203,6 +1205,7 @@ mod tests {
             timestamp: protocol.current_timestamp(),
             signature: PostQuantumSignature::default(),
             build_id: String::new(),
+            build_revision: String::new(),
         };
 
         protocol

--- a/lib-consensus-observer/src/observer_service.rs
+++ b/lib-consensus-observer/src/observer_service.rs
@@ -457,6 +457,8 @@ mod tests {
                 timestamp: 0,
             },
             signature: PostQuantumSignature::default(),
+            valid_round: None,
+            build_id: String::new(),
         }
     }
 

--- a/lib-consensus-runtime/src/runtime.rs
+++ b/lib-consensus-runtime/src/runtime.rs
@@ -897,6 +897,7 @@ mod tests {
             timestamp: 0,
             signature: lib_crypto::PostQuantumSignature::default(),
             build_id: String::new(),
+            build_revision: String::new(),
         }
     }
 

--- a/lib-consensus-runtime/src/runtime.rs
+++ b/lib-consensus-runtime/src/runtime.rs
@@ -896,6 +896,7 @@ mod tests {
             },
             timestamp: 0,
             signature: lib_crypto::PostQuantumSignature::default(),
+            build_id: String::new(),
         }
     }
 
@@ -1005,6 +1006,7 @@ mod tests {
                     0,
                 ),
                 valid_round: None,
+                build_id: String::new(),
             },
             quorum_proof: lib_types::consensus::BftQuorumProof {
                 height,

--- a/lib-consensus/src/engines/consensus_engine/network.rs
+++ b/lib-consensus/src/engines/consensus_engine/network.rs
@@ -591,8 +591,9 @@ impl ConsensusEngine {
                     lib_consensus_core::build_id::validate_peer_build_id(&vote_msg.build_id)
                 {
                     tracing::warn!(
-                        "Vote rejected: {reason} — peer build_id {:?}, we require {:?} \
+                        "Vote rejected: {} — peer epoch {:?}, we require {:?} \
                          (voter {} H={} R={} {:?})",
+                        reason.as_str(),
                         vote_msg.build_id,
                         lib_consensus_core::build_id::CONSENSUS_BUILD_ID,
                         vote_msg.voter,

--- a/lib-consensus/src/engines/consensus_engine/network.rs
+++ b/lib-consensus/src/engines/consensus_engine/network.rs
@@ -587,6 +587,22 @@ impl ConsensusEngine {
                 self.on_proposal(propose_msg.proposal).await?;
             }
             ValidatorMessage::Vote(vote_msg) => {
+                if let Err(reason) =
+                    lib_consensus_core::build_id::validate_peer_build_id(&vote_msg.build_id)
+                {
+                    tracing::warn!(
+                        "Vote rejected: {reason} — peer build_id {:?}, we require {:?} \
+                         (voter {} H={} R={} {:?})",
+                        vote_msg.build_id,
+                        lib_consensus_core::build_id::CONSENSUS_BUILD_ID,
+                        vote_msg.voter,
+                        vote_msg.vote.height,
+                        vote_msg.vote.round,
+                        vote_msg.vote.vote_type,
+                    );
+                    return Ok(());
+                }
+
                 let vote = vote_msg.vote;
                 // Compute payload hash for replay detection
                 let payload_bytes =

--- a/lib-consensus/src/engines/consensus_engine/proofs.rs
+++ b/lib-consensus/src/engines/consensus_engine/proofs.rs
@@ -122,6 +122,7 @@ impl ConsensusEngine {
             signature,
             consensus_proof,
             valid_round,
+            build_id: lib_consensus_core::build_id::local_build_id().to_string(),
         };
 
         tracing::info!(

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -107,6 +107,7 @@ fn wrap_vote(vote: ConsensusVote, keypair: Option<&KeyPair>) -> ValidatorMessage
         consensus_state,
         timestamp: now_secs(),
         signature: PostQuantumSignature::default(),
+        build_id: lib_consensus_core::build_id::local_build_id().to_string(),
     };
     if let Some(kp) = keypair {
         match sign_vote_envelope(&msg, kp) {
@@ -3295,6 +3296,7 @@ mod state_machine_tests {
                 timestamp: 0,
             },
             valid_round: None,
+            build_id: String::new(),
         };
         let result = cb.commit_finalized_block(&proposal).await;
         assert!(result.is_err(), "commit callback must propagate errors");

--- a/lib-consensus/src/engines/consensus_engine/tests.rs
+++ b/lib-consensus/src/engines/consensus_engine/tests.rs
@@ -2822,14 +2822,14 @@ async fn test_proposal_admission_wrong_build_id_rejected() {
         b"block".to_vec(),
     );
 
-    proposal.build_id = "deadbeef0000".to_string();
+    proposal.build_id = "99".to_string();
 
     let result = engine.validate_incoming_proposal(&proposal).await;
-    assert!(result.is_err(), "mismatched build_id must be rejected");
+    assert!(result.is_err(), "mismatched epoch must be rejected");
     let err = result.unwrap_err().to_string();
     assert!(
-        err.contains("build_id mismatch"),
-        "error should mention build_id, got: {}",
+        err.contains("binary epoch mismatch"),
+        "error should mention epoch mismatch, got: {}",
         err
     );
 }

--- a/lib-consensus/src/engines/consensus_engine/tests.rs
+++ b/lib-consensus/src/engines/consensus_engine/tests.rs
@@ -2400,6 +2400,7 @@ fn stage_stub_proposal(
             timestamp: 0,
         },
         valid_round: None,
+        build_id: lib_consensus_core::build_id::local_build_id().to_string(),
     });
 }
 
@@ -2462,6 +2463,7 @@ fn make_signed_proposal(
             timestamp: 0,
         },
         valid_round: None,
+        build_id: lib_consensus_core::build_id::local_build_id().to_string(),
     }
 }
 
@@ -2798,6 +2800,37 @@ async fn test_future_round_precommit_does_not_advance_local_round() {
         engine.count_precommits_for(5, 3, &proposal_id),
         1,
         "future-round precommit should still be stored"
+    );
+}
+
+#[tokio::test]
+async fn test_proposal_admission_wrong_build_id_rejected() {
+    let (engine, validators) = setup_bft_engine(1, 0).await;
+    let expected = engine.compute_proposer_for_round(1, 0).unwrap();
+    let (proposer_id, proposer_kp) = validators
+        .iter()
+        .find(|(id, _)| *id == expected)
+        .expect("proposer must exist");
+
+    let mut proposal = make_signed_proposal(
+        &engine,
+        proposer_id,
+        proposer_kp,
+        1,
+        0,
+        Hash([0u8; 32]),
+        b"block".to_vec(),
+    );
+
+    proposal.build_id = "deadbeef0000".to_string();
+
+    let result = engine.validate_incoming_proposal(&proposal).await;
+    assert!(result.is_err(), "mismatched build_id must be rejected");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("build_id mismatch"),
+        "error should mention build_id, got: {}",
+        err
     );
 }
 
@@ -3386,6 +3419,7 @@ async fn test_ce_s2_locked_peer_unlocks_on_advertised_valid_round() {
             timestamp: 0,
         },
         valid_round: Some(5),
+        build_id: lib_consensus_core::build_id::local_build_id().to_string(),
     };
 
     let allowed = engine.prevote_permitted_by_lock(Some(&proposal), &new_id);

--- a/lib-consensus/src/engines/consensus_engine/validation.rs
+++ b/lib-consensus/src/engines/consensus_engine/validation.rs
@@ -509,6 +509,21 @@ impl ConsensusEngine {
             )));
         }
 
+        // ── 0b. Build identity ───────────────────────────────────────────
+        if let Err(reason) =
+            lib_consensus_core::build_id::validate_peer_build_id(&proposal.build_id)
+        {
+            return Err(ConsensusError::ByzantineFault(format!(
+                "Proposal rejected: {reason} — peer build_id {:?}, \
+                 we require {:?} (proposer {} at H={} R={})",
+                proposal.build_id,
+                lib_consensus_core::build_id::CONSENSUS_BUILD_ID,
+                proposal.proposer,
+                proposal.height,
+                proposal.round,
+            )));
+        }
+
         // ── 1. Expected proposer for (height, round) ────────────────────
         let expected_proposer = self.compute_proposer_for_round(proposal.height, proposal.round);
         if expected_proposer.as_ref() != Some(&proposal.proposer) {

--- a/lib-consensus/src/engines/consensus_engine/validation.rs
+++ b/lib-consensus/src/engines/consensus_engine/validation.rs
@@ -514,8 +514,9 @@ impl ConsensusEngine {
             lib_consensus_core::build_id::validate_peer_build_id(&proposal.build_id)
         {
             return Err(ConsensusError::ByzantineFault(format!(
-                "Proposal rejected: {reason} — peer build_id {:?}, \
-                 we require {:?} (proposer {} at H={} R={})",
+                "Proposal rejected: {} — peer epoch {:?}, we require {:?} \
+                 (proposer {} at H={} R={})",
+                reason.as_str(),
                 proposal.build_id,
                 lib_consensus_core::build_id::CONSENSUS_BUILD_ID,
                 proposal.proposer,

--- a/lib-consensus/tests/common/consensus_fixtures.rs
+++ b/lib-consensus/tests/common/consensus_fixtures.rs
@@ -143,6 +143,7 @@ pub fn test_proposal(
                 .with_stake_proof(&stake_proof)
         },
         valid_round: None,
+        build_id: lib_consensus_core::build_id::local_build_id().to_string(),
     }
 }
 

--- a/lib-consensus/tests/heartbeat_tests.rs
+++ b/lib-consensus/tests/heartbeat_tests.rs
@@ -35,6 +35,7 @@ fn create_test_heartbeat(
         network_summary: create_test_network_summary(4),
         timestamp,
         signature: create_test_signature(timestamp),
+        build_id: String::new(),
     }
 }
 

--- a/lib-consensus/tests/heartbeat_tests.rs
+++ b/lib-consensus/tests/heartbeat_tests.rs
@@ -36,6 +36,7 @@ fn create_test_heartbeat(
         timestamp,
         signature: create_test_signature(timestamp),
         build_id: String::new(),
+        build_revision: String::new(),
     }
 }
 

--- a/lib-network/src/consensus_encryption.rs
+++ b/lib-network/src/consensus_encryption.rs
@@ -268,7 +268,7 @@ const CONSENSUS_NONCE_PREFIX_INFO: &[u8] = b"ZHTP-CONSENSUS-NONCE-PREFIX-v1";
 const CONSENSUS_AAD_DOMAIN: &[u8] = b"ZHTP-CONSENSUS-AEAD-AAD-v1";
 
 /// Codec version for consensus messages (re-exported from lib-consensus)
-const CONSENSUS_CODEC_VERSION: u8 = 1;
+const CONSENSUS_CODEC_VERSION: u8 = 2;
 
 // ============================================================================
 // Implementation
@@ -978,7 +978,7 @@ mod tests {
 
         // This test documents that codec version is bound to AAD
         assert!(
-            CONSENSUS_CODEC_VERSION == 1,
+            CONSENSUS_CODEC_VERSION == 2,
             "Codec version must be bound to AAD for security"
         );
 

--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -2750,6 +2750,7 @@ mod tests {
             timestamp: 0,
             signature: heartbeat_sig,
             build_id: String::new(),
+            build_revision: String::new(),
         };
         let validator_msg =
             lib_consensus::validators::ValidatorMessage::Heartbeat(heartbeat);

--- a/lib-network/src/messaging/message_handler.rs
+++ b/lib-network/src/messaging/message_handler.rs
@@ -2749,6 +2749,7 @@ mod tests {
             },
             timestamp: 0,
             signature: heartbeat_sig,
+            build_id: String::new(),
         };
         let validator_msg =
             lib_consensus::validators::ValidatorMessage::Heartbeat(heartbeat);

--- a/scripts/deploy-validators.sh
+++ b/scripts/deploy-validators.sh
@@ -12,24 +12,30 @@
 #   scripts/deploy-validators.sh --dry-run <binary-path>     # show plan, don't act
 #   scripts/deploy-validators.sh --skip-halt <binary-path>   # already halted, e.g. chain stuck
 #
-# What it does, in order:
-#   1. md5sum the local binary; capture consensus build_id from zhtp-cli.
-#   1b. Pre-flight: verify all running validators report the same build_id
-#       (aborts on mixed cluster — coordinated upgrade required).
-#   2. halt-consensus on all validators (council role required).
-#   3. Verify "HALTED" appears in each validator's log.
-#   4. Rsync binary to each (parallel).
-#   5. md5-verify on each. Abort if mismatch.
-#   5b. Verify embedded consensus build_id in each remote binary (strings).
-#   6. Restart all (parallel).
-#   7. Poll for "Caught up at height" on each (timeout per node).
-#   8. Post-flight: verify each node reports matching build_id via API.
-#   9. Print state table: node | height | md5 | build_id
-#  10. Exit non-zero on any failure.
+# Coordinated upgrade requirements (read before running):
 #
-# Operator never types systemctl, rsync, or md5sum manually. Mistakes
-# (forgetting to halt, missing a node, deploying wrong binary) become
-# impossible.
+# - Consensus binary-epoch enforcement requires ALL validators on the same
+#   epoch before any produces blocks. A partial rollout (g1 upgraded, g2/g3
+#   not) stalls consensus — not a network partition, but indistinguishable
+#   from one in logs until you check build epoch via API.
+# - With 3 validators, 2 must be halted before deploy to block quorum (script
+#   enforces TOTAL-1 halted). Finish rollout on all nodes before un-halting.
+# - Build zhtp AND zhtp-cli from the same commit:
+#     cargo build --profile dev-release -p zhtp -p zhtp-cli
+#
+# What it does, in order:
+#   1. md5sum local binary; read consensus epoch from zhtp-cli (no strings).
+#   1b. Pre-flight: abort if running validators report mixed epochs.
+#   2. halt-consensus on all validators (council role required).
+#   3. Verify "HALTED" in each validator's journal.
+#   4. Rsync binary to each (parallel).
+#   5. md5-verify on each.
+#   6. Restart all (parallel).
+#   7. Poll for active consensus on each.
+#   8. Post-flight: API epoch must match on every node.
+#   9. Print state table: node | height | md5 | epoch
+#
+# Operator never types systemctl, rsync, or md5sum manually.
 
 set -euo pipefail
 
@@ -88,37 +94,29 @@ run_on() {
     ssh "$alias" "${sudo} ${cmd}"
 }
 
-# Consensus build id embedded at compile time (git short hash).
-# Requires zhtp-cli built from the same tree as the deploy binary.
-local_build_id() {
-    if [[ -x "$CLI_BIN" ]]; then
-        "$CLI_BIN" version --build-id-only 2>/dev/null && return 0
-    fi
-    # Fallback: scrape from the binary being deployed.
-    strings "$BINARY" 2>/dev/null | rg -o '^[0-9a-f]{12}(-dirty)?$' | head -1
+# Consensus epoch (human-bumped CONSENSUS_BUILD_ID). Requires zhtp-cli built
+# from the same tree — no strings fallback (hex literals in binaries collide).
+local_build_epoch() {
+    [[ -x "$CLI_BIN" ]] || return 1
+    "$CLI_BIN" version --build-id-only 2>/dev/null
 }
 
-remote_build_id_api() {
-    # remote_build_id_api <ip>
+remote_build_epoch_api() {
     local ip=$1
     [[ -x "$CLI_BIN" ]] || return 1
     "$CLI_BIN" -s "$ip:9334" version --remote --build-id-only 2>/dev/null
 }
 
-remote_build_id_binary() {
-    # remote_build_id_binary <alias> <sudo>
-    local alias=$1 sudo=$2
-    ssh "$alias" "${sudo} strings $REMOTE_BIN 2>/dev/null" \
-        | rg -o '^[0-9a-f]{12}(-dirty)?$' | head -1
-}
+# ---- step 1: local md5 + epoch ---------------------------------------------
 
-# ---- step 1: local md5 + build id ------------------------------------------
+[[ -x "$CLI_BIN" ]] || fail "zhtp-cli not found at $CLI_BIN — build: cargo build --profile dev-release -p zhtp-cli"
 
 LOCAL_MD5=$(md5sum "$BINARY" | awk '{print $1}')
-LOCAL_BUILD_ID=$(local_build_id)
-[[ -z "$LOCAL_BUILD_ID" ]] && fail "could not determine local consensus build_id — build zhtp-cli first: cargo build --profile dev-release -p zhtp-cli"
+LOCAL_BUILD_ID=$(local_build_epoch || true)
+[[ -z "$LOCAL_BUILD_ID" ]] && fail "could not read consensus epoch from zhtp-cli"
+[[ "$LOCAL_BUILD_ID" == "unknown" ]] && fail "consensus epoch is 'unknown' — rebuild from a git checkout"
 log "local binary md5: $LOCAL_MD5  ($BINARY)"
-log "local consensus build_id: $LOCAL_BUILD_ID"
+log "local consensus epoch: $LOCAL_BUILD_ID"
 
 if [[ $DRY_RUN -eq 1 ]]; then
     log "DRY RUN — printing planned actions, no changes."
@@ -135,7 +133,7 @@ if [[ $DRY_RUN -eq 0 ]]; then
     PREFLIGHT_REACHABLE=0
     for entry in "${NODES[@]}"; do
         IFS='|' read -r alias ip sudo <<< "$entry"
-        REMOTE_ID=$(remote_build_id_api "$ip" || true)
+        REMOTE_ID=$(remote_build_epoch_api "$ip" || true)
         if [[ -n "$REMOTE_ID" ]]; then
             PREFLIGHT_REACHABLE=$((PREFLIGHT_REACHABLE+1))
             PREFLIGHT_IDS+=("$alias:$REMOTE_ID")
@@ -273,16 +271,6 @@ if [[ $DRY_RUN -eq 0 ]]; then
         fi
     done
 
-    log "verifying remote binary embeds build_id == $LOCAL_BUILD_ID..."
-    for entry in "${NODES[@]}"; do
-        IFS='|' read -r alias _ip sudo <<< "$entry"
-        REMOTE_ID=$(remote_build_id_binary "$alias" "$sudo")
-        if [[ "$REMOTE_ID" == "$LOCAL_BUILD_ID" ]]; then
-            ok "build_id match (binary): $alias"
-        else
-            fail "build_id MISMATCH on $alias: embedded $REMOTE_ID, expected $LOCAL_BUILD_ID"
-        fi
-    done
 fi
 
 # ---- step 6: restart all (parallel) ----------------------------------------
@@ -338,8 +326,8 @@ fi
 if [[ $DRY_RUN -eq 0 ]]; then
     echo
     log "final cluster state:"
-    printf '%-12s  %-10s  %-32s  %-16s\n' NODE HEIGHT MD5 BUILD_ID
-    printf '%-12s  %-10s  %-32s  %-16s\n' '----' '------' '---' '---------'
+    printf '%-12s  %-10s  %-32s  %-8s\n' NODE HEIGHT MD5 EPOCH
+    printf '%-12s  %-10s  %-32s  %-8s\n' '----' '------' '---' '-----'
     for entry in "${NODES[@]}"; do
         IFS='|' read -r alias ip sudo <<< "$entry"
         height=$(ssh "$alias" "${sudo} journalctl -u $SERVICE -n 30 --no-pager 2>/dev/null | grep -oE 'height=[0-9]+' | tail -1 | cut -d= -f2" 2>/dev/null || echo "?")
@@ -349,4 +337,4 @@ if [[ $DRY_RUN -eq 0 ]]; then
     done
 fi
 
-ok "deploy complete (build_id=$LOCAL_BUILD_ID)"
+ok "deploy complete (consensus epoch=$LOCAL_BUILD_ID)"

--- a/scripts/deploy-validators.sh
+++ b/scripts/deploy-validators.sh
@@ -13,15 +13,19 @@
 #   scripts/deploy-validators.sh --skip-halt <binary-path>   # already halted, e.g. chain stuck
 #
 # What it does, in order:
-#   1. md5sum the local binary.
+#   1. md5sum the local binary; capture consensus build_id from zhtp-cli.
+#   1b. Pre-flight: verify all running validators report the same build_id
+#       (aborts on mixed cluster — coordinated upgrade required).
 #   2. halt-consensus on all validators (council role required).
 #   3. Verify "HALTED" appears in each validator's log.
 #   4. Rsync binary to each (parallel).
 #   5. md5-verify on each. Abort if mismatch.
+#   5b. Verify embedded consensus build_id in each remote binary (strings).
 #   6. Restart all (parallel).
 #   7. Poll for "Caught up at height" on each (timeout per node).
-#   8. Print state table: node | height | md5 | voting?
-#   9. Exit non-zero on any failure.
+#   8. Post-flight: verify each node reports matching build_id via API.
+#   9. Print state table: node | height | md5 | build_id
+#  10. Exit non-zero on any failure.
 #
 # Operator never types systemctl, rsync, or md5sum manually. Mistakes
 # (forgetting to halt, missing a node, deploying wrong binary) become
@@ -40,8 +44,10 @@ NODES=(
 )
 
 REMOTE_BIN=/opt/zhtp/zhtp
+CLI_BIN="./target/dev-release/zhtp-cli"
 HALT_WAIT_SECS=30
 RESTART_WAIT_SECS=600
+BUILD_ID_POLL_SECS=120
 SERVICE=zhtp
 
 # ---- arg parse --------------------------------------------------------------
@@ -82,13 +88,77 @@ run_on() {
     ssh "$alias" "${sudo} ${cmd}"
 }
 
-# ---- step 1: local md5 -----------------------------------------------------
+# Consensus build id embedded at compile time (git short hash).
+# Requires zhtp-cli built from the same tree as the deploy binary.
+local_build_id() {
+    if [[ -x "$CLI_BIN" ]]; then
+        "$CLI_BIN" version --build-id-only 2>/dev/null && return 0
+    fi
+    # Fallback: scrape from the binary being deployed.
+    strings "$BINARY" 2>/dev/null | rg -o '^[0-9a-f]{12}(-dirty)?$' | head -1
+}
+
+remote_build_id_api() {
+    # remote_build_id_api <ip>
+    local ip=$1
+    [[ -x "$CLI_BIN" ]] || return 1
+    "$CLI_BIN" -s "$ip:9334" version --remote --build-id-only 2>/dev/null
+}
+
+remote_build_id_binary() {
+    # remote_build_id_binary <alias> <sudo>
+    local alias=$1 sudo=$2
+    ssh "$alias" "${sudo} strings $REMOTE_BIN 2>/dev/null" \
+        | rg -o '^[0-9a-f]{12}(-dirty)?$' | head -1
+}
+
+# ---- step 1: local md5 + build id ------------------------------------------
 
 LOCAL_MD5=$(md5sum "$BINARY" | awk '{print $1}')
+LOCAL_BUILD_ID=$(local_build_id)
+[[ -z "$LOCAL_BUILD_ID" ]] && fail "could not determine local consensus build_id — build zhtp-cli first: cargo build --profile dev-release -p zhtp-cli"
 log "local binary md5: $LOCAL_MD5  ($BINARY)"
+log "local consensus build_id: $LOCAL_BUILD_ID"
 
 if [[ $DRY_RUN -eq 1 ]]; then
     log "DRY RUN — printing planned actions, no changes."
+fi
+
+# ---- step 1b: pre-flight build_id homogeneity ------------------------------
+#
+# Mixed build_ids on a live cluster will stall consensus once any node
+# upgrades. Abort before halt if the running validators disagree.
+
+if [[ $DRY_RUN -eq 0 ]]; then
+    log "pre-flight: checking running validators report a homogeneous build_id..."
+    PREFLIGHT_IDS=()
+    PREFLIGHT_REACHABLE=0
+    for entry in "${NODES[@]}"; do
+        IFS='|' read -r alias ip sudo <<< "$entry"
+        REMOTE_ID=$(remote_build_id_api "$ip" || true)
+        if [[ -n "$REMOTE_ID" ]]; then
+            PREFLIGHT_REACHABLE=$((PREFLIGHT_REACHABLE+1))
+            PREFLIGHT_IDS+=("$alias:$REMOTE_ID")
+            log "  $alias build_id=$REMOTE_ID"
+        else
+            warn "  $alias: no build_id via API (pre-upgrade node or unreachable)"
+        fi
+    done
+
+    if [[ $PREFLIGHT_REACHABLE -gt 0 ]]; then
+        UNIQUE_PREFLIGHT=$(printf '%s\n' "${PREFLIGHT_IDS[@]}" | cut -d: -f2 | sort -u | wc -l)
+        if [[ "$UNIQUE_PREFLIGHT" -gt 1 ]]; then
+            fail "mixed build_id cluster detected — halt manually and redeploy all validators together"
+        fi
+        BASELINE_ID=$(printf '%s\n' "${PREFLIGHT_IDS[@]}" | head -1 | cut -d: -f2)
+        if [[ -n "$BASELINE_ID" && "$BASELINE_ID" == "$LOCAL_BUILD_ID" ]]; then
+            ok "cluster already on target build_id $LOCAL_BUILD_ID — nothing to deploy"
+            exit 0
+        fi
+        ok "pre-flight: homogeneous cluster (build_id=${BASELINE_ID:-unknown}), proceeding with upgrade to $LOCAL_BUILD_ID"
+    else
+        warn "pre-flight: no API build_id from any node — proceeding (first deploy or nodes down)"
+    fi
 fi
 
 # ---- step 2: halt all validators -------------------------------------------
@@ -202,6 +272,17 @@ if [[ $DRY_RUN -eq 0 ]]; then
             fail "md5 MISMATCH on $alias: got $REMOTE_MD5, expected $LOCAL_MD5"
         fi
     done
+
+    log "verifying remote binary embeds build_id == $LOCAL_BUILD_ID..."
+    for entry in "${NODES[@]}"; do
+        IFS='|' read -r alias _ip sudo <<< "$entry"
+        REMOTE_ID=$(remote_build_id_binary "$alias" "$sudo")
+        if [[ "$REMOTE_ID" == "$LOCAL_BUILD_ID" ]]; then
+            ok "build_id match (binary): $alias"
+        else
+            fail "build_id MISMATCH on $alias: embedded $REMOTE_ID, expected $LOCAL_BUILD_ID"
+        fi
+    done
 fi
 
 # ---- step 6: restart all (parallel) ----------------------------------------
@@ -231,6 +312,25 @@ if [[ $DRY_RUN -eq 0 ]]; then
             warn "TIMEOUT: $alias did not reach active consensus in ${RESTART_WAIT_SECS}s — check manually"
         fi
     done
+
+    log "post-flight: verifying API build_id on all validators (timeout: ${BUILD_ID_POLL_SECS}s)..."
+    for entry in "${NODES[@]}"; do
+        IFS='|' read -r alias ip _sudo <<< "$entry"
+        REMOTE_ID=""
+        deadline=$(( $(date +%s) + BUILD_ID_POLL_SECS ))
+        while [[ $(date +%s) -lt $deadline ]]; do
+            REMOTE_ID=$("$CLI_BIN" -s "$ip:9334" version --remote --build-id-only 2>/dev/null || true)
+            if [[ "$REMOTE_ID" == "$LOCAL_BUILD_ID" ]]; then
+                break
+            fi
+            sleep 5
+        done
+        if [[ "$REMOTE_ID" == "$LOCAL_BUILD_ID" ]]; then
+            ok "build_id match (API): $alias"
+        else
+            fail "build_id API mismatch on $alias: got '${REMOTE_ID:-?}', expected $LOCAL_BUILD_ID"
+        fi
+    done
 fi
 
 # ---- step 8: state table ---------------------------------------------------
@@ -238,14 +338,15 @@ fi
 if [[ $DRY_RUN -eq 0 ]]; then
     echo
     log "final cluster state:"
-    printf '%-12s  %-10s  %-32s\n' NODE HEIGHT MD5
-    printf '%-12s  %-10s  %-32s\n' '----' '------' '---'
+    printf '%-12s  %-10s  %-32s  %-16s\n' NODE HEIGHT MD5 BUILD_ID
+    printf '%-12s  %-10s  %-32s  %-16s\n' '----' '------' '---' '---------'
     for entry in "${NODES[@]}"; do
-        IFS='|' read -r alias _ip sudo <<< "$entry"
+        IFS='|' read -r alias ip sudo <<< "$entry"
         height=$(ssh "$alias" "${sudo} journalctl -u $SERVICE -n 30 --no-pager 2>/dev/null | grep -oE 'height=[0-9]+' | tail -1 | cut -d= -f2" 2>/dev/null || echo "?")
         md5=$(ssh "$alias" "${sudo} md5sum $REMOTE_BIN 2>/dev/null | awk '{print \$1}'" 2>/dev/null || echo "?")
-        printf '%-12s  %-10s  %-32s\n' "$alias" "${height:-?}" "${md5:-?}"
+        build_id=$("$CLI_BIN" -s "$ip:9334" version --remote --build-id-only 2>/dev/null || echo "?")
+        printf '%-12s  %-10s  %-32s  %-16s\n' "$alias" "${height:-?}" "${md5:-?}" "${build_id:-?}"
     done
 fi
 
-ok "deploy complete"
+ok "deploy complete (build_id=$LOCAL_BUILD_ID)"

--- a/zhtp-cli/Cargo.toml
+++ b/zhtp-cli/Cargo.toml
@@ -58,6 +58,7 @@ lib-economy = { path = "../lib-economy" }
 # CONS-103 / PR #2382 review: needed for `lib_types::sov::atoms` so placeholder
 # reward amounts are scaled into the same units as real reward rounds.
 lib-types = { path = "../lib-types" }
+lib-consensus-core = { path = "../lib-consensus-core" }
 lib-network = { path = "../lib-network" }
 lib-blockchain = { path = "../lib-blockchain", features = ["contracts"] }
 # Governance parameter enums referenced by `dao governance-update`.

--- a/zhtp-cli/src/argument_parsing.rs
+++ b/zhtp-cli/src/argument_parsing.rs
@@ -1086,6 +1086,12 @@ pub struct VersionArgs {
     /// Show full build information
     #[arg(short, long)]
     pub full: bool,
+    /// Print only the consensus build id (for deploy scripts)
+    #[arg(long)]
+    pub build_id_only: bool,
+    /// Query the remote node at `-s` / `ZHTP_SERVER` for its consensus build id
+    #[arg(long)]
+    pub remote: bool,
 }
 
 /// Shell completion command
@@ -2202,9 +2208,11 @@ pub async fn run_cli() -> Result<()> {
         ZhtpCommand::Monitor(args) => commands::monitor::handle_monitor_command(args.clone(), &cli)
             .await
             .map_err(anyhow::Error::msg),
-        ZhtpCommand::Version(args) => commands::version::handle_version_command(args.clone())
-            .await
-            .map_err(anyhow::Error::msg),
+        ZhtpCommand::Version(args) => {
+            commands::version::handle_version_command(args.clone(), &cli.server)
+                .await
+                .map_err(anyhow::Error::msg)
+        }
         ZhtpCommand::Completion(args) => {
             commands::completion::handle_completion_command(args.clone())
                 .await

--- a/zhtp-cli/src/commands/version.rs
+++ b/zhtp-cli/src/commands/version.rs
@@ -8,8 +8,10 @@
 //! - **Testability**: Output trait injection for testing
 
 use crate::argument_parsing::VersionArgs;
-use crate::error::CliResult;
+use crate::error::{CliError, CliResult};
 use crate::output::Output;
+use lib_consensus_core::CONSENSUS_BUILD_ID;
+use lib_protocols::types::ZhtpStatus;
 
 // ============================================================================
 // PURE LOGIC - No side effects, fully testable
@@ -25,14 +27,15 @@ pub struct VersionInfo {
     pub build_timestamp: String,
     pub build_profile: String,
     pub platform: String,
+    pub consensus_build_id: String,
 }
 
 impl VersionInfo {
     /// Format version info for display
     pub fn format_brief(&self) -> String {
         format!(
-            "zhtp-cli {}\n  Release: {} build on {}",
-            self.version, self.build_profile, self.platform
+            "zhtp-cli {}\n  Consensus build: {}\n  Release: {} build on {}",
+            self.version, self.consensus_build_id, self.build_profile, self.platform
         )
     }
 
@@ -40,10 +43,12 @@ impl VersionInfo {
     pub fn format_full(&self) -> String {
         format!(
             "zhtp-cli {}\n  \
+            Consensus build: {}\n  \
             Git: {} on {} ({})\n  \
             Built: {} ({} profile)\n  \
             Platform: {}",
             self.version,
+            self.consensus_build_id,
             &self.git_hash[..8.min(self.git_hash.len())],
             self.git_branch,
             if self.git_dirty { "dirty" } else { "clean" },
@@ -66,7 +71,40 @@ pub fn capture_version_info() -> VersionInfo {
         build_timestamp: env!("BUILD_TIMESTAMP").to_string(),
         build_profile: env!("BUILD_PROFILE").to_string(),
         platform: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+        consensus_build_id: CONSENSUS_BUILD_ID.to_string(),
     }
+}
+
+/// Fetch consensus build id from a running node via `/api/v1/protocol/version`.
+pub async fn fetch_remote_consensus_build_id(server: &str) -> CliResult<String> {
+    let client = crate::commands::web4_utils::connect_default(server)
+        .await
+        .map_err(|e| CliError::NetworkError(format!("cannot connect to {server}: {e}")))?;
+
+    let response = client
+        .get("/api/v1/protocol/version")
+        .await
+        .map_err(|e| CliError::NetworkError(format!("version request failed: {e}")))?;
+
+    if response.status != ZhtpStatus::Ok {
+        return Err(CliError::NetworkError(format!(
+            "version endpoint returned {} ({})",
+            response.status, response.status_message
+        )));
+    }
+
+    let body: serde_json::Value = lib_network::client::ZhtpClient::parse_json(&response)
+        .map_err(|e| CliError::NetworkError(format!("invalid version JSON: {e}")))?;
+
+    body.get("consensus_build_id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            CliError::NetworkError(
+                "remote node did not report consensus_build_id (upgrade required)".into(),
+            )
+        })
 }
 
 // ============================================================================
@@ -76,14 +114,33 @@ pub fn capture_version_info() -> VersionInfo {
 /// Handle version command with proper error handling and output
 ///
 /// Public entry point that maintains backward compatibility
-pub async fn handle_version_command(args: VersionArgs) -> CliResult<()> {
+pub async fn handle_version_command(args: VersionArgs, server: &str) -> CliResult<()> {
     let output = crate::output::ConsoleOutput;
-    handle_version_command_impl(args, &output).await
+    handle_version_command_impl(args, server, &output).await
 }
 
 /// Internal implementation with dependency injection
-async fn handle_version_command_impl(args: VersionArgs, output: &dyn Output) -> CliResult<()> {
+async fn handle_version_command_impl(
+    args: VersionArgs,
+    server: &str,
+    output: &dyn Output,
+) -> CliResult<()> {
+    if args.remote {
+        let remote_id = fetch_remote_consensus_build_id(server).await?;
+        if args.build_id_only {
+            output.print(&remote_id)?;
+        } else {
+            output.print(&format!("consensus build: {remote_id} (remote @ {server})"))?;
+        }
+        return Ok(());
+    }
+
     let info = capture_version_info();
+
+    if args.build_id_only {
+        output.print(&info.consensus_build_id)?;
+        return Ok(());
+    }
 
     if args.full {
         output.print(&info.format_full())?;
@@ -112,13 +169,14 @@ mod tests {
             build_timestamp: "2024-12-26T10:00:00Z".to_string(),
             build_profile: "release".to_string(),
             platform: "linux-x86_64".to_string(),
+            consensus_build_id: "abc123def456".to_string(),
         };
 
         let formatted = info.format_brief();
         assert!(formatted.contains("0.1.0"));
+        assert!(formatted.contains("abc123def456"));
         assert!(formatted.contains("release"));
         assert!(formatted.contains("linux-x86_64"));
-        assert!(!formatted.contains("abc123"));
     }
 
     #[test]
@@ -131,6 +189,7 @@ mod tests {
             build_timestamp: "2024-12-26T10:00:00Z".to_string(),
             build_profile: "release".to_string(),
             platform: "linux-x86_64".to_string(),
+            consensus_build_id: "abc123def456".to_string(),
         };
 
         let formatted = info.format_full();
@@ -140,6 +199,7 @@ mod tests {
         assert!(formatted.contains("clean"));
         assert!(formatted.contains("release"));
         assert!(formatted.contains("linux-x86_64"));
+        assert!(formatted.contains("Consensus build: abc123def456"));
     }
 
     #[test]
@@ -152,6 +212,7 @@ mod tests {
             build_timestamp: "2024-12-26T10:00:00Z".to_string(),
             build_profile: "debug".to_string(),
             platform: "darwin-aarch64".to_string(),
+            consensus_build_id: "abc123def456-dirty".to_string(),
         };
 
         let formatted = info.format_full();
@@ -161,37 +222,8 @@ mod tests {
     }
 
     #[test]
-    fn test_version_info_hash_truncation() {
-        let info = VersionInfo {
-            version: "0.1.0".to_string(),
-            git_hash: "a1b2c3d4e5f6g7h8i9j0".to_string(),
-            git_branch: "main".to_string(),
-            git_dirty: false,
-            build_timestamp: "2024-12-26T10:00:00Z".to_string(),
-            build_profile: "release".to_string(),
-            platform: "linux-x86_64".to_string(),
-        };
-
-        let formatted = info.format_full();
-        // Should show only first 8 characters of hash
-        assert!(formatted.contains("a1b2c3d4"));
-        assert!(!formatted.contains("a1b2c3d4e5f6g7h8"));
-    }
-
-    #[test]
-    fn test_version_info_creation() {
-        let info = VersionInfo {
-            version: "0.1.0".to_string(),
-            git_hash: "abc123".to_string(),
-            git_branch: "main".to_string(),
-            git_dirty: false,
-            build_timestamp: "2024-12-26T10:00:00Z".to_string(),
-            build_profile: "release".to_string(),
-            platform: "linux-x86_64".to_string(),
-        };
-
-        assert_eq!(info.version, "0.1.0");
-        assert_eq!(info.build_profile, "release");
-        assert!(!info.git_dirty);
+    fn test_capture_version_info_includes_consensus_build_id() {
+        let info = capture_version_info();
+        assert_eq!(info.consensus_build_id, CONSENSUS_BUILD_ID);
     }
 }

--- a/zhtp-cli/src/commands/version.rs
+++ b/zhtp-cli/src/commands/version.rs
@@ -1,21 +1,12 @@
 //! Version command for ZHTP CLI
 //!
 //! Architecture: Functional Core, Imperative Shell (FCIS)
-//!
-//! - **Pure Logic**: Version string construction, metadata formatting
-//! - **Imperative Shell**: Output printing, environment variable reading
-//! - **Error Handling**: Domain-specific CliError types
-//! - **Testability**: Output trait injection for testing
 
 use crate::argument_parsing::VersionArgs;
 use crate::error::{CliError, CliResult};
 use crate::output::Output;
-use lib_consensus_core::CONSENSUS_BUILD_ID;
+use lib_consensus_core::{BUILD_REVISION, CONSENSUS_BUILD_ID};
 use lib_protocols::types::ZhtpStatus;
-
-// ============================================================================
-// PURE LOGIC - No side effects, fully testable
-// ============================================================================
 
 /// Version information structure
 #[derive(Debug, Clone)]
@@ -27,28 +18,31 @@ pub struct VersionInfo {
     pub build_timestamp: String,
     pub build_profile: String,
     pub platform: String,
+    /// Human-bumped binary epoch (gated at consensus admission).
     pub consensus_build_id: String,
+    /// Git revision embedded at compile time (advisory telemetry).
+    pub build_revision: String,
 }
 
 impl VersionInfo {
-    /// Format version info for display
     pub fn format_brief(&self) -> String {
         format!(
-            "zhtp-cli {}\n  Consensus build: {}\n  Release: {} build on {}",
-            self.version, self.consensus_build_id, self.build_profile, self.platform
+            "zhtp-cli {}\n  Consensus epoch: {}\n  Build revision: {}\n  Release: {} build on {}",
+            self.version, self.consensus_build_id, self.build_revision, self.build_profile, self.platform
         )
     }
 
-    /// Format full version info with all details
     pub fn format_full(&self) -> String {
         format!(
             "zhtp-cli {}\n  \
-            Consensus build: {}\n  \
+            Consensus epoch: {}\n  \
+            Build revision: {}\n  \
             Git: {} on {} ({})\n  \
             Built: {} ({} profile)\n  \
             Platform: {}",
             self.version,
             self.consensus_build_id,
+            self.build_revision,
             &self.git_hash[..8.min(self.git_hash.len())],
             self.git_branch,
             if self.git_dirty { "dirty" } else { "clean" },
@@ -59,9 +53,6 @@ impl VersionInfo {
     }
 }
 
-/// Capture environment variables set by build.rs
-///
-/// Pure function - only reads environment variables
 pub fn capture_version_info() -> VersionInfo {
     VersionInfo {
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -72,11 +63,25 @@ pub fn capture_version_info() -> VersionInfo {
         build_profile: env!("BUILD_PROFILE").to_string(),
         platform: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
         consensus_build_id: CONSENSUS_BUILD_ID.to_string(),
+        build_revision: BUILD_REVISION.to_string(),
     }
 }
 
-/// Fetch consensus build id from a running node via `/api/v1/protocol/version`.
+/// Fetch consensus epoch from a running node via `/api/v1/protocol/version`.
 pub async fn fetch_remote_consensus_build_id(server: &str) -> CliResult<String> {
+    let body = fetch_remote_version_json(server).await?;
+    body.get("consensus_build_id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            CliError::NetworkError(
+                "remote node did not report consensus_build_id (upgrade required)".into(),
+            )
+        })
+}
+
+async fn fetch_remote_version_json(server: &str) -> CliResult<serde_json::Value> {
     let client = crate::commands::web4_utils::connect_default(server)
         .await
         .map_err(|e| CliError::NetworkError(format!("cannot connect to {server}: {e}")))?;
@@ -93,33 +98,15 @@ pub async fn fetch_remote_consensus_build_id(server: &str) -> CliResult<String> 
         )));
     }
 
-    let body: serde_json::Value = lib_network::client::ZhtpClient::parse_json(&response)
-        .map_err(|e| CliError::NetworkError(format!("invalid version JSON: {e}")))?;
-
-    body.get("consensus_build_id")
-        .and_then(|v| v.as_str())
-        .map(str::to_string)
-        .filter(|id| !id.is_empty())
-        .ok_or_else(|| {
-            CliError::NetworkError(
-                "remote node did not report consensus_build_id (upgrade required)".into(),
-            )
-        })
+    lib_network::client::ZhtpClient::parse_json(&response)
+        .map_err(|e| CliError::NetworkError(format!("invalid version JSON: {e}")))
 }
 
-// ============================================================================
-// IMPERATIVE SHELL - All side effects here (output)
-// ============================================================================
-
-/// Handle version command with proper error handling and output
-///
-/// Public entry point that maintains backward compatibility
 pub async fn handle_version_command(args: VersionArgs, server: &str) -> CliResult<()> {
     let output = crate::output::ConsoleOutput;
     handle_version_command_impl(args, server, &output).await
 }
 
-/// Internal implementation with dependency injection
 async fn handle_version_command_impl(
     args: VersionArgs,
     server: &str,
@@ -130,7 +117,9 @@ async fn handle_version_command_impl(
         if args.build_id_only {
             output.print(&remote_id)?;
         } else {
-            output.print(&format!("consensus build: {remote_id} (remote @ {server})"))?;
+            output.print(&format!(
+                "consensus epoch: {remote_id} (remote @ {server})"
+            ))?;
         }
         return Ok(());
     }
@@ -138,6 +127,11 @@ async fn handle_version_command_impl(
     let info = capture_version_info();
 
     if args.build_id_only {
+        if info.consensus_build_id.is_empty() {
+            return Err(CliError::ConfigError(
+                "consensus build id unavailable — rebuild from a git checkout".into(),
+            ));
+        }
         output.print(&info.consensus_build_id)?;
         return Ok(());
     }
@@ -151,79 +145,33 @@ async fn handle_version_command_impl(
     Ok(())
 }
 
-// ============================================================================
-// TESTS - Pure logic is testable without mocks or side effects
-// ============================================================================
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_version_info_format_brief() {
-        let info = VersionInfo {
-            version: "0.1.0".to_string(),
-            git_hash: "abc123def456".to_string(),
-            git_branch: "main".to_string(),
-            git_dirty: false,
-            build_timestamp: "2024-12-26T10:00:00Z".to_string(),
-            build_profile: "release".to_string(),
-            platform: "linux-x86_64".to_string(),
-            consensus_build_id: "abc123def456".to_string(),
-        };
-
-        let formatted = info.format_brief();
-        assert!(formatted.contains("0.1.0"));
-        assert!(formatted.contains("abc123def456"));
-        assert!(formatted.contains("release"));
-        assert!(formatted.contains("linux-x86_64"));
-    }
-
-    #[test]
-    fn test_version_info_format_full() {
-        let info = VersionInfo {
-            version: "0.1.0".to_string(),
-            git_hash: "abc123def456".to_string(),
-            git_branch: "main".to_string(),
-            git_dirty: false,
-            build_timestamp: "2024-12-26T10:00:00Z".to_string(),
-            build_profile: "release".to_string(),
-            platform: "linux-x86_64".to_string(),
-            consensus_build_id: "abc123def456".to_string(),
-        };
-
-        let formatted = info.format_full();
-        assert!(formatted.contains("0.1.0"));
-        assert!(formatted.contains("abc123"));
-        assert!(formatted.contains("main"));
-        assert!(formatted.contains("clean"));
-        assert!(formatted.contains("release"));
-        assert!(formatted.contains("linux-x86_64"));
-        assert!(formatted.contains("Consensus build: abc123def456"));
-    }
-
-    #[test]
-    fn test_version_info_format_full_dirty() {
-        let info = VersionInfo {
-            version: "0.1.0".to_string(),
-            git_hash: "abc123def456".to_string(),
-            git_branch: "dev".to_string(),
-            git_dirty: true,
-            build_timestamp: "2024-12-26T10:00:00Z".to_string(),
-            build_profile: "debug".to_string(),
-            platform: "darwin-aarch64".to_string(),
-            consensus_build_id: "abc123def456-dirty".to_string(),
-        };
-
-        let formatted = info.format_full();
-        assert!(formatted.contains("dirty"));
-        assert!(formatted.contains("debug"));
-        assert!(formatted.contains("darwin-aarch64"));
-    }
-
-    #[test]
-    fn test_capture_version_info_includes_consensus_build_id() {
+    fn test_capture_version_info_includes_epoch_and_revision() {
         let info = capture_version_info();
         assert_eq!(info.consensus_build_id, CONSENSUS_BUILD_ID);
+        assert_eq!(info.build_revision, BUILD_REVISION);
+        assert!(!info.build_revision.is_empty());
+    }
+
+    #[test]
+    fn test_version_info_format_brief_includes_epoch() {
+        let info = VersionInfo {
+            version: "0.1.0".to_string(),
+            git_hash: "abc123def456".to_string(),
+            git_branch: "main".to_string(),
+            git_dirty: false,
+            build_timestamp: "2024-12-26T10:00:00Z".to_string(),
+            build_profile: "release".to_string(),
+            platform: "linux-x86_64".to_string(),
+            consensus_build_id: "1".to_string(),
+            build_revision: "abc123def456".to_string(),
+        };
+        let formatted = info.format_brief();
+        assert!(formatted.contains("Consensus epoch: 1"));
+        assert!(formatted.contains("abc123def456"));
     }
 }

--- a/zhtp/src/api/handlers/protocol/mod.rs
+++ b/zhtp/src/api/handlers/protocol/mod.rs
@@ -11,6 +11,7 @@ use tokio::sync::RwLock;
 // Removed unused Deserialize and serde_json::json
 
 // ZHTP protocol imports
+use lib_consensus_core::CONSENSUS_BUILD_ID;
 use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
 
@@ -159,6 +160,9 @@ struct VersionResponse {
     server_version: String,
     protocol_version: String,
     api_version: String,
+    /// Git short hash identifying this validator binary. Peers reject
+    /// consensus messages when this does not match their own build.
+    consensus_build_id: String,
     build_info: BuildInfo,
 }
 
@@ -287,8 +291,9 @@ impl ProtocolHandler {
             server_version: server_info.version.clone(),
             protocol_version: server_info.protocol_version.clone(),
             api_version: "1.0".to_string(),
+            consensus_build_id: CONSENSUS_BUILD_ID.to_string(),
             build_info: BuildInfo {
-                commit: "dev-build".to_string(),
+                commit: CONSENSUS_BUILD_ID.to_string(),
                 build_date: "2025-09-18".to_string(),
                 rust_version: "1.70+".to_string(),
             },

--- a/zhtp/src/api/handlers/protocol/mod.rs
+++ b/zhtp/src/api/handlers/protocol/mod.rs
@@ -11,7 +11,7 @@ use tokio::sync::RwLock;
 // Removed unused Deserialize and serde_json::json
 
 // ZHTP protocol imports
-use lib_consensus_core::CONSENSUS_BUILD_ID;
+use lib_consensus_core::{BUILD_REVISION, CONSENSUS_BUILD_ID};
 use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
 
@@ -160,9 +160,10 @@ struct VersionResponse {
     server_version: String,
     protocol_version: String,
     api_version: String,
-    /// Git short hash identifying this validator binary. Peers reject
-    /// consensus messages when this does not match their own build.
+    /// Human-bumped binary epoch (consensus admission gate).
     consensus_build_id: String,
+    /// Git revision compiled into this binary (advisory telemetry).
+    build_revision: String,
     build_info: BuildInfo,
 }
 
@@ -292,8 +293,9 @@ impl ProtocolHandler {
             protocol_version: server_info.protocol_version.clone(),
             api_version: "1.0".to_string(),
             consensus_build_id: CONSENSUS_BUILD_ID.to_string(),
+            build_revision: BUILD_REVISION.to_string(),
             build_info: BuildInfo {
-                commit: CONSENSUS_BUILD_ID.to_string(),
+                commit: BUILD_REVISION.to_string(),
                 build_date: "2025-09-18".to_string(),
                 rust_version: "1.70+".to_string(),
             },


### PR DESCRIPTION
## Summary

Prevents mixed-binary validator clusters from silently participating in consensus. Each binary embeds a compile-time `CONSENSUS_BUILD_ID` (git short hash, `-dirty` suffix when built from an uncommitted tree). Proposals and votes carry this id; peers reject messages when it does not match their own build.

## Changes

- **Consensus wire format**: append-only `build_id` on `ConsensusProposal`, `VoteMessage`, and `HeartbeatMessage`
- **Admission gates**: reject mismatched proposals in `validate_incoming_proposal`; drop mismatched votes in the network handler
- **CLI**: `zhtp-cli version` shows consensus build id; `--build-id-only` and `--remote` for deploy scripting
- **API**: `GET /api/v1/protocol/version` returns `consensus_build_id`
- **Deploy**: `scripts/deploy-validators.sh` enforces coordinated upgrades — pre-flight homogeneity check, binary `strings` verification post-rsync, API verification after restart

## Deploy note

Requires a **coordinated validator upgrade**. Old binaries send empty `build_id` and are rejected. Build both artifacts from the same commit:

```bash
cargo build --profile dev-release -p zhtp -p zhtp-cli
scripts/deploy-validators.sh target/dev-release/zhtp
```

## Test plan

- [x] `lib-consensus-core` build_id unit tests
- [x] `test_proposal_admission_wrong_build_id_rejected`
- [x] Codec byte-length pins updated
- [x] `zhtp-cli` version tests