### PR TITLE
fix(reward-claim): UnregisteredSender blocks spend-delegate claims

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2449,8 +2449,28 @@ impl Blockchain {
             ));
         }
 
-        if !self.verify_transaction(&transaction)? {
-            return Err(anyhow::anyhow!("Transaction verification failed"));
+        // Surface ValidationError in the API response (not just node logs).
+        // `verify_transaction` collapses errors to bool and hid UnregisteredSender
+        // as a generic "Transaction verification failed" to clients.
+        {
+            let validator =
+                crate::transaction::validation::StatefulTransactionValidator::new(self);
+            if let Err(error) = validator.validate_transaction_with_state(&transaction) {
+                tracing::warn!("Transaction validation failed: {:?}", error);
+                tracing::warn!(
+                    "Transaction details: inputs={}, outputs={}, fee={}, type={:?}, memo_len={}, version={}",
+                    transaction.inputs.len(),
+                    transaction.outputs.len(),
+                    transaction.fee,
+                    transaction.transaction_type,
+                    transaction.memo.len(),
+                    transaction.version
+                );
+                return Err(anyhow::anyhow!(
+                    "Transaction verification failed: {:?}",
+                    error
+                ));
+            }
         }
 
         // Nonce gate: reject transactions whose nonce doesn't match the

--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -2467,7 +2467,7 @@ impl Blockchain {
                     transaction.version
                 );
                 return Err(anyhow::anyhow!(
-                    "Transaction verification failed: {:?}",
+                    "Transaction verification failed: {}",
                     error
                 ));
             }

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -2549,6 +2549,9 @@ impl<'a> StatefulTransactionValidator<'a> {
 
         // RewardClaim: signer is the spend delegate (system tx), but beneficiary
         // `owner_did` must exist in durable sled — same oracle as executor apply.
+        // Spend-delegate (or legacy token-creator) authorization must also match
+        // apply (`reward_claim.rs`) so a non-delegate claim is rejected at
+        // mempool admission instead of halting block apply (#2859 class).
         if transaction.transaction_type == TransactionType::RewardClaim {
             let data = transaction
                 .reward_claim_data()
@@ -2566,6 +2569,31 @@ impl<'a> StatefulTransactionValidator<'a> {
                 tracing::warn!(
                     "[REWARD_CLAIM] owner_did not registered in sled: {} ({e})",
                     &data.owner_did[..data.owner_did.len().min(32)]
+                );
+                return Err(ValidationError::InvalidTransaction);
+            }
+            if let Some(rewards_state) = blockchain.get_rewards_module_state(&data.token_id) {
+                if data.from != rewards_state.spend_delegate_key_id {
+                    tracing::warn!(
+                        "[REWARD_CLAIM] signer is not on-chain spend delegate: from={} expected={}",
+                        hex::encode(data.from),
+                        hex::encode(rewards_state.spend_delegate_key_id)
+                    );
+                    return Err(ValidationError::Unauthorized);
+                }
+            } else if let Some(contract) = blockchain.get_token_contract(&data.token_id) {
+                if contract.creator.key_id != data.from {
+                    tracing::warn!(
+                        "[REWARD_CLAIM] signer is not token creator (legacy path): from={} creator={}",
+                        hex::encode(data.from),
+                        hex::encode(contract.creator.key_id)
+                    );
+                    return Err(ValidationError::Unauthorized);
+                }
+            } else {
+                tracing::warn!(
+                    "[REWARD_CLAIM] token contract not found for claim token_id={}",
+                    hex::encode(data.token_id)
                 );
                 return Err(ValidationError::InvalidTransaction);
             }

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -2491,6 +2491,14 @@ impl<'a> StatefulTransactionValidator<'a> {
             && !is_threshold_type
             && transaction.transaction_type != TransactionType::IdentityRegistration
             && transaction.transaction_type != TransactionType::TokenTransfer
+            // RewardClaim is signed by the asset spend-delegate keystore (treasury),
+            // not a user identity. Authorization is Dilithium sig + on-chain
+            // RewardsModuleState.spend_delegate_key_id at apply; beneficiary
+            // `owner_did` is gated separately (sled) below. Requiring the
+            // delegate key in identity_registry/wallets rejects all claims
+            // after a store-backed restart (in-memory maps empty / delegate
+            // never registered as a user). Same exemption class as TokenTransfer.
+            && transaction.transaction_type != TransactionType::RewardClaim
             && transaction.transaction_type != TransactionType::TokenMint
             && transaction.transaction_type != TransactionType::TokenCreation
             && transaction.transaction_type != TransactionType::AssetLaunch

--- a/lib-blockchain/tests/common/reward_claim_harness.rs
+++ b/lib-blockchain/tests/common/reward_claim_harness.rs
@@ -162,6 +162,22 @@ pub fn mempool_blockchain(actors: &RewardClaimActors) -> Blockchain {
     blockchain
 }
 
+/// Beneficiary registered; treasury/spend-delegate key deliberately absent from
+/// identity maps — production path after store-backed restart (delegate is a
+/// keystore, not a user identity).
+pub fn mempool_blockchain_unregistered_treasury(actors: &RewardClaimActors) -> Blockchain {
+    let mut blockchain = Blockchain::new().expect("blockchain construct");
+    let store = attach_ephemeral_store(&mut blockchain);
+    put_identity_direct(store.as_ref(), &actors.owner_did, &actors.beneficiary.public_key);
+    register_identity_shadow(
+        &mut blockchain,
+        &actors.owner_did,
+        &actors.beneficiary.public_key,
+    );
+    install_bubl_mempool_fixtures(&mut blockchain, actors);
+    blockchain
+}
+
 /// Persist identities, BUBL contract, treasury balance; returns the setup block at height 1.
 pub fn seed_executor_store(
     store: &Arc<dyn BlockchainStore>,

--- a/lib-blockchain/tests/common/reward_claim_harness.rs
+++ b/lib-blockchain/tests/common/reward_claim_harness.rs
@@ -207,12 +207,24 @@ pub fn seed_executor_store(
 
 /// Signed welcome `RewardClaim` for `actors.beneficiary` at `nonce`.
 pub fn welcome_claim_tx(actors: &RewardClaimActors, nonce: u64) -> Transaction {
+    welcome_claim_tx_from(actors, nonce, &actors.treasury)
+}
+
+/// Welcome claim signed by `signer` with `data.from == signer.key_id`.
+///
+/// Use a non-treasury signer to assert mempool rejects unauthorized claims
+/// (must not reach apply / halt).
+pub fn welcome_claim_tx_from(
+    actors: &RewardClaimActors,
+    nonce: u64,
+    signer: &KeyPair,
+) -> Transaction {
     let data = RewardClaimData {
         event: RewardEventKind::Welcome,
         owner_did: actors.owner_did.clone(),
         recipient_key_id: actors.beneficiary.public_key.key_id,
         token_id: actors.token_id,
-        from: actors.treasury.public_key.key_id,
+        from: signer.public_key.key_id,
         amount: expected_amount_for_event(RewardEventKind::Welcome, 1),
         nonce,
         peer_did: None,
@@ -223,12 +235,12 @@ pub fn welcome_claim_tx(actors: &RewardClaimActors, nonce: u64) -> Transaction {
         data,
         lib_crypto::Signature {
             signature: Vec::new(),
-            public_key: actors.treasury.public_key.clone(),
+            public_key: signer.public_key.clone(),
             algorithm: SignatureAlgorithm::DEFAULT,
             timestamp: 0,
         },
         REWARD_CLAIM_MEMO.to_vec(),
     );
-    sign_transaction(&mut tx, &actors.treasury.private_key).expect("sign reward claim");
+    sign_transaction(&mut tx, &signer.private_key).expect("sign reward claim");
     tx
 }

--- a/lib-blockchain/tests/reward_claim_mempool_tests.rs
+++ b/lib-blockchain/tests/reward_claim_mempool_tests.rs
@@ -16,7 +16,7 @@ use common::block_builders;
 use common::reward_claim_harness::{
     mempool_blockchain, mempool_blockchain_shadow_phantom_beneficiary,
     mempool_blockchain_unregistered_beneficiary, mempool_blockchain_unregistered_treasury,
-    seed_executor_store, welcome_claim_tx, RewardClaimActors,
+    seed_executor_store, welcome_claim_tx, welcome_claim_tx_from, RewardClaimActors,
 };
 
 #[test]
@@ -42,6 +42,28 @@ fn unregistered_treasury_signer_accepted_into_mempool() {
         .add_pending_transaction(welcome_claim_tx(&actors, 0))
         .expect("RewardClaim must not require treasury identity registration");
     assert_eq!(blockchain.get_pending_transactions().len(), 1);
+}
+
+#[test]
+fn non_delegate_signer_rejected_from_mempool() {
+    // Without a mempool spend-delegate gate, any key with from==signer and a
+    // registered owner_did would admit and then halt apply (non-delegate Err).
+    let actors = RewardClaimActors::generate();
+    let mut blockchain = mempool_blockchain(&actors);
+    let impostor = lib_crypto::KeyPair::generate().expect("impostor keypair");
+
+    let err = blockchain
+        .add_pending_transaction(welcome_claim_tx_from(&actors, 0, &impostor))
+        .expect_err("non-delegate RewardClaim must be rejected at mempool");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("verification failed") || msg.contains("Unauthorized"),
+        "expected mempool unauthorized rejection, got: {msg}"
+    );
+    assert!(
+        blockchain.get_pending_transactions().is_empty(),
+        "non-delegate claim must not enter mempool"
+    );
 }
 
 #[test]

--- a/lib-blockchain/tests/reward_claim_mempool_tests.rs
+++ b/lib-blockchain/tests/reward_claim_mempool_tests.rs
@@ -15,8 +15,8 @@ mod common;
 use common::block_builders;
 use common::reward_claim_harness::{
     mempool_blockchain, mempool_blockchain_shadow_phantom_beneficiary,
-    mempool_blockchain_unregistered_beneficiary, seed_executor_store, welcome_claim_tx,
-    RewardClaimActors,
+    mempool_blockchain_unregistered_beneficiary, mempool_blockchain_unregistered_treasury,
+    seed_executor_store, welcome_claim_tx, RewardClaimActors,
 };
 
 #[test]
@@ -27,6 +27,20 @@ fn registered_owner_did_accepted_into_mempool() {
     blockchain
         .add_pending_transaction(welcome_claim_tx(&actors, 0))
         .expect("registered owner_did claim should enter mempool");
+    assert_eq!(blockchain.get_pending_transactions().len(), 1);
+}
+
+#[test]
+fn unregistered_treasury_signer_accepted_into_mempool() {
+    // Spend-delegate is a node keystore, not a registered user identity.
+    // Production claims failed with UnregisteredSender after restarts when
+    // validate_sender_identity_exists scanned only in-memory wallets/identities.
+    let actors = RewardClaimActors::generate();
+    let mut blockchain = mempool_blockchain_unregistered_treasury(&actors);
+
+    blockchain
+        .add_pending_transaction(welcome_claim_tx(&actors, 0))
+        .expect("RewardClaim must not require treasury identity registration");
     assert_eq!(blockchain.get_pending_transactions().len(), 1);
 }
 
@@ -94,9 +108,11 @@ fn duplicate_welcome_claim_rejected_from_mempool() {
         .add_pending_transaction(welcome_claim_tx(&actors, 0))
         .expect_err("duplicate welcome claim must be rejected");
     let msg = err.to_string();
+    // Same bytes → identical hash ("duplicate already pending"); re-signed
+    // payload with same claim keys → pending_reward_claim_conflicts.
     assert!(
-        msg.contains("conflicting RewardClaim"),
-        "expected mempool conflict rejection, got: {msg}"
+        msg.contains("conflicting RewardClaim") || msg.contains("duplicate already pending"),
+        "expected mempool conflict/duplicate rejection, got: {msg}"
     );
     assert_eq!(
         blockchain.get_pending_transactions().len(),


### PR DESCRIPTION
## Summary
Production rewards claims fail with:
`reward claim submit failed: Failed to submit reward claim: Transaction verification failed`

**Root cause (g1 logs):** `Transaction validation failed: UnregisteredSender`

`RewardClaim` is signed by the BUBL **spend-delegate keystore** (treasury), which is not a registered user identity/wallet. Stateful validation still ran `validate_sender_identity_exists` against in-memory wallet/identity maps (28 wallets on g1; no match). After a store-backed restart those maps no longer mirror sled, so every claim is rejected before the owner_did sled gate.

`TokenTransfer` already skips this check; `RewardClaim` did not.

## Fix
- Exempt `TransactionType::RewardClaim` from `validate_sender_identity_exists` (same class as TokenTransfer). Authorization remains Dilithium sig + `data.from` key_id + on-chain spend delegate at apply; beneficiary `owner_did` still sled-gated.
- Surface `ValidationError` in mempool reject strings (no more opaque client message).
- Regression test: claim accepted when treasury identity is absent and beneficiary is registered.

## Test plan
- [x] `cargo test -p lib-blockchain --test reward_claim_mempool_tests`
- [ ] Deploy and confirm `/api/v1/rewards/claim` no longer returns verification failed
- [ ] g1 journal: no new `UnregisteredSender` on RewardClaim

## Evidence
```
WARN Transaction validation failed: UnregisteredSender
Transaction details: ... type=RewardClaim ...
SECURITY CRITICAL: Transaction from unregistered wallet/identity!
Total wallets to check: 28
```

Not caused by timestamp PRs (#2892/#2893); those only affect day/week bucketing on plan/apply.