### PR TITLE
feat(sovereign-asset): TreasuryBind for legacy BUBL pre-80k (#2864)

### DIFF
--- a/lib-blockchain/src/execution/sovereign_asset.rs
+++ b/lib-blockchain/src/execution/sovereign_asset.rs
@@ -234,6 +234,24 @@ pub fn apply_asset_module_upgrade(
                 block_height,
             )?;
         }
+        AssetUpgradeModule::TreasuryBind { treasury_key_id } => {
+            if asset.treasury_key_id.is_some() {
+                return Err(TxApplyError::InvalidType(
+                    "treasury_key_id already set".into(),
+                ));
+            }
+            if *treasury_key_id == [0u8; 32] {
+                return Err(TxApplyError::InvalidType(
+                    "treasury_key_id must be non-zero".into(),
+                ));
+            }
+            if *treasury_key_id == asset.creator_key_id {
+                return Err(TxApplyError::InvalidType(
+                    "treasury_key_id must differ from creator".into(),
+                ));
+            }
+            asset.treasury_key_id = Some(*treasury_key_id);
+        }
     }
 
     mutator.put_sovereign_asset(&asset)?;
@@ -1061,6 +1079,41 @@ mod activate_pending_tests {
         assert!(mutator.get_sovereign_asset(&asset_id).unwrap().is_none());
         let gov = mutator.get_governance_module_state(&asset_id).unwrap().unwrap();
         assert!(gov.pending_transfer.is_some(), "unchanged when asset missing");
+    }
+
+    #[test]
+    fn treasury_bind_sets_key_id_once() {
+        let store = fresh_store();
+        let mut session = BlockSession::new(store.as_ref());
+        let creator = key(0x01);
+        let treasury = key(0x02);
+        let asset_id = key(0x03);
+        let payload = AssetModuleUpgradePayloadV1 {
+            asset_id,
+            module: AssetUpgradeModule::TreasuryBind {
+                treasury_key_id: treasury,
+            },
+            transfer_authority: false,
+        };
+
+        session.apply(|mutator, _| {
+            let mut asset = sample_creator_asset(asset_id, creator);
+            asset.treasury_key_id = None;
+            mutator.put_sovereign_asset(&asset).unwrap();
+        });
+        session.apply(|mutator, height| {
+            apply_asset_module_upgrade(mutator, creator, &payload, height).expect("treasury bind");
+        });
+
+        let mutator = StateMutator::new(store.as_ref());
+        let updated = mutator.get_sovereign_asset(&asset_id).unwrap().unwrap();
+        assert_eq!(updated.treasury_key_id, Some(treasury));
+
+        session.apply(|mutator, height| {
+            let err = apply_asset_module_upgrade(mutator, creator, &payload, height)
+                .expect_err("second bind rejected");
+            assert!(err.to_string().contains("already set"));
+        });
     }
 
     #[test]

--- a/lib-blockchain/src/transaction/asset_tx.rs
+++ b/lib-blockchain/src/transaction/asset_tx.rs
@@ -365,6 +365,8 @@ pub enum AssetUpgradeModule {
     Curve(CurveLaunchConfig),
     Rewards(RewardsLaunchConfig),
     Governance(GovernanceLaunchConfig),
+    /// One-time bind for legacy assets launched without `treasury_key_id` (#2864).
+    TreasuryBind { treasury_key_id: [u8; 32] },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -682,6 +684,20 @@ mod tests {
         let memo = payload.encode_memo().expect("encode");
         assert!(memo.starts_with(ASSET_LAUNCH_MEMO_PREFIX_V2));
         let decoded = AssetLaunchPayloadV1::decode_memo(&memo).expect("decode");
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn treasury_bind_upgrade_memo_round_trip() {
+        let payload = AssetModuleUpgradePayloadV1 {
+            asset_id: [0xAB; 32],
+            module: AssetUpgradeModule::TreasuryBind {
+                treasury_key_id: [0xCC; 32],
+            },
+            transfer_authority: false,
+        };
+        let memo = payload.encode_memo().expect("encode");
+        let decoded = AssetModuleUpgradePayloadV1::decode_memo(&memo).expect("decode");
         assert_eq!(decoded, payload);
     }
 }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -70,3 +70,11 @@ path = "seed_bubl_rewards_upgrade.rs"
 [[bin]]
 name = "replay_divergence"
 path = "replay_divergence.rs"
+
+[[bin]]
+name = "audit_sovereign_assets"
+path = "audit_sovereign_assets.rs"
+
+[[bin]]
+name = "seed_bubl_pre80k"
+path = "seed_bubl_pre80k.rs"

--- a/tools/audit_sovereign_assets.rs
+++ b/tools/audit_sovereign_assets.rs
@@ -1,0 +1,164 @@
+//! Read-only audit of sovereign `assets` sled records (epic Q7 migration).
+//!
+//! Usage:
+//!   cargo run -p tools --bin audit_sovereign_assets -- /path/to/sled
+
+use anyhow::{Context, Result};
+use lib_blockchain::contracts::sovereign_asset::{
+    deserialize_sovereign_asset, DaoClass, GovernanceModuleState, SovereignAsset,
+};
+use std::path::PathBuf;
+
+const TREE_ASSETS: &str = "assets";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WireFormat {
+    Current,
+    LegacyMigrated,
+}
+
+fn detect_wire_format(bytes: &[u8]) -> WireFormat {
+    if bincode::deserialize::<SovereignAsset>(bytes).is_ok() {
+        WireFormat::Current
+    } else {
+        WireFormat::LegacyMigrated
+    }
+}
+
+fn main() -> Result<()> {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/opt/zhtp/.zhtp/data/testnet/sled".to_string());
+
+    println!("Opening sled (read-only audit): {}", path);
+    let db = sled::open(PathBuf::from(&path))
+        .with_context(|| format!("failed to open sled at {path}"))?;
+    let assets = db
+        .open_tree(TREE_ASSETS)
+        .context("failed to open assets tree")?;
+
+    let mut total = 0u64;
+    let mut legacy = 0u64;
+    let mut current = 0u64;
+    let mut errors = 0u64;
+    let mut pending_burn = 0u64;
+
+    println!();
+    println!("{:-<100}", "");
+    println!(
+        "{:<18} {:<8} {:<8} {:<6} {:<8} {:<10} {}",
+        "asset_id", "format", "class", "burn", "treasury", "supply", "symbol"
+    );
+    println!("{:-<100}", "");
+
+    for entry in assets.iter() {
+        let (key, value) = entry.context("assets tree iteration failed")?;
+        let asset_id: [u8; 32] = key
+            .as_ref()
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("invalid asset key length {}", key.len()))?;
+
+        let format = detect_wire_format(&value);
+        match deserialize_sovereign_asset(&value) {
+            Ok(asset) => {
+                total += 1;
+                match format {
+                    WireFormat::Current => current += 1,
+                    WireFormat::LegacyMigrated => legacy += 1,
+                }
+                if asset.pending_burn_bps.is_some() {
+                    pending_burn += 1;
+                }
+                println!(
+                    "{:<18} {:<8} {:<8} {:<6} {:<8} {:<10} {}",
+                    hex::encode(&asset_id[..4]),
+                    match format {
+                        WireFormat::Current => "current",
+                        WireFormat::LegacyMigrated => "legacy",
+                    },
+                    asset.dao_class.as_str(),
+                    asset.burn_bps,
+                    asset.treasury_key_id.map(|_| "yes").unwrap_or("no"),
+                    asset.total_supply,
+                    asset.symbol,
+                );
+            }
+            Err(e) => {
+                errors += 1;
+                eprintln!(
+                    "ERROR asset {}: {}",
+                    hex::encode(asset_id),
+                    e
+                );
+            }
+        }
+    }
+
+    println!("{:-<100}", "");
+    println!("=== SOVEREIGN ASSET SLED AUDIT ===");
+    println!("  Total records:        {}", total);
+    println!("  Current wire format:  {}", current);
+    println!("  Legacy (migrated):    {}", legacy);
+    println!("  Deserialize errors:   {}", errors);
+    println!("  pending_burn_bps:     {}", pending_burn);
+
+    let mut pending_authority = 0u64;
+    let mut pending_below_80k = 0u64;
+    if let Ok(gov_tree) = db.open_tree("asset_governance") {
+        for entry in gov_tree.iter().flatten() {
+            if let Ok(state) = bincode::deserialize::<GovernanceModuleState>(&entry.1) {
+                if let Some(p) = state.pending_transfer {
+                    pending_authority += 1;
+                    if p.effective_height < 80_000 {
+                        pending_below_80k += 1;
+                        println!(
+                            "  WARN pending_transfer asset={} effective_height={}",
+                            hex::encode(&entry.0),
+                            p.effective_height
+                        );
+                    }
+                }
+            }
+        }
+    }
+    println!("  asset_governance pending_transfer: {}", pending_authority);
+    println!("  pending_transfer before 80k:       {}", pending_below_80k);
+
+    for tree_name in ["asset_rewards", "asset_curve"] {
+        let count = db
+            .open_tree(tree_name)
+            .map(|t| t.iter().count())
+            .unwrap_or(0);
+        println!("  {tree_name}:            {count}");
+    }
+
+    if total > 0 {
+        let fp = assets
+            .iter()
+            .filter_map(|e| e.ok())
+            .filter_map(|(_, v)| deserialize_sovereign_asset(&v).ok())
+            .filter(|a| a.dao_class == DaoClass::Fp)
+            .count();
+        let np = total as usize - fp;
+        println!("  dao_class FP:         {}", fp);
+        println!("  dao_class NP:         {}", np);
+    }
+
+    if errors > 0 {
+        anyhow::bail!("audit failed: {} deserialize errors", errors);
+    }
+
+    println!();
+    if total == 0 {
+        println!("OK: no sovereign asset records (empty assets tree).");
+    } else if legacy > 0 {
+        println!(
+            "OK: all {} records deserialize; {} legacy rows migrated to dao_class=Fp, burn_bps=0.",
+            total, legacy
+        );
+    } else {
+        println!("OK: all {} records deserialize in current wire format.", total);
+    }
+
+    Ok(())
+}

--- a/tools/seed_bubl_pre80k.rs
+++ b/tools/seed_bubl_pre80k.rs
@@ -1,0 +1,317 @@
+//! BUBL pre-80k readiness migration (#2864): treasury bind, delegate rotate, governance enable.
+//!
+//! Emits signed `AssetModuleUpgrade` / `AssetRewardsDelegateRotate` txs as JSON.
+//! Fund-delegate still uses `zhtp-cli asset rewards fund-delegate` (needs live nonce).
+//!
+//! Usage:
+//!   cargo run -p tools --bin seed_bubl_pre80k -- treasury-bind \
+//!     --keystore-dir /opt/zhtp/keystores/bubl-creator \
+//!     --treasury-dir /opt/zhtp/keystores/bubl-treasury \
+//!     --asset-id 6948e43dea1fa98ac4f0d2b713774f9ca3f70d63365ad17ad12ffa0b5394050d \
+//!     --chain-id 2
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use lib_blockchain::{
+    integration::crypto_integration::{Signature, SignatureAlgorithm},
+    transaction::{
+        asset_tx::{
+            AssetAuthorityProof, AssetModuleUpgradePayloadV1, AssetRewardsDelegateRotatePayloadV1,
+            AssetUpgradeModule, GovernanceLaunchConfig,
+        },
+        Transaction,
+    },
+};
+use lib_blockchain::contracts::sovereign_asset::GovernanceVerifierState;
+use lib_crypto::{KeyPair, PrivateKey, PublicKey};
+use lib_identity::identity::ZhtpIdentity;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+struct KeystorePrivateKey {
+    #[serde(with = "hex_bytes")]
+    dilithium_sk: [u8; 4896],
+    #[serde(default = "default_dilithium_pk", with = "hex_bytes")]
+    dilithium_pk: [u8; 2592],
+    #[serde(with = "hex_bytes")]
+    kyber_sk: [u8; 3168],
+    #[serde(with = "hex_bytes")]
+    master_seed: [u8; 64],
+}
+
+fn default_dilithium_pk() -> [u8; 2592] {
+    [0u8; 2592]
+}
+
+mod hex_bytes {
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D, const N: usize>(deserializer: D) -> Result<[u8; N], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let bytes = hex::decode(s).map_err(serde::de::Error::custom)?;
+        if bytes.len() != N {
+            return Err(serde::de::Error::custom(format!(
+                "expected {N} bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut arr = [0u8; N];
+        arr.copy_from_slice(&bytes);
+        Ok(arr)
+    }
+}
+
+const USER_IDENTITY_FILENAME: &str = "user_identity.json";
+const USER_PRIVATE_KEY_FILENAME: &str = "user_private_key.json";
+
+#[derive(Parser)]
+#[command(name = "seed_bubl_pre80k")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Bind `treasury_key_id` on a legacy sovereign asset (one-time).
+    TreasuryBind(TreasuryBindArgs),
+    /// Rotate rewards spend delegate (creator-signed pre-handoff).
+    RotateDelegate(RotateDelegateArgs),
+    /// Enable governance module with creator as initial single signer.
+    EnableGovernance(EnableGovernanceArgs),
+}
+
+#[derive(Parser)]
+struct SharedArgs {
+    #[arg(long)]
+    keystore_dir: PathBuf,
+    #[arg(long)]
+    asset_id: String,
+    #[arg(long, default_value_t = 0x02)]
+    chain_id: u8,
+    #[arg(long, default_value_t = 0)]
+    fee: u64,
+}
+
+#[derive(Parser)]
+struct TreasuryBindArgs {
+    #[command(flatten)]
+    shared: SharedArgs,
+    #[arg(long)]
+    treasury_dir: PathBuf,
+}
+
+#[derive(Parser)]
+struct RotateDelegateArgs {
+    #[command(flatten)]
+    shared: SharedArgs,
+    #[arg(long)]
+    new_delegate_dir: PathBuf,
+}
+
+#[derive(Parser)]
+struct EnableGovernanceArgs {
+    #[command(flatten)]
+    shared: SharedArgs,
+    /// Queue creator→governance handoff via module-upgrade timelock (default: true).
+    #[arg(long, default_value_t = true)]
+    queue_authority_transfer: bool,
+}
+
+fn load_keypair(keystore_dir: &std::path::Path) -> Result<KeyPair> {
+    let identity_file = keystore_dir.join(USER_IDENTITY_FILENAME);
+    let priv_file = keystore_dir.join(USER_PRIVATE_KEY_FILENAME);
+    let identity_json = std::fs::read_to_string(&identity_file)
+        .with_context(|| format!("read {}", identity_file.display()))?;
+    let priv_json = std::fs::read_to_string(&priv_file)
+        .with_context(|| format!("read {}", priv_file.display()))?;
+    let stored: KeystorePrivateKey = serde_json::from_str(&priv_json).context("parse private key")?;
+    let private_key = PrivateKey {
+        dilithium_sk: stored.dilithium_sk,
+        dilithium_pk: stored.dilithium_pk,
+        kyber_sk: stored.kyber_sk,
+        master_seed: stored.master_seed,
+    };
+    let identity = ZhtpIdentity::from_serialized(&identity_json, &private_key)
+        .context("restore identity from keystore")?;
+    Ok(KeyPair {
+        public_key: identity.public_key,
+        private_key,
+    })
+}
+
+fn parse_asset_id(hex_str: &str) -> Result<[u8; 32]> {
+    let trimmed = hex_str.trim();
+    let bytes = hex::decode(trimmed).context("asset_id hex")?;
+    anyhow::ensure!(bytes.len() == 32, "asset_id must be 32 bytes");
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+fn sign_module_upgrade(
+    keypair: &KeyPair,
+    payload: AssetModuleUpgradePayloadV1,
+    chain_id: u8,
+    fee: u64,
+) -> Result<Transaction> {
+    let memo = payload
+        .encode_memo()
+        .map_err(|e| anyhow::anyhow!("encode asset upgrade memo: {e}"))?;
+    let mut tx = Transaction::new_asset_module_upgrade_with_chain_id(
+        chain_id,
+        Signature {
+            signature: Vec::new(),
+            public_key: PublicKey::new(keypair.public_key.dilithium_pk),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 0,
+        },
+        memo,
+    );
+    tx.fee = fee;
+    tx.signature = keypair
+        .sign(tx.signing_hash().as_bytes())
+        .context("sign AssetModuleUpgrade")?;
+    Ok(tx)
+}
+
+fn sign_delegate_rotate(
+    keypair: &KeyPair,
+    payload: AssetRewardsDelegateRotatePayloadV1,
+    chain_id: u8,
+    fee: u64,
+) -> Result<Transaction> {
+    let memo = payload
+        .encode_memo()
+        .map_err(|e| anyhow::anyhow!("encode delegate rotate memo: {e}"))?;
+    let mut tx = Transaction::new_asset_rewards_delegate_rotate_with_chain_id(
+        chain_id,
+        Signature {
+            signature: Vec::new(),
+            public_key: PublicKey::new(keypair.public_key.dilithium_pk),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 0,
+        },
+        memo,
+    );
+    tx.fee = fee;
+    tx.signature = keypair
+        .sign(tx.signing_hash().as_bytes())
+        .context("sign AssetRewardsDelegateRotate")?;
+    Ok(tx)
+}
+
+fn emit_tx(step: &str, tx: &Transaction, extra: serde_json::Value) -> Result<()> {
+    let signed_hex = hex::encode(bincode::serialize(tx)?);
+    let mut output = serde_json::json!({
+        "step": step,
+        "tx_hash": hex::encode(tx.hash().as_bytes()),
+        "signed_tx": signed_hex,
+        "broadcast_hint": "POST /api/v1/blockchain/transaction/broadcast or zhtp-cli blockchain broadcast",
+    });
+    if let Some(obj) = output.as_object_mut() {
+        if let Some(map) = extra.as_object() {
+            for (k, v) in map {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+    }
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::TreasuryBind(args) => {
+            let asset_id = parse_asset_id(&args.shared.asset_id)?;
+            let creator = load_keypair(&args.shared.keystore_dir)?;
+            let treasury = load_keypair(&args.treasury_dir)?;
+            if creator.public_key.key_id == treasury.public_key.key_id {
+                anyhow::bail!("treasury keystore must differ from creator");
+            }
+            let payload = AssetModuleUpgradePayloadV1 {
+                asset_id,
+                module: AssetUpgradeModule::TreasuryBind {
+                    treasury_key_id: treasury.public_key.key_id,
+                },
+                transfer_authority: false,
+            };
+            let tx = sign_module_upgrade(
+                &creator,
+                payload,
+                args.shared.chain_id,
+                args.shared.fee,
+            )?;
+            emit_tx(
+                "treasury-bind",
+                &tx,
+                serde_json::json!({
+                    "migration": "2864-treasury-bind",
+                    "asset_id": hex::encode(asset_id),
+                    "creator_key_id": hex::encode(creator.public_key.key_id),
+                    "treasury_key_id": hex::encode(treasury.public_key.key_id),
+                }),
+            )?;
+        }
+        Command::RotateDelegate(args) => {
+            let asset_id = parse_asset_id(&args.shared.asset_id)?;
+            let creator = load_keypair(&args.shared.keystore_dir)?;
+            let delegate = load_keypair(&args.new_delegate_dir)?;
+            if creator.public_key.key_id == delegate.public_key.key_id {
+                anyhow::bail!("new delegate must differ from creator");
+            }
+            let payload = AssetRewardsDelegateRotatePayloadV1 {
+                asset_id,
+                new_delegate_key_id: delegate.public_key.key_id,
+                authority_proof: AssetAuthorityProof::CreatorSig,
+            };
+            let tx = sign_delegate_rotate(&creator, payload, args.shared.chain_id, args.shared.fee)?;
+            emit_tx(
+                "rotate-delegate",
+                &tx,
+                serde_json::json!({
+                    "migration": "2864-rotate-delegate",
+                    "asset_id": hex::encode(asset_id),
+                    "new_delegate_key_id": hex::encode(delegate.public_key.key_id),
+                }),
+            )?;
+        }
+        Command::EnableGovernance(args) => {
+            let asset_id = parse_asset_id(&args.shared.asset_id)?;
+            let creator = load_keypair(&args.shared.keystore_dir)?;
+            let gov = GovernanceLaunchConfig {
+                verifier: GovernanceVerifierState::Single {
+                    signer_key_id: creator.public_key.key_id,
+                },
+                threshold: None,
+            };
+            let payload = AssetModuleUpgradePayloadV1 {
+                asset_id,
+                module: AssetUpgradeModule::Governance(gov),
+                transfer_authority: args.queue_authority_transfer,
+            };
+            let tx = sign_module_upgrade(
+                &creator,
+                payload,
+                args.shared.chain_id,
+                args.shared.fee,
+            )?;
+            emit_tx(
+                "enable-governance",
+                &tx,
+                serde_json::json!({
+                    "migration": "2864-enable-governance",
+                    "asset_id": hex::encode(asset_id),
+                    "queue_authority_transfer": args.queue_authority_transfer,
+                    "initial_verifier": hex::encode(creator.public_key.key_id),
+                }),
+            )?;
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds `AssetUpgradeModule::TreasuryBind { treasury_key_id }` so legacy sovereign assets without a treasury wallet can bind one via creator-signed `AssetModuleUpgrade`.
- Adds `tools/seed_bubl_pre80k` to emit signed txs for treasury bind, delegate rotate, and governance enable.
- Adds `tools/audit_sovereign_assets` sled audit helper.

## Migration sequence (BUBL testnet)

1. Deploy this build (halt-consensus)
2. Broadcast `treasury-bind` → `bubl-treasury` key
3. Broadcast `rotate-delegate` → separate spend delegate
4. `zhtp-cli asset rewards fund-delegate` from creator
5. Broadcast `enable-governance` (queues authority transfer before block 80k)

Closes #2864 (protocol path).