### PR TITLE
fix: post-merge build breaks from #2858 field additions

### DIFF
--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -907,6 +907,7 @@ pub fn sign_domain_registration_system_tx(
         fee_tx_hash: fee_tx_hash_hex.to_string(),
         fee_amount_atoms: 0,
         fee_payer_wallet_id: [0u8; 32],
+        asset_id: None,
     };
     let memo = payload
         .encode_memo()

--- a/zhtp-cli/src/commands/launch_templates.rs
+++ b/zhtp-cli/src/commands/launch_templates.rs
@@ -5,7 +5,7 @@
 //! Split preview uses `AssetLaunchPayloadV1::split_initial_supply` — same path as the executor.
 
 use crate::error::{CliError, CliResult};
-use lib_blockchain::contracts::sovereign_asset::SupplyMode;
+use lib_blockchain::contracts::sovereign_asset::{DaoClass, SupplyMode};
 use lib_blockchain::transaction::asset_tx::{AssetLaunchPayloadV1, ASSET_LAUNCH_TREASURY_BPS};
 use serde::Deserialize;
 
@@ -168,6 +168,8 @@ pub fn preview_launch(
         rewards: None,
         governance: None,
         transfer_authority: false,
+        dao_class: DaoClass::Fp,
+        burn_bps: 0,
     };
     payload
         .validate_dao_launch_ui_constraints()

--- a/zhtp-cli/src/commands/token.rs
+++ b/zhtp-cli/src/commands/token.rs
@@ -13,7 +13,7 @@ use crate::commands::rewards::{build_rewards_policy_bundle, load_policy_bytes_fr
 use crate::commands::web4_utils::{connect_default, load_identity_from_keystore};
 use crate::error::{CliError, CliResult};
 use crate::output::Output;
-use lib_blockchain::contracts::sovereign_asset::{GovernanceVerifierState, SupplyMode};
+use lib_blockchain::contracts::sovereign_asset::{DaoClass, GovernanceVerifierState, SupplyMode};
 use lib_blockchain::rewards_policy::validate_rewards_policy;
 use lib_blockchain::transaction::asset_tx::{
     AssetLaunchPayloadV1, GovernanceLaunchConfig, RewardsLaunchConfig,
@@ -678,13 +678,19 @@ pub async fn handle_dao_asset_launch(
         .map(|raw| build_governance_launch_config(raw, options.governance_threshold))
         .transpose()?;
 
+    let dao_class = options
+        .dao_class
+        .as_deref()
+        .and_then(DaoClass::from_str)
+        .unwrap_or(DaoClass::Fp);
+
     let payload = AssetLaunchPayloadV1 {
         name: name.to_string(),
         symbol: symbol.to_string(),
         decimals,
         initial_supply: supply,
         treasury_key_id: treasury_key.key_id,
-        treasury_bps: 2_000,
+        treasury_bps: dao_class.treasury_bps(),
         supply_mode,
         manifest_cid,
         manifest_hash,
@@ -692,6 +698,8 @@ pub async fn handle_dao_asset_launch(
         rewards,
         governance,
         transfer_authority: options.transfer_authority,
+        dao_class,
+        burn_bps: 0,
     };
     payload.validate_dao_launch_ui_constraints().map_err(|e| {
         CliError::ConfigError(format!("DAO launch validation failed: {e}"))

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -860,6 +860,7 @@ impl Web4Handler {
                     // so client/server skeletons stay byte-identical.
                     fee_amount_atoms: 0,
                     fee_payer_wallet_id: [0u8; 32],
+                    asset_id: None,
                 };
                 (lib_blockchain::TransactionType::DomainRegistration, payload.encode_memo()
                     .map_err(|e| anyhow::anyhow!("Failed to encode domain registration: {}", e))?)
@@ -1196,6 +1197,7 @@ impl Web4Handler {
                     fee_tx_hash: fee_tx_hash_hex.clone(),
                     fee_amount_atoms: registration_fee_atoms,
                     fee_payer_wallet_id: owner_wallet_id_bytes,
+                    asset_id: None,
                 };
                 (lib_blockchain::TransactionType::DomainRegistration, payload.encode_memo()
                     .map_err(|e| anyhow::anyhow!("Failed to encode domain registration: {}", e))?)


### PR DESCRIPTION
## Summary
- Add missing `asset_id` on `DomainRegistrationPayload` initializers (lib-client, web4 domains handler)
- Add missing `dao_class` / `burn_bps` on `AssetLaunchPayloadV1` initializers (zhtp-cli token + launch templates)

## Context
Required to build `zhtp` + `zhtp-cli` after merging #2858, #2859, #2861. Development branch protection blocked direct push.

## Test plan
- [x] `cargo build --profile dev-release -p zhtp -p zhtp-cli`