### PR TITLE
fix(tools): set dao_class and burn_bps in seed_asset_launch (unbreaks development)

### DIFF
--- a/tools/seed_asset_launch.rs
+++ b/tools/seed_asset_launch.rs
@@ -10,7 +10,7 @@
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use lib_blockchain::{
-    contracts::sovereign_asset::SupplyMode,
+    contracts::sovereign_asset::{DaoClass, SupplyMode},
     integration::crypto_integration::{Signature, SignatureAlgorithm},
     protocol::ProtocolParams,
     rewards_policy::{policy_hash, validate_rewards_policy},
@@ -192,6 +192,9 @@ fn build_signed_asset_launch(
         rewards,
         governance: None,
         transfer_authority: false,
+        // Seeded assets are for-profit class: treasury_bps 2_000 == FP_TREASURY_BPS.
+        dao_class: DaoClass::Fp,
+        burn_bps: 0,
     };
     let memo = payload
         .encode_memo()
@@ -278,6 +281,8 @@ fn main() -> Result<()> {
         rewards: None,
         governance: None,
         transfer_authority: false,
+        dao_class: DaoClass::Fp,
+        burn_bps: 0,
     }
     .split_initial_supply();
 


### PR DESCRIPTION
## Problem

`development` does not compile. #2858 (commit `3495897d`) added `dao_class` and `burn_bps` to `AssetLaunchPayloadV1` but did not update the two initializers in `tools/seed_asset_launch.rs`:

```
error[E0063]: missing fields `burn_bps` and `dao_class` in initializer of `AssetLaunchPayloadV1`
   --> tools/seed_asset_launch.rs:181:19
error[E0063]: missing fields `burn_bps` and `dao_class` in initializer of `AssetLaunchPayloadV1`
   --> tools/seed_asset_launch.rs:267:43
```

Reproduces on a clean checkout of `development` at `e8815329` with `cargo check -p tools`. **This is failing CI on every open PR**, not just one.

## Fix

Set both fields explicitly. Seeded assets use `treasury_bps: 2_000`, which is `FP_TREASURY_BPS`, so `DaoClass::Fp` is the consistent class. `burn_bps: 0` preserves prior behaviour (no transfer burn).

## Verification

`cargo check -p tools` — 0 errors.