### PR TITLE
fix(msg): MSG-R1 deposit peek/ack (no delete-on-poll)

### DIFF
--- a/zhtp/src/messaging/deposit.rs
+++ b/zhtp/src/messaging/deposit.rs
@@ -1,168 +1,382 @@
-//! Deposit-on-disconnect: temporary encrypted dead drop on sender's node.
+//! Deposit store — durable (in-process) store-and-forward for undelivered messages.
 //!
-//! When the sender's phone goes offline, it deposits encrypted envelopes
-//! on its node. The node holds them until the recipient comes online,
-//! then relays via QUIC mesh. Deposits auto-expire after TTL.
+//! ## Delivery model (MSG-R1 / MSG-R5)
+//!
+//! Envelopes stay in the store until the client **acks** them. Polling and inbound
+//! streaming **peek** only; they never delete. That way a disconnect mid-response
+//! cannot lose mail.
+//!
+//! Each envelope gets a stable `message_id` = hex(blake3(envelope_bytes)).
+//! Duplicate deposits of the same bytes are ignored (idempotent).
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
-use tracing::{info, warn};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-/// Default deposit TTL: 48 hours.
-const DEFAULT_DEPOSIT_TTL_SECS: u64 = 48 * 3600;
-/// Max envelopes per sender-recipient pair.
-const MAX_ENVELOPES_PER_PAIR: usize = 100;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
 
-/// A pending delivery stored on the sender's node.
-#[derive(Debug, Clone)]
+/// How long undelivered deposits are kept before GC purges them.
+const DEPOSIT_TTL: Duration = Duration::from_secs(48 * 3600); // 48 hours
+
+/// Maximum pending envelopes per (sender, recipient) pair.
+const MAX_PENDING_PER_PAIR: usize = 100;
+
+/// A single pending delivery (one envelope).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PendingDelivery {
-    pub sender_did: String,
-    pub recipient_did: String,
-    /// Opaque encrypted envelopes — node cannot read these.
-    pub envelopes: Vec<Vec<u8>>,
+    /// Stable id: hex(blake3(envelope_bytes)).
+    pub message_id: String,
+    /// Opaque PQ-encrypted envelope (bincode of client SecureMessage / MessageEnvelope).
+    pub envelope: Vec<u8>,
+    /// Unix seconds when deposited (API / clients).
     pub deposited_at: u64,
-    pub expires_at: u64,
+    /// Monotonic clock for TTL GC (not serialized).
+    #[serde(skip, default = "Instant::now")]
+    pub deposited_instant: Instant,
+    /// Sender DID (for cancellation / auth).
+    pub sender_did: String,
+    /// Recipient DID.
+    pub recipient_did: String,
 }
 
-/// Deposit store: keyed by (sender_did, recipient_did).
-#[derive(Debug)]
+/// Compute stable message id from envelope bytes.
+pub fn message_id_for_envelope(envelope: &[u8]) -> String {
+    hex::encode(lib_crypto::hash_blake3(envelope))
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// In-memory deposit store (process-local; Phase 3 will add sled).
+#[derive(Debug, Default)]
 pub struct DepositStore {
-    deposits: Arc<RwLock<HashMap<(String, String), PendingDelivery>>>,
+    /// Keyed by (sender_did, recipient_did).
+    pending: RwLock<HashMap<(String, String), Vec<PendingDelivery>>>,
+    /// Index message_id → (sender, recipient) for O(1) ack.
+    by_id: RwLock<HashMap<String, (String, String)>>,
 }
 
 impl DepositStore {
     pub fn new() -> Self {
         Self {
-            deposits: Arc::new(RwLock::new(HashMap::new())),
+            pending: RwLock::new(HashMap::new()),
+            by_id: RwLock::new(HashMap::new()),
         }
     }
 
-    /// Deposit encrypted envelopes for a recipient.
-    pub async fn deposit(
+    /// Deposit a single envelope. Returns `(message_id, is_new)`.
+    /// If the same envelope bytes were already deposited, returns existing id and `false`.
+    pub fn deposit_one(
+        &self,
+        sender_did: &str,
+        recipient_did: &str,
+        envelope: Vec<u8>,
+    ) -> Result<(String, bool), String> {
+        let message_id = message_id_for_envelope(&envelope);
+        let key = (sender_did.to_string(), recipient_did.to_string());
+
+        {
+            let by_id = self.by_id.read();
+            if by_id.contains_key(&message_id) {
+                debug!(
+                    message_id = %message_id,
+                    "deposit: duplicate envelope, already stored"
+                );
+                return Ok((message_id, false));
+            }
+        }
+
+        let mut store = self.pending.write();
+        let mut by_id = self.by_id.write();
+
+        // Re-check under write lock
+        if by_id.contains_key(&message_id) {
+            return Ok((message_id, false));
+        }
+
+        let queue = store.entry(key.clone()).or_default();
+
+        if queue.len() >= MAX_PENDING_PER_PAIR {
+            warn!(
+                sender = %sender_did,
+                recipient = %recipient_did,
+                max = MAX_PENDING_PER_PAIR,
+                "deposit store full for pair — rejecting"
+            );
+            return Err(format!(
+                "deposit store full: max {MAX_PENDING_PER_PAIR} pending for this pair"
+            ));
+        }
+
+        queue.push(PendingDelivery {
+            message_id: message_id.clone(),
+            envelope,
+            deposited_at: now_unix(),
+            deposited_instant: Instant::now(),
+            sender_did: sender_did.to_string(),
+            recipient_did: recipient_did.to_string(),
+        });
+        by_id.insert(message_id.clone(), key);
+
+        info!(
+            sender = %sender_did,
+            recipient = %recipient_did,
+            message_id = %message_id,
+            pending = queue.len(),
+            "message deposited"
+        );
+        Ok((message_id, true))
+    }
+
+    /// Deposit many envelopes. Returns `(accepted_count, message_ids)`.
+    /// Stops on first capacity error after accepting earlier envelopes.
+    pub fn deposit(
         &self,
         sender_did: &str,
         recipient_did: &str,
         envelopes: Vec<Vec<u8>>,
-    ) -> Result<usize, String> {
-        if envelopes.len() > MAX_ENVELOPES_PER_PAIR {
-            return Err(format!(
-                "Too many envelopes ({}, max {})",
-                envelopes.len(),
-                MAX_ENVELOPES_PER_PAIR
-            ));
+    ) -> Result<(usize, Vec<String>), String> {
+        if envelopes.is_empty() {
+            return Err("no envelopes".to_string());
         }
-
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-
-        let count = envelopes.len();
-        let delivery = PendingDelivery {
-            sender_did: sender_did.to_string(),
-            recipient_did: recipient_did.to_string(),
-            envelopes,
-            deposited_at: now,
-            expires_at: now + DEFAULT_DEPOSIT_TTL_SECS,
-        };
-
-        let key = (sender_did.to_string(), recipient_did.to_string());
-        let mut deposits = self.deposits.write().await;
-        // Append envelopes to existing deposit instead of overwriting
-        if let Some(existing) = deposits.get_mut(&key) {
-            if existing.envelopes.len() + count <= MAX_ENVELOPES_PER_PAIR {
-                existing.envelopes.extend(delivery.envelopes);
-                existing.expires_at = delivery.expires_at; // refresh TTL
-            } else {
-                return Err(format!(
-                    "Too many envelopes ({}, max {})",
-                    existing.envelopes.len() + count,
-                    MAX_ENVELOPES_PER_PAIR
-                ));
+        let mut ids = Vec::with_capacity(envelopes.len());
+        let mut accepted = 0usize;
+        for env in envelopes {
+            match self.deposit_one(sender_did, recipient_did, env) {
+                Ok((id, is_new)) => {
+                    ids.push(id);
+                    if is_new {
+                        accepted += 1;
+                    }
+                }
+                Err(e) => {
+                    if accepted == 0 && ids.is_empty() {
+                        return Err(e);
+                    }
+                    // Partial success: return what we took
+                    break;
+                }
             }
-        } else {
-            deposits.insert(key, delivery);
         }
-
-        info!(
-            "Deposited {} envelopes from {} for {} (FULL recipient={}, expires in {}h)",
-            count,
-            &sender_did[..16.min(sender_did.len())],
-            &recipient_did[..16.min(recipient_did.len())],
-            recipient_did,
-            DEFAULT_DEPOSIT_TTL_SECS / 3600,
-        );
-
-        Ok(count)
+        Ok((accepted, ids))
     }
 
-    /// Retrieve and remove all pending envelopes for a recipient.
-    pub async fn collect_for_recipient(&self, recipient_did: &str) -> Vec<PendingDelivery> {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-
-        let mut deposits = self.deposits.write().await;
-        info!(
-            "collect_for_recipient: store has {} entries, looking for {}",
-            deposits.len(),
-            recipient_did
-        );
-        for ((s, r), d) in deposits.iter() {
-            info!(
-                "  entry: sender={}, recipient={}, envelopes={}, expires_at={}, matches={}",
-                s,
-                r,
-                d.envelopes.len(),
-                d.expires_at,
-                d.recipient_did == recipient_did
+    /// Peek all pending envelopes for a recipient (does **not** remove).
+    pub fn peek_for_recipient(&self, recipient_did: &str) -> Vec<PendingDelivery> {
+        let store = self.pending.read();
+        let mut out = Vec::new();
+        for ((_, recip), queue) in store.iter() {
+            if recip == recipient_did {
+                out.extend(queue.iter().cloned());
+            }
+        }
+        if !out.is_empty() {
+            debug!(
+                recipient = %recipient_did,
+                count = out.len(),
+                "peeked pending deposits (retained until ack)"
             );
         }
-        let mut collected = Vec::new();
+        out
+    }
 
-        deposits.retain(|(_sender, _recipient), delivery| {
-            if delivery.recipient_did == recipient_did && delivery.expires_at > now {
-                collected.push(delivery.clone());
-                false // remove from store
-            } else if delivery.expires_at <= now {
-                false // expired, remove
-            } else {
-                true // keep
+    /// Remove specific messages by id (client ACK). Returns count removed.
+    pub fn ack(&self, message_ids: &[String]) -> usize {
+        if message_ids.is_empty() {
+            return 0;
+        }
+        let mut store = self.pending.write();
+        let mut by_id = self.by_id.write();
+        let mut removed = 0;
+
+        for mid in message_ids {
+            let Some((sender, recipient)) = by_id.remove(mid) else {
+                continue;
+            };
+            if let Some(queue) = store.get_mut(&(sender.clone(), recipient.clone())) {
+                let before = queue.len();
+                queue.retain(|d| d.message_id != *mid);
+                removed += before - queue.len();
+                if queue.is_empty() {
+                    store.remove(&(sender, recipient));
+                }
             }
+        }
+
+        if removed > 0 {
+            info!(count = removed, "acked and removed deposits");
+        }
+        removed
+    }
+
+    /// Cancel undelivered messages from a sender to a recipient.
+    /// Returns number of envelopes cancelled.
+    pub fn cancel(&self, sender_did: &str, recipient_did: &str) -> usize {
+        let key = (sender_did.to_string(), recipient_did.to_string());
+        let mut store = self.pending.write();
+        let mut by_id = self.by_id.write();
+
+        let Some(queue) = store.remove(&key) else {
+            return 0;
+        };
+        let count = queue.len();
+        for d in &queue {
+            by_id.remove(&d.message_id);
+        }
+        if count > 0 {
+            info!(
+                sender = %sender_did,
+                recipient = %recipient_did,
+                count,
+                "cancelled undelivered deposits"
+            );
+        }
+        count
+    }
+
+    /// Purge expired deposits. Returns number of envelopes purged.
+    pub fn gc_expired(&self) -> usize {
+        let mut store = self.pending.write();
+        let mut by_id = self.by_id.write();
+        let mut purged = 0;
+        let now = Instant::now();
+
+        store.retain(|_, queue| {
+            let before = queue.len();
+            for d in queue.iter() {
+                if now.duration_since(d.deposited_instant) >= DEPOSIT_TTL {
+                    by_id.remove(&d.message_id);
+                }
+            }
+            queue.retain(|d| now.duration_since(d.deposited_instant) < DEPOSIT_TTL);
+            purged += before - queue.len();
+            !queue.is_empty()
         });
 
-        collected
+        if purged > 0 {
+            info!(purged, "GC purged expired deposits");
+        }
+        purged
     }
 
-    /// Cancel a deposit (sender came back online).
-    pub async fn cancel(&self, sender_did: &str, recipient_did: &str) -> bool {
-        let key = (sender_did.to_string(), recipient_did.to_string());
-        let mut deposits = self.deposits.write().await;
-        deposits.remove(&key).is_some()
+    /// Alias used by cleanup task (historical name).
+    pub fn cleanup_expired(&self) -> usize {
+        self.gc_expired()
     }
 
-    /// Clean up expired deposits.
-    pub async fn cleanup_expired(&self) -> usize {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-
-        let mut deposits = self.deposits.write().await;
-        let before = deposits.len();
-        deposits.retain(|_, d| d.expires_at > now);
-        before - deposits.len()
+    /// Total pending envelopes across all pairs.
+    pub fn total_pending(&self) -> usize {
+        self.pending.read().values().map(|q| q.len()).sum()
     }
 
-    /// Check if there are any pending deposits for a recipient.
-    pub async fn has_pending(&self, recipient_did: &str) -> bool {
-        let deposits = self.deposits.read().await;
-        deposits.values().any(|d| d.recipient_did == recipient_did)
+    pub fn has_pending(&self, recipient_did: &str) -> bool {
+        self.pending
+            .read()
+            .iter()
+            .any(|((_, r), q)| r == recipient_did && !q.is_empty())
+    }
+}
+
+/// Shared deposit store handle.
+pub type SharedDepositStore = Arc<DepositStore>;
+
+/// Create a new shared deposit store.
+pub fn new_shared_deposit_store() -> SharedDepositStore {
+    Arc::new(DepositStore::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deposit_peek_does_not_remove() {
+        let store = DepositStore::new();
+        let (id, is_new) = store
+            .deposit_one("did:sov:alice", "did:sov:bob", vec![1, 2, 3])
+            .unwrap();
+        assert!(is_new);
+        assert!(!id.is_empty());
+
+        let peeked = store.peek_for_recipient("did:sov:bob");
+        assert_eq!(peeked.len(), 1);
+        assert_eq!(peeked[0].message_id, id);
+
+        // Still there
+        assert_eq!(store.peek_for_recipient("did:sov:bob").len(), 1);
+        assert_eq!(store.total_pending(), 1);
     }
 
-    pub async fn pending_count(&self) -> usize {
-        self.deposits.read().await.len()
+    #[test]
+    fn ack_removes() {
+        let store = DepositStore::new();
+        let (id, _) = store
+            .deposit_one("did:sov:alice", "did:sov:bob", vec![9, 9, 9])
+            .unwrap();
+        assert_eq!(store.ack(&[id]), 1);
+        assert_eq!(store.total_pending(), 0);
+        assert!(store.peek_for_recipient("did:sov:bob").is_empty());
+    }
+
+    #[test]
+    fn duplicate_deposit_idempotent() {
+        let store = DepositStore::new();
+        let env = vec![7, 7, 7];
+        let (id1, new1) = store
+            .deposit_one("did:sov:a", "did:sov:b", env.clone())
+            .unwrap();
+        let (id2, new2) = store.deposit_one("did:sov:a", "did:sov:b", env).unwrap();
+        assert_eq!(id1, id2);
+        assert!(new1);
+        assert!(!new2);
+        assert_eq!(store.total_pending(), 1);
+    }
+
+    #[test]
+    fn cancel_clears_pair() {
+        let store = DepositStore::new();
+        store
+            .deposit_one("did:sov:alice", "did:sov:bob", vec![1])
+            .unwrap();
+        store
+            .deposit_one("did:sov:alice", "did:sov:bob", vec![2])
+            .unwrap();
+        assert_eq!(store.cancel("did:sov:alice", "did:sov:bob"), 2);
+        assert_eq!(store.total_pending(), 0);
+    }
+
+    #[test]
+    fn max_pending_enforced() {
+        let store = DepositStore::new();
+        for i in 0..MAX_PENDING_PER_PAIR {
+            store
+                .deposit_one("did:sov:a", "did:sov:b", vec![i as u8])
+                .unwrap();
+        }
+        let err = store
+            .deposit_one("did:sov:a", "did:sov:b", vec![255])
+            .unwrap_err();
+        assert!(err.contains("full"));
+    }
+
+    #[test]
+    fn batch_deposit() {
+        let store = DepositStore::new();
+        let (n, ids) = store
+            .deposit(
+                "did:sov:a",
+                "did:sov:b",
+                vec![vec![1], vec![2], vec![1]], // third is dup of first
+            )
+            .unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(ids.len(), 3);
+        assert_eq!(store.total_pending(), 2);
     }
 }

--- a/zhtp/src/messaging/deposit.rs
+++ b/zhtp/src/messaging/deposit.rs
@@ -1,4 +1,4 @@
-//! Deposit store — durable (in-process) store-and-forward for undelivered messages.
+//! Deposit store — process-local (in-memory) store-and-forward for undelivered messages.
 //!
 //! ## Delivery model (MSG-R1 / MSG-R5)
 //!
@@ -6,8 +6,9 @@
 //! streaming **peek** only; they never delete. That way a disconnect mid-response
 //! cannot lose mail.
 //!
-//! Each envelope gets a stable `message_id` = hex(blake3(envelope_bytes)).
-//! Duplicate deposits of the same bytes are ignored (idempotent).
+//! Storage is **not** durable across process restart (Phase 3 / sled persistence).
+//! Within a running process: stable `message_id` = hex(blake3(envelope_bytes));
+//! duplicate deposits of the same bytes are ignored (idempotent).
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -186,8 +187,12 @@ impl DepositStore {
         out
     }
 
-    /// Remove specific messages by id (client ACK). Returns count removed.
-    pub fn ack(&self, message_ids: &[String]) -> usize {
+    /// Remove specific messages by id **only if** they are addressed to
+    /// `recipient_did` (client ACK). Returns count removed.
+    ///
+    /// Ids that are unknown or belong to another recipient are ignored (not
+    /// removed). Callers must pass the authenticated caller's canonical DID.
+    pub fn ack(&self, recipient_did: &str, message_ids: &[String]) -> usize {
         if message_ids.is_empty() {
             return 0;
         }
@@ -196,9 +201,19 @@ impl DepositStore {
         let mut removed = 0;
 
         for mid in message_ids {
-            let Some((sender, recipient)) = by_id.remove(mid) else {
+            let Some((sender, recipient)) = by_id.get(mid).cloned() else {
                 continue;
             };
+            if recipient != recipient_did {
+                debug!(
+                    message_id = %mid,
+                    caller = %recipient_did,
+                    owner = %recipient,
+                    "ack ignored: message not addressed to caller"
+                );
+                continue;
+            }
+            by_id.remove(mid);
             if let Some(queue) = store.get_mut(&(sender.clone(), recipient.clone())) {
                 let before = queue.len();
                 queue.retain(|d| d.message_id != *mid);
@@ -210,7 +225,11 @@ impl DepositStore {
         }
 
         if removed > 0 {
-            info!(count = removed, "acked and removed deposits");
+            info!(
+                count = removed,
+                recipient = %recipient_did,
+                "acked and removed deposits"
+            );
         }
         removed
     }
@@ -319,9 +338,22 @@ mod tests {
         let (id, _) = store
             .deposit_one("did:sov:alice", "did:sov:bob", vec![9, 9, 9])
             .unwrap();
-        assert_eq!(store.ack(&[id]), 1);
+        assert_eq!(store.ack("did:sov:bob", &[id]), 1);
         assert_eq!(store.total_pending(), 0);
         assert!(store.peek_for_recipient("did:sov:bob").is_empty());
+    }
+
+    #[test]
+    fn ack_ignores_wrong_recipient() {
+        let store = DepositStore::new();
+        let (id, _) = store
+            .deposit_one("did:sov:alice", "did:sov:bob", vec![1, 2, 3])
+            .unwrap();
+        // Eve must not be able to ack Bob's mail
+        assert_eq!(store.ack("did:sov:eve", &[id.clone()]), 0);
+        assert_eq!(store.total_pending(), 1);
+        assert_eq!(store.ack("did:sov:bob", &[id]), 1);
+        assert_eq!(store.total_pending(), 0);
     }
 
     #[test]

--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -51,6 +51,12 @@ struct PresenceWatchRequest {
     target_dids: Vec<String>,
 }
 
+#[derive(Deserialize)]
+struct AckRequest {
+    /// Message ids returned by receive / computed as hex(blake3(envelope)).
+    message_ids: Vec<String>,
+}
+
 // ── Handler ────────────────────────────────────────────────────────
 
 fn json_response(data: serde_json::Value) -> Result<ZhtpResponse> {
@@ -168,10 +174,14 @@ impl MessagingHandler {
             }));
         }
 
-        // Always deposit locally — recipient may poll any node, or come online later
-        let _ = self.deposits
-            .deposit(&envelope.sender_did, &recipient_did, vec![envelope_bytes.clone()])
-            .await;
+        // Deposit when no live subscriber (MSG-R2 will deposit before push too).
+        if let Err(e) = self.deposits.deposit_one(
+            &envelope.sender_did,
+            &recipient_did,
+            envelope_bytes.clone(),
+        ) {
+            return Ok(error_resp(ZhtpStatus::BadRequest, &e));
+        }
 
         // Also relay via mesh so all nodes have the message
         if let Ok(mesh_router) = crate::runtime::mesh_router_provider::get_global_mesh_router().await {
@@ -229,19 +239,43 @@ impl MessagingHandler {
         match self
             .deposits
             .deposit(&req.sender_did, &req.recipient_did, envelopes)
-            .await
         {
-            Ok(count) => json_response(json!({
+            Ok((count, message_ids)) => json_response(json!({
                 "status": "deposited",
                 "count": count,
+                "message_ids": message_ids,
                 "ttl_hours": 48,
             })),
             Err(e) => Ok(error_resp(ZhtpStatus::BadRequest, &e)),
         }
     }
 
+    /// POST /api/v1/msg/ack
+    /// Client confirms receipt; removes envelopes from the deposit store (MSG-R1).
+    async fn handle_ack(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
+        let req: AckRequest = serde_json::from_slice(&request.body)
+            .map_err(|e| anyhow::anyhow!("Invalid request: {}", e))?;
+
+        if req.message_ids.is_empty() {
+            return Ok(error_resp(ZhtpStatus::BadRequest, "message_ids required"));
+        }
+
+        if request.requester.is_none() {
+            return Ok(error_resp(
+                ZhtpStatus::Unauthorized,
+                "Authenticated DID required",
+            ));
+        }
+
+        let removed = self.deposits.ack(&req.message_ids);
+        json_response(json!({
+            "status": "success",
+            "acked": removed,
+        }))
+    }
+
     /// GET /api/v1/msg/receive
-    /// Poll for pending messages (deposits from other users).
+    /// Peek pending messages (does not remove — client must POST /msg/ack).
     async fn handle_receive(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
         // Extract recipient DID from authenticated session.
         // The requester identity hash may differ from the DID (key_id = blake3(dil||kyber)
@@ -318,24 +352,25 @@ impl MessagingHandler {
         // Mark as online
         self.presence.set_online(&recipient_did).await;
 
-        // Collect pending deposits
-        let deliveries = self.deposits.collect_for_recipient(&recipient_did).await;
+        // Peek only — retain until explicit ack (MSG-R1)
+        let deliveries = self.deposits.peek_for_recipient(&recipient_did);
         info!(
-            "msg/receive collected {} deliveries for {}",
+            "msg/receive peeked {} deliveries for {}",
             deliveries.len(),
             recipient_did
         );
 
-        let mut all_envelopes: Vec<serde_json::Value> = Vec::new();
-        for delivery in &deliveries {
-            for env_bytes in &delivery.envelopes {
-                all_envelopes.push(json!({
-                    "sender_did": delivery.sender_did,
-                    "envelope_hex": hex::encode(env_bytes),
-                    "deposited_at": delivery.deposited_at,
-                }));
-            }
-        }
+        let all_envelopes: Vec<serde_json::Value> = deliveries
+            .iter()
+            .map(|d| {
+                json!({
+                    "message_id": d.message_id,
+                    "sender_did": d.sender_did,
+                    "envelope_hex": hex::encode(&d.envelope),
+                    "deposited_at": d.deposited_at,
+                })
+            })
+            .collect();
 
         json_response(json!({
             "status": "success",
@@ -395,6 +430,9 @@ impl ZhtpRequestHandler for MessagingHandler {
             }
             (ZhtpMethod::Get, "/api/v1/msg/receive") => {
                 Ok(self.handle_receive(&request).await?)
+            }
+            (ZhtpMethod::Post, "/api/v1/msg/ack") => {
+                Ok(self.handle_ack(&request).await?)
             }
             (ZhtpMethod::Post, "/api/v1/msg/presence/watch") => {
                 Ok(self.handle_presence_watch(&request).await?)

--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -175,12 +175,16 @@ impl MessagingHandler {
         }
 
         // Deposit when no live subscriber (MSG-R2 will deposit before push too).
+        // Local store-full is not fatal: still mesh-relay so peers can deposit.
         if let Err(e) = self.deposits.deposit_one(
             &envelope.sender_did,
             &recipient_did,
             envelope_bytes.clone(),
         ) {
-            return Ok(error_resp(ZhtpStatus::BadRequest, &e));
+            warn!(
+                error = %e,
+                "msg/send: local deposit failed — continuing mesh relay"
+            );
         }
 
         // Also relay via mesh so all nodes have the message
@@ -250,8 +254,35 @@ impl MessagingHandler {
         }
     }
 
+    /// Resolve authenticated requester → canonical DID (same paths as receive).
+    async fn resolve_caller_did(&self, request: &ZhtpRequest) -> Result<String, String> {
+        let requester_key_id = request
+            .requester
+            .as_ref()
+            .map(|id| hex::encode(&id.0))
+            .unwrap_or_default();
+        if requester_key_id.is_empty() {
+            return Err("Authenticated DID required".to_string());
+        }
+        let key_id_did = format!("did:zhtp:{}", requester_key_id);
+        let bound = match (
+            crate::session_manager::session_manager_handle(),
+            request.requester.as_ref(),
+        ) {
+            (Some(mgr), Some(req_id)) => mgr.canonical_did_for_quic_key(&req_id.0).await,
+            _ => None,
+        };
+        if let Some(did) = bound {
+            return Ok(did);
+        }
+        let blockchain = self.blockchain.read().await;
+        Ok(blockchain
+            .did_by_device_key_id(&requester_key_id)
+            .unwrap_or(key_id_did))
+    }
+
     /// POST /api/v1/msg/ack
-    /// Client confirms receipt; removes envelopes from the deposit store (MSG-R1).
+    /// Client confirms receipt; removes only envelopes addressed to the caller.
     async fn handle_ack(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
         let req: AckRequest = serde_json::from_slice(&request.body)
             .map_err(|e| anyhow::anyhow!("Invalid request: {}", e))?;
@@ -260,14 +291,12 @@ impl MessagingHandler {
             return Ok(error_resp(ZhtpStatus::BadRequest, "message_ids required"));
         }
 
-        if request.requester.is_none() {
-            return Ok(error_resp(
-                ZhtpStatus::Unauthorized,
-                "Authenticated DID required",
-            ));
-        }
+        let recipient_did = match self.resolve_caller_did(request).await {
+            Ok(d) => d,
+            Err(e) => return Ok(error_resp(ZhtpStatus::Unauthorized, &e)),
+        };
 
-        let removed = self.deposits.ack(&req.message_ids);
+        let removed = self.deposits.ack(&recipient_did, &req.message_ids);
         json_response(json!({
             "status": "success",
             "acked": removed,
@@ -275,74 +304,18 @@ impl MessagingHandler {
     }
 
     /// GET /api/v1/msg/receive
-    /// Peek pending messages (does not remove — client must POST /msg/ack).
+    /// Peek pending messages (does not remove — client must POST /api/v1/msg/ack).
     async fn handle_receive(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
-        // Extract recipient DID from authenticated session.
-        // The requester identity hash may differ from the DID (key_id = blake3(dil||kyber)
-        // vs DID = blake3(dil) only). Look up the canonical DID from the identity registry.
+        let recipient_did = match self.resolve_caller_did(request).await {
+            Ok(d) => d,
+            Err(e) => return Ok(error_resp(ZhtpStatus::Unauthorized, &e)),
+        };
+
         let requester_key_id = request
             .requester
             .as_ref()
             .map(|id| hex::encode(&id.0))
             .unwrap_or_default();
-
-        if requester_key_id.is_empty() {
-            return Ok(error_resp(
-                ZhtpStatus::Unauthorized,
-                "Authenticated DID required",
-            ));
-        }
-
-        // Resolve the polling device's QUIC identity to the canonical chain
-        // DID the deposit was keyed under. Three paths, first hit wins:
-        //
-        // (1) **Session-bound device map.** OPAQUE login records
-        //     (quic_key_id → canonical_did) in SessionManager via
-        //     `bind_device_to_canonical_did`. Handles mobiles that generate
-        //     an ephemeral QUIC keypair per session (the dominant case):
-        //     mobile logs in with password → server binds this connection's
-        //     QUIC key under the user's canonical DID → /msg/receive on the
-        //     same connection (or any future connection whose key has been
-        //     bound) resolves correctly.
-        //
-        // (2) **Direct DID match.** A registry entry keyed by
-        //     `did:zhtp:<requester_key_id>` (rare — happens when the QUIC
-        //     key coincides with the canonical DID derivation).
-        //
-        // (3) **Public-key hash match.** Legacy / non-OPAQUE flow: scan all
-        //     identity_registry entries, hash `dilithium_pk` and
-        //     `dilithium_pk||kyber_pk`, see if either matches the requester
-        //     key_id. Genesis identities and identities registered before
-        //     OPAQUE existed land here.
-        //
-        // Fallback: derive a stub DID from the key_id itself. Deposit store
-        // returns empty for unknown DIDs — better than 500-ing.
-        let key_id_did = format!("did:zhtp:{}", requester_key_id);
-        let recipient_did = {
-            // (1) Session-bound device map.
-            let bound = match (
-                crate::session_manager::session_manager_handle(),
-                request.requester.as_ref(),
-            ) {
-                (Some(mgr), Some(req_id)) => {
-                    mgr.canonical_did_for_quic_key(&req_id.0).await
-                }
-                _ => None,
-            };
-            if let Some(did) = bound {
-                did
-            } else {
-                let blockchain = self.blockchain.read().await;
-                // #58: sled-first direct-match + Dilithium / Dilithium+Kyber hash
-                // resolution. Reads durable `identity_metadata` so a store-backed
-                // node resolves the requester after a restart (the in-memory
-                // `identity_registry` is empty then). Falls back to the raw
-                // key-id DID when no identity matches, as before.
-                blockchain
-                    .did_by_device_key_id(&requester_key_id)
-                    .unwrap_or(key_id_did)
-            }
-        };
 
         info!(
             "msg/receive lookup: requester_key_id={} -> recipient_did={}",

--- a/zhtp/src/messaging/inbound_stream.rs
+++ b/zhtp/src/messaging/inbound_stream.rs
@@ -6,7 +6,8 @@
 //!
 //! 1. Resolve the canonical recipient DID against the chain identity registry
 //!    (same logic as `handle_receive`).
-//! 2. Drain any existing deposits for this DID as the first batch of frames.
+//! 2. Peek existing deposits for this DID as the first batch of frames
+//!    (does not remove — client must POST `/api/v1/msg/ack`).
 //! 3. Register an mpsc subscriber and write each subsequent envelope as a
 //!    `[u32 BE length][envelope bytes]` frame.
 //! 4. On any write error (client disconnect, transport failure) we unregister
@@ -15,9 +16,8 @@
 //! Wire framing: each frame is `[4 bytes BE length][payload bytes]`. No
 //! sub-framing of envelopes; one frame == one bincode-serialized MessageEnvelope.
 //!
-//! The deposit store remains the offline-drain backstop. If the subscriber
-//! disconnects mid-stream, new envelopes from this point on will accumulate
-//! there until the client reopens.
+//! Deposits remain until client ack. Disconnect mid-stream does not lose
+//! already-peeked mail — it is still in the store.
 
 use anyhow::Result;
 use quinn::SendStream;
@@ -76,25 +76,23 @@ pub async fn run_inbound_stream(
 
     let provider = crate::runtime::messaging_provider::get_global_messaging_provider();
 
-    // 1. Drain existing deposits as the initial batch.
+    // 1. Peek existing deposits (MSG-R1: do not remove without client ack).
     if let Ok(deposits) = provider.get_deposits().await {
-        let deliveries = deposits.collect_for_recipient(&recipient_did).await;
+        let deliveries = deposits.peek_for_recipient(&recipient_did);
         let mut count = 0usize;
         for delivery in deliveries {
-            for envelope in delivery.envelopes {
-                if write_frame(&mut send, &envelope).await.is_err() {
-                    info!(
-                        "msg/inbound: client disconnected during initial drain for {}",
-                        recipient_did
-                    );
-                    return Ok(());
-                }
-                count += 1;
+            if write_frame(&mut send, &delivery.envelope).await.is_err() {
+                info!(
+                    "msg/inbound: client disconnected during initial peek for {}",
+                    recipient_did
+                );
+                return Ok(());
             }
+            count += 1;
         }
         if count > 0 {
             info!(
-                "msg/inbound: drained {} envelopes from deposit store for {}",
+                "msg/inbound: peeked {} envelopes from deposit store for {}",
                 count, recipient_did
             );
         }

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -1077,7 +1077,7 @@ impl ZhtpUnifiedServer {
                 let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(300));
                 loop {
                     interval.tick().await;
-                    let expired = deposits_cleanup.cleanup_expired().await;
+                    let expired = deposits_cleanup.cleanup_expired();
                     if expired > 0 {
                         tracing::info!("Cleaned up {} expired message deposits", expired);
                     }
@@ -1092,7 +1092,7 @@ impl ZhtpUnifiedServer {
                 let provider =
                     crate::runtime::messaging_provider::get_global_messaging_provider();
                 while let Some((recipient_did, envelope)) = relay_rx.recv().await {
-                    // Try live push first
+                    // Try live push first (MSG-R2 will deposit before push).
                     if provider.try_push(&recipient_did, envelope.clone()).await {
                         tracing::debug!(
                             "Relay pushed to live subscriber for {}",
@@ -1104,10 +1104,7 @@ impl ZhtpUnifiedServer {
                     let sender = bincode::deserialize::<crate::messaging::envelope::MessageEnvelope>(&envelope)
                         .map(|env| env.sender_did)
                         .unwrap_or_else(|_| "mesh_relay".to_string());
-                    if let Err(e) = deposits_relay
-                        .deposit(&sender, &recipient_did, vec![envelope])
-                        .await
-                    {
+                    if let Err(e) = deposits_relay.deposit_one(&sender, &recipient_did, envelope) {
                         tracing::warn!("Failed to deposit relayed message: {}", e);
                     }
                 }


### PR DESCRIPTION
## Summary
- Deposit store peeks only; envelopes stay until `POST /api/v1/msg/ack`
- Stable `message_id = hex(blake3(envelope))` with idempotent deposits
- `/msg/receive` and `/msg/inbound` no longer delete on read

## Stack
1. **This PR** — MSG-R1 (#2897)
2. MSG-R2 live push durability (#2898)
3. MSG-R3 shared DID resolver (#2899)
4. MSG-R4 honest send status (#2900)

Epic: #2896

## Test plan
- [ ] `cargo test -p zhtp --lib messaging::deposit`
- [ ] Poll `/msg/receive` twice → same messages until ack
- [ ] `POST /msg/ack` with `message_ids` → inbox empty

Closes #2897