### PR TITLE
feat(sa-4): chain-native rewards handler via configure-rewards

### DIFF
--- a/docs/ops/dao-launch-bootstrap.md
+++ b/docs/ops/dao-launch-bootstrap.md
@@ -58,9 +58,9 @@ Populate with:
 The creator identity becomes:
 
 - `TokenCreation` / `AssetLaunch` signer
-- Interim rewards spender (`ZHTP_REWARDS_TREASURY_KEYSTORE`)
+- Launch signer only (creator key stays cold after handoff)
 
-**Future (N3):** rewards spend moves to a dedicated hot delegate keystore; creator key leaves validators.
+Rewards spending uses a dedicated hot delegate bound via `node configure-rewards` (SA-4).
 
 ---
 
@@ -124,17 +124,10 @@ On **each** validator (`zhtp-g1`, `g2`, `g3`), bind the on-chain spend delegate:
 export ZHTP_CHAIN_ID=2
 ```
 
-Writes `rewards_activation.toml` under the node data dir. Validators scan
-`asset_rewards/` (pure `AssetLaunch`) plus legacy `token_contracts` rows.
-
-**Deprecated fallback** (historical `TokenCreation` BUBL only):
-
-```bash
-export ZHTP_REWARDS_TREASURY_KEYSTORE=/opt/zhtp/keystores/bubl-creator
-```
-
-Handler activates when the configured keystore matches the on-chain spend delegate
-and delegate balance is positive.
+Writes `rewards_activation.toml` under the node data dir. Handler activates when the
+configured keystore `key_id` matches on-chain `spend_delegate_key_id` and delegate
+balance is positive. Env-var keystore overrides (`ZHTP_REWARDS_TREASURY_KEYSTORE`) are
+removed — `configure-rewards` is required.
 
 Verify:
 

--- a/docs/ops/dao-launch-bootstrap.md
+++ b/docs/ops/dao-launch-bootstrap.md
@@ -113,9 +113,48 @@ Record outputs:
 
 ---
 
-## Step 4 — Enable rewards on validators
+## Step 4 — Enable rewards on validators (SA-4)
 
-On **each** validator (`zhtp-g1`, `g2`, `g3`), bind the on-chain spend delegate:
+SA-4 splits **activation** (no private key on disk; enables read endpoints) from
+**delegate keystore** (hot wallet; required only for claim POSTs). This is strictly
+better key exposure than the pre-SA-4 posture (creator/treasury key on one box via env
+var): the spendable delegate key stays on **one** validator; the other validators serve
+mobile read traffic without holding signing material.
+
+### Keystore posture (do not put the hot wallet on every box)
+
+| Validator | `rewards_activation.toml` | Hot delegate keystore (`bubl-rewards-hot`) |
+|-----------|---------------------------|---------------------------------------------|
+| g1 | yes | **yes** — only node that signs `RewardClaim` txs |
+| g2 | yes (copy from g1) | **no** — reads only; claim POSTs return 503 |
+| g3 | yes (copy from g1) | **no** — reads only; claim POSTs return 503 |
+
+The activation file records `asset_id` and a `delegate_keystore_dir` path. Read
+endpoints (`/status`, `/balance`, `/history`) need only `asset_id` in the file.
+Claim endpoints additionally require the keystore directory to exist locally, the
+signer `key_id` to match on-chain `spend_delegate_key_id`, and delegate balance &gt; 0.
+
+### Rollout order (load-bearing — do not invert)
+
+Without `rewards_activation.toml`, **every** `/api/v1/rewards/*` route — including
+reads the mobile app calls — returns **503**. The safe sequence:
+
+1. **Activation first (while the current binary is still running)** — on **all**
+   validators, materialise `rewards_activation.toml` *before* deploying the SA-4
+   binary that drops `ZHTP_REWARDS_TREASURY_KEYSTORE`:
+   - **g1:** run `configure-rewards` (writes toml + validates keystore against chain)
+   - **g2 / g3:** copy g1's `rewards_activation.toml` into each node's data dir (do
+     **not** copy the hot keystore)
+2. **Verify reads on all three** — `curl …/api/v1/rewards/status/<did>` must not be 503
+   on g1, g2, and g3.
+3. **Deploy SA-4 binary second** — env-var fallback is gone; nodes missing the toml
+   lose all rewards routes immediately on restart.
+
+> **Pre-merge check:** confirm whether g1/g2/g3 systemd units still set
+> `ZHTP_REWARDS_TREASURY_KEYSTORE`. If yes, step 1 can lag until the env path is
+> retired; if no, step 1 is mandatory before any SA-4 deploy.
+
+### g1 — write activation + attach keystore
 
 ```bash
 ./target/dev-release/zhtp-cli node configure-rewards \
@@ -124,18 +163,29 @@ On **each** validator (`zhtp-g1`, `g2`, `g3`), bind the on-chain spend delegate:
 export ZHTP_CHAIN_ID=2
 ```
 
-Writes `rewards_activation.toml` under the node data dir. Handler activates when the
-configured keystore `key_id` matches on-chain `spend_delegate_key_id` and delegate
-balance is positive. Env-var keystore overrides (`ZHTP_REWARDS_TREASURY_KEYSTORE`) are
-removed — `configure-rewards` is required.
-
-Verify:
+### g2 / g3 — activation file only
 
 ```bash
-curl -s "https://<validator>:9334/api/v1/rewards/status/<did>"
+# After g1 step succeeds, copy the toml (not the keystore):
+scp g1:/var/lib/zhtp/rewards_activation.toml /var/lib/zhtp/rewards_activation.toml
+systemctl restart zhtp   # or your deploy script
 ```
 
-503 means keystore unset, wrong signer, or zero balance.
+Env-var overrides (`ZHTP_REWARDS_TREASURY_KEYSTORE`, `ZHTP_REWARDS_TOKEN_ID`) are
+removed in SA-4 — `rewards_activation.toml` is required.
+
+### Verify
+
+```bash
+# Reads — must succeed on g1, g2, g3 once toml is present
+curl -s "https://<validator>:9334/api/v1/rewards/status/<did>"
+
+# Claims — only g1 (or whichever node holds the hot keystore)
+curl -s -X POST "https://g1:9334/api/v1/rewards/claim" …
+```
+
+503 on reads → missing or invalid `rewards_activation.toml`. 503 on claims on a
+read-only replica → expected (no local keystore).
 
 ---
 

--- a/scripts/effective-reset-testnet.sh
+++ b/scripts/effective-reset-testnet.sh
@@ -23,8 +23,8 @@
 #   cargo run -p tools --bin seed_founding_dao -- \
 #     --keystore-dir /opt/zhtp/keystores/bubl-creator \
 #     --token bubl --supply-atoms 1000000000000000000000000000 --chain-id 2
-# Broadcast signed_tx, then set ZHTP_REWARDS_TREASURY_KEYSTORE to bubl-creator.
-# ZHTP_REWARDS_TOKEN_ID is optional (defaults to deterministic BUBL token_id).
+# Broadcast signed_tx, then on each validator:
+#   zhtp-cli node configure-rewards --asset-id <launch_tx_hash> --delegate-keystore <hot-wallet-dir>
 
 set -euo pipefail
 

--- a/tools/seed_asset_launch.rs
+++ b/tools/seed_asset_launch.rs
@@ -297,9 +297,10 @@ fn main() -> Result<()> {
         "tx_hash": hex::encode(tx.hash().as_bytes()),
         "signed_tx": signed_hex,
         "submit_hint": "Broadcast AssetLaunch tx via zhtp-cli or mempool",
-        "rewards_env": {
-            "ZHTP_REWARDS_ASSET_ID": hex::encode(asset_id),
-            "ZHTP_REWARDS_TREASURY_KEYSTORE": args.rewards_delegate_dir.as_ref().map(|p| p.display().to_string()),
+        "configure_rewards": {
+            "asset_id": hex::encode(asset_id),
+            "delegate_keystore": args.rewards_delegate_dir.as_ref().map(|p| p.display().to_string()),
+            "hint": "zhtp-cli node configure-rewards --asset-id <asset_id> --delegate-keystore <path>"
         }
     });
 

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -6,14 +6,12 @@
 //!
 //! ## Configuration
 //!
-//! Activated via `rewards_activation.toml` (written by `zhtp-cli node
-//! configure-rewards`) or the deprecated `ZHTP_REWARDS_TREASURY_KEYSTORE` env
-//! path. Both require a spend-delegate keystore whose key_id matches the
-//! on-chain `RewardsModuleState` and holds a positive token balance.
-//! `ZHTP_REWARDS_TOKEN_ID` may override the asset id on the legacy env path.
-//! `ZHTP_REWARDS_ASSET_ID` is a deprecated alias (remove after 2026-09-01).
-//! Without a matching delegate signer the handler installs but every endpoint
-//! returns 503.
+//! Activated exclusively via `rewards_activation.toml` (written by
+//! `zhtp-cli node configure-rewards`). Requires a spend-delegate keystore whose
+//! `key_id` matches on-chain `RewardsModuleState.spend_delegate_key_id` and
+//! holds a positive token balance. Read endpoints use the configured `asset_id`
+//! from the activation file; write endpoints (claims) require a loaded delegate
+//! signer. Without activation every endpoint returns 503.
 //!
 //! ## Storage (N4 / Q6)
 //!
@@ -50,9 +48,6 @@ mod settlement;
 
 // ── Constants ────────────────────────────────────────────────────────
 
-/// Deprecated env alias — use `ZHTP_REWARDS_TOKEN_ID`. Scheduled removal 2026-09-01.
-const DEPRECATED_REWARDS_ASSET_ID_ENV: &str = "ZHTP_REWARDS_ASSET_ID";
-
 /// 18-decimal atom multiplier.
 const ATOM_18: u128 = 1_000_000_000_000_000_000;
 
@@ -81,8 +76,10 @@ struct ConversationRequest {
 
 pub struct RewardsHandler {
     blockchain: Arc<RwLock<Blockchain>>,
-    /// None when the treasury keystore env var is unset or load failed.
-    /// All POST/GET endpoints return 503 in that case.
+    /// On-chain asset id from `rewards_activation.toml` (enables read endpoints).
+    configured_asset_id: Option<[u8; 32]>,
+    /// None when delegate keystore is unset, unfunded, or chain validation failed.
+    /// POST claim endpoints return 503; GET may still serve reads when configured.
     treasury: Option<TreasuryConfig>,
 }
 
@@ -96,25 +93,43 @@ struct TreasuryConfig {
 
 impl RewardsHandler {
     pub fn new(blockchain: Arc<RwLock<Blockchain>>) -> Result<Self> {
-        // Startup-time lookup: read the BUBL token contract under a non-async
+        // Startup-time lookup: resolve on-chain spend delegate under a non-async
         // borrow of the blockchain (RewardsHandler::new is sync). The
         // blockchain Arc is shared; at startup no API traffic is yet
         // dispatched, so `blocking_read` here is uncontended. Wrapped in
         // `block_in_place` so the runtime can park the worker.
-        let treasury = tokio::task::block_in_place(|| {
+        let (configured_asset_id, treasury) = tokio::task::block_in_place(|| {
             let bc = blockchain.blocking_read();
-            load_treasury(&bc)
+            let configured_asset_id = crate::rewards_activation::configured_asset_id_from_file();
+            let treasury = load_treasury(&bc);
+            (configured_asset_id, treasury)
         });
 
-        if treasury.is_some() {
-            info!("Rewards: spend delegate loaded — /api/v1/rewards/* active (chain-native state only)");
-        } else {
-            info!(
-                "Rewards: delegate keystore unset or unfunded — /api/v1/rewards/* will return 503 on this node"
-            );
+        match (&configured_asset_id, &treasury) {
+            (Some(id), Some(_)) => {
+                info!(
+                    "Rewards: spend delegate loaded for asset {} — /api/v1/rewards/* active",
+                    hex::encode(&id[..8])
+                );
+            }
+            (Some(id), None) => {
+                info!(
+                    "Rewards: activation present for asset {} but delegate signer not loaded — reads only",
+                    hex::encode(&id[..8])
+                );
+            }
+            (None, _) => {
+                info!(
+                    "Rewards: no rewards_activation.toml — /api/v1/rewards/* will return 503"
+                );
+            }
         }
 
-        Ok(Self { blockchain, treasury })
+        Ok(Self {
+            blockchain,
+            configured_asset_id,
+            treasury,
+        })
     }
 
     // ── helpers ──────────────────────────────────────────────────────
@@ -195,7 +210,15 @@ impl RewardsHandler {
     }
 
     fn rewards_asset_id(&self) -> Option<[u8; 32]> {
-        self.treasury.as_ref().map(|t| t.rewards_asset_id)
+        self.treasury
+            .as_ref()
+            .map(|t| t.rewards_asset_id)
+            .or(self.configured_asset_id)
+    }
+
+    fn require_rewards_asset_id(&self) -> Result<[u8; 32], ZhtpResponse> {
+        self.rewards_asset_id()
+            .ok_or_else(Self::unavailable)
     }
 
     // ── handlers ─────────────────────────────────────────────────────
@@ -372,13 +395,14 @@ impl RewardsHandler {
             Ok(k) => k,
             Err(msg) => return Self::bad(msg),
         };
+        let token_id = match self.require_rewards_asset_id() {
+            Ok(id) => id,
+            Err(resp) => return resp,
+        };
         let bc = self.blockchain.read().await;
-        let token_id = self
-            .rewards_asset_id()
-            .unwrap_or_else(|| lib_blockchain::contracts::utils::generate_custom_token_id("Bubble", "BUBL"));
         let stats = bc.reward_lifetime_stats(&token_id, did);
 
-        // Spendable BUBL is on-chain under the holder's key_id.
+        // Spendable balance is on-chain under the holder's key_id.
         let (spendable_balance, asset_id_hex) = match &self.treasury {
             Some(treasury) => {
                 let balance = bc
@@ -420,9 +444,10 @@ impl RewardsHandler {
             return Self::bad(msg);
         }
 
-        let token_id = self.rewards_asset_id().unwrap_or_else(|| {
-            lib_blockchain::contracts::utils::generate_custom_token_id("Bubble", "BUBL")
-        });
+        let token_id = match self.require_rewards_asset_id() {
+            Ok(id) => id,
+            Err(resp) => return resp,
+        };
 
         let now = Self::now_secs();
         let date = Self::utc_date();
@@ -518,9 +543,10 @@ impl RewardsHandler {
         }
         let limit = limit.min(HISTORY_MAX_LIMIT);
 
-        let token_id = self
-            .rewards_asset_id()
-            .unwrap_or_else(|| lib_blockchain::contracts::utils::generate_custom_token_id("Bubble", "BUBL"));
+        let token_id = match self.require_rewards_asset_id() {
+            Ok(id) => id,
+            Err(resp) => return resp,
+        };
         let bc = self.blockchain.read().await;
         let cursor_seq = cursor.map(|c| c.1);
         let (page, has_more) = bc.reward_claim_history(&token_id, did, limit, cursor_seq);
@@ -671,44 +697,6 @@ pub(crate) fn chain_id_from_env() -> u8 {
 
 // ── Treasury loader ──────────────────────────────────────────────────
 
-fn rewards_token_id_override() -> Option<String> {
-    if let Ok(id) = std::env::var("ZHTP_REWARDS_TOKEN_ID") {
-        return Some(id);
-    }
-    if let Ok(id) = std::env::var(DEPRECATED_REWARDS_ASSET_ID_ENV) {
-        warn!(
-            "rewards: {} is deprecated — use ZHTP_REWARDS_TOKEN_ID (removal scheduled 2026-09-01)",
-            DEPRECATED_REWARDS_ASSET_ID_ENV
-        );
-        return Some(id);
-    }
-    None
-}
-
-fn parse_token_id_hex(hex_id: &str) -> Option<[u8; 32]> {
-    let bytes = hex::decode(hex_id).ok()?;
-    if bytes.len() != 32 {
-        return None;
-    }
-    let mut out = [0u8; 32];
-    out.copy_from_slice(&bytes);
-    Some(out)
-}
-
-fn resolve_legacy_rewards_asset_id(
-    blockchain: &Blockchain,
-    signer_key_id: &[u8; 32],
-) -> Option<[u8; 32]> {
-    if let Some(hex_id) = rewards_token_id_override() {
-        return parse_token_id_hex(&hex_id);
-    }
-
-    crate::rewards_activation::scan_chain_eligible_assets(blockchain)
-        .into_iter()
-        .find(|asset| asset.spend_delegate_key_id == *signer_key_id)
-        .map(|asset| asset.asset_id)
-}
-
 fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {
     let eligible = crate::rewards_activation::scan_chain_eligible_assets(blockchain);
     if !eligible.is_empty() {
@@ -726,32 +714,19 @@ fn load_treasury(blockchain: &Blockchain) -> Option<TreasuryConfig> {
         }
     }
 
-    if let Some(activation) = crate::rewards_activation::resolve_activation() {
-        return load_treasury_from_dir(
-            blockchain,
-            &activation.delegate_keystore_dir,
-            Some(activation.asset_id),
-            activation.source,
-        );
-    }
-
-    // Legacy interim: env-only keystore + BUBL token_id discovery (TokenCreation path).
-    let dir = std::env::var("ZHTP_REWARDS_TREASURY_KEYSTORE").ok()?;
-    warn!(
-        "rewards: ZHTP_REWARDS_TREASURY_KEYSTORE is deprecated — use `zhtp-cli node configure-rewards` (removal after 2026-09-01)"
-    );
+    let activation = crate::rewards_activation::resolve_activation()?;
     load_treasury_from_dir(
         blockchain,
-        &PathBuf::from(&dir),
-        None,
-        crate::rewards_activation::ActivationSource::LegacyEnv,
+        &activation.delegate_keystore_dir,
+        activation.asset_id,
+        activation.source,
     )
 }
 
 fn load_treasury_from_dir(
     blockchain: &Blockchain,
     path: &PathBuf,
-    asset_id_override: Option<[u8; 32]>,
+    rewards_asset_id: [u8; 32],
     source: crate::rewards_activation::ActivationSource,
 ) -> Option<TreasuryConfig> {
     if !path.is_dir() {
@@ -776,32 +751,14 @@ fn load_treasury_from_dir(
     };
     let signer_key_id = keypair.public_key.key_id;
 
-    let rewards_asset_id = if let Some(id) = asset_id_override {
-        match crate::rewards_activation::validate_activation_against_chain(
-            blockchain,
-            &id,
-            &signer_key_id,
-        ) {
-            Ok(_) => id,
-            Err(e) => {
-                warn!("rewards: chain-native activation rejected: {e}");
-                return None;
-            }
-        }
-    } else {
-        let token_id = resolve_legacy_rewards_asset_id(blockchain, &signer_key_id)?;
-        match crate::rewards_activation::validate_activation_against_chain(
-            blockchain,
-            &token_id,
-            &signer_key_id,
-        ) {
-            Ok(_) => token_id,
-            Err(e) => {
-                warn!("rewards: legacy env activation rejected: {e}");
-                return None;
-            }
-        }
-    };
+    if let Err(e) = crate::rewards_activation::validate_activation_against_chain(
+        blockchain,
+        &rewards_asset_id,
+        &signer_key_id,
+    ) {
+        warn!("rewards: chain-native activation rejected: {e}");
+        return None;
+    }
 
     let balance = match blockchain.token_balance(&rewards_asset_id, &signer_key_id) {
         Ok(balance) => balance,
@@ -823,7 +780,6 @@ fn load_treasury_from_dir(
     }
     let source_label = match source {
         crate::rewards_activation::ActivationSource::ConfigFile => "rewards_activation.toml",
-        crate::rewards_activation::ActivationSource::LegacyEnv => "ZHTP_REWARDS_TREASURY_KEYSTORE",
     };
     info!(
         "rewards: signer loaded via {source_label} — token_id={} key_id={} balance={}",

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -6,12 +6,13 @@
 //!
 //! ## Configuration
 //!
-//! Activated exclusively via `rewards_activation.toml` (written by
-//! `zhtp-cli node configure-rewards`). Requires a spend-delegate keystore whose
-//! `key_id` matches on-chain `RewardsModuleState.spend_delegate_key_id` and
-//! holds a positive token balance. Read endpoints use the configured `asset_id`
-//! from the activation file; write endpoints (claims) require a loaded delegate
-//! signer. Without activation every endpoint returns 503.
+//! Activated via `rewards_activation.toml` (written by `zhtp-cli node configure-rewards`
+//! or copied across validators). **Ops posture:** place the toml on every validator
+//! (enables read endpoints); mount the hot delegate keystore on **one** validator only
+//! (enables claim POSTs). Read endpoints need only `asset_id` in the file; claims
+//! additionally require a local keystore whose `key_id` matches on-chain
+//! `spend_delegate_key_id` with positive delegate balance. Without the toml, every
+//! endpoint returns 503.
 //!
 //! ## Storage (N4 / Q6)
 //!

--- a/zhtp/src/rewards_activation.rs
+++ b/zhtp/src/rewards_activation.rs
@@ -1,9 +1,9 @@
-//! Chain-native rewards handler activation (DAO N3, #2813).
+//! Chain-native rewards handler activation (DAO N3 / SA-4, #2813).
 //!
 //! Operators bind a spend-delegate keystore to an on-chain asset via
 //! `rewards_activation.toml` under the node data dir (written by
-//! `zhtp-cli node configure-rewards`). Legacy `ZHTP_REWARDS_TREASURY_KEYSTORE`
-//! remains as a deprecated fallback for interim BUBL `TokenCreation` nodes.
+//! `zhtp-cli node configure-rewards`). The rewards handler does not activate
+//! without this file — env-var ticker/keystore hacks are removed.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -33,7 +33,6 @@ pub struct ResolvedActivation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActivationSource {
     ConfigFile,
-    LegacyEnv,
 }
 
 pub fn activation_config_path() -> PathBuf {
@@ -68,6 +67,12 @@ pub fn read_activation_file() -> Option<RewardsActivationFile> {
             None
         }
     }
+}
+
+/// Asset id from `rewards_activation.toml` when present (no keystore validation).
+pub fn configured_asset_id_from_file() -> Option<[u8; 32]> {
+    let file = read_activation_file()?;
+    parse_asset_id_hex(&file.asset_id).ok()
 }
 
 pub fn resolve_activation() -> Option<ResolvedActivation> {
@@ -204,5 +209,17 @@ mod tests {
         let id = [0xab_u8; 32];
         let hex = hex::encode(id);
         assert_eq!(parse_asset_id_hex(&hex).unwrap(), id);
+    }
+
+    #[test]
+    fn activation_file_roundtrip_toml() {
+        let asset_id = [0x42_u8; 32];
+        let file = RewardsActivationFile {
+            asset_id: hex::encode(asset_id),
+            delegate_keystore_dir: "/tmp/delegate".to_string(),
+        };
+        let raw = toml::to_string(&file).expect("serialize");
+        let parsed: RewardsActivationFile = toml::from_str(&raw).expect("parse");
+        assert_eq!(parse_asset_id_hex(&parsed.asset_id).unwrap(), asset_id);
     }
 }

--- a/zhtp/src/rewards_activation.rs
+++ b/zhtp/src/rewards_activation.rs
@@ -1,9 +1,10 @@
 //! Chain-native rewards handler activation (DAO N3 / SA-4, #2813).
 //!
-//! Operators bind a spend-delegate keystore to an on-chain asset via
-//! `rewards_activation.toml` under the node data dir (written by
-//! `zhtp-cli node configure-rewards`). The rewards handler does not activate
-//! without this file — env-var ticker/keystore hacks are removed.
+//! Operators record the rewards `asset_id` in `rewards_activation.toml` under the
+//! node data dir (`zhtp-cli node configure-rewards` on the signing node; copy the
+//! toml to read replicas without copying the hot keystore). The file enables read
+//! endpoints cluster-wide; only the node with a loadable delegate keystore signs
+//! claims. Env-var ticker/keystore hacks are removed in SA-4.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -993,11 +993,9 @@ impl ZhtpUnifiedServer {
         let cbe_handler: Arc<dyn ZhtpRequestHandler> = Arc::new(CbeHandler::new());
         zhtp_router.register_handler("/api/v1/cbe".to_string(), cbe_handler);
 
-        // BUBL rewards endpoints — inline-mint from the treasury identity to
-        // user wallets. Loads its treasury keystore from the env var
-        // `ZHTP_REWARDS_TREASURY_KEYSTORE`; without it, all /rewards/* return
-        // 503. We currently ship the keystore on g1 only so the treasury key
-        // has exactly one exposure surface.
+        // Rewards endpoints — spend-delegate attestation via signed RewardClaim txs.
+        // Activated via rewards_activation.toml (zhtp-cli node configure-rewards);
+        // without it, all /rewards/* return 503.
         match crate::api::handlers::RewardsHandler::new(blockchain.clone()) {
             Ok(h) => {
                 let handler: Arc<dyn ZhtpRequestHandler> = Arc::new(h);


### PR DESCRIPTION
## Summary

SA-4 (#2784): validator rewards handler uses on-chain `RewardsModuleState` + `rewards_activation.toml`; env-var/ticker hacks removed.

- **Removed** `ZHTP_REWARDS_TREASURY_KEYSTORE`, `ZHTP_REWARDS_TOKEN_ID`, BUBL ticker fallbacks
- **Required** `rewards_activation.toml` on every validator that serves `/api/v1/rewards/*`

Depends on SA-3 (merged #2885).

## Keystore posture (do not put the hot wallet on every box)

The handler separates **activation** (toml, no private key) from **delegate keystore** (hot wallet, signing only):

| Node | `rewards_activation.toml` | Hot delegate keystore |
|------|---------------------------|------------------------|
| g1 | yes | **yes** — signs `RewardClaim` txs |
| g2, g3 | yes (copy toml from g1) | **no** — read endpoints only; claim POSTs → 503 |

This is strictly better than pre-SA-4 (treasury key on one box via env): spendable delegate material stays on one validator; g2/g3 serve mobile reads without holding signing keys.

Read endpoints (`/status`, `/balance`, `/history`) need only `asset_id` in the toml. Claim endpoints additionally require a loadable local keystore matching on-chain `spend_delegate_key_id` with positive balance.

## Rollout order (load-bearing)

Without `rewards_activation.toml`, **all** `/api/v1/rewards/*` routes — including reads the mobile app calls — return **503**.

1. **Activation first** (current binary already reads the toml):
   - **g1:** `zhtp-cli node configure-rewards --asset-id … --delegate-keystore …`
   - **g2/g3:** copy g1's `rewards_activation.toml` (do **not** copy the keystore)
   - Verify reads on all three before step 2
2. **Deploy SA-4 binary second** — env fallback removed; missing toml → 503 on restart

> **Pre-merge:** confirm whether g1/g2/g3 systemd units still set `ZHTP_REWARDS_TREASURY_KEYSTORE` (determines whether step 1 can lag until env path is retired).

Details: `docs/ops/dao-launch-bootstrap.md` § Step 4.

## Test plan

- [x] `cargo check -p zhtp --features full-blockchain`
- [x] `cargo test -p lib-blockchain --lib test_asset_rewards_delegate_rotate_on_pure_launch_asset`
- [x] `cargo test -p zhtp --lib activation_file_roundtrip_toml`