### PR TITLE
feat(sa-3): finish AssetLaunch canonical write path

### DIFF
--- a/docs/ops/dao-launch-bootstrap.md
+++ b/docs/ops/dao-launch-bootstrap.md
@@ -66,10 +66,10 @@ The creator identity becomes:
 
 ## Step 2 — Build signed token launch tx
 
-### BUBL (TokenCreation — current testnet)
+### BUBL (AssetLaunch — canonical path, SA-3)
 
 ```bash
-cargo run -p tools --bin seed_founding_dao -- \
+cargo run -p tools --bin seed_asset_launch -- \
   --keystore-dir /opt/zhtp/keystores/bubl-creator \
   --token bubl \
   --supply-atoms 1000000000000000000000000000 \
@@ -79,33 +79,31 @@ cargo run -p tools --bin seed_founding_dao -- \
 
 Copy the `signed_tx` hex from JSON output.
 
-> **Do not use `seed_asset_launch` for Phase 1 BUBL bootstrap.** That path emits
-> `AssetLaunch` txs (SA-3 / N3) and is incompatible with interim Phase 1 rewards,
-> which expect a `TokenCreation` signer and `ZHTP_REWARDS_TREASURY_KEYSTORE`.
-> Reserve `tools/seed_asset_launch.rs` for the N3 chain-native activation migration
-> ([#2813](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2813)).
+> **Legacy note:** testnet BUBL deployed before SA-3 may still exist via historical
+> `TokenCreation`. New launches must use `AssetLaunch` only. `TokenCreation` is
+> rejected by `POST /api/v1/token/create` and sunset at block **80,000** in consensus
+> (`TOKEN_CREATION_SUNSET_HEIGHT`).
 
 ---
 
 ## Step 3 — Broadcast launch tx
 
-**Phase 1 (current): use Option B.** `zhtp-cli token create` still hardcodes
-`chain_id = 0x03` in `zhtp-cli/src/commands/token.rs`; txs signed that way are
-rejected on v2 testnet (`genesis.toml` `chain_id = 2`). Broadcast the
-`signed_tx` from `seed_founding_dao` (with `--chain-id 2`) until the CLI gains
-explicit chain-id selection.
+Prefer the sovereign-asset API (QUIC on testnet validators):
 
 ```bash
-# Option A: zhtp-cli (NOT for Phase 1 v2 testnet — chain_id hardcoded 0x03)
-# zhtp-cli token create --name Bubble --symbol BUBL \
-#   --supply 1000000000000000000000000000 --decimals 18 \
-#   --treasury-recipient <32-byte-hex-key_id>
+# Option A: zhtp-cli (recommended)
+./target/dev-release/zhtp-cli -s <host>:9334 dao launch \
+  --template fp-starter --keystore-dir /opt/zhtp/keystores/bubl-creator
 
-# Option B: POST pre-signed tx from seed_founding_dao (required for Phase 1)
-curl -s -X POST "https://<validator>:9334/api/v1/token/create" \
-  -H "Content-Type: application/json" \
-  -d '{"signed_tx":"<hex>"}'
+# Option B: broadcast pre-signed hex from seed_asset_launch
+./target/dev-release/zhtp-cli -s <host>:9334 blockchain broadcast-raw \
+  --tx-hex "<signed_tx_hex>"
+
+# Option C: POST /api/v1/assets/launch (same payload as Option A)
 ```
+
+`POST /api/v1/token/create` accepts `AssetLaunch` only during migration shim;
+`TokenCreation` returns **400 deprecated**.
 
 Record outputs:
 
@@ -115,22 +113,28 @@ Record outputs:
 
 ---
 
-## Step 4 — Enable rewards on validators (interim)
+## Step 4 — Enable rewards on validators
 
-On **each** validator (`zhtp-g1`, `g2`, `g3`), set environment and restart:
+On **each** validator (`zhtp-g1`, `g2`, `g3`), bind the on-chain spend delegate:
 
 ```bash
-export ZHTP_REWARDS_TREASURY_KEYSTORE=/opt/zhtp/keystores/bubl-creator
-# Optional override (defaults to deterministic BUBL token_id):
-# export ZHTP_REWARDS_TOKEN_ID=<hex>
+./target/dev-release/zhtp-cli node configure-rewards \
+  --asset-id <launch_tx_hash_hex> \
+  --delegate-keystore /opt/zhtp/keystores/bubl-rewards-hot
 export ZHTP_CHAIN_ID=2
 ```
 
-Handler activates when:
+Writes `rewards_activation.toml` under the node data dir. Validators scan
+`asset_rewards/` (pure `AssetLaunch`) plus legacy `token_contracts` rows.
 
-1. Keystore loads successfully
-2. Signer is the on-chain token **creator**
-3. Creator holds positive token balance
+**Deprecated fallback** (historical `TokenCreation` BUBL only):
+
+```bash
+export ZHTP_REWARDS_TREASURY_KEYSTORE=/opt/zhtp/keystores/bubl-creator
+```
+
+Handler activates when the configured keystore matches the on-chain spend delegate
+and delegate balance is positive.
 
 Verify:
 
@@ -155,30 +159,9 @@ Replace `asset_id` placeholder in the example with launch tx hash after migratio
 
 ---
 
-## Migration to chain-native activation (N3)
-
-When [#2813](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2813) ships:
-
-1. Remove `ZHTP_REWARDS_TREASURY_KEYSTORE` from validator env
-2. Fund `spend_delegate_key_id` on-chain
-3. Validators scan assets with `rewards` module bit + delegate balance > 0
-4. Use `zhtp-cli node configure-rewards --asset-id <hex> --delegate-keystore ...` (interim CLI)
-5. Build launch via `seed_asset_launch` (not `seed_founding_dao`):
-
-```bash
-cargo run -p tools --bin seed_asset_launch -- \
-  --keystore-dir /opt/zhtp/keystores/bubl-creator \
-  --token bubl \
-  --supply-atoms 1000000000000000000000000000 \
-  --chain-id 2 \
-  --rewards-delegate-dir /opt/zhtp/keystores/bubl-rewards-hot
-```
-
----
-
 ## Related
 
-- `tools/seed_founding_dao.rs` — TokenCreation builder
-- `tools/seed_asset_launch.rs` — AssetLaunch + rewards delegate
+- `tools/seed_asset_launch.rs` — canonical `AssetLaunch` + rewards delegate builder
+- `tools/seed_founding_dao.rs` — **deprecated** `TokenCreation` builder (replay only)
 - `scripts/effective-reset-testnet.sh` — wipe + post-reset checklist
 - Epic child issues: P3–P5, N2–N4, D3 BUBL migration

--- a/docs/protocol/genesis-3-testnet-reset.md
+++ b/docs/protocol/genesis-3-testnet-reset.md
@@ -235,7 +235,7 @@ Allow extra time (up to T+3h) if followers are still catching up from genesis.
 
 After shrunk genesis is live:
 
-1. **CBE / BUBL** — founding `TokenCreation` + contract deploy txs in blocks 1..k (not genesis rows)
+1. **CBE / BUBL** — founding `AssetLaunch` txs (+ CBE curve contract deploy) in blocks 1..k (not genesis rows). Historical chains may replay `TokenCreation` below block 80,000 only.
 2. **Wallets** — `WalletRegistration` / UBI / coinbase in early blocks ([#2733](https://github.com/SOVEREIGN-NET/The-Sovereign-Network/issues/2733))
 3. **Domains** — `./scripts/replay-domains.sh` if domain snapshot exists
 4. **Sites** — redeploy per ops checklist

--- a/lib-blockchain/src/block/creation.rs
+++ b/lib-blockchain/src/block/creation.rs
@@ -246,6 +246,48 @@ mod tests {
     }
 
     #[test]
+    fn select_transactions_filters_token_creation_at_sunset_block_height() {
+        use crate::contracts::sovereign_asset::token_creation_allowed_in_block_at_height_with_sunset;
+        use crate::types::TransactionType;
+
+        let sunset = 10u64;
+        let block_height = sunset;
+        let token_tx = Transaction {
+            version: 1,
+            chain_id: 0x03,
+            transaction_type: TransactionType::TokenCreation,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 100,
+            signature: crate::integration::crypto_integration::Signature {
+                signature: vec![0u8; 64],
+                public_key: PublicKey::new([1u8; 2592]),
+                algorithm: SignatureAlgorithm::DEFAULT,
+                timestamp: 0,
+            },
+            memo: vec![],
+            payload: crate::transaction::TransactionPayload::None,
+        };
+        let transfer = make_tx(200);
+
+        let selected = select_transactions_for_block_filtered(
+            &[token_tx, transfer],
+            10,
+            usize::MAX,
+            |tx| {
+                if tx.transaction_type == TransactionType::TokenCreation {
+                    token_creation_allowed_in_block_at_height_with_sunset(block_height, sunset)
+                } else {
+                    true
+                }
+            },
+        );
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].transaction_type, TransactionType::Transfer);
+    }
+
+    #[test]
     fn select_transactions_dedupes_by_hash() {
         let tx = make_tx(100);
         let duplicate = tx.clone();

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -978,11 +978,14 @@ impl Blockchain {
     pub async fn apply_block_trusted_for_sync(&mut self, block: Block) -> Result<()> {
         if let Some(ref exec_arc) = self.executor {
             use crate::execution::executor::BlockExecutor;
-            let catchup_exec = std::sync::Arc::new(BlockExecutor::new_catchup_sync(
-                std::sync::Arc::clone(exec_arc.store()),
-                exec_arc.fee_model().clone(),
-                Default::default(),
-            ));
+            let catchup_exec = std::sync::Arc::new(
+                BlockExecutor::new_catchup_sync(
+                    std::sync::Arc::clone(exec_arc.store()),
+                    exec_arc.fee_model().clone(),
+                    Default::default(),
+                )
+                .with_token_creation_sunset_height(exec_arc.token_creation_sunset_height()),
+            );
             // Temporarily swap in the catchup executor, apply, restore.
             let original = self.executor.replace(catchup_exec);
             let result = self.process_and_commit_block(block).await;

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -1355,6 +1355,36 @@ impl Blockchain {
             .find(|a| a.asset_id == *asset_id)
     }
 
+    /// Sovereign asset ids with an on-chain rewards module (`asset_rewards/` sled tree).
+    pub fn list_rewards_module_asset_ids(&self) -> Vec<[u8; 32]> {
+        let Some(store) = self.get_store() else {
+            return Vec::new();
+        };
+        match store.list_rewards_module_asset_ids() {
+            Ok(ids) => ids,
+            Err(e) => {
+                warn!("Failed to list rewards module asset ids: {e}");
+                Vec::new()
+            }
+        }
+    }
+
+    /// `AssetLaunched` events persisted at apply time (SA-3 / ADR §6.1).
+    pub fn list_asset_launched_events(
+        &self,
+    ) -> Vec<crate::contracts::sovereign_asset::AssetLaunchedEvent> {
+        let Some(store) = self.get_store() else {
+            return Vec::new();
+        };
+        match store.list_asset_launched_events() {
+            Ok(events) => events,
+            Err(e) => {
+                warn!("Failed to list asset launched events: {e}");
+                Vec::new()
+            }
+        }
+    }
+
     /// On-chain rewards module state (`asset_rewards/` sled tree).
     pub fn get_rewards_module_state(
         &self,

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -1161,11 +1161,12 @@ impl Blockchain {
         }
 
         let rebuilt = std::sync::Arc::new(
-            crate::execution::executor::BlockExecutor::new_with_token_creation_fee(
+            crate::execution::executor::BlockExecutor::new_with_token_creation_fee_and_sunset(
                 std::sync::Arc::clone(executor.store()),
                 executor.fee_model().clone(),
                 executor.limits().clone(),
                 self.tx_fee_config.token_creation_fee,
+                executor.token_creation_sunset_height(),
             ),
         );
         self.executor = Some(rebuilt);

--- a/lib-blockchain/src/contracts/sovereign_asset/events.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/events.rs
@@ -1,0 +1,19 @@
+//! Sovereign Asset chain events (SA-3 / ADR §6.1).
+
+use serde::{Deserialize, Serialize};
+
+/// Emitted when an [`AssetLaunch`] transaction is applied (ADR §6.1 step 4).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssetLaunchedEvent {
+    pub asset_id: [u8; 32],
+    pub module_bitmask: u8,
+    pub block_height: u64,
+    pub block_time: u64,
+    pub symbol: String,
+}
+
+impl AssetLaunchedEvent {
+    pub fn event_type() -> &'static str {
+        "AssetLaunched"
+    }
+}

--- a/lib-blockchain/src/contracts/sovereign_asset/mod.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/mod.rs
@@ -1,9 +1,12 @@
 //! Sovereign Asset — unified DAO/token primitive (ADR: docs/arch/sovereign-asset.md).
 
+mod events;
 mod migration;
 mod projection;
 mod state;
 mod types;
+
+pub use events::AssetLaunchedEvent;
 
 pub use migration::deserialize_sovereign_asset;
 

--- a/lib-blockchain/src/contracts/sovereign_asset/state.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/state.rs
@@ -124,9 +124,9 @@ pub const GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT: u64 = 80_000;
 ///
 /// Aligned with [`GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT`] so testnet replay below 80k stays
 /// deterministic while post-cutover launches use the sovereign-asset write path only.
-#[cfg(test)]
-pub const TOKEN_CREATION_SUNSET_HEIGHT: u64 = u64::MAX;
-#[cfg(not(test))]
+///
+/// Tests inject a lower sunset via [`BlockExecutor::with_token_creation_sunset_height`]
+/// rather than swapping this constant per build profile.
 pub const TOKEN_CREATION_SUNSET_HEIGHT: u64 = 80_000;
 
 /// Returns true when `TokenCreation` may still be applied at `block_height` (replay / apply).
@@ -145,9 +145,32 @@ pub fn token_creation_apply_allowed_at_height_with_sunset(
 }
 
 /// Returns true when new `TokenCreation` submissions are accepted at the given chain tip.
+///
+/// Gates on the height the tx would be applied at (`chain_tip + 1`), not the tip itself.
 #[inline]
 pub fn token_creation_submission_allowed_at_tip(chain_tip: u64) -> bool {
-    token_creation_apply_allowed_at_height(chain_tip)
+    token_creation_submission_allowed_at_tip_with_sunset(chain_tip, TOKEN_CREATION_SUNSET_HEIGHT)
+}
+
+/// Testable mempool gate (production sunset = 80_000).
+#[inline]
+pub fn token_creation_submission_allowed_at_tip_with_sunset(chain_tip: u64, sunset_height: u64) -> bool {
+    token_creation_apply_allowed_at_height_with_sunset(chain_tip.saturating_add(1), sunset_height)
+}
+
+/// Returns true when `TokenCreation` may be included in a block at `block_height`.
+#[inline]
+pub fn token_creation_allowed_in_block_at_height(block_height: u64) -> bool {
+    token_creation_allowed_in_block_at_height_with_sunset(block_height, TOKEN_CREATION_SUNSET_HEIGHT)
+}
+
+/// Testable block-assembly gate (production sunset = 80_000).
+#[inline]
+pub fn token_creation_allowed_in_block_at_height_with_sunset(
+    block_height: u64,
+    sunset_height: u64,
+) -> bool {
+    token_creation_apply_allowed_at_height_with_sunset(block_height, sunset_height)
 }
 
 /// Epic Q1–Q3 / Q8 economic rules (mint class, treasury spend auth, reward liquidity, burn).
@@ -180,8 +203,29 @@ mod sunset_tests {
     }
 
     #[test]
-    fn test_build_never_sunsets_token_creation() {
-        assert!(token_creation_apply_allowed_at_height(u64::MAX - 1));
+    fn submission_gate_uses_apply_height_not_tip() {
+        const SUNSET: u64 = 80_000;
+        assert!(token_creation_submission_allowed_at_tip_with_sunset(
+            SUNSET - 2,
+            SUNSET
+        ));
+        assert!(!token_creation_submission_allowed_at_tip_with_sunset(
+            SUNSET - 1,
+            SUNSET
+        ));
+    }
+
+    #[test]
+    fn block_assembly_gate_matches_apply_height() {
+        const SUNSET: u64 = 80_000;
+        assert!(token_creation_allowed_in_block_at_height_with_sunset(
+            SUNSET - 1,
+            SUNSET
+        ));
+        assert!(!token_creation_allowed_in_block_at_height_with_sunset(
+            SUNSET,
+            SUNSET
+        ));
     }
 }
 

--- a/lib-blockchain/src/contracts/sovereign_asset/state.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/state.rs
@@ -120,6 +120,36 @@ pub const GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT: u64 = 0;
 #[cfg(not(test))]
 pub const GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT: u64 = 80_000;
 
+/// Block height at which new `TokenCreation` transactions are rejected (use `AssetLaunch`).
+///
+/// Aligned with [`GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT`] so testnet replay below 80k stays
+/// deterministic while post-cutover launches use the sovereign-asset write path only.
+#[cfg(test)]
+pub const TOKEN_CREATION_SUNSET_HEIGHT: u64 = u64::MAX;
+#[cfg(not(test))]
+pub const TOKEN_CREATION_SUNSET_HEIGHT: u64 = 80_000;
+
+/// Returns true when `TokenCreation` may still be applied at `block_height` (replay / apply).
+#[inline]
+pub fn token_creation_apply_allowed_at_height(block_height: u64) -> bool {
+    token_creation_apply_allowed_at_height_with_sunset(block_height, TOKEN_CREATION_SUNSET_HEIGHT)
+}
+
+/// Testable sunset gate (production sunset = 80_000).
+#[inline]
+pub fn token_creation_apply_allowed_at_height_with_sunset(
+    block_height: u64,
+    sunset_height: u64,
+) -> bool {
+    block_height < sunset_height
+}
+
+/// Returns true when new `TokenCreation` submissions are accepted at the given chain tip.
+#[inline]
+pub fn token_creation_submission_allowed_at_tip(chain_tip: u64) -> bool {
+    token_creation_apply_allowed_at_height(chain_tip)
+}
+
 /// Epic Q1–Q3 / Q8 economic rules (mint class, treasury spend auth, reward liquidity, burn).
 /// Inactive below [`GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT`] so replay matches pre-rules history.
 #[inline]
@@ -130,6 +160,29 @@ pub fn economic_rules_active(block_height: u64) -> bool {
 /// Default multisig threshold: floor(N/2) + 1.
 pub fn default_governance_threshold(n: usize) -> u8 {
     ((n / 2) + 1) as u8
+}
+
+#[cfg(test)]
+mod sunset_tests {
+    use super::*;
+
+    #[test]
+    fn prod_token_creation_sunset_is_80k() {
+        const PROD_SUNSET: u64 = 80_000;
+        assert!(token_creation_apply_allowed_at_height_with_sunset(
+            PROD_SUNSET - 1,
+            PROD_SUNSET
+        ));
+        assert!(!token_creation_apply_allowed_at_height_with_sunset(
+            PROD_SUNSET,
+            PROD_SUNSET
+        ));
+    }
+
+    #[test]
+    fn test_build_never_sunsets_token_creation() {
+        assert!(token_creation_apply_allowed_at_height(u64::MAX - 1));
+    }
 }
 
 /// Validate governance verifier bounds at launch/upgrade.

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -226,6 +226,8 @@ pub struct ExecutorConfig {
     pub protocol_params: ProtocolParams,
     /// Fixed fee for canonical TokenCreation transactions
     pub token_creation_fee: u64,
+    /// Block height at which `TokenCreation` is rejected (injectable in tests).
+    pub token_creation_sunset_height: u64,
 }
 
 impl Default for ExecutorConfig {
@@ -236,6 +238,8 @@ impl Default for ExecutorConfig {
             allow_empty_blocks: true,
             protocol_params: ProtocolParams::default(),
             token_creation_fee: DEFAULT_TOKEN_CREATION_FEE,
+            token_creation_sunset_height:
+                crate::contracts::sovereign_asset::TOKEN_CREATION_SUNSET_HEIGHT,
         }
     }
 }
@@ -249,6 +253,11 @@ impl ExecutorConfig {
 
     pub fn with_token_creation_fee(mut self, fee: u64) -> Self {
         self.token_creation_fee = fee;
+        self
+    }
+
+    pub fn with_token_creation_sunset_height(mut self, height: u64) -> Self {
+        self.token_creation_sunset_height = height;
         self
     }
 
@@ -315,6 +324,7 @@ pub struct BlockExecutor {
     fee_model: FeeModelV2,
     limits: BlockLimits,
     token_creation_fee: u64,
+    token_creation_sunset_height: u64,
     /// When true, skip fee validation for all transactions.
     /// Used during catch-up sync to replay already-committed peer blocks
     /// whose transactions were valid under older fee rules.
@@ -400,14 +410,36 @@ impl BlockExecutor {
         limits: BlockLimits,
         token_creation_fee: u64,
     ) -> Self {
+        Self::new_with_token_creation_fee_and_sunset(
+            store,
+            fee_model,
+            limits,
+            token_creation_fee,
+            crate::contracts::sovereign_asset::TOKEN_CREATION_SUNSET_HEIGHT,
+        )
+    }
+
+    pub fn new_with_token_creation_fee_and_sunset(
+        store: Arc<dyn BlockchainStore>,
+        fee_model: FeeModelV2,
+        limits: BlockLimits,
+        token_creation_fee: u64,
+        token_creation_sunset_height: u64,
+    ) -> Self {
         Self {
             store,
             fee_model,
             limits,
             token_creation_fee,
+            token_creation_sunset_height,
             skip_fee_validation: false,
             skip_prev_hash_validation: false,
         }
+    }
+
+    pub fn with_token_creation_sunset_height(mut self, height: u64) -> Self {
+        self.token_creation_sunset_height = height;
+        self
     }
 
     /// Create a new block executor with explicit fee model and limits
@@ -431,6 +463,8 @@ impl BlockExecutor {
             fee_model,
             limits: BlockLimits::for_trusted_replay(),
             token_creation_fee: DEFAULT_TOKEN_CREATION_FEE,
+            token_creation_sunset_height:
+                crate::contracts::sovereign_asset::TOKEN_CREATION_SUNSET_HEIGHT,
             skip_fee_validation: true,
             skip_prev_hash_validation: false, // MUST validate chain continuity
         }
@@ -465,6 +499,8 @@ impl BlockExecutor {
             fee_model,
             limits: BlockLimits::for_trusted_replay(),
             token_creation_fee,
+            token_creation_sunset_height:
+                crate::contracts::sovereign_asset::TOKEN_CREATION_SUNSET_HEIGHT,
             skip_fee_validation: true,
             skip_prev_hash_validation: true,
         }
@@ -478,6 +514,7 @@ impl BlockExecutor {
             fee_model,
             limits,
             token_creation_fee: config.token_creation_fee,
+            token_creation_sunset_height: config.token_creation_sunset_height,
             skip_fee_validation: false,
             skip_prev_hash_validation: false,
         }
@@ -500,6 +537,7 @@ impl BlockExecutor {
             fee_model,
             limits: BlockLimits::for_trusted_replay(),
             token_creation_fee: config.token_creation_fee,
+            token_creation_sunset_height: config.token_creation_sunset_height,
             skip_fee_validation: true,
             skip_prev_hash_validation: true,
         }
@@ -522,6 +560,10 @@ impl BlockExecutor {
 
     pub fn token_creation_fee(&self) -> u64 {
         self.token_creation_fee
+    }
+
+    pub fn token_creation_sunset_height(&self) -> u64 {
+        self.token_creation_sunset_height
     }
 
     /// Get reference to the block limits
@@ -634,6 +676,12 @@ impl BlockExecutor {
                 tx_count, self.limits.max_tx_count
             )));
         }
+
+        crate::validation::block_validate::validate_block_consensus_policy(
+            block,
+            self.token_creation_sunset_height,
+        )
+        .map_err(|e| BlockApplyError::ValidationFailed(e.to_string()))?;
 
         Ok(())
     }
@@ -861,8 +909,9 @@ impl BlockExecutor {
             )?;
 
             if tx.transaction_type == TransactionType::TokenCreation
-                && !crate::contracts::sovereign_asset::token_creation_apply_allowed_at_height(
+                && !crate::contracts::sovereign_asset::token_creation_apply_allowed_at_height_with_sunset(
                     block_height,
+                    self.token_creation_sunset_height,
                 )
             {
                 return Err(BlockApplyError::TxFailed {
@@ -4251,6 +4300,8 @@ mod tests {
             fee_model: FeeModelV2::default(),
             limits: BlockLimits::default(),
             token_creation_fee: DEFAULT_TOKEN_CREATION_FEE,
+            token_creation_sunset_height:
+                crate::contracts::sovereign_asset::TOKEN_CREATION_SUNSET_HEIGHT,
             skip_fee_validation: true,
             skip_prev_hash_validation: true,
         }
@@ -5155,6 +5206,72 @@ mod tests {
         assert!(
             result.is_err(),
             "TokenCreation with non-canonical high fee should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_token_creation_rejected_at_sunset_height() {
+        const SUNSET: u64 = 1;
+        let store = create_test_store();
+        let executor = create_test_executor(store.clone()).with_token_creation_sunset_height(SUNSET);
+
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let block = create_block_with_txs(
+            SUNSET,
+            genesis.header.block_hash,
+            vec![create_token_creation_tx("At Sunset", "SUN", 1_000_000, [0xBB; 32])],
+        );
+        let err = executor
+            .apply_block(&block)
+            .expect_err("TokenCreation at sunset must reject block");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("TokenCreation") || msg.contains("deprecated") || msg.contains("Forbidden"),
+            "expected sunset rejection, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_token_creation_allowed_below_sunset_height() {
+        const SUNSET: u64 = 2;
+        let store = create_test_store();
+        let executor = create_test_executor(store.clone()).with_token_creation_sunset_height(SUNSET);
+
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let block = create_block_with_txs(
+            SUNSET - 1,
+            genesis.header.block_hash,
+            vec![create_token_creation_tx("Below Sunset", "PRE", 1_000_000, [0xAA; 32])],
+        );
+        executor
+            .apply_block(&block)
+            .expect("TokenCreation below sunset must apply");
+    }
+
+    #[test]
+    fn test_token_creation_sunset_rejected_in_validate_block_resources() {
+        const SUNSET: u64 = 1;
+        let store = create_test_store();
+        let executor = create_test_executor(store).with_token_creation_sunset_height(SUNSET);
+
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let block = create_block_with_txs(
+            SUNSET,
+            genesis.header.block_hash,
+            vec![create_token_creation_tx("Sunset", "SUN", 1_000_000, [0xCC; 32])],
+        );
+        let err = executor
+            .apply_block(&block)
+            .expect_err("forbidden TokenCreation must fail pre-apply validation");
+        assert!(
+            matches!(err, BlockApplyError::ValidationFailed(_)),
+            "expected ValidationFailed, got: {err:?}"
         );
     }
 

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -860,6 +860,19 @@ impl BlockExecutor {
                 state_write_bytes,
             )?;
 
+            if tx.transaction_type == TransactionType::TokenCreation
+                && !crate::contracts::sovereign_asset::token_creation_apply_allowed_at_height(
+                    block_height,
+                )
+            {
+                return Err(BlockApplyError::TxFailed {
+                    index,
+                    reason: TxApplyError::InvalidType(
+                        "TokenCreation is deprecated at this height; use AssetLaunch".to_string(),
+                    ),
+                });
+            }
+
             // validate_tx_stateless
             self.validate_tx_stateless(tx)
                 .map_err(|e| BlockApplyError::TxFailed { index, reason: e })?;
@@ -5316,6 +5329,119 @@ mod tests {
             .expect("read policy doc")
             .expect("policy doc exists");
         assert!(!stored_doc.is_empty());
+    }
+
+    #[test]
+    fn test_asset_launch_emits_asset_launched_event() {
+        use crate::contracts::sovereign_asset::AssetLaunchedEvent;
+
+        let store = create_test_store();
+        let executor = create_test_executor(store.clone());
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let payload = crate::transaction::asset_tx::AssetLaunchPayloadV1 {
+            name: "Launch Event".to_string(),
+            symbol: "LEVT".to_string(),
+            decimals: 8,
+            initial_supply: 500,
+            treasury_key_id: [0xAA; 32],
+            treasury_bps: 2_000,
+            supply_mode: crate::contracts::sovereign_asset::SupplyMode::Fixed,
+            manifest_cid: [3u8; 32],
+            manifest_hash: [4u8; 32],
+            curve: None,
+            rewards: None,
+            governance: None,
+            transfer_authority: false,
+            dao_class: crate::contracts::sovereign_asset::DaoClass::Fp,
+            burn_bps: 0,
+        };
+        let memo = payload.encode_memo().expect("memo");
+        let tx = Transaction {
+            version: 2,
+            chain_id: 0x03,
+            transaction_type: TransactionType::AssetLaunch,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: create_dummy_signature(),
+            memo,
+            payload: crate::transaction::TransactionPayload::None,
+        };
+        let asset_id = hash_transaction(&tx).as_array();
+        let block1 = create_block_with_txs(1, genesis.header.block_hash, vec![tx]);
+        executor.apply_block(&block1).expect("launch");
+
+        let events = store.list_asset_launched_events().expect("events");
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0],
+            AssetLaunchedEvent {
+                asset_id,
+                module_bitmask: 0,
+                block_height: 1,
+                block_time: block1.header.timestamp,
+                symbol: "LEVT".to_string(),
+            }
+        );
+        let reward_ids = store.list_rewards_module_asset_ids().expect("ids");
+        assert!(reward_ids.is_empty());
+    }
+
+    #[test]
+    fn test_asset_launch_rewards_module_discoverable_without_token_contract() {
+        let store = create_test_store();
+        let executor = create_test_executor(store.clone());
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let (asset_id, _) = launch_rewards_asset(&executor, &genesis);
+        let token_id = TokenId::new(asset_id);
+        assert!(
+            store.get_token_contract(&token_id).expect("read").is_none(),
+            "pure AssetLaunch must not require token_contracts row"
+        );
+        let reward_ids = store.list_rewards_module_asset_ids().expect("ids");
+        assert_eq!(reward_ids, vec![asset_id]);
+    }
+
+    #[test]
+    fn test_asset_rewards_delegate_rotate_on_pure_launch_asset() {
+        use crate::transaction::asset_tx::{
+            AssetAuthorityProof, AssetRewardsDelegateRotatePayloadV1,
+        };
+
+        let store = create_test_store();
+        let executor = create_test_executor(store.clone());
+        let genesis = create_genesis_block();
+        executor.apply_block(&genesis).unwrap();
+
+        let (asset_id, tip_block) = launch_rewards_asset(&executor, &genesis);
+        let new_delegate = [0xEE; 32];
+        let payload = AssetRewardsDelegateRotatePayloadV1 {
+            asset_id,
+            new_delegate_key_id: new_delegate,
+            authority_proof: AssetAuthorityProof::CreatorSig,
+        };
+        let memo = payload.encode_memo().expect("memo");
+        let rotate_tx = Transaction::new_asset_rewards_delegate_rotate_with_chain_id(
+            0x03,
+            create_dummy_signature(),
+            memo,
+        );
+        let block3 = create_block_with_txs(3, tip_block.header.block_hash, vec![rotate_tx]);
+        executor
+            .apply_block(&block3)
+            .expect("delegate rotate on AssetLaunch asset");
+
+        let state = store
+            .get_rewards_module_state(&asset_id)
+            .expect("read")
+            .expect("state");
+        assert_eq!(state.spend_delegate_key_id, new_delegate);
+        // launch_rewards_asset applies a policy bind tx at block 2 (nonce 1) before rotate.
+        assert_eq!(state.nonce, 2);
     }
 
     fn rewards_policy_for_asset(

--- a/lib-blockchain/src/execution/sovereign_asset.rs
+++ b/lib-blockchain/src/execution/sovereign_asset.rs
@@ -2,11 +2,11 @@
 
 use crate::contracts::sovereign_asset::{
     project_from_token_contract, validate_governance_verifier, AssetAuthority, AssetIdSource,
-    AssetModuleFlags, CurveModuleHeader, GovernanceModuleHeader, GovernanceModuleState,
-    GovernanceVerifierKind, GovernanceVerifierState, PendingAuthorityTransfer,
-    PendingBurnBpsUpdate, PendingRewardsPolicyUpdate, RewardsModuleHeader, RewardsModuleState,
-    SovereignAsset, SupplyMode, AUTHORITY_TRANSFER_TIMELOCK_BLOCKS,
-    GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT, MAX_TRANSFER_BURN_BPS,
+    AssetLaunchedEvent, AssetModuleFlags, CurveModuleHeader, GovernanceModuleHeader,
+    GovernanceModuleState, GovernanceVerifierKind, GovernanceVerifierState,
+    PendingAuthorityTransfer, PendingBurnBpsUpdate, PendingRewardsPolicyUpdate,
+    RewardsModuleHeader, RewardsModuleState, SovereignAsset, SupplyMode,
+    AUTHORITY_TRANSFER_TIMELOCK_BLOCKS, GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT, MAX_TRANSFER_BURN_BPS,
     REWARDS_POLICY_DECREASE_TIMELOCK_BLOCKS,
 };
 use crate::execution::mint_and_allocate::mint_and_allocate;
@@ -154,6 +154,14 @@ pub fn apply_asset_launch(
         creator_recipient,
         payload.initial_supply,
     )?;
+
+    mutator.put_asset_launched_event(&AssetLaunchedEvent {
+        asset_id,
+        module_bitmask: module_flags.0,
+        block_height,
+        block_time,
+        symbol: payload.symbol.clone(),
+    })?;
 
     Ok(AssetLaunchOutcome {
         asset_id,

--- a/lib-blockchain/src/execution/tx_apply.rs
+++ b/lib-blockchain/src/execution/tx_apply.rs
@@ -331,6 +331,20 @@ impl<'a> StateMutator<'a> {
         Ok(self.store.list_rewards_module_asset_ids()?)
     }
 
+    pub fn put_asset_launched_event(
+        &self,
+        event: &crate::contracts::sovereign_asset::AssetLaunchedEvent,
+    ) -> TxApplyResult<()> {
+        self.store.put_asset_launched_event(event)?;
+        Ok(())
+    }
+
+    pub fn list_asset_launched_events(
+        &self,
+    ) -> TxApplyResult<Vec<crate::contracts::sovereign_asset::AssetLaunchedEvent>> {
+        Ok(self.store.list_asset_launched_events()?)
+    }
+
     pub fn list_governance_module_asset_ids(&self) -> TxApplyResult<Vec<[u8; 32]>> {
         Ok(self.store.list_governance_module_asset_ids()?)
     }

--- a/lib-blockchain/src/storage/keys.rs
+++ b/lib-blockchain/src/storage/keys.rs
@@ -191,6 +191,15 @@ pub fn asset_module_state_key(asset_id: &[u8; 32]) -> &[u8; 32] {
     asset_id
 }
 
+/// Key for `asset_events/` tree: block height (BE u64) || asset_id (32 bytes).
+#[inline]
+pub fn asset_launched_event_key(block_height: u64, asset_id: &[u8; 32]) -> [u8; 40] {
+    let mut key = [0u8; 40];
+    key[0..8].copy_from_slice(&block_height.to_be_bytes());
+    key[8..40].copy_from_slice(asset_id);
+    key
+}
+
 /// Key prefix for token supply tree: token_id (32 bytes) → supply_u64
 #[inline]
 pub fn token_supply_key(token: &TokenId) -> [u8; 32] {

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -1181,6 +1181,20 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
         Ok(Vec::new())
     }
 
+    fn put_asset_launched_event(
+        &self,
+        event: &crate::contracts::sovereign_asset::AssetLaunchedEvent,
+    ) -> StorageResult<()> {
+        let _ = event;
+        Ok(())
+    }
+
+    fn list_asset_launched_events(
+        &self,
+    ) -> StorageResult<Vec<crate::contracts::sovereign_asset::AssetLaunchedEvent>> {
+        Ok(Vec::new())
+    }
+
     fn list_governance_module_asset_ids(&self) -> StorageResult<Vec<[u8; 32]>>;
 
     fn get_rewards_policy_document(

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -76,6 +76,7 @@ const TREE_ASSET_SYMBOLS: &str = "asset_symbols";
 const TREE_ASSET_CURVE: &str = "asset_curve";
 const TREE_ASSET_REWARDS: &str = "asset_rewards";
 const TREE_ASSET_GOVERNANCE: &str = "asset_governance";
+const TREE_ASSET_EVENTS: &str = "asset_events";
 const TREE_REWARDS_POLICY_DOCS: &str = "rewards_policy_docs";
 
 /// The single key under which an in-progress block commit's post-image is
@@ -146,6 +147,7 @@ pub struct SledStore {
     asset_curve: Tree,
     asset_rewards: Tree,
     asset_governance: Tree,
+    asset_events: Tree,
     rewards_policy_docs: Tree,
 
     // Transaction state
@@ -483,6 +485,9 @@ impl SledStore {
         let asset_governance = db
             .open_tree(TREE_ASSET_GOVERNANCE)
             .map_err(|e| StorageError::Database(e.to_string()))?;
+        let asset_events = db
+            .open_tree(TREE_ASSET_EVENTS)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
         let rewards_policy_docs = db
             .open_tree(TREE_REWARDS_POLICY_DOCS)
             .map_err(|e| StorageError::Database(e.to_string()))?;
@@ -540,6 +545,7 @@ impl SledStore {
             asset_curve,
             asset_rewards,
             asset_governance,
+            asset_events,
             rewards_policy_docs,
             tx_active: AtomicBool::new(false),
             tx_height: AtomicU64::new(0),
@@ -990,6 +996,7 @@ impl SledStore {
             TREE_ASSET_CURVE => &self.asset_curve,
             TREE_ASSET_REWARDS => &self.asset_rewards,
             TREE_ASSET_GOVERNANCE => &self.asset_governance,
+            TREE_ASSET_EVENTS => &self.asset_events,
             TREE_REWARDS_POLICY_DOCS => &self.rewards_policy_docs,
             _ => return None,
         })
@@ -1849,6 +1856,33 @@ impl BlockchainStore for SledStore {
             }
         }
         Ok(ids)
+    }
+
+    fn put_asset_launched_event(
+        &self,
+        event: &crate::contracts::sovereign_asset::AssetLaunchedEvent,
+    ) -> StorageResult<()> {
+        self.require_transaction()?;
+        let key = keys::asset_launched_event_key(event.block_height, &event.asset_id);
+        let value = Self::serialize(event)?;
+        let mut batch_guard = self.tx_batch.lock().unwrap();
+        if let Some(ref mut batch) = *batch_guard {
+            batch.tree(TREE_ASSET_EVENTS).insert(key.as_ref(), value);
+        }
+        Ok(())
+    }
+
+    fn list_asset_launched_events(
+        &self,
+    ) -> StorageResult<Vec<crate::contracts::sovereign_asset::AssetLaunchedEvent>> {
+        let mut events = Vec::new();
+        for entry in self.asset_events.iter().flatten() {
+            let event: crate::contracts::sovereign_asset::AssetLaunchedEvent =
+                Self::deserialize(&entry.1)?;
+            events.push(event);
+        }
+        events.sort_by_key(|e| (e.block_height, e.asset_id));
+        Ok(events)
     }
 
     fn list_governance_module_asset_ids(&self) -> StorageResult<Vec<[u8; 32]>> {

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -1831,16 +1831,23 @@ impl<'a> StatefulTransactionValidator<'a> {
         );
 
         if transaction.transaction_type == TransactionType::TokenCreation {
-            if let Some(blockchain) = self.blockchain {
-                if !crate::contracts::sovereign_asset::token_creation_submission_allowed_at_tip(
-                    blockchain.get_height(),
-                ) {
+            let chain_tip = match self.blockchain {
+                Some(blockchain) => blockchain.get_height(),
+                None => {
                     tracing::warn!(
-                        "rejecting deprecated TokenCreation at chain tip {}; use AssetLaunch",
-                        blockchain.get_height()
+                        "rejecting TokenCreation: no blockchain context for sunset gate"
                     );
                     return Err(ValidationError::InvalidTransactionType);
                 }
+            };
+            if !crate::contracts::sovereign_asset::token_creation_submission_allowed_at_tip(
+                chain_tip,
+            ) {
+                tracing::warn!(
+                    "rejecting deprecated TokenCreation for apply height {}; use AssetLaunch",
+                    chain_tip.saturating_add(1)
+                );
+                return Err(ValidationError::InvalidTransactionType);
             }
         }
 

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -1830,6 +1830,20 @@ impl<'a> StatefulTransactionValidator<'a> {
             transaction.memo.len()
         );
 
+        if transaction.transaction_type == TransactionType::TokenCreation {
+            if let Some(blockchain) = self.blockchain {
+                if !crate::contracts::sovereign_asset::token_creation_submission_allowed_at_tip(
+                    blockchain.get_height(),
+                ) {
+                    tracing::warn!(
+                        "rejecting deprecated TokenCreation at chain tip {}; use AssetLaunch",
+                        blockchain.get_height()
+                    );
+                    return Err(ValidationError::InvalidTransactionType);
+                }
+            }
+        }
+
         // Check if this is a system transaction (empty inputs = coinbase-style), except token contract calls
         let is_token = is_token_contract_execution(transaction);
         tracing::debug!("[BREADCRUMB] is_token_contract_execution = {}", is_token);

--- a/lib-blockchain/src/validation/block_validate.rs
+++ b/lib-blockchain/src/validation/block_validate.rs
@@ -10,9 +10,12 @@
 //! 3. **Semantic** - data helix root and contextual linkage
 
 use crate::block::Block;
+use crate::contracts::sovereign_asset::{
+    token_creation_allowed_in_block_at_height_with_sunset, TOKEN_CREATION_SUNSET_HEIGHT,
+};
 use crate::fees::{classify_transaction, FeeParamsV2};
 use crate::storage::{BlockHash, BlockchainStore};
-use crate::types::Hash;
+use crate::types::{Hash, TransactionType};
 
 use super::errors::{BlockValidateError, BlockValidateResult};
 
@@ -191,7 +194,40 @@ fn validate_timestamp(
     Ok(())
 }
 
-/// Full block validation (structure + context)
+/// Consensus policy checks on block contents (pre-execution, pre-vote safe).
+///
+/// Rejects blocks that contain transaction types forbidden at the block's height.
+/// Uses the production sunset unless a custom height is passed for tests.
+pub fn validate_block_consensus_policy(
+    block: &Block,
+    token_creation_sunset_height: u64,
+) -> BlockValidateResult<()> {
+    for (index, tx) in block.transactions.iter().enumerate() {
+        if tx.transaction_type == TransactionType::TokenCreation
+            && !token_creation_allowed_in_block_at_height_with_sunset(
+                block.header.height,
+                token_creation_sunset_height,
+            )
+        {
+            return Err(BlockValidateError::ForbiddenTransaction {
+                index,
+                tx_type: "TokenCreation".to_string(),
+                reason: format!(
+                    "TokenCreation is deprecated at block height {}; use AssetLaunch",
+                    block.header.height
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// [`validate_block_consensus_policy`] with the production sunset height.
+pub fn validate_block_consensus_policy_at_prod_sunset(block: &Block) -> BlockValidateResult<()> {
+    validate_block_consensus_policy(block, TOKEN_CREATION_SUNSET_HEIGHT)
+}
+
+/// Full block validation (structure + context + consensus policy)
 pub fn validate_block(
     block: &Block,
     store: &dyn BlockchainStore,
@@ -199,6 +235,7 @@ pub fn validate_block(
 ) -> BlockValidateResult<()> {
     validate_block_structure(block, config)?;
     validate_block_context(block, store, config)?;
+    validate_block_consensus_policy_at_prod_sunset(block)?;
     Ok(())
 }
 
@@ -371,6 +408,38 @@ mod tests {
         assert!(matches!(
             result.unwrap_err(),
             BlockValidateError::PayloadBytesExceeded { .. }
+        ));
+    }
+
+    #[test]
+    fn test_block_consensus_policy_rejects_token_creation_at_sunset() {
+        use crate::contracts::sovereign_asset::TOKEN_CREATION_SUNSET_HEIGHT;
+        use crate::types::TransactionType;
+
+        let tx = Transaction {
+            version: 1,
+            chain_id: 0x03,
+            transaction_type: TransactionType::TokenCreation,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: Signature {
+                signature: vec![0u8; 64],
+                public_key: PublicKey::new([0u8; 2592]),
+                algorithm: SignatureAlgorithm::DEFAULT,
+                timestamp: 0,
+            },
+            memo: vec![],
+            payload: crate::transaction::TransactionPayload::None,
+        };
+
+        let mut block = create_test_block(vec![tx]);
+        block.header.height = TOKEN_CREATION_SUNSET_HEIGHT;
+
+        let result = validate_block_consensus_policy(&block, TOKEN_CREATION_SUNSET_HEIGHT);
+        assert!(matches!(
+            result.unwrap_err(),
+            BlockValidateError::ForbiddenTransaction { .. }
         ));
     }
 

--- a/lib-blockchain/src/validation/errors.rs
+++ b/lib-blockchain/src/validation/errors.rs
@@ -73,6 +73,13 @@ pub enum BlockValidateError {
 
     #[error("Block state write bytes exceeded: {actual} > max {max}")]
     StateWriteBytesExceeded { actual: u64, max: u32 },
+
+    #[error("Forbidden transaction at index {index} ({tx_type}): {reason}")]
+    ForbiddenTransaction {
+        index: usize,
+        tx_type: String,
+        reason: String,
+    },
 }
 
 /// Transaction validation error

--- a/lib-blockchain/src/validation/mod.rs
+++ b/lib-blockchain/src/validation/mod.rs
@@ -26,8 +26,10 @@ pub mod tx_validate;
 pub use errors::{BlockValidateError, BlockValidateResult, TxValidateError, TxValidateResult};
 
 pub use block_validate::{
-    validate_block, validate_block_context, validate_block_resource_limits,
-    validate_block_structure, BlockResourceUsage, BlockValidateConfig,
+    validate_block, validate_block_consensus_policy,
+    validate_block_consensus_policy_at_prod_sunset, validate_block_context,
+    validate_block_resource_limits, validate_block_structure, BlockResourceUsage,
+    BlockValidateConfig,
 };
 
 pub use tx_validate::{

--- a/zhtp/src/api/handlers/token/mod.rs
+++ b/zhtp/src/api/handlers/token/mod.rs
@@ -18,7 +18,7 @@ use lib_protocols::zhtp::ZhtpRequestHandler;
 // Blockchain imports
 use lib_blockchain::contracts::sovereign_asset::{AssetIdSource, SovereignAsset};
 use lib_blockchain::contracts::utils::generate_custom_token_id;
-use lib_blockchain::transaction::{TokenCreationPayloadV1, Transaction};
+use lib_blockchain::transaction::Transaction;
 use lib_blockchain::types::transaction_type::TransactionType;
 use lib_blockchain::{Blockchain, BlockchainQuery};
 use lib_crypto::types::keys::PublicKey;
@@ -187,11 +187,10 @@ impl TokenHandler {
         Self { blockchain }
     }
 
-    /// POST /api/v1/token/create — submit a signed founding `TokenCreation` tx.
+    /// POST /api/v1/token/create — legacy shim (deprecated).
     ///
-    /// BUBL and other GENESIS-6 DAO tokens deploy via `TokenCreation` (see
-    /// `tools/seed_founding_dao`). `AssetLaunch` is the SA-3 sovereign-asset path
-    /// for *other* tickers — not BUBL on the current testnet.
+    /// New sovereign assets must use `POST /api/v1/assets/launch` (`AssetLaunch`).
+    /// This route still accepts `AssetLaunch` during migration; `TokenCreation` is rejected.
     async fn handle_create_token(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
         let create_req: CreateTokenRequest = serde_json::from_slice(&request.body)
             .map_err(|e| anyhow::anyhow!("Invalid request: {}", e))?;
@@ -239,113 +238,27 @@ impl TokenHandler {
             }));
         }
 
-        if tx.transaction_type != TransactionType::TokenCreation {
-            let reason = if tx.transaction_type == TransactionType::ContractExecution {
-                "Deprecated token create transaction type. Use TokenCreation for DAO tokens (BUBL) or AssetLaunch for SA-3 sovereign assets"
-                    .to_string()
-            } else {
-                format!(
-                    "Invalid transaction type for token/create: expected AssetLaunch or TokenCreation, got {:?}",
-                    tx.transaction_type
-                )
-            };
-            tracing::error!("[token/create] invalid tx type: {}", reason);
-            return Ok(create_error_response(ZhtpStatus::BadRequest, reason));
+        if tx.transaction_type == TransactionType::TokenCreation {
+            tracing::warn!(
+                "[token/create] rejected deprecated TokenCreation — use POST /api/v1/assets/launch"
+            );
+            return Ok(create_error_response(
+                ZhtpStatus::BadRequest,
+                "TokenCreation is deprecated. Use POST /api/v1/assets/launch with a signed AssetLaunch transaction.".to_string(),
+            ));
         }
 
-        let payload = match TokenCreationPayloadV1::decode_memo(&tx.memo) {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::error!("[token/create] payload decode FAILED: {}", e);
-                return Ok(create_error_response(
-                    ZhtpStatus::BadRequest,
-                    format!("Invalid token creation payload: {}", e),
-                ));
-            }
+        let reason = if tx.transaction_type == TransactionType::ContractExecution {
+            "Deprecated token create transaction type. Use AssetLaunch via POST /api/v1/assets/launch"
+                .to_string()
+        } else {
+            format!(
+                "Invalid transaction type for token/create: expected AssetLaunch, got {:?}",
+                tx.transaction_type
+            )
         };
-        if create_req.enforce_dao_launch_constraints {
-            if let Err(e) = payload.validate_dao_launch_ui_constraints() {
-                tracing::error!("[token/create] token creation constraints FAILED: {}", e);
-                return Ok(create_error_response(
-                    ZhtpStatus::BadRequest,
-                    format!("Token creation validation failed: {}", e),
-                ));
-            }
-        }
-        let (creator_allocation, treasury_allocation) = payload.split_initial_supply();
-        let TokenCreationPayloadV1 {
-            name,
-            symbol,
-            initial_supply,
-            decimals,
-            treasury_allocation_bps,
-            treasury_recipient,
-        } = payload;
-        let treasury_recipient_hex = hex::encode(treasury_recipient);
-        tracing::info!(
-            "[token/create] name='{}' symbol='{}' supply={} decimals={} treasury_bps={} treasury={}",
-            name,
-            symbol,
-            initial_supply,
-            decimals,
-            treasury_allocation_bps,
-            treasury_recipient_hex
-        );
-
-        if name.is_empty() || symbol.is_empty() {
-            return Ok(create_error_response(
-                ZhtpStatus::BadRequest,
-                "Name and symbol are required".to_string(),
-            ));
-        }
-
-        if symbol.len() > 10 {
-            return Ok(create_error_response(
-                ZhtpStatus::BadRequest,
-                "Symbol must be 10 characters or less".to_string(),
-            ));
-        }
-
-        let token_id = generate_custom_token_id(&name, &symbol);
-
-        // Check if token already exists (duplicate name+symbol)
-        {
-            let blockchain = self.blockchain.read().await;
-            if blockchain.get_token_contract(&token_id).is_some() {
-                return Ok(create_error_response(
-                    ZhtpStatus::Conflict,
-                    format!(
-                        "Token with name '{}' and symbol '{}' already exists",
-                        name, symbol
-                    ),
-                ));
-            }
-        }
-
-        if let Err(e) = self.submit_to_mempool(tx).await {
-            tracing::error!("[token/create] submit_to_mempool FAILED: {}", e);
-            return Ok(create_error_response(ZhtpStatus::BadRequest, e.to_string()));
-        }
-
-        info!("Token creation submitted: {} ({})", name, symbol);
-
-        // u128 amount fields are serialised as decimal strings — serde_json
-        // cannot represent u128 numerically (max safe is i64), and the
-        // earlier u128/JSON panics fixed elsewhere in the codebase set the
-        // precedent.
-        create_json_response(json!({
-            "success": true,
-            "token_id": hex::encode(token_id),
-            "name": name,
-            "symbol": symbol,
-            "initial_supply": initial_supply.to_string(),
-            "decimals": decimals,
-            "treasury_allocation_bps": treasury_allocation_bps,
-            "treasury_recipient": treasury_recipient_hex,
-            "creator_allocation": creator_allocation.to_string(),
-            "treasury_allocation": treasury_allocation.to_string(),
-            "tx_status": "submitted_to_mempool"
-        }))
+        tracing::error!("[token/create] invalid tx type: {}", reason);
+        Ok(create_error_response(ZhtpStatus::BadRequest, reason))
     }
 
     /// POST /api/v1/token/mint - Mint tokens (creator only)

--- a/zhtp/src/rewards_activation.rs
+++ b/zhtp/src/rewards_activation.rs
@@ -5,6 +5,7 @@
 //! `zhtp-cli node configure-rewards`). Legacy `ZHTP_REWARDS_TREASURY_KEYSTORE`
 //! remains as a deprecated fallback for interim BUBL `TokenCreation` nodes.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use lib_blockchain::Blockchain;
@@ -93,33 +94,64 @@ pub fn resolve_activation() -> Option<ResolvedActivation> {
     })
 }
 
+fn eligible_asset_entry(
+    blockchain: &Blockchain,
+    asset_id: [u8; 32],
+    state: &RewardsModuleState,
+) -> Option<ChainEligibleAsset> {
+    let balance = match blockchain.token_balance(&asset_id, &state.spend_delegate_key_id) {
+        Ok(balance) => balance,
+        Err(e) => {
+            warn!(
+                "rewards: token_balance lookup failed for asset {} delegate {}: {e}",
+                hex::encode(&asset_id[..8]),
+                hex::encode(&state.spend_delegate_key_id[..8]),
+            );
+            return None;
+        }
+    };
+    if balance == 0 {
+        return None;
+    }
+    Some(ChainEligibleAsset {
+        asset_id,
+        spend_delegate_key_id: state.spend_delegate_key_id,
+        delegate_balance: balance,
+        policy_hash: state.policy_hash,
+    })
+}
+
 /// Assets with on-chain rewards module and a funded spend delegate (no keystore required).
+///
+/// Primary scan: `asset_rewards/` sled rows (pure `AssetLaunch` path).
+/// Legacy fallback: `token_contracts` entries that also carry rewards module state (BUBL
+/// `TokenCreation` migration).
 pub fn scan_chain_eligible_assets(blockchain: &Blockchain) -> Vec<ChainEligibleAsset> {
     let mut out = Vec::new();
-    for (asset_id, _) in blockchain.iter_token_contract_entries() {
+    let mut seen = HashSet::new();
+
+    for asset_id in blockchain.list_rewards_module_asset_ids() {
+        seen.insert(asset_id);
         let Some(state) = blockchain.get_rewards_module_state(&asset_id) else {
             continue;
         };
-        let balance = match blockchain.token_balance(&asset_id, &state.spend_delegate_key_id) {
-            Ok(balance) => balance,
-            Err(e) => {
-                warn!(
-                    "rewards: token_balance lookup failed for asset {} delegate {}: {e}",
-                    hex::encode(&asset_id[..8]),
-                    hex::encode(&state.spend_delegate_key_id[..8]),
-                );
-                continue;
-            }
-        };
-        if balance > 0 {
-            out.push(ChainEligibleAsset {
-                asset_id,
-                spend_delegate_key_id: state.spend_delegate_key_id,
-                delegate_balance: balance,
-                policy_hash: state.policy_hash,
-            });
+        if let Some(entry) = eligible_asset_entry(blockchain, asset_id, &state) {
+            out.push(entry);
         }
     }
+
+    for (asset_id, _) in blockchain.iter_token_contract_entries() {
+        if seen.contains(&asset_id) {
+            continue;
+        }
+        let Some(state) = blockchain.get_rewards_module_state(&asset_id) else {
+            continue;
+        };
+        if let Some(entry) = eligible_asset_entry(blockchain, asset_id, &state) {
+            out.push(entry);
+        }
+    }
+
     out
 }
 

--- a/zhtp/src/runtime/components/consensus.rs
+++ b/zhtp/src/runtime/components/consensus.rs
@@ -1486,10 +1486,18 @@ impl lib_consensus::types::ConsensusBlockchainProvider for ConsensusBlockchainAd
         // as the blockchain difficulty may have been adjusted far above what testnet can mine quickly.
         let mining_config = lib_blockchain::types::mining::get_mining_config_from_env();
 
-        let selected = lib_blockchain::block::creation::select_transactions_for_block(
+        let selected = lib_blockchain::block::creation::select_transactions_for_block_filtered(
             &valid_pending,
             lib_blockchain::MAX_TRANSACTIONS_PER_BLOCK,
             lib_blockchain::MAX_BLOCK_SIZE,
+            |tx| {
+                if tx.transaction_type == lib_blockchain::types::TransactionType::TokenCreation {
+                    return lib_blockchain::contracts::sovereign_asset::token_creation_allowed_in_block_at_height(
+                        next_height,
+                    );
+                }
+                true
+            },
         );
 
         let block = lib_blockchain::block::creation::create_block(
@@ -1550,6 +1558,8 @@ impl lib_consensus::types::ConsensusBlockchainProvider for ConsensusBlockchainAd
         }
         match bincode::deserialize::<lib_blockchain::block::Block>(block_data) {
             Ok(block) => {
+                lib_blockchain::validation::validate_block_consensus_policy_at_prod_sunset(&block)
+                    .map_err(|e| format!("block consensus policy violation: {e}"))?;
                 let count = block.transactions.len() as u32;
                 let fees: u64 = block.transactions.iter().map(|tx| tx.fee).sum();
                 Ok((count, fees))

--- a/zhtp/src/runtime/services/mining_service.rs
+++ b/zhtp/src/runtime/services/mining_service.rs
@@ -118,13 +118,21 @@ impl MiningService {
         transactions_for_block.extend(ubi_txs);
         let remaining = 10usize.saturating_sub(transactions_for_block.len());
         if remaining > 0 {
-            transactions_for_block.extend(
-                blockchain
-                    .pending_transactions
-                    .iter()
-                    .take(remaining)
-                    .cloned(),
+            let next_height = blockchain.height.saturating_add(1);
+            let selected = lib_blockchain::block::creation::select_transactions_for_block_filtered(
+                &blockchain.pending_transactions,
+                remaining,
+                lib_blockchain::MAX_BLOCK_SIZE,
+                |tx| {
+                    if tx.transaction_type == lib_blockchain::types::TransactionType::TokenCreation {
+                        return lib_blockchain::contracts::sovereign_asset::token_creation_allowed_in_block_at_height(
+                            next_height,
+                        );
+                    }
+                    true
+                },
             );
+            transactions_for_block.extend(selected);
         }
 
         if transactions_for_block.is_empty() {


### PR DESCRIPTION
## Summary
Completes SA-3 acceptance criteria for making `AssetLaunch` the real sovereign-asset write path.

- **`AssetLaunched` events** persisted in `asset_events/` sled tree at `apply_asset_launch`
- **`TokenCreation` sunset** at block 80,000 in executor apply + mempool validation (replay-safe below 80k)
- **API**: `POST /api/v1/token/create` rejects `TokenCreation`; directs to `POST /api/v1/assets/launch`
- **Rewards scan**: primary `asset_rewards/` index with legacy `token_contracts` fallback
- **Tests**: launched event, pure launch without `token_contracts` row, delegate rotate lifecycle, sunset constants
- **Runbooks**: `docs/ops/dao-launch-bootstrap.md`, `docs/protocol/genesis-3-testnet-reset.md`

## Test plan
- [x] `cargo test -p lib-blockchain --lib asset_launch`
- [x] `cargo test -p lib-blockchain --lib delegate_rotate_on_pure`
- [x] `cargo test -p lib-blockchain --lib sunset_tests`

Closes SA-3 remaining gaps (#2783) — SA-4 next.