### PR TITLE
fix(lib-client): MSG-NODE-001 session open errors + UHP handshake parity

### DIFF
--- a/lib-client/src/quic_session.rs
+++ b/lib-client/src/quic_session.rs
@@ -8,16 +8,23 @@
 //! RPC, and inbound work on the shared `CLIENT_ENDPOINT_RUNTIME` from
 //! lib-network. FFI callers may call from any thread; commands route through
 //! a tokio mpsc queue.
+//!
+//! # MSG-NODE-001 — errors + handshake parity
+//!
+//! `zhtp_quic_session_open` uses the **canonical** UHP initiator
+//! (`quic_handshake::handshake_as_initiator` / `quic_uhp_capabilities`).
+//! On failure it returns null and stores a structured last-error string
+//! (`stage=…: message`) retrievable via `zhtp_quic_session_last_error`.
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::ffi::{c_char, CStr};
+use std::cell::RefCell;
+use std::ffi::{c_char, CStr, CString};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
-use tokio::io::AsyncReadExt;
 use tokio::sync::oneshot;
 
 use lib_identity::types::IdentityType;
@@ -28,6 +35,79 @@ use lib_protocols::types::{ZhtpMethod, ZhtpRequest};
 use lib_protocols::wire::read_response;
 
 use crate::identity::Identity;
+
+// =============================================================================
+// LAST ERROR (thread-local for FFI)
+// =============================================================================
+
+thread_local! {
+    static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+    static LAST_STAGE: RefCell<&'static str> = const { RefCell::new("none") };
+}
+
+fn clear_last_error() {
+    LAST_ERROR.with(|e| *e.borrow_mut() = None);
+    LAST_STAGE.with(|s| *s.borrow_mut() = "none");
+}
+
+fn set_last_error(stage: &'static str, message: impl AsRef<str>) {
+    let msg = message.as_ref().to_string();
+    eprintln!("[zhtp_quic_session] stage={} error={}", stage, msg);
+    LAST_STAGE.with(|s| *s.borrow_mut() = stage);
+    LAST_ERROR.with(|e| {
+        *e.borrow_mut() = Some(format!("stage={}: {}", stage, msg));
+    });
+}
+
+fn set_last_error_from_anyhow(fallback_stage: &'static str, err: &anyhow::Error) {
+    let full = format!("{:#}", err);
+    let stage = classify_stage(&full).unwrap_or(fallback_stage);
+    set_last_error(stage, full);
+}
+
+/// Parse `stage=foo` markers embedded in error chains (from ZhtpClient).
+fn classify_stage(msg: &str) -> Option<&'static str> {
+    const STAGES: &[&str] = &[
+        "resolve",
+        "quic",
+        "tls",
+        "uhp_handshake",
+        "trust",
+        "session_keys",
+        "config",
+        "identity",
+        "alpn",
+        "runtime",
+        "client_init",
+        "inbound",
+        "rpc",
+        "args",
+    ];
+    for stage in STAGES {
+        if msg.contains(&format!("stage={}", stage)) {
+            // SAFETY: stage is a static str from STAGES.
+            return Some(*stage);
+        }
+    }
+    // Heuristic fallbacks for older error strings.
+    let lower = msg.to_ascii_lowercase();
+    if lower.contains("uhp") || lower.contains("handshake") || lower.contains("length prefix") {
+        return Some("uhp_handshake");
+    }
+    if lower.contains("resolve") || lower.contains("dns") {
+        return Some("resolve");
+    }
+    if lower.contains("quic connection") || lower.contains("connection failed") {
+        return Some("quic");
+    }
+    if lower.contains("alpn") {
+        return Some("alpn");
+    }
+    if lower.contains("identity") || lower.contains("public_key") || lower.contains("private_key") {
+        return Some("identity");
+    }
+    None
+}
 
 // =============================================================================
 // HANDLES
@@ -96,11 +176,7 @@ fn spawn_session_worker(
         let runtime = match lib_network::client::client_endpoint_runtime() {
             Ok(rt) => rt,
             Err(e) => {
-                eprintln!(
-                    "[zhtp_quic_session] client_endpoint_runtime failed: {:?}",
-                    e
-                );
-                let _ = ready.send(Err(e.context("client_endpoint_runtime")));
+                let _ = ready.send(Err(e.context("client_endpoint_runtime (stage=runtime)")));
                 return;
             }
         };
@@ -114,20 +190,15 @@ fn spawn_session_worker(
             let mut client = match ZhtpClient::new_with_config(identity, trust, config).await {
                 Ok(c) => c,
                 Err(e) => {
-                    eprintln!(
-                        "[zhtp_quic_session] ZhtpClient::new_with_config failed: {:?}",
-                        e
-                    );
-                    let _ = ready.send(Err(e.context("ZhtpClient::new_with_config")));
+                    let _ = ready.send(Err(e.context("ZhtpClient::new_with_config (stage=client_init)")));
                     return;
                 }
             };
             if let Err(e) = client.connect_with_sni(&addr, &server_name).await {
-                eprintln!(
-                    "[zhtp_quic_session] connect failed addr={} sni={} alpn={}: {:?}",
-                    addr, server_name, session_alpn, e
-                );
-                let _ = ready.send(Err(e.context("ZhtpClient::connect_with_sni")));
+                let _ = ready.send(Err(e.context(format!(
+                    "ZhtpClient::connect_with_sni addr={} sni={} alpn={}",
+                    addr, server_name, session_alpn
+                ))));
                 return;
             }
             // Hand the open client to the loop and signal the caller
@@ -145,7 +216,12 @@ async fn session_loop(
     let client = Arc::new(client);
     while let Some(cmd) = rx.recv().await {
         match cmd {
-            SessionCmd::Rpc { method, path, body, reply } => {
+            SessionCmd::Rpc {
+                method,
+                path,
+                body,
+                reply,
+            } => {
                 let c = client.clone();
                 tokio::spawn(async move {
                     let r = do_rpc(&c, method, path, body).await;
@@ -186,15 +262,17 @@ async fn do_inbound_open(
 ) -> Result<InboundStreamHandle> {
     let requester = Some(client.identity().id.clone());
     let request = ZhtpRequest::get(path, requester)?;
-    let (_send, mut recv, expected_id) =
-        client.open_authenticated_stream(request).await?;
+    let (_send, mut recv, expected_id) = client
+        .open_authenticated_stream(request)
+        .await
+        .context("open authenticated stream (stage=inbound)")?;
 
     let wire_response = read_response(&mut recv)
         .await
-        .context("Failed to read inbound stream header")?;
+        .context("Failed to read inbound stream header (stage=inbound)")?;
     if wire_response.request_id != expected_id {
         return Err(anyhow!(
-            "inbound stream: request_id mismatch (expected {}, got {})",
+            "inbound stream: request_id mismatch (expected {}, got {}) (stage=inbound)",
             hex::encode(expected_id),
             wire_response.request_id_hex()
         ));
@@ -202,7 +280,7 @@ async fn do_inbound_open(
     let status = wire_response.response.status.code() as u16;
     if !(200..300).contains(&status) {
         return Err(anyhow!(
-            "inbound stream: server returned status {}",
+            "inbound stream: server returned status {} (stage=inbound)",
             status
         ));
     }
@@ -282,9 +360,17 @@ fn to_zhtp_identity(id: &Identity) -> Result<ZhtpIdentity> {
         .public_key
         .as_slice()
         .try_into()
-        .map_err(|_| anyhow!("public_key must be 2592 bytes"))?;
+        .map_err(|_| {
+            anyhow!(
+                "public_key must be 2592 bytes, got {} (stage=identity)",
+                id.public_key.len()
+            )
+        })?;
     let dilithium_sk: [u8; 4896] = if id.private_key.len() == 4896 {
-        id.private_key.as_slice().try_into().unwrap()
+        id.private_key
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("private_key 4896-byte conversion failed (stage=identity)"))?
     } else if id.private_key.len() == 4864 {
         // crystals-dilithium format; pad to pqcrypto's 4896-byte layout.
         let mut arr = [0u8; 4896];
@@ -292,7 +378,7 @@ fn to_zhtp_identity(id: &Identity) -> Result<ZhtpIdentity> {
         arr
     } else {
         return Err(anyhow!(
-            "private_key must be 4864 or 4896 bytes, got {}",
+            "private_key must be 4864 or 4896 bytes, got {} (stage=identity)",
             id.private_key.len()
         ));
     };
@@ -300,13 +386,25 @@ fn to_zhtp_identity(id: &Identity) -> Result<ZhtpIdentity> {
         .kyber_public_key
         .as_slice()
         .try_into()
-        .map_err(|_| anyhow!("kyber_public_key must be 1568 bytes"))?;
+        .map_err(|_| {
+            anyhow!(
+                "kyber_public_key must be 1568 bytes, got {} (stage=identity)",
+                id.kyber_public_key.len()
+            )
+        })?;
     let kyber_sk: [u8; 3168] = id
         .kyber_secret_key
         .as_slice()
         .try_into()
-        .map_err(|_| anyhow!("kyber_secret_key must be 3168 bytes"))?;
+        .map_err(|_| {
+            anyhow!(
+                "kyber_secret_key must be 3168 bytes, got {} (stage=identity)",
+                id.kyber_secret_key.len()
+            )
+        })?;
 
+    // Device type matches mobile operational keys used for transport auth.
+    // DID is derived from the Dilithium public key inside from_raw_keys.
     ZhtpIdentity::from_raw_keys(
         IdentityType::Device,
         dilithium_pk,
@@ -315,6 +413,83 @@ fn to_zhtp_identity(id: &Identity) -> Result<ZhtpIdentity> {
         kyber_sk,
         id.device_id.clone(),
     )
+    .map_err(|e| anyhow!("from_raw_keys: {} (stage=identity)", e))
+}
+
+// =============================================================================
+// Pure Rust open (shared by FFI + tests)
+// =============================================================================
+
+/// Open a persistent authenticated QUIC session (canonical UHP initiator).
+///
+/// `alpn` must be `1` (`zhtp-uhp/2`). `sni` is the TLS server name (hostname);
+/// dial host may be an IP after ZDNS bootstrap.
+pub fn open_session(
+    host: &str,
+    port: u16,
+    sni: Option<&str>,
+    alpn: u8,
+    identity: &Identity,
+) -> Result<*mut QuicSessionHandle> {
+    clear_last_error();
+
+    if host.is_empty() {
+        set_last_error("args", "host is empty");
+        return Err(anyhow!("host is empty (stage=args)"));
+    }
+    if alpn != 1 {
+        set_last_error(
+            "alpn",
+            format!(
+                "session_alpn must be 1 (zhtp-uhp/2), got {} — public ALPN has no UHP",
+                alpn
+            ),
+        );
+        return Err(anyhow!("invalid alpn {} (stage=alpn)", alpn));
+    }
+
+    let addr = format!("{}:{}", host, port);
+    let server_name = match sni {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => "zhtp-node".to_string(),
+    };
+
+    let zhtp_identity = match to_zhtp_identity(identity) {
+        Ok(z) => z,
+        Err(e) => {
+            set_last_error_from_anyhow("identity", &e);
+            return Err(e);
+        }
+    };
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<SessionCmd>(64);
+    let (ready_tx, ready_rx) = oneshot::channel::<Result<()>>();
+    let worker = spawn_session_worker(addr, server_name, alpn, zhtp_identity, rx, ready_tx);
+
+    match ready_rx.blocking_recv() {
+        Ok(Ok(())) => {
+            clear_last_error();
+            Ok(Box::into_raw(Box::new(QuicSessionHandle {
+                tx,
+                _worker: Some(worker),
+            })))
+        }
+        Ok(Err(e)) => {
+            set_last_error_from_anyhow("uhp_handshake", &e);
+            drop(tx);
+            let _ = worker.join();
+            Err(e)
+        }
+        Err(_) => {
+            set_last_error(
+                "runtime",
+                "session worker exited without reporting connect result",
+            );
+            drop(tx);
+            let _ = worker.join();
+            Err(anyhow!("session worker dropped ready channel (stage=runtime)"))
+        }
+    }
 }
 
 // =============================================================================
@@ -324,7 +499,7 @@ fn to_zhtp_identity(id: &Identity) -> Result<ZhtpIdentity> {
 /// Open a persistent QUIC session.
 /// `alpn`: must be `1` (`zhtp-uhp/2`, authenticated UHP). Public ALPN (`0`)
 /// is not supported here — gateways treat `zhtp-public/1` as no-UHP read-only.
-/// Returns null on failure.
+/// Returns null on failure — call `zhtp_quic_session_last_error` for details.
 #[no_mangle]
 pub extern "C" fn zhtp_quic_session_open(
     host: *const c_char,
@@ -334,70 +509,98 @@ pub extern "C" fn zhtp_quic_session_open(
     alpn: u8,
     identity: *const crate::IdentityHandle,
 ) -> *mut QuicSessionHandle {
+    clear_last_error();
+
     if host.is_null() {
-        return std::ptr::null_mut();
-    }
-    // Session path always performs UHP v2 after connect; public ALPN is rejected.
-    if alpn != 1 {
+        set_last_error("args", "host pointer is null");
         return std::ptr::null_mut();
     }
     if identity.is_null() {
+        set_last_error("args", "identity pointer is null");
         return std::ptr::null_mut();
     }
 
     let host_str = match unsafe { CStr::from_ptr(host) }.to_str() {
-        Ok(s) => s.to_string(),
-        Err(_) => return std::ptr::null_mut(),
+        Ok(s) => s,
+        Err(_) => {
+            set_last_error("args", "host is not valid UTF-8");
+            return std::ptr::null_mut();
+        }
     };
-    let addr = format!("{}:{}", host_str, port);
 
-    let server_name = if sni.is_null() {
-        "zhtp-node".to_string()
+    let sni_opt = if sni.is_null() {
+        None
     } else {
         match unsafe { CStr::from_ptr(sni) }.to_str() {
-            Ok(s) if !s.is_empty() => s.to_string(),
-            _ => "zhtp-node".to_string(),
+            Ok(s) if !s.is_empty() => Some(s),
+            Ok(_) => None,
+            Err(_) => {
+                set_last_error("args", "sni is not valid UTF-8");
+                return std::ptr::null_mut();
+            }
         }
     };
 
     let id = unsafe { (*identity).inner.clone() };
 
-    let zhtp_identity = match to_zhtp_identity(&id) {
-        Ok(z) => z,
-        Err(_) => return std::ptr::null_mut(),
-    };
+    match open_session(host_str, port, sni_opt, alpn, &id) {
+        Ok(ptr) => ptr,
+        Err(_) => std::ptr::null_mut(),
+    }
+}
 
-    let (tx, rx) = tokio::sync::mpsc::channel::<SessionCmd>(64);
-    let (ready_tx, ready_rx) = oneshot::channel::<Result<()>>();
-    let worker = spawn_session_worker(addr, server_name, alpn, zhtp_identity, rx, ready_tx);
+/// Last structured error from session open / inbound / rpc on this thread.
+///
+/// Format: `stage=<name>: <message chain>`.
+/// Returns a newly allocated C string; free with `zhtp_client_string_free`
+/// (or `zhtp_quic_session_last_error_free`). Null if no error stored.
+#[no_mangle]
+pub extern "C" fn zhtp_quic_session_last_error() -> *mut c_char {
+    LAST_ERROR.with(|e| match e.borrow().as_ref() {
+        Some(msg) => match CString::new(msg.as_str()) {
+            Ok(c) => c.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        },
+        None => std::ptr::null_mut(),
+    })
+}
 
-    // Block until the worker has finished the QUIC connect + UHP
-    // handshake. Returning the handle before the connection is
-    // ready would race the next rpc() against an unconnected
-    // client and produce the same `closed` errors the temp-runtime
-    // bug used to.
-    match ready_rx.blocking_recv() {
-        Ok(Ok(())) => {}
-        Ok(Err(_)) => {
-            // Worker exits naturally once we drop the tx (its rx ends).
-            drop(tx);
-            let _ = worker.join();
-            return std::ptr::null_mut();
-        }
-        Err(_) => {
-            // The worker dropped the ready sender without reporting a result.
-            // Mirror the other startup-failure path and clean up before
-            // returning a null handle.
-            drop(tx);
-            let _ = worker.join();
-            return std::ptr::null_mut();
+/// Stage token only (`uhp_handshake`, `quic`, `resolve`, …). Static C string
+/// — do not free. Returns `"none"` when no error is stored.
+#[no_mangle]
+pub extern "C" fn zhtp_quic_session_last_error_stage() -> *const c_char {
+    LAST_STAGE.with(|s| stage_as_c_str(*s.borrow()))
+}
+
+fn stage_as_c_str(stage: &str) -> *const c_char {
+    // Explicit NUL-terminated statics — do not free.
+    match stage {
+        "resolve" => b"resolve\0".as_ptr() as *const c_char,
+        "quic" => b"quic\0".as_ptr() as *const c_char,
+        "tls" => b"tls\0".as_ptr() as *const c_char,
+        "uhp_handshake" => b"uhp_handshake\0".as_ptr() as *const c_char,
+        "trust" => b"trust\0".as_ptr() as *const c_char,
+        "session_keys" => b"session_keys\0".as_ptr() as *const c_char,
+        "config" => b"config\0".as_ptr() as *const c_char,
+        "identity" => b"identity\0".as_ptr() as *const c_char,
+        "alpn" => b"alpn\0".as_ptr() as *const c_char,
+        "runtime" => b"runtime\0".as_ptr() as *const c_char,
+        "client_init" => b"client_init\0".as_ptr() as *const c_char,
+        "inbound" => b"inbound\0".as_ptr() as *const c_char,
+        "rpc" => b"rpc\0".as_ptr() as *const c_char,
+        "args" => b"args\0".as_ptr() as *const c_char,
+        _ => b"none\0".as_ptr() as *const c_char,
+    }
+}
+
+/// Free a string returned by `zhtp_quic_session_last_error`.
+#[no_mangle]
+pub extern "C" fn zhtp_quic_session_last_error_free(s: *mut c_char) {
+    if !s.is_null() {
+        unsafe {
+            drop(CString::from_raw(s));
         }
     }
-
-    Box::into_raw(Box::new(QuicSessionHandle {
-        tx,
-        _worker: Some(worker),
-    }))
 }
 
 /// Issue an RPC on the session. Each call opens a new bidi stream and runs
@@ -411,24 +614,35 @@ pub extern "C" fn zhtp_quic_session_rpc(
     body_ptr: *const u8,
     body_len: usize,
 ) -> *mut RpcResponse {
+    clear_last_error();
     if session.is_null() || method.is_null() || path.is_null() {
+        set_last_error("args", "session/method/path pointer is null");
         return std::ptr::null_mut();
     }
     let session = unsafe { &*session };
 
     let method_str = match unsafe { CStr::from_ptr(method) }.to_str() {
         Ok(s) => s,
-        Err(_) => return std::ptr::null_mut(),
+        Err(_) => {
+            set_last_error("args", "method is not valid UTF-8");
+            return std::ptr::null_mut();
+        }
     };
     let path_str = match unsafe { CStr::from_ptr(path) }.to_str() {
         Ok(s) => s.to_string(),
-        Err(_) => return std::ptr::null_mut(),
+        Err(_) => {
+            set_last_error("args", "path is not valid UTF-8");
+            return std::ptr::null_mut();
+        }
     };
     let method = match method_str.to_ascii_uppercase().as_str() {
         "GET" => ZhtpMethod::Get,
         "POST" => ZhtpMethod::Post,
         "DELETE" => ZhtpMethod::Delete,
-        _ => return std::ptr::null_mut(),
+        _ => {
+            set_last_error("args", format!("unsupported method '{}'", method_str));
+            return std::ptr::null_mut();
+        }
     };
 
     let body: Vec<u8> = if body_ptr.is_null() || body_len == 0 {
@@ -448,12 +662,20 @@ pub extern "C" fn zhtp_quic_session_rpc(
         })
         .is_err()
     {
+        set_last_error("rpc", "session channel closed");
         return std::ptr::null_mut();
     }
 
     match reply_rx.blocking_recv() {
         Ok(Ok(resp)) => Box::into_raw(Box::new(resp)),
-        _ => std::ptr::null_mut(),
+        Ok(Err(e)) => {
+            set_last_error_from_anyhow("rpc", &e);
+            std::ptr::null_mut()
+        }
+        Err(_) => {
+            set_last_error("rpc", "rpc worker dropped reply channel");
+            std::ptr::null_mut()
+        }
     }
 }
 
@@ -490,25 +712,41 @@ pub extern "C" fn zhtp_quic_session_inbound_open(
     session: *mut QuicSessionHandle,
     path: *const c_char,
 ) -> *mut InboundStreamHandle {
+    clear_last_error();
     if session.is_null() || path.is_null() {
+        set_last_error("args", "session/path pointer is null");
         return std::ptr::null_mut();
     }
     let session = unsafe { &*session };
     let path = match unsafe { CStr::from_ptr(path) }.to_str() {
         Ok(s) => s.to_string(),
-        Err(_) => return std::ptr::null_mut(),
+        Err(_) => {
+            set_last_error("args", "path is not valid UTF-8");
+            return std::ptr::null_mut();
+        }
     };
     let (reply_tx, reply_rx) = oneshot::channel();
     if session
         .tx
-        .blocking_send(SessionCmd::InboundOpen { path, reply: reply_tx })
+        .blocking_send(SessionCmd::InboundOpen {
+            path,
+            reply: reply_tx,
+        })
         .is_err()
     {
+        set_last_error("inbound", "session channel closed");
         return std::ptr::null_mut();
     }
     match reply_rx.blocking_recv() {
         Ok(Ok(h)) => Box::into_raw(Box::new(h)),
-        _ => std::ptr::null_mut(),
+        Ok(Err(e)) => {
+            set_last_error_from_anyhow("inbound", &e);
+            std::ptr::null_mut()
+        }
+        Err(_) => {
+            set_last_error("inbound", "inbound open worker dropped reply");
+            std::ptr::null_mut()
+        }
     }
 }
 
@@ -522,12 +760,16 @@ pub extern "C" fn zhtp_quic_session_inbound_read(
     out_len: *mut usize,
 ) -> i32 {
     if stream.is_null() || out_ptr.is_null() || out_len.is_null() {
+        set_last_error("args", "inbound_read null pointer");
         return -2;
     }
     let stream = unsafe { &*stream };
     let mut rx = match stream.rx.lock() {
         Ok(r) => r,
-        Err(_) => return -2,
+        Err(_) => {
+            set_last_error("inbound", "inbound stream mutex poisoned");
+            return -2;
+        }
     };
 
     let event = if timeout_ms == 0 {
@@ -560,7 +802,10 @@ pub extern "C" fn zhtp_quic_session_inbound_read(
             0
         }
         Some(InboundEvent::Closed) => -1,
-        Some(InboundEvent::Error(_)) => -2,
+        Some(InboundEvent::Error(e)) => {
+            set_last_error("inbound", e);
+            -2
+        }
         None => 1,
     }
 }
@@ -569,10 +814,7 @@ pub extern "C" fn zhtp_quic_session_inbound_read(
 pub extern "C" fn zhtp_quic_session_inbound_frame_free(ptr: *const u8, len: usize) {
     if !ptr.is_null() && len > 0 {
         unsafe {
-            let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
-                ptr as *mut u8,
-                len,
-            ));
+            let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr as *mut u8, len));
         }
     }
 }
@@ -592,4 +834,112 @@ pub extern "C" fn zhtp_quic_session_close(session: *mut QuicSessionHandle) {
     let handle = unsafe { Box::from_raw(session) };
     let _ = handle.tx.blocking_send(SessionCmd::Close);
     drop(handle);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::generate_identity;
+    use lib_network::protocols::quic_handshake::quic_uhp_capabilities;
+    use lib_network::handshake::PqcCapability;
+
+    #[test]
+    fn quic_uhp_capabilities_is_minimal_production_shape() {
+        let caps = quic_uhp_capabilities();
+        assert_eq!(caps.protocols, vec!["quic".to_string()]);
+        assert_eq!(caps.pqc_capability, PqcCapability::Kyber1024Dilithium5);
+    }
+
+    #[test]
+    fn last_error_reports_bad_alpn() {
+        let id = generate_identity("test-device".into()).expect("identity");
+        let err = open_session("127.0.0.1", 9334, Some("g1.example"), 0, &id)
+            .expect_err("public alpn must fail");
+        assert!(err.to_string().contains("alpn"), "{err}");
+        let stage = LAST_STAGE.with(|s| *s.borrow());
+        assert_eq!(stage, "alpn");
+        let msg = LAST_ERROR.with(|e| e.borrow().clone()).expect("last error");
+        assert!(msg.starts_with("stage=alpn:"), "{msg}");
+    }
+
+    #[test]
+    fn last_error_reports_identity_key_length() {
+        let mut id = generate_identity("test-device".into()).expect("identity");
+        id.public_key.truncate(10);
+        let err = open_session("127.0.0.1", 9334, Some("g1.example"), 1, &id)
+            .expect_err("bad key must fail");
+        assert!(err.to_string().contains("2592") || err.to_string().contains("identity"), "{err}");
+        let stage = LAST_STAGE.with(|s| *s.borrow());
+        assert_eq!(stage, "identity");
+    }
+
+    #[test]
+    fn classify_stage_parses_markers() {
+        assert_eq!(
+            classify_stage("UHP v2 handshake failed (stage=uhp_handshake)"),
+            Some("uhp_handshake")
+        );
+        assert_eq!(
+            classify_stage("Failed to resolve address: x (stage=resolve)"),
+            Some("resolve")
+        );
+        assert_eq!(
+            classify_stage("Failed to read length prefix byte 0: connection lost"),
+            Some("uhp_handshake")
+        );
+    }
+
+    /// Live session open against a running node (optional).
+    ///
+    /// ```text
+    /// ZHTP_SESSION_TEST_HOST=77.42.37.161 ZHTP_SESSION_TEST_SNI=zhtp-node \
+    ///   cargo test -p lib-client live_session_open -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "requires reachable ZHTP node (set ZHTP_SESSION_TEST_HOST)"]
+    fn live_session_open_and_health_rpc() {
+        let host = std::env::var("ZHTP_SESSION_TEST_HOST").expect("ZHTP_SESSION_TEST_HOST");
+        let port: u16 = std::env::var("ZHTP_SESSION_TEST_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(9334);
+        let sni = std::env::var("ZHTP_SESSION_TEST_SNI").unwrap_or_else(|_| "zhtp-node".into());
+        let id = generate_identity("msg-node-001-live".into()).expect("identity");
+
+        let ptr = open_session(&host, port, Some(&sni), 1, &id).unwrap_or_else(|e| {
+            panic!(
+                "session open failed: {:#} last={}",
+                e,
+                LAST_ERROR.with(|x| x.borrow().clone().unwrap_or_default())
+            );
+        });
+        assert!(!ptr.is_null());
+
+        let session = unsafe { &*ptr };
+        let (reply_tx, reply_rx) = oneshot::channel();
+        session
+            .tx
+            .blocking_send(SessionCmd::Rpc {
+                method: ZhtpMethod::Get,
+                path: "/api/v1/protocol/health".into(),
+                body: Vec::new(),
+                reply: reply_tx,
+            })
+            .expect("send rpc");
+        let resp = reply_rx
+            .blocking_recv()
+            .expect("reply")
+            .expect("health rpc");
+        assert!(
+            (200..300).contains(&resp.status),
+            "health status {}",
+            resp.status
+        );
+
+        zhtp_quic_session_close(ptr);
+    }
 }

--- a/lib-client/src/quic_session.rs
+++ b/lib-client/src/quic_session.rs
@@ -15,17 +15,25 @@
 //! (`quic_handshake::handshake_as_initiator` / `quic_uhp_capabilities`).
 //! On failure it returns null and stores a structured last-error string
 //! (`stage=…: message`) retrievable via `zhtp_quic_session_last_error`.
+//!
+//! Last-error storage is **process-global** (mutex, last-writer-wins) so
+//! mobile can read it from a different OS thread than the one that called
+//! `open` (Dart isolates / JNI pools). Concurrent opens can overwrite each
+//! other's error — that is intentional and safer than a silent empty read.
+//!
+//! `zhtp_quic_session_open` **blocks** the caller until connect + UHP finish;
+//! mobile must not call it on the UI thread.
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::cell::RefCell;
 use std::ffi::{c_char, CStr, CString};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use tokio::sync::oneshot;
+use tracing::debug;
 
 use lib_identity::types::IdentityType;
 use lib_identity::ZhtpIdentity;
@@ -37,26 +45,61 @@ use lib_protocols::wire::read_response;
 use crate::identity::Identity;
 
 // =============================================================================
-// LAST ERROR (thread-local for FFI)
+// LAST ERROR (process-global for FFI — any thread may read)
 // =============================================================================
 
-thread_local! {
-    static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
-    static LAST_STAGE: RefCell<&'static str> = const { RefCell::new("none") };
+/// Canonical stage tokens + NUL-terminated C strings (single source of truth).
+/// Order is stable for `classify_stage` scans; keep longest names first only
+/// if a shorter name were a prefix of a longer one (none are today).
+const STAGES: &[(&str, &[u8])] = &[
+    ("resolve", b"resolve\0"),
+    ("quic", b"quic\0"),
+    ("tls", b"tls\0"),
+    ("uhp_handshake", b"uhp_handshake\0"),
+    ("trust", b"trust\0"),
+    ("session_keys", b"session_keys\0"),
+    ("config", b"config\0"),
+    ("identity", b"identity\0"),
+    ("alpn", b"alpn\0"),
+    ("runtime", b"runtime\0"),
+    ("client_init", b"client_init\0"),
+    ("inbound", b"inbound\0"),
+    ("rpc", b"rpc\0"),
+    ("args", b"args\0"),
+];
+
+const STAGE_NONE: &[u8] = b"none\0";
+
+struct LastErrorState {
+    stage: &'static str,
+    message: Option<String>,
+}
+
+fn last_error_slot() -> &'static Mutex<LastErrorState> {
+    static SLOT: OnceLock<Mutex<LastErrorState>> = OnceLock::new();
+    SLOT.get_or_init(|| {
+        Mutex::new(LastErrorState {
+            stage: "none",
+            message: None,
+        })
+    })
 }
 
 fn clear_last_error() {
-    LAST_ERROR.with(|e| *e.borrow_mut() = None);
-    LAST_STAGE.with(|s| *s.borrow_mut() = "none");
+    if let Ok(mut g) = last_error_slot().lock() {
+        g.stage = "none";
+        g.message = None;
+    }
 }
 
 fn set_last_error(stage: &'static str, message: impl AsRef<str>) {
     let msg = message.as_ref().to_string();
-    eprintln!("[zhtp_quic_session] stage={} error={}", stage, msg);
-    LAST_STAGE.with(|s| *s.borrow_mut() = stage);
-    LAST_ERROR.with(|e| {
-        *e.borrow_mut() = Some(format!("stage={}: {}", stage, msg));
-    });
+    // Debug only — avoid noisy stderr / leaking dial details on mobile release.
+    debug!(stage, error = %msg, "zhtp_quic_session last_error");
+    if let Ok(mut g) = last_error_slot().lock() {
+        g.stage = stage;
+        g.message = Some(format!("stage={}: {}", stage, msg));
+    }
 }
 
 fn set_last_error_from_anyhow(fallback_stage: &'static str, err: &anyhow::Error) {
@@ -65,27 +108,24 @@ fn set_last_error_from_anyhow(fallback_stage: &'static str, err: &anyhow::Error)
     set_last_error(stage, full);
 }
 
+fn current_stage() -> &'static str {
+    last_error_slot()
+        .lock()
+        .map(|g| g.stage)
+        .unwrap_or("none")
+}
+
+fn current_error_message() -> Option<String> {
+    last_error_slot()
+        .lock()
+        .ok()
+        .and_then(|g| g.message.clone())
+}
+
 /// Parse `stage=foo` markers embedded in error chains (from ZhtpClient).
 fn classify_stage(msg: &str) -> Option<&'static str> {
-    const STAGES: &[&str] = &[
-        "resolve",
-        "quic",
-        "tls",
-        "uhp_handshake",
-        "trust",
-        "session_keys",
-        "config",
-        "identity",
-        "alpn",
-        "runtime",
-        "client_init",
-        "inbound",
-        "rpc",
-        "args",
-    ];
-    for stage in STAGES {
+    for (stage, _) in STAGES {
         if msg.contains(&format!("stage={}", stage)) {
-            // SAFETY: stage is a static str from STAGES.
             return Some(*stage);
         }
     }
@@ -107,6 +147,15 @@ fn classify_stage(msg: &str) -> Option<&'static str> {
         return Some("identity");
     }
     None
+}
+
+fn stage_as_c_str(stage: &str) -> *const c_char {
+    for (name, cstr) in STAGES {
+        if *name == stage {
+            return cstr.as_ptr() as *const c_char;
+        }
+    }
+    STAGE_NONE.as_ptr() as *const c_char
 }
 
 // =============================================================================
@@ -417,14 +466,18 @@ fn to_zhtp_identity(id: &Identity) -> Result<ZhtpIdentity> {
 }
 
 // =============================================================================
-// Pure Rust open (shared by FFI + tests)
+// Pure Rust open (shared by FFI + tests — not a public crate API)
 // =============================================================================
 
 /// Open a persistent authenticated QUIC session (canonical UHP initiator).
 ///
+/// **Blocking:** waits for QUIC connect + full UHP handshake on the caller
+/// thread (via oneshot from the shared endpoint runtime). Callers must not
+/// invoke this from a UI/main thread.
+///
 /// `alpn` must be `1` (`zhtp-uhp/2`). `sni` is the TLS server name (hostname);
 /// dial host may be an IP after ZDNS bootstrap.
-pub fn open_session(
+fn open_session(
     host: &str,
     port: u16,
     sni: Option<&str>,
@@ -497,9 +550,14 @@ pub fn open_session(
 // =============================================================================
 
 /// Open a persistent QUIC session.
+///
 /// `alpn`: must be `1` (`zhtp-uhp/2`, authenticated UHP). Public ALPN (`0`)
 /// is not supported here — gateways treat `zhtp-public/1` as no-UHP read-only.
-/// Returns null on failure — call `zhtp_quic_session_last_error` for details.
+///
+/// **Blocking** until connect + UHP complete — call off the UI thread.
+///
+/// Returns null on failure — call `zhtp_quic_session_last_error` (any thread;
+/// process-global last-writer-wins) for details.
 #[no_mangle]
 pub extern "C" fn zhtp_quic_session_open(
     host: *const c_char,
@@ -549,48 +607,32 @@ pub extern "C" fn zhtp_quic_session_open(
     }
 }
 
-/// Last structured error from session open / inbound / rpc on this thread.
+/// Last structured error from session open / inbound / rpc.
+///
+/// Process-global (not thread-local): readable from any OS thread after a
+/// failed call on another thread (Dart isolate / JNI pool safe). Concurrent
+/// failures last-writer-wins.
 ///
 /// Format: `stage=<name>: <message chain>`.
-/// Returns a newly allocated C string; free with `zhtp_client_string_free`
-/// (or `zhtp_quic_session_last_error_free`). Null if no error stored.
+/// Returns a newly allocated C string; free with
+/// `zhtp_quic_session_last_error_free`. Null if no error stored.
 #[no_mangle]
 pub extern "C" fn zhtp_quic_session_last_error() -> *mut c_char {
-    LAST_ERROR.with(|e| match e.borrow().as_ref() {
-        Some(msg) => match CString::new(msg.as_str()) {
+    match current_error_message() {
+        Some(msg) => match CString::new(msg) {
             Ok(c) => c.into_raw(),
             Err(_) => std::ptr::null_mut(),
         },
         None => std::ptr::null_mut(),
-    })
+    }
 }
 
 /// Stage token only (`uhp_handshake`, `quic`, `resolve`, …). Static C string
-/// — do not free. Returns `"none"` when no error is stored.
+/// — do not free. Returns `"none"` when no error is stored. Same process-global
+/// contract as `zhtp_quic_session_last_error`.
 #[no_mangle]
 pub extern "C" fn zhtp_quic_session_last_error_stage() -> *const c_char {
-    LAST_STAGE.with(|s| stage_as_c_str(*s.borrow()))
-}
-
-fn stage_as_c_str(stage: &str) -> *const c_char {
-    // Explicit NUL-terminated statics — do not free.
-    match stage {
-        "resolve" => b"resolve\0".as_ptr() as *const c_char,
-        "quic" => b"quic\0".as_ptr() as *const c_char,
-        "tls" => b"tls\0".as_ptr() as *const c_char,
-        "uhp_handshake" => b"uhp_handshake\0".as_ptr() as *const c_char,
-        "trust" => b"trust\0".as_ptr() as *const c_char,
-        "session_keys" => b"session_keys\0".as_ptr() as *const c_char,
-        "config" => b"config\0".as_ptr() as *const c_char,
-        "identity" => b"identity\0".as_ptr() as *const c_char,
-        "alpn" => b"alpn\0".as_ptr() as *const c_char,
-        "runtime" => b"runtime\0".as_ptr() as *const c_char,
-        "client_init" => b"client_init\0".as_ptr() as *const c_char,
-        "inbound" => b"inbound\0".as_ptr() as *const c_char,
-        "rpc" => b"rpc\0".as_ptr() as *const c_char,
-        "args" => b"args\0".as_ptr() as *const c_char,
-        _ => b"none\0".as_ptr() as *const c_char,
-    }
+    stage_as_c_str(current_stage())
 }
 
 /// Free a string returned by `zhtp_quic_session_last_error`.
@@ -759,6 +801,7 @@ pub extern "C" fn zhtp_quic_session_inbound_read(
     out_ptr: *mut *const u8,
     out_len: *mut usize,
 ) -> i32 {
+    clear_last_error();
     if stream.is_null() || out_ptr.is_null() || out_len.is_null() {
         set_last_error("args", "inbound_read null pointer");
         return -2;
@@ -806,7 +849,7 @@ pub extern "C" fn zhtp_quic_session_inbound_read(
             set_last_error("inbound", e);
             -2
         }
-        None => 1,
+        None => 1, // timeout / empty — last_error already cleared
     }
 }
 
@@ -860,9 +903,8 @@ mod tests {
         let err = open_session("127.0.0.1", 9334, Some("g1.example"), 0, &id)
             .expect_err("public alpn must fail");
         assert!(err.to_string().contains("alpn"), "{err}");
-        let stage = LAST_STAGE.with(|s| *s.borrow());
-        assert_eq!(stage, "alpn");
-        let msg = LAST_ERROR.with(|e| e.borrow().clone()).expect("last error");
+        assert_eq!(current_stage(), "alpn");
+        let msg = current_error_message().expect("last error");
         assert!(msg.starts_with("stage=alpn:"), "{msg}");
     }
 
@@ -872,9 +914,50 @@ mod tests {
         id.public_key.truncate(10);
         let err = open_session("127.0.0.1", 9334, Some("g1.example"), 1, &id)
             .expect_err("bad key must fail");
-        assert!(err.to_string().contains("2592") || err.to_string().contains("identity"), "{err}");
-        let stage = LAST_STAGE.with(|s| *s.borrow());
-        assert_eq!(stage, "identity");
+        assert!(
+            err.to_string().contains("2592") || err.to_string().contains("identity"),
+            "{err}"
+        );
+        assert_eq!(current_stage(), "identity");
+    }
+
+    #[test]
+    fn last_error_is_readable_across_threads() {
+        // Contract: open on T1, last_error on T2 (Dart isolate / JNI pool).
+        let id = generate_identity("cross-thread".into()).expect("identity");
+        open_session("127.0.0.1", 9334, Some("g1.example"), 0, &id).expect_err("alpn");
+        let reader = std::thread::spawn(|| {
+            (
+                current_stage().to_string(),
+                current_error_message().expect("cross-thread last error"),
+            )
+        });
+        let (stage, msg) = reader.join().expect("join");
+        assert_eq!(stage, "alpn");
+        assert!(msg.starts_with("stage=alpn:"), "{msg}");
+    }
+
+    #[test]
+    fn stage_table_c_str_covers_every_token() {
+        for (name, cstr) in STAGES {
+            assert!(
+                cstr.ends_with(&[0]),
+                "stage {name} C string must be NUL-terminated"
+            );
+            let body = &cstr[..cstr.len() - 1];
+            assert_eq!(
+                std::str::from_utf8(body).expect("utf8"),
+                *name,
+                "C string body must match stage name"
+            );
+            let ptr = stage_as_c_str(name);
+            let got = unsafe { CStr::from_ptr(ptr) }.to_str().expect("c str");
+            assert_eq!(got, *name);
+        }
+        assert_eq!(
+            unsafe { CStr::from_ptr(stage_as_c_str("not-a-stage")).to_str().unwrap() },
+            "none"
+        );
     }
 
     #[test]
@@ -914,7 +997,7 @@ mod tests {
             panic!(
                 "session open failed: {:#} last={}",
                 e,
-                LAST_ERROR.with(|x| x.borrow().clone().unwrap_or_default())
+                current_error_message().unwrap_or_default()
             );
         });
         assert!(!ptr.is_null());

--- a/lib-network/src/client/zhtp_client.rs
+++ b/lib-network/src/client/zhtp_client.rs
@@ -417,18 +417,25 @@ impl ZhtpClient {
         // is returned.
         let candidates: Vec<SocketAddr> = tokio::net::lookup_host(addr)
             .await
-            .with_context(|| format!("Failed to resolve address: {}", addr))?
+            .with_context(|| {
+                format!("Failed to resolve address: {} (stage=resolve)", addr)
+            })?
             .collect();
         let socket_addr: SocketAddr = candidates
             .iter()
             .find(|s| s.is_ipv4())
             .or_else(|| candidates.first())
             .copied()
-            .ok_or_else(|| anyhow!("Address '{}' resolved to no socket addresses", addr))?;
+            .ok_or_else(|| {
+                anyhow!(
+                    "Address '{}' resolved to no socket addresses (stage=resolve)",
+                    addr
+                )
+            })?;
 
         if self.trust_config.bootstrap_mode && !self.config.allow_bootstrap {
             return Err(anyhow!(
-                "Bootstrap mode requires ZhtpClientConfig::allow_bootstrap to be true"
+                "Bootstrap mode requires ZhtpClientConfig::allow_bootstrap to be true (stage=config)"
             ));
         }
 
@@ -436,10 +443,10 @@ impl ZhtpClient {
         let verifier = match self.trust_verifier {
             Some(ref v) => Arc::clone(v),
             None => {
-                let v = Arc::new(ZhtpTrustVerifier::new(
-                    addr.to_string(),
-                    self.trust_config.clone(),
-                )?);
+                let v = Arc::new(
+                    ZhtpTrustVerifier::new(addr.to_string(), self.trust_config.clone())
+                        .context("trust verifier init (stage=tls)")?,
+                );
                 self.trust_verifier = Some(Arc::clone(&v));
                 v
             }
@@ -449,28 +456,50 @@ impl ZhtpClient {
         // ZhtpClients, so we mustn't mutate its default config (that would
         // race against concurrent connects from other ZhtpClient instances).
         // `connect_with` applies the config to just this connection.
-        let client_config = Self::configure_client(verifier, self.config.session_alpn)?;
+        let client_config = Self::configure_client(verifier, self.config.session_alpn)
+            .context("client TLS/ALPN config (stage=tls)")?;
         let connection = self
             .endpoint
-            .connect_with(client_config, socket_addr, server_name)?
+            .connect_with(client_config, socket_addr, server_name)
+            .with_context(|| {
+                format!(
+                    "QUIC connect setup failed addr={} sni={} (stage=quic)",
+                    socket_addr, server_name
+                )
+            })?
             .await
-            .context("QUIC connection failed")?;
+            .with_context(|| {
+                format!(
+                    "QUIC connection failed addr={} sni={} (stage=quic)",
+                    socket_addr, server_name
+                )
+            })?;
 
-        // Perform UHP v2 handshake
+        // Perform UHP v2 handshake (canonical initiator — same as production
+        // gateways expect; capabilities from quic_uhp_capabilities()).
         let handshake_result = quic_handshake::handshake_as_initiator(
             &connection,
             &self.identity,
             &self.handshake_ctx,
         )
         .await
-        .context("UHP v2 handshake failed")?;
+        .with_context(|| {
+            format!(
+                "UHP v2 handshake failed addr={} sni={} (stage=uhp_handshake)",
+                socket_addr, server_name
+            )
+        })?;
 
         let peer_did = handshake_result.verified_peer.identity.did.clone();
 
         // Verify node DID matches trust configuration and bind for TOFU anchor updates
         if let Some(ref verifier) = self.trust_verifier {
-            verifier.verify_node_did(&peer_did)?;
-            verifier.bind_node_did(&peer_did)?;
+            verifier
+                .verify_node_did(&peer_did)
+                .context("node DID trust check (stage=trust)")?;
+            verifier
+                .bind_node_did(&peer_did)
+                .context("node DID bind (stage=trust)")?;
         }
 
         // Derive V2 session keys
@@ -478,7 +507,7 @@ impl ZhtpClient {
             &handshake_result.session_key,
             &handshake_result.handshake_hash,
         )
-        .context("Failed to derive V2 session keys")?;
+        .context("Failed to derive V2 session keys (stage=session_keys)")?;
 
         Ok(AuthenticatedConnection {
             quic_conn: connection,

--- a/lib-network/src/protocols/quic_handshake.rs
+++ b/lib-network/src/protocols/quic_handshake.rs
@@ -206,7 +206,7 @@ pub async fn handshake_as_initiator(
             "QUIC: starting UHP v2 handshake as initiator"
         );
 
-        let capabilities = create_quic_capabilities();
+        let capabilities = quic_uhp_capabilities();
         let result = crate::handshake::core::handshake_as_initiator(
             &mut stream,
             &ctx,
@@ -214,7 +214,7 @@ pub async fn handshake_as_initiator(
             capabilities,
         )
         .await
-        .context("UHP v2 handshake failed")?;
+        .context("UHP v2 handshake failed (stage=uhp_handshake)")?;
 
         stream.finish().await?;
 
@@ -346,13 +346,15 @@ pub async fn handshake_as_responder(
         );
 
         trace!(peer_addr = %conn.remote_address(), "QUIC responder: calling core::handshake_as_responder...");
-        let capabilities = create_quic_capabilities();
+        let capabilities = quic_uhp_capabilities();
         let result = crate::handshake::core::handshake_as_responder(
             &mut stream,
             &ctx,
             identity,
             capabilities,
-        ).await.context("UHP v2 handshake failed")?;
+        )
+        .await
+        .context("UHP v2 handshake failed (stage=uhp_handshake)")?;
         trace!(peer_addr = %conn.remote_address(), "QUIC responder: core handshake completed successfully");
 
         stream.finish().await?;
@@ -395,9 +397,14 @@ pub async fn handshake_as_responder(
 /// `lib-network/tests/handshake_wire_bytes_test.rs::capture_client_hello_bytes_for_diff`.
 /// Run that test with `--nocapture` to get the canonical hex dump and
 /// compare against an equivalent capture from any reimplementation.
+///
 /// Minimal QUIC capabilities — matches the mobile `quinn-ffi`
 /// `build_capabilities()` envelope that production gateways accept.
-fn create_quic_capabilities() -> HandshakeCapabilities {
+///
+/// Shared by initiator, responder, and external golden tests so there is
+/// exactly one constructor for the capabilities that enter the signed
+/// transcript (MSG-NODE-001).
+pub fn quic_uhp_capabilities() -> HandshakeCapabilities {
     let mut caps = HandshakeCapabilities::default();
     caps.protocols = vec!["quic".to_string()];
     caps.pqc_capability = PqcCapability::Kyber1024Dilithium5;

--- a/lib-network/tests/handshake_wire_bytes_test.rs
+++ b/lib-network/tests/handshake_wire_bytes_test.rs
@@ -27,23 +27,17 @@
 //! `diff` against it.
 
 use lib_network::handshake::core::{handshake_as_initiator, handshake_as_responder};
-use lib_network::handshake::{HandshakeCapabilities, HandshakeContext, NonceCache, PqcCapability};
+use lib_network::handshake::{HandshakeCapabilities, HandshakeContext, NonceCache};
+use lib_network::protocols::quic_handshake::quic_uhp_capabilities;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use tempfile::tempdir;
 use tokio::io::{duplex, AsyncRead, AsyncWrite, DuplexStream, ReadBuf};
 
-/// Build the same `HandshakeCapabilities` shape the QUIC adapter uses
-/// in production (see `lib-network/src/protocols/quic_handshake.rs`,
-/// `create_quic_capabilities`). Keep this in sync with the production
-/// constructor — that is the entire point of the test. If you change
-/// one, change the other and re-bless the hex.
+/// Production QUIC capabilities — single constructor (MSG-NODE-001).
 fn quic_capabilities_shape() -> HandshakeCapabilities {
-    let mut caps = HandshakeCapabilities::default();
-    caps.protocols = vec!["quic".to_string()];
-    caps.pqc_capability = PqcCapability::Kyber1024Dilithium5;
-    caps
+    quic_uhp_capabilities()
 }
 
 fn make_identity(device: &str) -> lib_identity::ZhtpIdentity {

--- a/lib-network/tests/quic_handshake_roundtrip_test.rs
+++ b/lib-network/tests/quic_handshake_roundtrip_test.rs
@@ -217,7 +217,5 @@ async fn quic_handshake_roundtrip_succeeds() {
     );
 }
 
-// (Earlier draft had a second test asserting `HandshakeCapabilities::default()`
-// shape — removed per review: the QUIC adapters use `create_quic_capabilities()`
-// internally, not the bare `Default` impl, so the assertion didn't actually
-// guard against capability drift on the QUIC path.)
+// Capability shape is pinned by `quic_uhp_capabilities()` +
+// `handshake_wire_bytes_test` (MSG-NODE-001).


### PR DESCRIPTION
## Summary
Implements **MSG-NODE-001** for mobile persistent QUIC session reliability.

- **Structured FFI errors**: `zhtp_quic_session_last_error`, `zhtp_quic_session_last_error_stage`, `zhtp_quic_session_last_error_free` — format `stage=<name>: <chain>` so mobile never only sees `openFailed`
- **Handshake parity**: public `quic_uhp_capabilities()` is the single capabilities constructor for initiator/responder/wire golden test (canonical path already used by `zhtp_quic_session_open` → `ZhtpClient`)
- **Connect stages**: resolve / quic / uhp_handshake / trust / identity / alpn tagged in error chains
- **Tests**: unit (alpn, identity, stage parse) + ignored live open; **live open + health RPC passed against g1**

Closes #2911

## Mobile integration

```text
handle = zhtp_quic_session_open(...)
if handle == null {
  err = zhtp_quic_session_last_error()   // free with zhtp_quic_session_last_error_free
  stage = zhtp_quic_session_last_error_stage()  // static C string, do not free
}
```

## Test plan
- [x] `cargo test -p lib-client --lib quic_session`
- [x] `cargo test -p lib-network --test handshake_wire_bytes_test`
- [x] Live: `ZHTP_SESSION_TEST_HOST=77.42.37.161 cargo test -p lib-client --lib live_session_open -- --ignored`
- [ ] Mobile rebuild natives + soak `/msg/inbound`

## Notes
Quinn-FFI one-shot is unchanged. If Quinn-FFI ClientHello diverges from `quic_uhp_capabilities`, mobile should align **to** the canonical initiator (or share this module), not the reverse.