### PR TITLE
fix(#2879): smoke script symbol validation

### DIFF
--- a/scripts/dao-launch-smoke-test.sh
+++ b/scripts/dao-launch-smoke-test.sh
@@ -21,17 +21,29 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SERVER="${ZHTP_SERVER:-https://g1.testnet.zhtp.org}"
 CHAIN_ID="${CHAIN_ID:-2}"
 TS="$(date +%s)"
+# Symbols must be uppercase A-Z only (DAO launch validation).
+symbol_suffix() {
+  # 3 uppercase letters (dao launch max symbol length is 6)
+  python3 -c "import string; t=int('${1}') % (26**3); print(''.join(string.ascii_uppercase[(t//(26**i))%26] for i in range(2,-1,-1)))"
+}
+SUFFIX="$(symbol_suffix "$TS")"
 FP_NAME="Smoke FP ${TS}"
-FP_SYMBOL="SFP${TS: -4}"
+FP_SYMBOL="SFP${SUFFIX}"
 NP_NAME="Smoke NP ${TS}"
-NP_SYMBOL="SNP${TS: -4}"
+NP_SYMBOL="SNP${SUFFIX}"
 
 run_cli() {
   if [[ "${SKIP_LAUNCH:-0}" == "1" ]]; then
     echo "[dry-run] zhtp-cli $*"
     return 0
   fi
-  (cd "$ROOT" && cargo run -q -p zhtp-cli -- "$@")
+  local cli="$ROOT/target/release/zhtp-cli"
+  if [[ ! -x "$cli" ]]; then
+    cli="cargo run -q -p zhtp-cli --manifest-path $ROOT/Cargo.toml --"
+    (cd "$ROOT" && $cli "$@")
+  else
+    "$cli" "$@"
+  fi
 }
 
 echo "=== DAO launch smoke (#2879) ==="


### PR DESCRIPTION
## Summary

Fixes `dao-launch-smoke-test.sh` so generated symbols pass DAO launch validation:
- Uppercase A-Z only (no digits from timestamp suffix)
- Max 6 characters (`SFP`/`SNP` + 3-letter suffix)
- Prefer `target/release/zhtp-cli` when built

## Test plan

- [x] Preview FP (`balanced`) and NP (`np-mission`) locally
- [ ] Live launch on testnet (requires DNS reachability to `g1.testnet.zhtp.org`)