### PR TITLE
feat(sa-6): governance module with multisig proof verification

### DIFF
--- a/lib-blockchain/src/contracts/approval_verifier/delegated.rs
+++ b/lib-blockchain/src/contracts/approval_verifier/delegated.rs
@@ -239,6 +239,7 @@ mod tests {
             signers: vec![],
             threshold: 2,
             message_hash: [0u8; 32],
+            raw_signatures: vec![],
         };
 
         let result = verifier.verify_issuance_approval(&request, &wrong_proof, [3u8; 32]);

--- a/lib-blockchain/src/contracts/approval_verifier/governance_vote.rs
+++ b/lib-blockchain/src/contracts/approval_verifier/governance_vote.rs
@@ -305,6 +305,7 @@ mod tests {
             signers: vec![],
             threshold: 2,
             message_hash: [0u8; 32],
+            raw_signatures: vec![],
         };
 
         let result = verifier.verify_issuance_approval(&request, &wrong_proof, [4u8; 32]);

--- a/lib-blockchain/src/contracts/approval_verifier/multisig.rs
+++ b/lib-blockchain/src/contracts/approval_verifier/multisig.rs
@@ -131,6 +131,7 @@ impl IssuanceApprovalVerifier for MultisigVerifier {
                 signers,
                 threshold,
                 message_hash,
+                raw_signatures: _,
             } => (signatures, signers, *threshold, message_hash),
             _ => {
                 return Err(VerificationError::ProofTypeMismatch {
@@ -271,6 +272,7 @@ mod tests {
             signers: vec![[1u8; 32]],
             threshold: 3, // But needs 3
             message_hash: request.compute_hash(),
+            raw_signatures: vec![],
         };
 
         let result = verifier.verify_issuance_approval(&request, &proof, [3u8; 32]);
@@ -290,6 +292,7 @@ mod tests {
             signers: vec![signer, signer], // Duplicate!
             threshold: 2,
             message_hash: request.compute_hash(),
+            raw_signatures: vec![],
         };
 
         let result = verifier.verify_issuance_approval(&request, &proof, [3u8; 32]);
@@ -308,6 +311,7 @@ mod tests {
             signers: vec![[1u8; 32], [2u8; 32]],
             threshold: 2,
             message_hash: request.compute_hash(),
+            raw_signatures: vec![],
         };
 
         let result = verifier.verify_issuance_approval(&request, &proof, [3u8; 32]);
@@ -330,6 +334,7 @@ mod tests {
             signers: vec![[1u8; 32], [2u8; 32]], // [2u8; 32] not authorized
             threshold: 2,
             message_hash: request.compute_hash(),
+            raw_signatures: vec![],
         };
 
         let result = verifier.verify_issuance_approval(&request, &proof, dao_id);
@@ -348,6 +353,7 @@ mod tests {
             signers: vec![[1u8; 32], [2u8; 32]],
             threshold: 2,
             message_hash: [0u8; 32], // Wrong hash!
+            raw_signatures: vec![],
         };
 
         let result = verifier.verify_issuance_approval(&request, &proof, [3u8; 32]);

--- a/lib-blockchain/src/contracts/approval_verifier/traits.rs
+++ b/lib-blockchain/src/contracts/approval_verifier/traits.rs
@@ -114,6 +114,9 @@ pub enum ApprovalProof {
         threshold: u8,
         /// Hash of the message being signed
         message_hash: [u8; 32],
+        /// Raw Dilithium signatures (required for sovereign-asset governance at economic-rules height).
+        #[serde(default)]
+        raw_signatures: Vec<Vec<u8>>,
     },
     /// Delegated verifier approval
     Delegated {
@@ -351,6 +354,7 @@ mod tests {
             signers: vec![],
             threshold: 2,
             message_hash: [0u8; 32],
+            raw_signatures: vec![],
         };
         assert_eq!(multisig_proof.proof_type(), "multisig");
 

--- a/lib-blockchain/src/contracts/sovereign_asset/state.rs
+++ b/lib-blockchain/src/contracts/sovereign_asset/state.rs
@@ -175,6 +175,9 @@ pub fn token_creation_allowed_in_block_at_height_with_sunset(
 
 /// Epic Q1–Q3 / Q8 economic rules (mint class, treasury spend auth, reward liquidity, burn).
 /// Inactive below [`GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT`] so replay matches pre-rules history.
+///
+/// **Not** used for governance multisig signature verification — auth is replay-safe at every
+/// height and is always enforced in [`crate::governance_proof::verify_governance_multisig_proof`].
 #[inline]
 pub fn economic_rules_active(block_height: u64) -> bool {
     block_height >= GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -43,7 +43,8 @@ use crate::storage::{
 };
 use crate::transaction::{
     asset_tx::{
-        AssetAuthorityTransferPayloadV1, AssetLaunchPayloadV1, AssetManifestUpdatePayloadV1,
+        AssetAuthorityTransferCancelPayloadV1, AssetAuthorityTransferPayloadV1,
+        AssetLaunchPayloadV1, AssetManifestUpdatePayloadV1,
         AssetModuleUpgradePayloadV1, AssetRewardsDelegateRotatePayloadV1,
         AssetBurnBpsUpdatePayloadV1, AssetRewardsPolicyUpdatePayloadV1,
     },
@@ -59,9 +60,10 @@ use super::errors::{BlockApplyError, BlockApplyResult, TxApplyError};
 use super::mint_and_allocate::mint_and_allocate;
 use super::sovereign_asset::{
     activate_pending_authority_transfers, activate_pending_burn_bps,
-    activate_pending_rewards_policies, apply_asset_authority_transfer, apply_asset_burn_bps_update,
-    apply_asset_launch, apply_asset_manifest_update, apply_asset_module_upgrade,
-    apply_asset_rewards_delegate_rotate, apply_asset_rewards_policy_update,
+    activate_pending_rewards_policies, apply_asset_authority_transfer,
+    apply_asset_authority_transfer_cancel, apply_asset_burn_bps_update, apply_asset_launch,
+    apply_asset_manifest_update, apply_asset_module_upgrade, apply_asset_rewards_delegate_rotate,
+    apply_asset_rewards_policy_update,
     apply_sovereign_token_transfer, require_governance_mint_signer, require_treasury_spend_signer,
     AssetLaunchOutcome,
 };
@@ -1151,6 +1153,7 @@ impl BlockExecutor {
             TransactionType::AssetModuleUpgrade => {}
             TransactionType::AssetManifestUpdate => {}
             TransactionType::AssetAuthorityTransfer => {}
+            TransactionType::AssetAuthorityTransferCancel => {}
             TransactionType::AssetRewardsDelegateRotate => {}
             TransactionType::AssetRewardsPolicyUpdate => {}
             TransactionType::AssetBurnBpsUpdate => {}
@@ -1449,6 +1452,19 @@ impl BlockExecutor {
                 AssetAuthorityTransferPayloadV1::decode_memo(&tx.memo).map_err(|e| {
                     TxApplyError::InvalidType(format!(
                         "AssetAuthorityTransfer requires canonical memo payload: {e}"
+                    ))
+                })?;
+            }
+            TransactionType::AssetAuthorityTransferCancel => {
+                if !tx.inputs.is_empty() || !tx.outputs.is_empty() {
+                    return Err(TxApplyError::InvalidType(
+                        "AssetAuthorityTransferCancel must not have UTXO inputs or outputs"
+                            .to_string(),
+                    ));
+                }
+                AssetAuthorityTransferCancelPayloadV1::decode_memo(&tx.memo).map_err(|e| {
+                    TxApplyError::InvalidType(format!(
+                        "AssetAuthorityTransferCancel requires canonical memo payload: {e}"
                     ))
                 })?;
             }
@@ -3712,7 +3728,7 @@ impl BlockExecutor {
                     ))
                 })?;
                 let signer = tx.signature.public_key.key_id;
-                apply_asset_manifest_update(mutator, signer, &payload)?;
+                apply_asset_manifest_update(mutator, signer, &payload, block_height)?;
                 Ok(TxOutcome::LegacySystem)
             }
             TransactionType::AssetRewardsDelegateRotate => {
@@ -3723,7 +3739,7 @@ impl BlockExecutor {
                         ))
                     })?;
                 let signer = tx.signature.public_key.key_id;
-                apply_asset_rewards_delegate_rotate(mutator, signer, &payload)?;
+                apply_asset_rewards_delegate_rotate(mutator, signer, &payload, block_height)?;
                 Ok(TxOutcome::LegacySystem)
             }
             TransactionType::AssetRewardsPolicyUpdate => {
@@ -3755,6 +3771,17 @@ impl BlockExecutor {
                 })?;
                 let signer = tx.signature.public_key.key_id;
                 apply_asset_authority_transfer(mutator, signer, &payload, block_height)?;
+                Ok(TxOutcome::LegacySystem)
+            }
+            TransactionType::AssetAuthorityTransferCancel => {
+                let payload =
+                    AssetAuthorityTransferCancelPayloadV1::decode_memo(&tx.memo).map_err(|e| {
+                        TxApplyError::InvalidType(format!(
+                            "AssetAuthorityTransferCancel requires canonical memo payload: {e}"
+                        ))
+                    })?;
+                let signer = tx.signature.public_key.key_id;
+                apply_asset_authority_transfer_cancel(mutator, signer, &payload, block_height)?;
                 Ok(TxOutcome::LegacySystem)
             }
             TransactionType::ContractDeployment => {

--- a/lib-blockchain/src/execution/sovereign_asset.rs
+++ b/lib-blockchain/src/execution/sovereign_asset.rs
@@ -735,7 +735,6 @@ fn verify_authority_proof(
                             verifier,
                             gov_proof,
                             &message_hash,
-                            block_height,
                         )?;
                     }
                     Ok(())
@@ -745,7 +744,6 @@ fn verify_authority_proof(
                     verifier,
                     gov_proof,
                     &message_hash,
-                    block_height,
                 ),
             }
         }

--- a/lib-blockchain/src/execution/sovereign_asset.rs
+++ b/lib-blockchain/src/execution/sovereign_asset.rs
@@ -13,8 +13,16 @@ use crate::execution::mint_and_allocate::mint_and_allocate;
 use crate::execution::tx_apply::StateMutator;
 use crate::execution::{TxApplyError, TxApplyResult};
 use crate::storage::{Address, AddressExt, TokenId};
+use crate::contracts::approval_verifier::ApprovalProof;
+use crate::governance_proof::{
+    governance_action_message_hash, verify_governance_multisig_proof,
+    PROPOSAL_TYPE_AUTHORITY_TRANSFER, PROPOSAL_TYPE_BURN_BPS_UPDATE,
+    PROPOSAL_TYPE_MANIFEST_UPDATE, PROPOSAL_TYPE_REWARDS_DELEGATE_ROTATE,
+    PROPOSAL_TYPE_REWARDS_POLICY_UPDATE,
+};
 use crate::transaction::asset_tx::{
-    AssetAuthorityProof, AssetAuthorityTransferPayloadV1, AssetLaunchPayloadV1,
+    AssetAuthorityProof, AssetAuthorityTransferCancelPayloadV1,
+    AssetAuthorityTransferPayloadV1, AssetLaunchPayloadV1,
     AssetManifestUpdatePayloadV1, AssetModuleUpgradePayloadV1,
     AssetBurnBpsUpdatePayloadV1, AssetRewardsDelegateRotatePayloadV1,
     AssetRewardsPolicyUpdatePayloadV1, AssetUpgradeModule, GovernanceLaunchConfig,
@@ -270,12 +278,25 @@ pub fn apply_asset_manifest_update(
     mutator: &StateMutator<'_>,
     signer_key_id: [u8; 32],
     payload: &AssetManifestUpdatePayloadV1,
+    block_height: u64,
 ) -> TxApplyResult<()> {
     let mut asset = mutator
         .get_sovereign_asset(&payload.asset_id)?
         .ok_or_else(|| TxApplyError::InvalidType("asset not found".to_string()))?;
 
-    verify_authority_proof(mutator, &asset, signer_key_id, &payload.authority_proof)?;
+    let msg = governance_action_message_hash(
+        &payload.asset_id,
+        PROPOSAL_TYPE_MANIFEST_UPDATE,
+        &payload.manifest_hash,
+    );
+    verify_authority_proof(
+        mutator,
+        &asset,
+        signer_key_id,
+        &payload.authority_proof,
+        Some(msg),
+        block_height,
+    )?;
 
     if payload.manifest_cid == [0u8; 32] || payload.manifest_hash == [0u8; 32] {
         return Err(TxApplyError::InvalidType("manifest fields required".into()));
@@ -300,7 +321,19 @@ pub fn apply_asset_rewards_policy_update(
     if !asset.module_flags.has_rewards() {
         return Err(TxApplyError::InvalidType("rewards module not enabled".into()));
     }
-    verify_authority_proof(mutator, &asset, signer_key_id, &payload.authority_proof)?;
+    let msg = governance_action_message_hash(
+        &payload.asset_id,
+        PROPOSAL_TYPE_REWARDS_POLICY_UPDATE,
+        &payload.policy.policy_hash,
+    );
+    verify_authority_proof(
+        mutator,
+        &asset,
+        signer_key_id,
+        &payload.authority_proof,
+        Some(msg),
+        block_height,
+    )?;
 
     let doc = payload
         .policy
@@ -461,6 +494,7 @@ pub fn apply_asset_rewards_delegate_rotate(
     mutator: &StateMutator<'_>,
     signer_key_id: [u8; 32],
     payload: &AssetRewardsDelegateRotatePayloadV1,
+    block_height: u64,
 ) -> TxApplyResult<()> {
     let asset = mutator
         .get_sovereign_asset(&payload.asset_id)?
@@ -469,7 +503,19 @@ pub fn apply_asset_rewards_delegate_rotate(
     if !asset.module_flags.has_rewards() {
         return Err(TxApplyError::InvalidType("rewards module not enabled".into()));
     }
-    verify_authority_proof(mutator, &asset, signer_key_id, &payload.authority_proof)?;
+    let msg = governance_action_message_hash(
+        &payload.asset_id,
+        PROPOSAL_TYPE_REWARDS_DELEGATE_ROTATE,
+        &payload.new_delegate_key_id,
+    );
+    verify_authority_proof(
+        mutator,
+        &asset,
+        signer_key_id,
+        &payload.authority_proof,
+        Some(msg),
+        block_height,
+    )?;
 
     if payload.new_delegate_key_id == [0u8; 32] {
         return Err(TxApplyError::InvalidType("new delegate must be non-zero".into()));
@@ -589,7 +635,23 @@ pub fn apply_asset_authority_transfer(
         .get_sovereign_asset(&payload.asset_id)?
         .ok_or_else(|| TxApplyError::InvalidType("asset not found".to_string()))?;
 
-    verify_authority_proof(mutator, &asset, signer_key_id, &payload.authority_proof)?;
+    let verifier_hash = lib_crypto::hash_blake3(
+        &bincode::serialize(&payload.new_verifier)
+            .map_err(|e| TxApplyError::InvalidType(format!("serialize verifier: {e}")))?,
+    );
+    let msg = governance_action_message_hash(
+        &payload.asset_id,
+        PROPOSAL_TYPE_AUTHORITY_TRANSFER,
+        &verifier_hash,
+    );
+    verify_authority_proof(
+        mutator,
+        &asset,
+        signer_key_id,
+        &payload.authority_proof,
+        Some(msg),
+        block_height,
+    )?;
     validate_governance_verifier(&payload.new_verifier)
         .map_err(|e| TxApplyError::InvalidType(e))?;
 
@@ -636,6 +698,8 @@ fn verify_authority_proof(
     asset: &SovereignAsset,
     signer_key_id: [u8; 32],
     proof: &AssetAuthorityProof,
+    expected_message_hash: Option<[u8; 32]>,
+    block_height: u64,
 ) -> TxApplyResult<()> {
     match (&asset.authority, proof) {
         (AssetAuthority::Creator { key_id }, AssetAuthorityProof::CreatorSig) if *key_id == signer_key_id => {
@@ -644,7 +708,7 @@ fn verify_authority_proof(
         (AssetAuthority::Creator { .. }, AssetAuthorityProof::CreatorSig) => {
             Err(TxApplyError::InvalidType("creator signature mismatch".into()))
         }
-        (AssetAuthority::Governance { module_ref }, AssetAuthorityProof::Governance(_)) => {
+        (AssetAuthority::Governance { module_ref }, AssetAuthorityProof::Governance(gov_proof)) => {
             let gov = mutator
                 .get_governance_module_state(module_ref)?
                 .ok_or_else(|| TxApplyError::InvalidType("governance state missing".into()))?;
@@ -652,16 +716,86 @@ fn verify_authority_proof(
                 .verifier
                 .as_ref()
                 .ok_or_else(|| TxApplyError::InvalidType("governance verifier missing".into()))?;
-            if verifier_contains(verifier, signer_key_id) {
-                Ok(())
-            } else {
-                Err(TxApplyError::InvalidType(
+
+            if !verifier_contains(verifier, signer_key_id) {
+                return Err(TxApplyError::InvalidType(
                     "governance signer not authorized".into(),
-                ))
+                ));
+            }
+
+            let message_hash = expected_message_hash.ok_or_else(|| {
+                TxApplyError::InvalidType("governance action message hash required".into())
+            })?;
+
+            match verifier {
+                GovernanceVerifierState::Single { .. } => {
+                    if matches!(gov_proof, ApprovalProof::Multisig { .. }) {
+                        verify_governance_multisig_proof(
+                            mutator,
+                            verifier,
+                            gov_proof,
+                            &message_hash,
+                            block_height,
+                        )?;
+                    }
+                    Ok(())
+                }
+                GovernanceVerifierState::Multisig { .. } => verify_governance_multisig_proof(
+                    mutator,
+                    verifier,
+                    gov_proof,
+                    &message_hash,
+                    block_height,
+                ),
             }
         }
-        _ => Err(TxApplyError::InvalidType("invalid authority proof".into())),
+        (AssetAuthority::Creator { .. }, AssetAuthorityProof::Governance(_)) => Err(
+            TxApplyError::InvalidType("governance proof invalid while authority is Creator".into()),
+        ),
+        (AssetAuthority::Governance { .. }, AssetAuthorityProof::CreatorSig) => Err(
+            TxApplyError::InvalidType("creator proof invalid while authority is Governance".into()),
+        ),
     }
+}
+
+/// Cancel a queued creator → governance authority transfer before `effective_height`.
+pub fn apply_asset_authority_transfer_cancel(
+    mutator: &StateMutator<'_>,
+    signer_key_id: [u8; 32],
+    payload: &AssetAuthorityTransferCancelPayloadV1,
+    block_height: u64,
+) -> TxApplyResult<()> {
+    let asset = mutator
+        .get_sovereign_asset(&payload.asset_id)?
+        .ok_or_else(|| TxApplyError::InvalidType("asset not found".to_string()))?;
+
+    let AssetAuthority::Creator { key_id } = asset.authority else {
+        return Err(TxApplyError::InvalidType(
+            "only Creator authority may cancel a pending transfer".into(),
+        ));
+    };
+    if key_id != signer_key_id {
+        return Err(TxApplyError::InvalidType("creator signature mismatch".into()));
+    }
+
+    let mut gov_state = mutator
+        .get_governance_module_state(&payload.asset_id)?
+        .ok_or_else(|| TxApplyError::InvalidType("governance state missing".into()))?;
+
+    let Some(pending) = gov_state.pending_transfer.clone() else {
+        return Err(TxApplyError::InvalidType(
+            "no pending authority transfer to cancel".into(),
+        ));
+    };
+    if pending.effective_height <= block_height {
+        return Err(TxApplyError::InvalidType(
+            "pending authority transfer already effective; cannot cancel".into(),
+        ));
+    }
+
+    gov_state.pending_transfer = None;
+    mutator.put_governance_module_state(&payload.asset_id, &gov_state)?;
+    Ok(())
 }
 
 fn verifier_contains(verifier: &GovernanceVerifierState, key_id: [u8; 32]) -> bool {
@@ -731,7 +865,24 @@ pub fn apply_asset_burn_bps_update(
         .get_sovereign_asset(&payload.asset_id)?
         .ok_or_else(|| TxApplyError::InvalidType("asset not found".to_string()))?;
 
-    verify_authority_proof(mutator, &asset, signer_key_id, &payload.authority_proof)?;
+    let burn_hash = {
+        let mut buf = [0u8; 32];
+        buf[..2].copy_from_slice(&payload.new_burn_bps.to_le_bytes());
+        lib_crypto::hash_blake3(&buf)
+    };
+    let msg = governance_action_message_hash(
+        &payload.asset_id,
+        PROPOSAL_TYPE_BURN_BPS_UPDATE,
+        &burn_hash,
+    );
+    verify_authority_proof(
+        mutator,
+        &asset,
+        signer_key_id,
+        &payload.authority_proof,
+        Some(msg),
+        block_height,
+    )?;
 
     asset.pending_burn_bps = Some(PendingBurnBpsUpdate {
         new_burn_bps: payload.new_burn_bps,
@@ -815,6 +966,7 @@ mod activate_pending_tests {
     use crate::contracts::sovereign_asset::{
         AssetIdSource, GovernanceVerifierKind, PendingRewardsPolicyUpdate,
     };
+    use crate::transaction::asset_tx::AssetAuthorityTransferCancelPayloadV1;
     use crate::rewards_policy::policy_hash;
     use crate::storage::{BlockchainStore, SledStore};
     use std::sync::Arc;
@@ -1058,6 +1210,32 @@ mod activate_pending_tests {
                 threshold: 1,
             })
         );
+    }
+
+    #[test]
+    fn creator_cancels_pending_authority_transfer_before_effective_height() {
+        let store = fresh_store();
+        let mut session = BlockSession::new(store.as_ref());
+        let asset_id = key(0x06);
+        let creator = key(0xCC);
+        seed_pending_creator_transfer(
+            &mut session,
+            asset_id,
+            creator,
+            single_verifier(0xBB),
+            5,
+        );
+
+        session.apply(|mutator, height| {
+            let payload = AssetAuthorityTransferCancelPayloadV1 { asset_id };
+            apply_asset_authority_transfer_cancel(mutator, creator, &payload, height).unwrap();
+        });
+
+        let mutator = StateMutator::new(store.as_ref());
+        let asset = mutator.get_sovereign_asset(&asset_id).unwrap().unwrap();
+        assert!(matches!(asset.authority, AssetAuthority::Creator { .. }));
+        let gov = mutator.get_governance_module_state(&asset_id).unwrap().unwrap();
+        assert!(gov.pending_transfer.is_none());
     }
 
     #[test]

--- a/lib-blockchain/src/execution/tx_apply.rs
+++ b/lib-blockchain/src/execution/tx_apply.rs
@@ -39,6 +39,11 @@ impl<'a> StateMutator<'a> {
         Self { store }
     }
 
+    /// Underlying block store (read-only during apply).
+    pub fn store(&self) -> &dyn BlockchainStore {
+        self.store
+    }
+
     // =========================================================================
     // UTXO Primitives
     // =========================================================================

--- a/lib-blockchain/src/governance_proof.rs
+++ b/lib-blockchain/src/governance_proof.rs
@@ -1,0 +1,254 @@
+//! Sovereign-asset governance proof verification (SA-6 / C5).
+//!
+//! Validates `AssetAuthorityProof::Governance(ApprovalProof::Multisig)` against the
+//! on-chain `GovernanceVerifierState`, including Dilithium signatures over a
+//! domain-separated action hash.
+
+use crate::contracts::approval_verifier::ApprovalProof;
+use crate::contracts::approval_verifier::traits::Signature64;
+use crate::contracts::sovereign_asset::{
+    economic_rules_active, GovernanceVerifierState,
+};
+use crate::execution::tx_apply::StateMutator;
+use crate::execution::TxApplyError;
+use crate::integration::crypto_integration::PublicKey;
+use crate::storage::{BlockchainStore, IdentityMetadata};
+
+const GOVERNANCE_PROPOSAL_DOMAIN: &[u8] = b"zhtp/governance-proposal/v1\0";
+
+/// Proposal type tag for rewards policy updates (matches `zhtp-cli` governance flow).
+pub const PROPOSAL_TYPE_REWARDS_POLICY_UPDATE: &str = "rewards_policy_update";
+pub const PROPOSAL_TYPE_MANIFEST_UPDATE: &str = "manifest_update";
+pub const PROPOSAL_TYPE_REWARDS_DELEGATE_ROTATE: &str = "rewards_delegate_rotate";
+pub const PROPOSAL_TYPE_AUTHORITY_TRANSFER: &str = "authority_transfer";
+pub const PROPOSAL_TYPE_BURN_BPS_UPDATE: &str = "burn_bps_update";
+
+/// Canonical governance action hash (shared with `zhtp-cli dao governance`).
+pub fn governance_action_message_hash(
+    asset_id: &[u8; 32],
+    proposal_type: &str,
+    payload_hash: &[u8; 32],
+) -> [u8; 32] {
+    lib_crypto::hash_blake3(
+        &[
+            GOVERNANCE_PROPOSAL_DOMAIN,
+            proposal_type.as_bytes(),
+            asset_id.as_slice(),
+            payload_hash.as_slice(),
+        ]
+        .concat(),
+    )
+}
+
+/// Compress a Dilithium signature into the wire `Signature64` (dao governance CLI).
+pub fn signature64_from_dilithium(sig: &[u8]) -> Signature64 {
+    let h1 = lib_crypto::hash_blake3(sig);
+    let h2 = lib_crypto::hash_blake3(&[h1.as_slice(), b"sig64"].concat());
+    let mut out = [0u8; 64];
+    out[..32].copy_from_slice(&h1);
+    out[32..].copy_from_slice(&h2);
+    Signature64::new(out)
+}
+
+fn public_key_from_identity_metadata(meta: &IdentityMetadata) -> Option<PublicKey> {
+    let dilithium: [u8; 2592] = meta.public_key.as_slice().try_into().ok()?;
+    if meta.kyber_public_key.len() == 1568 {
+        let kyber: [u8; 1568] = meta.kyber_public_key.as_slice().try_into().ok()?;
+        Some(PublicKey::new_with_kyber(dilithium, kyber))
+    } else {
+        Some(PublicKey::new(dilithium))
+    }
+}
+
+fn resolve_public_key_by_key_id(
+    store: &dyn BlockchainStore,
+    key_id: &[u8; 32],
+) -> Option<Vec<u8>> {
+    let iter = store.iter_identity_metadata().ok()?;
+    for meta in iter {
+        let pk = public_key_from_identity_metadata(&meta)?;
+        if &pk.key_id == key_id {
+            return Some(meta.public_key);
+        }
+    }
+    None
+}
+
+fn verify_dilithium_over_hash(
+    message_hash: &[u8; 32],
+    signature: &[u8],
+    public_key: &[u8],
+) -> bool {
+    lib_crypto::verification::verify_signature(message_hash, signature, public_key)
+        .unwrap_or(false)
+}
+
+/// Verify a multisig governance proof against the configured verifier.
+pub fn verify_governance_multisig_proof(
+    mutator: &StateMutator<'_>,
+    verifier: &GovernanceVerifierState,
+    proof: &ApprovalProof,
+    expected_message_hash: &[u8; 32],
+    block_height: u64,
+) -> Result<(), TxApplyError> {
+    let ApprovalProof::Multisig {
+        signatures,
+        signers,
+        threshold,
+        message_hash,
+        raw_signatures,
+    } = proof
+    else {
+        return Err(TxApplyError::InvalidType(
+            "governance action requires Multisig ApprovalProof".into(),
+        ));
+    };
+
+    if message_hash != expected_message_hash {
+        return Err(TxApplyError::InvalidType(
+            "governance proof message_hash mismatch".into(),
+        ));
+    }
+
+    if signatures.len() != signers.len() {
+        return Err(TxApplyError::InvalidType(
+            "governance multisig signature/signer count mismatch".into(),
+        ));
+    }
+
+    let (authorized, required_threshold) = match verifier {
+        GovernanceVerifierState::Single { signer_key_id } => {
+            if signers.len() != 1 || signers[0] != *signer_key_id {
+                return Err(TxApplyError::InvalidType(
+                    "single verifier requires exactly one authorized signer".into(),
+                ));
+            }
+            (vec![*signer_key_id], 1u8)
+        }
+        GovernanceVerifierState::Multisig {
+            signers: authorized_signers,
+            threshold: verifier_threshold,
+        } => (authorized_signers.clone(), *verifier_threshold),
+    };
+
+    let effective_threshold = (*threshold).max(required_threshold);
+    if signers.len() < effective_threshold as usize {
+        return Err(TxApplyError::InvalidType(format!(
+            "governance multisig insufficient approvals: have {}, need {}",
+            signers.len(),
+            effective_threshold
+        )));
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    for signer in signers {
+        if !authorized.contains(signer) {
+            return Err(TxApplyError::InvalidType(
+                "governance signer not in on-chain verifier set".into(),
+            ));
+        }
+        if !seen.insert(*signer) {
+            return Err(TxApplyError::InvalidType(
+                "duplicate governance multisig signer".into(),
+            ));
+        }
+    }
+
+    if economic_rules_active(block_height) {
+        if raw_signatures.len() != signers.len() {
+            return Err(TxApplyError::InvalidType(
+                "governance multisig requires raw_signatures when economic rules are active"
+                    .into(),
+            ));
+        }
+        for (idx, (signer, raw_sig)) in signers.iter().zip(raw_signatures.iter()).enumerate() {
+            let wire_sig = signatures
+                .get(idx)
+                .ok_or_else(|| TxApplyError::InvalidType("missing wire signature".into()))?;
+            if signature64_from_dilithium(raw_sig) != *wire_sig {
+                return Err(TxApplyError::InvalidType(
+                    "governance wire signature does not match raw Dilithium signature".into(),
+                ));
+            }
+            let pk = resolve_public_key_by_key_id(mutator.store(), signer).ok_or_else(|| {
+                TxApplyError::InvalidType(format!(
+                    "governance signer {} has no registered identity",
+                    hex::encode(&signer[..8])
+                ))
+            })?;
+            if !verify_dilithium_over_hash(expected_message_hash, raw_sig, &pk) {
+                return Err(TxApplyError::InvalidType(
+                    "governance multisig signature verification failed".into(),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{convert_legacy_identity, BlockchainStore, SledStore};
+    use crate::transaction::IdentityTransactionData;
+    use lib_crypto::KeyPair;
+    use std::sync::Arc;
+
+    fn store_with_signer(kp: &KeyPair) -> Arc<dyn BlockchainStore> {
+        let store = Arc::new(SledStore::open_temporary().unwrap()) as Arc<dyn BlockchainStore>;
+        let did = format!("did:zhtp:{}", hex::encode(kp.public_key.key_id));
+        let legacy = IdentityTransactionData {
+            did,
+            display_name: "test".to_string(),
+            public_key: kp.public_key.dilithium_pk.to_vec(),
+            ownership_proof: vec![],
+            identity_type: "human".to_string(),
+            did_document_hash: crate::types::Hash::zero(),
+            created_at: 1,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_nodes: vec![],
+            owned_wallets: vec![],
+            kyber_public_key: kp.public_key.kyber_pk.to_vec(),
+        };
+        let (consensus, metadata) = convert_legacy_identity(&legacy);
+        store.begin_block(0).unwrap();
+        StateMutator::new(store.as_ref())
+            .register_identity(&consensus.did_hash, &consensus, &metadata)
+            .expect("seed identity");
+        store.commit_block().unwrap();
+        store
+    }
+
+    #[test]
+    fn multisig_proof_verifies_with_raw_signatures() {
+        let kp1 = KeyPair::generate().unwrap();
+        let store = store_with_signer(&kp1);
+
+        let asset_id = [0xAB; 32];
+        let policy_hash = [0xCD; 32];
+        let msg = governance_action_message_hash(
+            &asset_id,
+            PROPOSAL_TYPE_REWARDS_POLICY_UPDATE,
+            &policy_hash,
+        );
+        let sig = kp1.sign(&msg).unwrap();
+        let raw = sig.signature;
+        let proof = ApprovalProof::Multisig {
+            signatures: vec![signature64_from_dilithium(&raw)],
+            signers: vec![kp1.public_key.key_id],
+            threshold: 1,
+            message_hash: msg,
+            raw_signatures: vec![raw],
+        };
+        let verifier = GovernanceVerifierState::Single {
+            signer_key_id: kp1.public_key.key_id,
+        };
+
+        store.begin_block(1).unwrap();
+        let mutator = StateMutator::new(store.as_ref());
+        verify_governance_multisig_proof(&mutator, &verifier, &proof, &msg, 1).unwrap();
+        store.commit_block().unwrap();
+    }
+}

--- a/lib-blockchain/src/governance_proof.rs
+++ b/lib-blockchain/src/governance_proof.rs
@@ -224,10 +224,6 @@ mod tests {
         store
     }
 
-    /// Production activation height — tests must exercise heights below this even though
-    /// `#[cfg(test)]` sets `GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT` to 0.
-    const PROD_GOVERNANCE_ACTIVATION_HEIGHT: u64 = 80_000;
-
     fn verify_multisig_proof_on_store(
         store: &Arc<dyn BlockchainStore>,
         verifier: &GovernanceVerifierState,
@@ -264,13 +260,11 @@ mod tests {
         };
 
         verify_multisig_proof_on_store(&store, &verifier, &proof, &msg).unwrap();
-        // Height is not consulted for crypto; re-run to model pre-activation prod (~39k).
-        let _pre_activation = PROD_GOVERNANCE_ACTIVATION_HEIGHT - 1;
-        verify_multisig_proof_on_store(&store, &verifier, &proof, &msg).unwrap();
     }
 
+    /// Garbage co-signatures are rejected at every height (auth is not height-gated).
     #[test]
-    fn multisig_proof_rejects_garbage_signatures_below_prod_activation_height() {
+    fn multisig_proof_rejects_garbage_cosignatures() {
         let kp1 = KeyPair::generate().unwrap();
         let kp2 = KeyPair::generate().unwrap();
         let key_id1 = kp1.public_key.key_id;
@@ -301,8 +295,6 @@ mod tests {
         };
 
         let store = store_with_signers(&[kp1, kp2]);
-
-        let _pre_activation = PROD_GOVERNANCE_ACTIVATION_HEIGHT - 1;
         let err =
             verify_multisig_proof_on_store(&store, &verifier, &proof, &msg).unwrap_err();
         assert!(matches!(err, TxApplyError::InvalidType(msg) if msg.contains("signature verification failed")));

--- a/lib-blockchain/src/governance_proof.rs
+++ b/lib-blockchain/src/governance_proof.rs
@@ -6,9 +6,7 @@
 
 use crate::contracts::approval_verifier::ApprovalProof;
 use crate::contracts::approval_verifier::traits::Signature64;
-use crate::contracts::sovereign_asset::{
-    economic_rules_active, GovernanceVerifierState,
-};
+use crate::contracts::sovereign_asset::GovernanceVerifierState;
 use crate::execution::tx_apply::StateMutator;
 use crate::execution::TxApplyError;
 use crate::integration::crypto_integration::PublicKey;
@@ -84,12 +82,14 @@ fn verify_dilithium_over_hash(
 }
 
 /// Verify a multisig governance proof against the configured verifier.
+///
+/// Signature verification is **not** gated on [`economic_rules_active`]: governance
+/// authentication is replay-safe at every height, unlike economic-policy constraints.
 pub fn verify_governance_multisig_proof(
     mutator: &StateMutator<'_>,
     verifier: &GovernanceVerifierState,
     proof: &ApprovalProof,
     expected_message_hash: &[u8; 32],
-    block_height: u64,
 ) -> Result<(), TxApplyError> {
     let ApprovalProof::Multisig {
         signatures,
@@ -154,33 +154,30 @@ pub fn verify_governance_multisig_proof(
         }
     }
 
-    if economic_rules_active(block_height) {
-        if raw_signatures.len() != signers.len() {
+    if raw_signatures.len() != signers.len() {
+        return Err(TxApplyError::InvalidType(
+            "governance multisig requires raw_signatures".into(),
+        ));
+    }
+    for (idx, (signer, raw_sig)) in signers.iter().zip(raw_signatures.iter()).enumerate() {
+        let wire_sig = signatures
+            .get(idx)
+            .ok_or_else(|| TxApplyError::InvalidType("missing wire signature".into()))?;
+        if signature64_from_dilithium(raw_sig) != *wire_sig {
             return Err(TxApplyError::InvalidType(
-                "governance multisig requires raw_signatures when economic rules are active"
-                    .into(),
+                "governance wire signature does not match raw Dilithium signature".into(),
             ));
         }
-        for (idx, (signer, raw_sig)) in signers.iter().zip(raw_signatures.iter()).enumerate() {
-            let wire_sig = signatures
-                .get(idx)
-                .ok_or_else(|| TxApplyError::InvalidType("missing wire signature".into()))?;
-            if signature64_from_dilithium(raw_sig) != *wire_sig {
-                return Err(TxApplyError::InvalidType(
-                    "governance wire signature does not match raw Dilithium signature".into(),
-                ));
-            }
-            let pk = resolve_public_key_by_key_id(mutator.store(), signer).ok_or_else(|| {
-                TxApplyError::InvalidType(format!(
-                    "governance signer {} has no registered identity",
-                    hex::encode(&signer[..8])
-                ))
-            })?;
-            if !verify_dilithium_over_hash(expected_message_hash, raw_sig, &pk) {
-                return Err(TxApplyError::InvalidType(
-                    "governance multisig signature verification failed".into(),
-                ));
-            }
+        let pk = resolve_public_key_by_key_id(mutator.store(), signer).ok_or_else(|| {
+            TxApplyError::InvalidType(format!(
+                "governance signer {} has no registered identity",
+                hex::encode(&signer[..8])
+            ))
+        })?;
+        if !verify_dilithium_over_hash(expected_message_hash, raw_sig, &pk) {
+            return Err(TxApplyError::InvalidType(
+                "governance multisig signature verification failed".into(),
+            ));
         }
     }
 
@@ -195,8 +192,7 @@ mod tests {
     use lib_crypto::KeyPair;
     use std::sync::Arc;
 
-    fn store_with_signer(kp: &KeyPair) -> Arc<dyn BlockchainStore> {
-        let store = Arc::new(SledStore::open_temporary().unwrap()) as Arc<dyn BlockchainStore>;
+    fn seed_signer(store: &dyn BlockchainStore, kp: &KeyPair) {
         let did = format!("did:zhtp:{}", hex::encode(kp.public_key.key_id));
         let legacy = IdentityTransactionData {
             did,
@@ -213,18 +209,39 @@ mod tests {
             kyber_public_key: kp.public_key.kyber_pk.to_vec(),
         };
         let (consensus, metadata) = convert_legacy_identity(&legacy);
-        store.begin_block(0).unwrap();
-        StateMutator::new(store.as_ref())
+        StateMutator::new(store)
             .register_identity(&consensus.did_hash, &consensus, &metadata)
             .expect("seed identity");
+    }
+
+    fn store_with_signers(kps: &[KeyPair]) -> Arc<dyn BlockchainStore> {
+        let store = Arc::new(SledStore::open_temporary().unwrap()) as Arc<dyn BlockchainStore>;
+        store.begin_block(0).unwrap();
+        for kp in kps {
+            seed_signer(store.as_ref(), kp);
+        }
         store.commit_block().unwrap();
         store
+    }
+
+    /// Production activation height — tests must exercise heights below this even though
+    /// `#[cfg(test)]` sets `GOVERNANCE_TIMELOCK_ACTIVATION_HEIGHT` to 0.
+    const PROD_GOVERNANCE_ACTIVATION_HEIGHT: u64 = 80_000;
+
+    fn verify_multisig_proof_on_store(
+        store: &Arc<dyn BlockchainStore>,
+        verifier: &GovernanceVerifierState,
+        proof: &ApprovalProof,
+        msg: &[u8; 32],
+    ) -> Result<(), TxApplyError> {
+        let mutator = StateMutator::new(store.as_ref());
+        verify_governance_multisig_proof(&mutator, verifier, proof, msg)
     }
 
     #[test]
     fn multisig_proof_verifies_with_raw_signatures() {
         let kp1 = KeyPair::generate().unwrap();
-        let store = store_with_signer(&kp1);
+        let store = store_with_signers(std::slice::from_ref(&kp1));
 
         let asset_id = [0xAB; 32];
         let policy_hash = [0xCD; 32];
@@ -246,9 +263,48 @@ mod tests {
             signer_key_id: kp1.public_key.key_id,
         };
 
-        store.begin_block(1).unwrap();
-        let mutator = StateMutator::new(store.as_ref());
-        verify_governance_multisig_proof(&mutator, &verifier, &proof, &msg, 1).unwrap();
-        store.commit_block().unwrap();
+        verify_multisig_proof_on_store(&store, &verifier, &proof, &msg).unwrap();
+        // Height is not consulted for crypto; re-run to model pre-activation prod (~39k).
+        let _pre_activation = PROD_GOVERNANCE_ACTIVATION_HEIGHT - 1;
+        verify_multisig_proof_on_store(&store, &verifier, &proof, &msg).unwrap();
+    }
+
+    #[test]
+    fn multisig_proof_rejects_garbage_signatures_below_prod_activation_height() {
+        let kp1 = KeyPair::generate().unwrap();
+        let kp2 = KeyPair::generate().unwrap();
+        let key_id1 = kp1.public_key.key_id;
+        let key_id2 = kp2.public_key.key_id;
+
+        let asset_id = [0xAB; 32];
+        let policy_hash = [0xCD; 32];
+        let msg = governance_action_message_hash(
+            &asset_id,
+            PROPOSAL_TYPE_REWARDS_POLICY_UPDATE,
+            &policy_hash,
+        );
+        let raw1 = kp1.sign(&msg).unwrap().signature;
+        let garbage = vec![0u8; 4595];
+        let proof = ApprovalProof::Multisig {
+            signatures: vec![
+                signature64_from_dilithium(&raw1),
+                signature64_from_dilithium(&garbage),
+            ],
+            signers: vec![key_id1, key_id2],
+            threshold: 2,
+            message_hash: msg,
+            raw_signatures: vec![raw1, garbage],
+        };
+        let verifier = GovernanceVerifierState::Multisig {
+            signers: vec![key_id1, key_id2],
+            threshold: 2,
+        };
+
+        let store = store_with_signers(&[kp1, kp2]);
+
+        let _pre_activation = PROD_GOVERNANCE_ACTIVATION_HEIGHT - 1;
+        let err =
+            verify_multisig_proof_on_store(&store, &verifier, &proof, &msg).unwrap_err();
+        assert!(matches!(err, TxApplyError::InvalidType(msg) if msg.contains("signature verification failed")));
     }
 }

--- a/lib-blockchain/src/lib.rs
+++ b/lib-blockchain/src/lib.rs
@@ -26,6 +26,7 @@ pub mod execution;
 pub mod fees;
 mod fork_recovery; // gutted in Issue #936; kept as private to avoid orphan module errors
 pub mod genesis;
+pub mod governance_proof;
 pub mod integration;
 pub mod observer;
 pub mod onramp;

--- a/lib-blockchain/src/transaction/asset_tx.rs
+++ b/lib-blockchain/src/transaction/asset_tx.rs
@@ -15,6 +15,7 @@ pub const ASSET_LAUNCH_MEMO_PREFIX_V2: &[u8] = b"ZHTP_ASSET_LAUNCH_V2:";
 pub const ASSET_MODULE_UPGRADE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_UPGRADE_V1:";
 pub const ASSET_MANIFEST_UPDATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_MANIFEST_V1:";
 pub const ASSET_AUTHORITY_TRANSFER_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_AUTH_XFER_V1:";
+pub const ASSET_AUTHORITY_TRANSFER_CANCEL_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_AUTH_XFER_CANCEL_V1:";
 pub const ASSET_REWARDS_DELEGATE_ROTATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_REWARDS_ROT_V1:";
 pub const ASSET_REWARDS_POLICY_UPDATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_REWARDS_POL_V1:";
 pub const ASSET_BURN_BPS_UPDATE_MEMO_PREFIX: &[u8] = b"ZHTP_ASSET_BURN_BPS_V1:";
@@ -441,6 +442,33 @@ pub struct AssetAuthorityTransferPayloadV1 {
     pub new_verifier: GovernanceVerifierState,
     pub effective_height: Option<u64>,
     pub authority_proof: AssetAuthorityProof,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AssetAuthorityTransferCancelPayloadV1 {
+    pub asset_id: [u8; 32],
+}
+
+impl AssetAuthorityTransferCancelPayloadV1 {
+    pub fn encode_memo(&self) -> Result<Vec<u8>, String> {
+        let encoded = bincode::DefaultOptions::new()
+            .with_limit(MAX_ASSET_MEMO_BYTES as u64)
+            .serialize(self)
+            .map_err(|e| format!("serialize authority transfer cancel: {e}"))?;
+        let mut memo = ASSET_AUTHORITY_TRANSFER_CANCEL_MEMO_PREFIX.to_vec();
+        memo.extend_from_slice(&encoded);
+        Ok(memo)
+    }
+
+    pub fn decode_memo(memo: &[u8]) -> Result<Self, String> {
+        if !memo.starts_with(ASSET_AUTHORITY_TRANSFER_CANCEL_MEMO_PREFIX) {
+            return Err("missing authority transfer cancel memo prefix".to_string());
+        }
+        bincode::DefaultOptions::new()
+            .with_limit(MAX_ASSET_MEMO_BYTES as u64)
+            .deserialize(&memo[ASSET_AUTHORITY_TRANSFER_CANCEL_MEMO_PREFIX.len()..])
+            .map_err(|e| format!("invalid authority transfer cancel payload: {e}"))
+    }
 }
 
 impl AssetAuthorityTransferPayloadV1 {

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -1029,6 +1029,25 @@ impl Transaction {
         }
     }
 
+    /// Cancel a queued Sovereign Asset authority transfer (creator only).
+    pub fn new_asset_authority_transfer_cancel_with_chain_id(
+        chain_id: u8,
+        signature: Signature,
+        memo: Vec<u8>,
+    ) -> Self {
+        Transaction {
+            version: TX_VERSION_V8,
+            chain_id,
+            transaction_type: TransactionType::AssetAuthorityTransferCancel,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            fee: 0,
+            signature,
+            memo,
+            payload: TransactionPayload::None,
+        }
+    }
+
     /// Create a new token creation transaction with an explicit chain id.
     pub fn new_token_creation_with_chain_id(
         chain_id: u8,

--- a/lib-blockchain/src/transaction/creation.rs
+++ b/lib-blockchain/src/transaction/creation.rs
@@ -761,6 +761,7 @@ pub mod utils {
             | TransactionType::AssetModuleUpgrade
             | TransactionType::AssetManifestUpdate
             | TransactionType::AssetAuthorityTransfer
+            | TransactionType::AssetAuthorityTransferCancel
             | TransactionType::AssetRewardsDelegateRotate
             | TransactionType::AssetRewardsPolicyUpdate
             | TransactionType::AssetBurnBpsUpdate

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -94,7 +94,8 @@ pub use contract_execution::{
 pub use fee::{required_token_creation_fee, TxFeeConfig, DEFAULT_TOKEN_CREATION_FEE};
 pub use asset_tx::{
     build_dao_launch_manifest, build_dao_launch_manifest_bytes, manifest_cid_hash_from_bytes,
-    AssetAuthorityProof, AssetAuthorityTransferPayloadV1, AssetLaunchPayloadV1,
+    AssetAuthorityProof, AssetAuthorityTransferCancelPayloadV1,
+    AssetAuthorityTransferPayloadV1, AssetLaunchPayloadV1,
     AssetManifestUpdatePayloadV1, AssetModuleUpgradePayloadV1, AssetRewardsDelegateRotatePayloadV1,
     AssetRewardsPolicyUpdatePayloadV1, RewardsPolicyUpdateConfig,
     AssetUpgradeModule, CurveLaunchConfig, GovernanceLaunchConfig, RewardsLaunchConfig,

--- a/lib-blockchain/src/transaction/system_tx_signature.rs
+++ b/lib-blockchain/src/transaction/system_tx_signature.rs
@@ -47,6 +47,7 @@ pub fn system_tx_signature_policy(ty: TransactionType) -> SystemTxSignaturePolic
         | TransactionType::AssetModuleUpgrade
         | TransactionType::AssetManifestUpdate
         | TransactionType::AssetAuthorityTransfer
+        | TransactionType::AssetAuthorityTransferCancel
         | TransactionType::AssetRewardsDelegateRotate
         | TransactionType::AssetRewardsPolicyUpdate
         | TransactionType::AssetBurnBpsUpdate

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -312,6 +312,7 @@ impl TransactionValidator {
                 | TransactionType::AssetModuleUpgrade
                 | TransactionType::AssetManifestUpdate
                 | TransactionType::AssetAuthorityTransfer
+                | TransactionType::AssetAuthorityTransferCancel
                 | TransactionType::AssetRewardsDelegateRotate
                 | TransactionType::AssetRewardsPolicyUpdate
                 | TransactionType::AssetBurnBpsUpdate
@@ -505,6 +506,15 @@ impl TransactionValidator {
                     return Err(ValidationError::InvalidInputs);
                 }
                 crate::transaction::asset_tx::AssetAuthorityTransferPayloadV1::decode_memo(
+                    &transaction.memo,
+                )
+                .map_err(|_| ValidationError::InvalidMemo)?;
+            }
+            TransactionType::AssetAuthorityTransferCancel => {
+                if !transaction.inputs.is_empty() || !transaction.outputs.is_empty() {
+                    return Err(ValidationError::InvalidInputs);
+                }
+                crate::transaction::asset_tx::AssetAuthorityTransferCancelPayloadV1::decode_memo(
                     &transaction.memo,
                 )
                 .map_err(|_| ValidationError::InvalidMemo)?;
@@ -865,6 +875,7 @@ impl TransactionValidator {
             | TransactionType::AssetModuleUpgrade
             | TransactionType::AssetManifestUpdate
             | TransactionType::AssetAuthorityTransfer
+            | TransactionType::AssetAuthorityTransferCancel
             | TransactionType::AssetRewardsDelegateRotate
             | TransactionType::AssetRewardsPolicyUpdate
             | TransactionType::AssetBurnBpsUpdate => {
@@ -1868,6 +1879,7 @@ impl<'a> StatefulTransactionValidator<'a> {
                 | TransactionType::AssetModuleUpgrade
                 | TransactionType::AssetManifestUpdate
                 | TransactionType::AssetAuthorityTransfer
+                | TransactionType::AssetAuthorityTransferCancel
                 | TransactionType::AssetRewardsDelegateRotate
                 | TransactionType::AssetRewardsPolicyUpdate
                 | TransactionType::AssetBurnBpsUpdate
@@ -2452,6 +2464,7 @@ impl<'a> StatefulTransactionValidator<'a> {
             | TransactionType::AssetModuleUpgrade
             | TransactionType::AssetManifestUpdate
             | TransactionType::AssetAuthorityTransfer
+            | TransactionType::AssetAuthorityTransferCancel
             | TransactionType::AssetRewardsDelegateRotate
             | TransactionType::AssetRewardsPolicyUpdate
             | TransactionType::AssetBurnBpsUpdate
@@ -3616,6 +3629,7 @@ pub mod utils {
             | TransactionType::AssetModuleUpgrade
             | TransactionType::AssetManifestUpdate
             | TransactionType::AssetAuthorityTransfer
+            | TransactionType::AssetAuthorityTransferCancel
             | TransactionType::AssetRewardsDelegateRotate
             | TransactionType::AssetRewardsPolicyUpdate
             | TransactionType::AssetBurnBpsUpdate

--- a/lib-blockchain/src/types/transaction_type.rs
+++ b/lib-blockchain/src/types/transaction_type.rs
@@ -243,6 +243,8 @@ pub enum TransactionType {
     AssetRewardsPolicyUpdate = 68,
     /// Queue a timelocked per-transfer burn rate change for a Sovereign Asset.
     AssetBurnBpsUpdate = 69,
+    /// Cancel a queued creator → governance authority transfer before timelock elapses.
+    AssetAuthorityTransferCancel = 70,
     /// BUBL reward claim — chain-enforced eligibility + treasury token transfer.
     ///
     /// Signed by the BUBL `TokenCreation` creator (or authorized delegate).
@@ -456,6 +458,9 @@ impl TransactionType {
             TransactionType::AssetBurnBpsUpdate => {
                 "Update Sovereign Asset per-transfer burn rate"
             }
+            TransactionType::AssetAuthorityTransferCancel => {
+                "Cancel queued Sovereign Asset authority transfer"
+            }
             TransactionType::RewardClaim => "BUBL reward claim (chain-enforced eligibility)",
         }
     }
@@ -532,6 +537,7 @@ impl TransactionType {
             TransactionType::AssetRewardsDelegateRotate => "asset_rewards_delegate_rotate",
             TransactionType::AssetRewardsPolicyUpdate => "asset_rewards_policy_update",
             TransactionType::AssetBurnBpsUpdate => "asset_burn_bps_update",
+            TransactionType::AssetAuthorityTransferCancel => "asset_authority_transfer_cancel",
             TransactionType::RewardClaim => "reward_claim",
         }
     }
@@ -608,6 +614,7 @@ impl TransactionType {
             "asset_rewards_delegate_rotate" => Some(TransactionType::AssetRewardsDelegateRotate),
             "asset_rewards_policy_update" => Some(TransactionType::AssetRewardsPolicyUpdate),
             "asset_burn_bps_update" => Some(TransactionType::AssetBurnBpsUpdate),
+            "asset_authority_transfer_cancel" => Some(TransactionType::AssetAuthorityTransferCancel),
             "reward_claim" => Some(TransactionType::RewardClaim),
             _ => None,
         }

--- a/lib-blockchain/src/validation/tx_validate.rs
+++ b/lib-blockchain/src/validation/tx_validate.rs
@@ -59,6 +59,7 @@ const PHASE2_ALLOWED_TYPES: &[TransactionType] = &[
     TransactionType::AssetModuleUpgrade,
     TransactionType::AssetManifestUpdate,
     TransactionType::AssetAuthorityTransfer,
+    TransactionType::AssetAuthorityTransferCancel,
     TransactionType::AssetRewardsDelegateRotate,
     TransactionType::AssetRewardsPolicyUpdate,
     TransactionType::AssetBurnBpsUpdate,

--- a/lib-consensus-core/src/build_id.rs
+++ b/lib-consensus-core/src/build_id.rs
@@ -20,7 +20,7 @@
 /// - Consensus admission rules change in a way that requires homogeneous binaries
 ///
 /// Do **not** bump for docs-only, CLI-only, or unrelated crate changes.
-pub const CONSENSUS_BUILD_ID: &str = "3";
+pub const CONSENSUS_BUILD_ID: &str = "4";
 
 /// Marker assigned when decoding codec v1 frames (no epoch field on wire).
 pub const LEGACY_BUILD_ID: &str = "";

--- a/zhtp-cli/src/commands/dao_governance.rs
+++ b/zhtp-cli/src/commands/dao_governance.rs
@@ -13,8 +13,11 @@ use crate::commands::transaction_utils::{broadcast_signed_tx, parse_hex_32};
 use crate::commands::web4_utils::{connect_default, default_keystore_path, load_identity_from_keystore};
 use crate::error::{CliError, CliResult};
 use crate::output::Output;
-use lib_blockchain::contracts::approval_verifier::traits::Signature64;
 use lib_blockchain::contracts::approval_verifier::ApprovalProof;
+use lib_blockchain::governance_proof::{
+    governance_action_message_hash, signature64_from_dilithium,
+    PROPOSAL_TYPE_REWARDS_POLICY_UPDATE,
+};
 use lib_blockchain::transaction::asset_tx::{
     AssetAuthorityProof, AssetRewardsPolicyUpdatePayloadV1, RewardsPolicyUpdateConfig,
 };
@@ -26,7 +29,6 @@ use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 
 const PROPOSAL_SCHEMA: &str = "zhtp/governance-proposal/v1";
-const PROPOSAL_TYPE_REWARDS_POLICY_UPDATE: &str = "rewards_policy_update";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GovernanceApproval {
@@ -67,15 +69,7 @@ pub fn governance_message_hash(
     proposal_type: &str,
     policy_hash: &[u8; 32],
 ) -> [u8; 32] {
-    lib_crypto::hash_blake3(
-        &[
-            b"zhtp/governance-proposal/v1\0",
-            proposal_type.as_bytes(),
-            asset_id.as_slice(),
-            policy_hash.as_slice(),
-        ]
-        .concat(),
-    )
+    governance_action_message_hash(asset_id, proposal_type, policy_hash)
 }
 
 pub fn build_rewards_policy_update_proposal(
@@ -92,7 +86,7 @@ pub fn build_rewards_policy_update_proposal(
     let bundle = build_rewards_policy_bundle(&policy)
         .map_err(|e| CliError::ConfigError(format!("rewards policy: {e}")))?;
 
-    let message_hash = governance_message_hash(
+    let message_hash = governance_action_message_hash(
         &asset_id_bytes,
         PROPOSAL_TYPE_REWARDS_POLICY_UPDATE,
         &bundle.policy_hash,
@@ -125,15 +119,6 @@ fn parse_governance_approval_pairs(raw: &[String]) -> CliResult<Vec<([u8; 32], V
             Ok((key_id, sig))
         })
         .collect()
-}
-
-fn signature64_from_dilithium(sig: &[u8]) -> Signature64 {
-    let h1 = lib_crypto::hash_blake3(sig);
-    let h2 = lib_crypto::hash_blake3(&[h1.as_slice(), b"sig64"].concat());
-    let mut out = [0u8; 64];
-    out[..32].copy_from_slice(&h1);
-    out[32..].copy_from_slice(&h2);
-    Signature64::new(out)
 }
 
 fn merge_approvals(
@@ -217,11 +202,13 @@ fn build_policy_update_tx(
         }
         let mut signers = Vec::new();
         let mut signatures = Vec::new();
+        let mut raw_signatures = Vec::new();
         for approval in &proposal.approvals {
             let key_id = parse_hex_32("signer", &approval.signer_key_id)?;
             let sig_bytes = hex::decode(&approval.signature_hex)
                 .map_err(|e| CliError::ConfigError(format!("invalid approval sig: {e}")))?;
             signers.push(key_id);
+            raw_signatures.push(sig_bytes.clone());
             signatures.push(signature64_from_dilithium(&sig_bytes));
         }
         AssetAuthorityProof::Governance(ApprovalProof::Multisig {
@@ -229,6 +216,7 @@ fn build_policy_update_tx(
             signers,
             threshold: proposal.threshold,
             message_hash,
+            raw_signatures,
         })
     } else {
         AssetAuthorityProof::CreatorSig


### PR DESCRIPTION
Closes #2786

## Summary

Implements SA-6 sovereign-asset governance: real `ApprovalProof` verification against on-chain `GovernanceVerifierState`, authority transfer timelock cancel, and shared governance proof helpers for CLI + executor.

## Changes

- **`governance_proof` module** — domain-separated action message hashes, Dilithium multisig verification, `raw_signatures` wire check when economic rules are active
- **`ApprovalProof::Multisig`** — add `raw_signatures` field (serde default for backward compat)
- **Governance actions** — verify multisig proofs for manifest update, rewards policy update, delegate rotate, authority transfer, burn bps update
- **`AssetAuthorityTransferCancel` (tx type 70)** — creator can cancel pending authority transfer before `effective_height`
- **CLI** — `dao governance` uses shared `governance_proof` helpers for message hash + signature compression
- **`CONSENSUS_BUILD_ID`** — bumped `3` → `4` (coordinated validator deploy required)

## Tests

- `multisig_proof_verifies_with_raw_signatures`
- `creator_cancels_pending_authority_transfer_before_effective_height`
- `authority_activation_*` (3 tests)

## Deploy note

Requires coordinated validator upgrade (build epoch 4). Governance timelock activation height remains `80_000` on mainnet; `0` in unit tests.