### PR TITLE
chore: bump CONSENSUS_BUILD_ID to 6 (reward-claim deploy)

### DIFF
--- a/lib-consensus-core/src/build_id.rs
+++ b/lib-consensus-core/src/build_id.rs
@@ -20,8 +20,9 @@
 /// - Consensus admission rules change in a way that requires homogeneous binaries
 ///
 /// Do **not** bump for docs-only, CLI-only, or unrelated crate changes.
-// SA-7 (manifest pin gate) requires epoch 5; keep above development's SA-6 epoch 4.
-pub const CONSENSUS_BUILD_ID: &str = "5";
+// Epoch 6: RewardClaim mempool gates (UnregisteredSender fix + spend-delegate
+// admission). Homogeneous cluster required so nodes agree on mempool admits.
+pub const CONSENSUS_BUILD_ID: &str = "6";
 
 /// Marker assigned when decoding codec v1 frames (no epoch field on wire).
 pub const LEGACY_BUILD_ID: &str = "";


### PR DESCRIPTION
## Summary
- Bumps consensus epoch **5 → 6** to match the live testnet deploy of the RewardClaim mempool fix (#2908).
- Without this, the next `development` deploy would look like an epoch **downgrade** and be blocked or mixed.

Live cluster is already on epoch 6 (rewards-only binary, **no messaging R1–R4**).

## Test plan
- [x] Deployed g1/g2/g3; all active, height aligned, epoch 6