### PR TITLE
fix(msg): MSG-R2 always deposit before live push

### DIFF
--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -140,7 +140,7 @@ impl MessagingHandler {
     }
 
     /// POST /api/v1/msg/send
-    /// Relay an encrypted envelope to the recipient via QUIC mesh.
+    /// Deposit first (durable), then best-effort live push + mesh relay.
     async fn handle_send(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
         let req: SendRequest = serde_json::from_slice(&request.body)
             .map_err(|e| anyhow::anyhow!("Invalid request: {}", e))?;
@@ -155,26 +155,7 @@ impl MessagingHandler {
 
         let recipient_did = envelope.recipient_did.clone();
 
-        let messaging_provider =
-            crate::runtime::messaging_provider::get_global_messaging_provider();
-
-        // Check if recipient has a live inbound subscriber on this node — push it
-        // straight onto the stream. Skips the deposit-then-poll round trip.
-        if messaging_provider
-            .try_push(&recipient_did, envelope_bytes.clone())
-            .await
-        {
-            info!(
-                "Message pushed to live subscriber for {}",
-                &recipient_did[..16.min(recipient_did.len())]
-            );
-            return json_response(json!({
-                "status": "delivered",
-                "recipient_did": recipient_did,
-            }));
-        }
-
-        // Deposit when no live subscriber (MSG-R2 will deposit before push too).
+        // MSG-R2: always deposit first — live push is best-effort only.
         // Local store-full is not fatal: still mesh-relay so peers can deposit.
         if let Err(e) = self.deposits.deposit_one(
             &envelope.sender_did,
@@ -186,6 +167,13 @@ impl MessagingHandler {
                 "msg/send: local deposit failed — continuing mesh relay"
             );
         }
+
+        let messaging_provider =
+            crate::runtime::messaging_provider::get_global_messaging_provider();
+
+        let _pushed = messaging_provider
+            .try_push(&recipient_did, envelope_bytes.clone())
+            .await;
 
         // Also relay via mesh so all nodes have the message
         if let Ok(mesh_router) = crate::runtime::mesh_router_provider::get_global_mesh_router().await {

--- a/zhtp/src/runtime/messaging_provider.rs
+++ b/zhtp/src/runtime/messaging_provider.rs
@@ -101,7 +101,10 @@ impl MessagingProvider {
 
     /// Attempt to push an envelope to the registered subscriber for this DID.
     /// Returns `true` if the push succeeded. `false` means no subscriber or
-    /// the subscriber's queue is full — caller should fall back to deposit.
+    /// the subscriber's queue is full.
+    ///
+    /// Callers must **deposit first** (MSG-R2). A successful push is not
+    /// delivery confirmation — the deposit remains until client ack.
     pub async fn try_push(&self, recipient_did: &str, envelope: Vec<u8>) -> bool {
         let subscribers = self.subscribers.read().await;
         if let Some(entry) = subscribers.get(recipient_did) {

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -1084,28 +1084,27 @@ impl ZhtpUnifiedServer {
                 }
             });
 
-            // Wire mesh relay receiver — incoming relayed messages either push to a
-            // live inbound subscriber or fall back to the deposit store.
+            // Wire mesh relay receiver — always deposit first (MSG-R2), then
+            // best-effort live push. Deposit stays until client ack.
             let deposits_relay = deposits.clone();
             let (relay_tx, mut relay_rx) = tokio::sync::mpsc::channel::<(String, Vec<u8>)>(256);
             tokio::spawn(async move {
                 let provider =
                     crate::runtime::messaging_provider::get_global_messaging_provider();
                 while let Some((recipient_did, envelope)) = relay_rx.recv().await {
-                    // Try live push first (MSG-R2 will deposit before push).
-                    if provider.try_push(&recipient_did, envelope.clone()).await {
-                        tracing::debug!(
-                            "Relay pushed to live subscriber for {}",
-                            recipient_did
-                        );
-                        continue;
-                    }
-                    // Fallback: deposit
+                    // MSG-R2: always deposit first, then best-effort live push.
                     let sender = bincode::deserialize::<crate::messaging::envelope::MessageEnvelope>(&envelope)
                         .map(|env| env.sender_did)
                         .unwrap_or_else(|_| "mesh_relay".to_string());
-                    if let Err(e) = deposits_relay.deposit_one(&sender, &recipient_did, envelope) {
+                    if let Err(e) = deposits_relay.deposit_one(&sender, &recipient_did, envelope.clone()) {
                         tracing::warn!("Failed to deposit relayed message: {}", e);
+                        continue;
+                    }
+                    if provider.try_push(&recipient_did, envelope).await {
+                        tracing::debug!(
+                            "Relay deposited + pushed to live subscriber for {}",
+                            recipient_did
+                        );
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- `msg/send` and mesh relay **deposit first**, then best-effort `try_push`
- Live stream drop can no longer lose mail that never hit the store

## Stack
Depends on MSG-R1 (#2897). Part of epic #2896.

## Test plan
- [ ] Send while recipient has open `/msg/inbound` → message still in deposit until ack
- [ ] Kill inbound mid-stream → reconnect/poll still sees message

Closes #2898