### PR TITLE
fix(msg): MSG-R3 shared DID resolver for receive and inbound

### DIFF
--- a/zhtp/src/messaging/did_resolve.rs
+++ b/zhtp/src/messaging/did_resolve.rs
@@ -1,0 +1,84 @@
+//! Shared recipient DID resolution for messaging endpoints.
+//!
+//! MSG-R3: `/msg/receive` and `/msg/inbound` must use the same resolver so a
+//! client does not see an empty inbox on one path and mail on the other.
+//!
+//! Resolution order (first hit wins):
+//! 1. Session-bound device map (OPAQUE login: quic_key → canonical DID)
+//! 2. Blockchain durable identity lookup by device key id
+//! 3. Fallback stub DID `did:zhtp:{key_id}` (empty inbox, not an error)
+
+use lib_blockchain::Blockchain;
+use lib_protocols::types::ZhtpRequest;
+
+/// Resolve the authenticated requester to the canonical recipient DID.
+///
+/// `requester_key_id` is hex-encoded `IdentityId` (32 bytes).
+/// Optional `request` supplies the raw key bytes for session-manager lookup.
+/// Optional `blockchain` is preferred for path (2); falls back to global chain.
+pub async fn resolve_recipient_did(
+    requester_key_id: &str,
+    request: Option<&ZhtpRequest>,
+    blockchain: Option<&Blockchain>,
+) -> String {
+    let key_id_did = format!("did:zhtp:{}", requester_key_id);
+
+    // (1) Session-bound device map (OPAQUE / mobile ephemeral QUIC keys).
+    if let Some(req) = request {
+        if let (Some(mgr), Some(req_id)) = (
+            crate::session_manager::session_manager_handle(),
+            req.requester.as_ref(),
+        ) {
+            if let Some(did) = mgr.canonical_did_for_quic_key(&req_id.0).await {
+                return did;
+            }
+        }
+    } else if let Ok(key_bytes) = hex::decode(requester_key_id) {
+        // Inbound stream path: only key_id hex is available; try session map
+        // if we have a 32-byte key.
+        if key_bytes.len() == 32 {
+            if let Some(mgr) = crate::session_manager::session_manager_handle() {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&key_bytes);
+                if let Some(did) = mgr.canonical_did_for_quic_key(&arr).await {
+                    return did;
+                }
+            }
+        }
+    }
+
+    // (2) Durable blockchain identity lookup (sled-first).
+    if let Some(bc) = blockchain {
+        if let Some(did) = bc.did_by_device_key_id(requester_key_id) {
+            return did;
+        }
+    } else if let Ok(blockchain_arc) =
+        crate::runtime::blockchain_provider::get_global_blockchain().await
+    {
+        let bc = blockchain_arc.read().await;
+        if let Some(did) = bc.did_by_device_key_id(requester_key_id) {
+            return did;
+        }
+    }
+
+    // (3) Stub — deposit store returns empty for unknown DIDs.
+    key_id_did
+}
+
+/// Convenience for HTTP handlers that have a full request + local blockchain.
+pub async fn resolve_recipient_did_from_request(
+    request: &ZhtpRequest,
+    blockchain: &Blockchain,
+) -> Result<String, String> {
+    let requester_key_id = request
+        .requester
+        .as_ref()
+        .map(|id| hex::encode(&id.0))
+        .unwrap_or_default();
+
+    if requester_key_id.is_empty() {
+        return Err("Authenticated DID required".to_string());
+    }
+
+    Ok(resolve_recipient_did(&requester_key_id, Some(request), Some(blockchain)).await)
+}

--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
-use lib_blockchain::{Blockchain, BlockchainQuery};
+use lib_blockchain::Blockchain;
 use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
 
@@ -242,31 +242,10 @@ impl MessagingHandler {
         }
     }
 
-    /// Resolve authenticated requester → canonical DID (same paths as receive).
+    /// Resolve authenticated requester → canonical DID (shared with inbound / receive).
     async fn resolve_caller_did(&self, request: &ZhtpRequest) -> Result<String, String> {
-        let requester_key_id = request
-            .requester
-            .as_ref()
-            .map(|id| hex::encode(&id.0))
-            .unwrap_or_default();
-        if requester_key_id.is_empty() {
-            return Err("Authenticated DID required".to_string());
-        }
-        let key_id_did = format!("did:zhtp:{}", requester_key_id);
-        let bound = match (
-            crate::session_manager::session_manager_handle(),
-            request.requester.as_ref(),
-        ) {
-            (Some(mgr), Some(req_id)) => mgr.canonical_did_for_quic_key(&req_id.0).await,
-            _ => None,
-        };
-        if let Some(did) = bound {
-            return Ok(did);
-        }
         let blockchain = self.blockchain.read().await;
-        Ok(blockchain
-            .did_by_device_key_id(&requester_key_id)
-            .unwrap_or(key_id_did))
+        super::did_resolve::resolve_recipient_did_from_request(request, &blockchain).await
     }
 
     /// POST /api/v1/msg/ack

--- a/zhtp/src/messaging/inbound_stream.rs
+++ b/zhtp/src/messaging/inbound_stream.rs
@@ -4,47 +4,22 @@
 //! `ZhtpResponseWire` (status 200, empty body), it hands the send stream to
 //! `run_inbound_stream`. We then:
 //!
-//! 1. Resolve the canonical recipient DID against the chain identity registry
-//!    (same logic as `handle_receive`).
-//! 2. Peek existing deposits for this DID as the first batch of frames
+//! 1. Resolve the canonical recipient DID (same logic as `handle_receive` — MSG-R3).
+//! 2. **Peek** existing deposits and write them as the first batch of frames
 //!    (does not remove — client must POST `/api/v1/msg/ack`).
 //! 3. Register an mpsc subscriber and write each subsequent envelope as a
 //!    `[u32 BE length][envelope bytes]` frame.
 //! 4. On any write error (client disconnect, transport failure) we unregister
-//!    the subscriber and return.
+//!    the subscriber and return. Deposits remain until ack, so reconnect is safe.
 //!
 //! Wire framing: each frame is `[4 bytes BE length][payload bytes]`. No
 //! sub-framing of envelopes; one frame == one bincode-serialized MessageEnvelope.
-//!
-//! Deposits remain until client ack. Disconnect mid-stream does not lose
-//! already-peeked mail — it is still in the store.
+//! Clients compute `message_id = hex(blake3(envelope))` for ack.
 
 use anyhow::Result;
 use quinn::SendStream;
 use tokio::io::AsyncWriteExt;
 use tracing::{info, warn};
-
-/// Resolve the authenticated requester's key_id to a canonical chain DID.
-/// Mirrors the logic in `handle_receive`. Tries:
-/// 1. `did:zhtp:{key_id_hex}` direct registry lookup.
-/// 2. Registry scan: `blake3(public_key) == key_id`.
-/// 3. Registry scan: `blake3(public_key || kyber_public_key) == key_id`.
-async fn resolve_recipient_did(requester_key_id: &str) -> Option<String> {
-    let blockchain_arc =
-        crate::runtime::blockchain_provider::get_global_blockchain().await.ok()?;
-    let blockchain = blockchain_arc.read().await;
-
-    // #58: sled-first direct-match + Dilithium / Dilithium+Kyber resolution via
-    // the facade, which reads durable `identity_metadata` so this survives a
-    // restart (the in-memory `identity_registry` is empty then). Falls back to
-    // the raw key_id DID suffix when no identity matches, as before.
-    let key_id_did = format!("did:zhtp:{}", requester_key_id);
-    Some(
-        blockchain
-            .did_by_device_key_id(requester_key_id)
-            .unwrap_or(key_id_did),
-    )
-}
 
 /// Write a single framed envelope to the send stream.
 async fn write_frame(send: &mut SendStream, envelope: &[u8]) -> Result<()> {
@@ -60,23 +35,23 @@ pub async fn run_inbound_stream(
     mut send: SendStream,
     requester_key_id: String,
 ) -> Result<()> {
-    let recipient_did = match resolve_recipient_did(&requester_key_id).await {
-        Some(d) => d,
-        None => {
-            warn!(
-                "msg/inbound: could not resolve recipient DID for key_id={}",
-                requester_key_id
-            );
-            let _ = send.finish();
-            return Ok(());
-        }
-    };
+    let recipient_did =
+        super::did_resolve::resolve_recipient_did(&requester_key_id, None, None).await;
+
+    if recipient_did.is_empty() {
+        warn!(
+            "msg/inbound: empty recipient DID for key_id={}",
+            requester_key_id
+        );
+        let _ = send.finish();
+        return Ok(());
+    }
 
     info!("msg/inbound: stream opened for {}", recipient_did);
 
     let provider = crate::runtime::messaging_provider::get_global_messaging_provider();
 
-    // 1. Peek existing deposits (MSG-R1: do not remove without client ack).
+    // 1. Peek existing deposits (MSG-R1: do not remove before/without client ack).
     if let Ok(deposits) = provider.get_deposits().await {
         let deliveries = deposits.peek_for_recipient(&recipient_did);
         let mut count = 0usize;
@@ -86,6 +61,7 @@ pub async fn run_inbound_stream(
                     "msg/inbound: client disconnected during initial peek for {}",
                     recipient_did
                 );
+                // Envelopes still in store — client can reconnect or poll.
                 return Ok(());
             }
             count += 1;
@@ -111,6 +87,8 @@ pub async fn run_inbound_stream(
     );
 
     // 3. Push frames until the peer disconnects or a write fails.
+    // Live pushes are also deposited by send/relay, so disconnect mid-stream
+    // does not lose mail — client acks after processing.
     while let Some(envelope) = rx.recv().await {
         if write_frame(&mut send, &envelope).await.is_err() {
             info!("msg/inbound: write failed (client gone) for {}", recipient_did);

--- a/zhtp/src/messaging/mod.rs
+++ b/zhtp/src/messaging/mod.rs
@@ -7,6 +7,7 @@ pub mod envelope;
 pub mod session;
 pub mod ratchet;
 pub mod deposit;
+pub mod did_resolve;
 pub mod presence;
 pub mod handler;
 pub mod inbound_stream;


### PR DESCRIPTION
## Summary
- New `messaging/did_resolve` used by both `/msg/receive` and `/msg/inbound`
- Session bind → sled identity → stub DID (same inbox on poll and stream)

## Stack
Depends on MSG-R2. Part of epic #2896.

## Test plan
- [ ] OPAQUE/mobile session: receive and inbound resolve same canonical DID
- [ ] After restart, sled-backed identity still resolves

Closes #2899