### PR TITLE
feat(messaging): complete BUBL epic [MSG-R5–R15]

### DIFF
--- a/docs/arch/messaging-store-and-forward.md
+++ b/docs/arch/messaging-store-and-forward.md
@@ -1,0 +1,60 @@
+# Messaging store-and-forward delivery model (BUBL)
+
+**Epic:** #2896  
+**Status:** Production target for node relay (`/api/v1/msg/*`)
+
+## Model
+
+1. **Deposit first** — every send path writes the sealed envelope to a durable deposit store before live push or mesh relay.
+2. **Peek, never delete on poll** — `GET /api/v1/msg/receive` and `GET /api/v1/msg/inbound` return envelopes but leave them in the store.
+3. **Delete only on client ack or TTL** — `POST /api/v1/msg/ack` removes ids addressed to the authenticated caller. Undelivered mail expires after 48 hours.
+4. **Honest status** — `POST /api/v1/msg/send` returns `"queued"` (stored only) or `"pushed"` (stored + live inbound frame). Never `"delivered"`.
+5. **E2E unchanged** — node stores opaque ciphertext; optional node at-rest encryption is a second layer over the same blob.
+
+## Message id
+
+```
+message_id = hex(blake3(envelope_bytes))
+```
+
+Clients and nodes compute the same id. Duplicate deposits and mesh re-relays are idempotent. After ack, a short tombstone drops re-relays of the same bytes.
+
+## Durability
+
+Path: `{node_data_dir}/messaging_deposits.sled` (sled trees `deposits`, `tombstones`).
+
+Restart reloads undelivered mail into memory indexes.
+
+## Auth
+
+- `send` / `deposit`: `sender_did` (and envelope `sender_did`) must match the authenticated key session (MSG-R8).
+- Optional: `ZHTP_MSG_VERIFY_ENVELOPES=1` requires Dilithium envelope signature vs on-chain sender key (MSG-R9).
+- `ack` / `receive` / `inbound` / `cancel`: recipient or sender is session-bound via shared DID resolver.
+
+## Mesh
+
+- Always deposit locally first.
+- **Presence-directed relay (MSG-R14):** if the recipient is online on this node (inbound subscriber or presence), skip mesh flood.
+- Otherwise fan-out `MessageRelay` to connected peers; peers deposit + optional push; dedupe by `message_id` / tombstones.
+
+## Cancel
+
+`POST /api/v1/msg/cancel` with `{ "recipient_did": "..." }` cancels the caller's undelivered mail to that recipient on this node.
+
+## Operator knobs
+
+| Env | Effect |
+|-----|--------|
+| `ZHTP_MSG_AT_REST_KEY` | 64 hex chars (32-byte key): encrypt deposit blobs on disk |
+| `ZHTP_MSG_VERIFY_ENVELOPES` | `1` / `true`: require valid Dilithium envelope sig on send/deposit |
+
+## Metrics
+
+`GET /api/v1/msg/stats` — queue depth (`pending`) and counters (deposits, acks, mesh, verify rejects). Logs redact DIDs (MSG-R12).
+
+## Client integration notes (#2489)
+
+1. After receive/inbound, persist envelopes locally, then `POST /api/v1/msg/ack` with `message_ids`.
+2. Treat send `status` as transport hint only; reliability is deposit + ack.
+3. Use lib-client `message_id_for_envelope` / `ack_request_body` for id and ack JSON.
+4. Deduplicate multi-node copies by `message_id` before display.

--- a/docs/ops/messaging-bubl-operator.md
+++ b/docs/ops/messaging-bubl-operator.md
@@ -1,0 +1,43 @@
+# BUBL messaging — operator notes
+
+## Data path
+
+- Deposit DB: `$NODE_DATA_DIR/messaging_deposits.sled`
+- Backup/restore: include this directory with other node state if undelivered mail must survive host moves.
+- TTL: 48h undelivered; GC every 5 minutes in-process.
+
+## Health
+
+```
+GET /api/v1/msg/stats
+```
+
+Key fields:
+
+- `metrics.pending` — undelivered envelopes on this node
+- `metrics.deposits_accepted` / `acks_removed` / `gc_expired`
+- `metrics.mesh_relays_in` / `mesh_relays_out`
+- `metrics.verify_rejects` / `auth_rejects` — spikes indicate misconfigured clients or attack
+
+## Optional hardening
+
+```bash
+# 32-byte key as 64 hex chars (generate: openssl rand -hex 32)
+export ZHTP_MSG_AT_REST_KEY="$(openssl rand -hex 32)"
+
+# Require Dilithium envelope signatures on send/deposit
+export ZHTP_MSG_VERIFY_ENVELOPES=1
+```
+
+**Warning:** changing or losing `ZHTP_MSG_AT_REST_KEY` makes existing encrypted blobs unreadable; rotate only with empty queue or accept loss of pending mail.
+
+## Deploy notes
+
+- Messaging Phase 2+ (durable store) is a **node** change; redeploy validators/gateways that accept `/api/v1/msg/*`.
+- Mobile/lib-client must use peek + ack (not assume delete-on-poll) and treat send status as `queued`/`pushed`.
+- Rolling restart: undelivered mail survives if `messaging_deposits.sled` is on persistent disk.
+
+## Related
+
+- Design: `docs/arch/messaging-store-and-forward.md`
+- Epic: GitHub #2896

--- a/lib-client/src/messaging.rs
+++ b/lib-client/src/messaging.rs
@@ -504,6 +504,34 @@ pub fn decode_envelope(hex_str: &str) -> Result<MessageEnvelope> {
         .map_err(|e| ClientError::CryptoError(format!("Deserialize failed: {}", e)))
 }
 
+/// Stable node `message_id` for an envelope (hex blake3 of wire bytes).
+/// Matches server `message_id_for_envelope` — use for ack and client-side dedupe.
+pub fn message_id_for_envelope(envelope: &MessageEnvelope) -> Result<String> {
+    let bytes = bincode::serialize(envelope)
+        .map_err(|e| ClientError::CryptoError(format!("Serialize failed: {}", e)))?;
+    Ok(message_id_for_envelope_bytes(&bytes))
+}
+
+/// Stable node `message_id` from raw envelope bytes (hex blake3).
+pub fn message_id_for_envelope_bytes(envelope_bytes: &[u8]) -> String {
+    hex::encode(Blake3::hash(envelope_bytes))
+}
+
+/// JSON body for `POST /api/v1/msg/ack` after the client has persisted mail.
+///
+/// Delivery model (BUBL):
+/// - `POST /msg/send` returns `status`: `"queued"` | `"pushed"` (never `"delivered"`).
+/// - `GET /msg/receive` and inbound stream **peek** only; mail stays until ack.
+/// - Client must `POST /msg/ack` with these ids after durable local store.
+pub fn ack_request_body(message_ids: &[String]) -> Result<String> {
+    #[derive(Serialize)]
+    struct Body<'a> {
+        message_ids: &'a [String],
+    }
+    serde_json::to_string(&Body { message_ids })
+        .map_err(|e| ClientError::CryptoError(format!("ack body serialize: {e}")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/zhtp/src/messaging/deposit.rs
+++ b/zhtp/src/messaging/deposit.rs
@@ -33,11 +33,15 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use bincode::Options;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
 use super::metrics::{metrics, redact_did};
+
+/// Max bincode size when loading a single stored deposit (DoS guard).
+const MAX_STORED_DEPOSIT_BYTES: u64 = 512 * 1024;
 
 /// How long undelivered deposits are kept before GC purges them.
 const DEPOSIT_TTL: Duration = Duration::from_secs(48 * 3600); // 48 hours
@@ -97,7 +101,16 @@ fn load_at_rest_key() -> Option<[u8; 32]> {
     if raw.is_empty() {
         return None;
     }
-    let bytes = hex::decode(raw).ok()?;
+    let bytes = match hex::decode(raw) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(
+                error = %e,
+                "ZHTP_MSG_AT_REST_KEY is not valid hex — at-rest disabled"
+            );
+            return None;
+        }
+    };
     if bytes.len() != 32 {
         warn!(
             len = bytes.len(),
@@ -108,6 +121,25 @@ fn load_at_rest_key() -> Option<[u8; 32]> {
     let mut key = [0u8; 32];
     key.copy_from_slice(&bytes);
     Some(key)
+}
+
+/// Match `bincode::serialize` defaults (fixint) with a size limit for load-time DoS guard.
+fn deposit_bincode() -> impl Options {
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .with_limit(MAX_STORED_DEPOSIT_BYTES)
+}
+
+fn deserialize_stored(v: &[u8]) -> Result<StoredDeposit, String> {
+    deposit_bincode()
+        .deserialize(v)
+        .map_err(|e| format!("deserialize deposit: {e}"))
+}
+
+fn serialize_stored(stored: &StoredDeposit) -> Result<Vec<u8>, String> {
+    deposit_bincode()
+        .serialize(stored)
+        .map_err(|e| format!("serialize deposit: {e}"))
 }
 
 fn seal_blob(plain: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, String> {
@@ -185,6 +217,11 @@ impl DepositStore {
         Self::open(path)
     }
 
+    /// Whether envelope blobs are encrypted at rest with a loaded key.
+    pub fn at_rest_enabled(&self) -> bool {
+        self.at_rest_key.is_some()
+    }
+
     fn from_db(db: sled::Db, at_rest_key: Option<[u8; 32]>) -> Self {
         let deposits = db
             .open_tree(TREE_DEPOSITS)
@@ -215,7 +252,7 @@ impl DepositStore {
                 skipped += 1;
                 continue;
             };
-            let Ok(stored) = bincode::deserialize::<StoredDeposit>(&v) else {
+            let Ok(stored) = deserialize_stored(&v) else {
                 skipped += 1;
                 continue;
             };
@@ -274,7 +311,14 @@ impl DepositStore {
             return false;
         };
         if raw.len() != 8 {
-            return true;
+            // Corrupt entry — drop so delivery can recover.
+            let _ = self.tombstones.remove(message_id.as_bytes());
+            warn!(
+                message_id = %message_id,
+                len = raw.len(),
+                "corrupt tombstone removed"
+            );
+            return false;
         }
         let mut buf = [0u8; 8];
         buf.copy_from_slice(&raw);
@@ -303,7 +347,7 @@ impl DepositStore {
             recipient_did: delivery.recipient_did.clone(),
             at_rest,
         };
-        let bytes = bincode::serialize(&stored).map_err(|e| format!("serialize deposit: {e}"))?;
+        let bytes = serialize_stored(&stored)?;
         self.deposits
             .insert(delivery.message_id.as_bytes(), bytes)
             .map_err(|e| format!("sled insert: {e}"))?;

--- a/zhtp/src/messaging/deposit.rs
+++ b/zhtp/src/messaging/deposit.rs
@@ -1,45 +1,82 @@
-//! Deposit store — process-local (in-memory) store-and-forward for undelivered messages.
+//! Deposit store — durable store-and-forward for undelivered messages.
 //!
-//! ## Delivery model (MSG-R1 / MSG-R5)
+//! ## Delivery model (MSG-R1 / MSG-R5–R7)
 //!
-//! Envelopes stay in the store until the client **acks** them. Polling and inbound
-//! streaming **peek** only; they never delete. That way a disconnect mid-response
-//! cannot lose mail.
+//! Envelopes stay in the store until the client **acks** them (or TTL GC).
+//! Polling and inbound streaming **peek** only; they never delete.
 //!
-//! Storage is **not** durable across process restart (Phase 3 / sled persistence).
-//! Within a running process: stable `message_id` = hex(blake3(envelope_bytes));
-//! duplicate deposits of the same bytes are ignored (idempotent).
+//! ## Durability (MSG-R5)
+//!
+//! Primary storage is a `sled` tree under the node data directory
+//! (`messaging_deposits.sled`). On open, indexes are rebuilt from disk so
+//! undelivered mail survives process restart.
+//!
+//! ## Message id (MSG-R6)
+//!
+//! Stable `message_id` = hex(blake3(envelope_bytes)); duplicate deposits of
+//! the same bytes are ignored (idempotent). Mesh re-relays hit the same id.
+//!
+//! ## Tombstones (MSG-R10)
+//!
+//! After ack (or cancel of a specific id), a short-lived tombstone prevents
+//! mesh peers from re-depositing the same envelope.
+//!
+//! ## At-rest encryption (MSG-R13)
+//!
+//! Optional: set `ZHTP_MSG_AT_REST_KEY` to 64 hex chars (32-byte key). Envelope
+//! blobs are ChaCha20-Poly1305 encrypted on disk; metadata (DIDs, ids) remains
+//! plaintext for indexing.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
+use super::metrics::{metrics, redact_did};
+
 /// How long undelivered deposits are kept before GC purges them.
 const DEPOSIT_TTL: Duration = Duration::from_secs(48 * 3600); // 48 hours
+
+/// Tombstone retention after ack (mesh re-relay window).
+const TOMBSTONE_TTL: Duration = Duration::from_secs(24 * 3600);
 
 /// Maximum pending envelopes per (sender, recipient) pair.
 const MAX_PENDING_PER_PAIR: usize = 100;
 
-/// A single pending delivery (one envelope).
+const TREE_DEPOSITS: &str = "deposits";
+const TREE_TOMBSTONES: &str = "tombstones";
+
+/// A single pending delivery (one envelope) — API / peek surface.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PendingDelivery {
     /// Stable id: hex(blake3(envelope_bytes)).
     pub message_id: String,
     /// Opaque PQ-encrypted envelope (bincode of client SecureMessage / MessageEnvelope).
     pub envelope: Vec<u8>,
-    /// Unix seconds when deposited (API / clients).
+    /// Unix seconds when deposited (API / clients / TTL).
     pub deposited_at: u64,
-    /// Monotonic clock for TTL GC (not serialized).
-    #[serde(skip, default = "Instant::now")]
-    pub deposited_instant: Instant,
     /// Sender DID (for cancellation / auth).
     pub sender_did: String,
     /// Recipient DID.
     pub recipient_did: String,
+}
+
+/// On-disk record (envelope may be at-rest encrypted).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredDeposit {
+    message_id: String,
+    /// Plain or at-rest-encrypted envelope bytes.
+    envelope_blob: Vec<u8>,
+    deposited_at: u64,
+    sender_did: String,
+    recipient_did: String,
+    /// True when `envelope_blob` is ChaCha20-Poly1305 sealed.
+    at_rest: bool,
 }
 
 /// Compute stable message id from envelope bytes.
@@ -54,21 +91,227 @@ fn now_unix() -> u64 {
         .as_secs()
 }
 
-/// In-memory deposit store (process-local; Phase 3 will add sled).
-#[derive(Debug, Default)]
+fn load_at_rest_key() -> Option<[u8; 32]> {
+    let raw = std::env::var("ZHTP_MSG_AT_REST_KEY").ok()?;
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let bytes = hex::decode(raw).ok()?;
+    if bytes.len() != 32 {
+        warn!(
+            len = bytes.len(),
+            "ZHTP_MSG_AT_REST_KEY must be 32 bytes (64 hex chars) — at-rest disabled"
+        );
+        return None;
+    }
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&bytes);
+    Some(key)
+}
+
+fn seal_blob(plain: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, String> {
+    lib_crypto::symmetric::chacha20::encrypt_data(plain, key)
+        .map_err(|e| format!("at-rest encrypt failed: {e}"))
+}
+
+fn open_blob(blob: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, String> {
+    lib_crypto::symmetric::chacha20::decrypt_data(blob, key)
+        .map_err(|e| format!("at-rest decrypt failed: {e}"))
+}
+
+/// Durable deposit store (sled + in-memory indexes).
 pub struct DepositStore {
+    db: sled::Db,
+    deposits: sled::Tree,
+    tombstones: sled::Tree,
     /// Keyed by (sender_did, recipient_did).
     pending: RwLock<HashMap<(String, String), Vec<PendingDelivery>>>,
     /// Index message_id → (sender, recipient) for O(1) ack.
     by_id: RwLock<HashMap<String, (String, String)>>,
+    at_rest_key: Option<[u8; 32]>,
+}
+
+impl std::fmt::Debug for DepositStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DepositStore")
+            .field("pending", &self.total_pending())
+            .field("at_rest", &self.at_rest_key.is_some())
+            .finish()
+    }
 }
 
 impl DepositStore {
+    /// In-memory sled (tests / fallback when disk open fails).
     pub fn new() -> Self {
-        Self {
+        let db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .expect("temporary sled for deposit store");
+        Self::from_db(db, load_at_rest_key())
+    }
+
+    /// Open (or create) a persistent store at `path`.
+    ///
+    /// Uses `ZHTP_MSG_AT_REST_KEY` when set (see `open_with_at_rest_key` for tests).
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, String> {
+        Self::open_with_at_rest_key(path, load_at_rest_key())
+    }
+
+    /// Open persistent store with an explicit at-rest key (tests / controlled config).
+    pub fn open_with_at_rest_key(
+        path: impl AsRef<Path>,
+        at_rest_key: Option<[u8; 32]>,
+    ) -> Result<Self, String> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {parent:?}: {e}"))?;
+        }
+        let db = sled::open(path).map_err(|e| format!("open deposit sled {path:?}: {e}"))?;
+        if at_rest_key.is_some() {
+            info!(
+                path = %path.display(),
+                "messaging deposit store opened with at-rest encryption"
+            );
+        } else {
+            info!(path = %path.display(), "messaging deposit store opened");
+        }
+        Ok(Self::from_db(db, at_rest_key))
+    }
+
+    /// Default path under node data dir.
+    pub fn open_default() -> Result<Self, String> {
+        let path: PathBuf = crate::node_data_dir().join("messaging_deposits.sled");
+        Self::open(path)
+    }
+
+    fn from_db(db: sled::Db, at_rest_key: Option<[u8; 32]>) -> Self {
+        let deposits = db
+            .open_tree(TREE_DEPOSITS)
+            .expect("open deposits tree");
+        let tombstones = db
+            .open_tree(TREE_TOMBSTONES)
+            .expect("open tombstones tree");
+        let store = Self {
+            db,
+            deposits,
+            tombstones,
             pending: RwLock::new(HashMap::new()),
             by_id: RwLock::new(HashMap::new()),
+            at_rest_key,
+        };
+        store.rebuild_indexes();
+        store
+    }
+
+    fn rebuild_indexes(&self) {
+        let mut pending = HashMap::new();
+        let mut by_id = HashMap::new();
+        let mut loaded = 0usize;
+        let mut skipped = 0usize;
+
+        for item in self.deposits.iter() {
+            let Ok((_k, v)) = item else {
+                skipped += 1;
+                continue;
+            };
+            let Ok(stored) = bincode::deserialize::<StoredDeposit>(&v) else {
+                skipped += 1;
+                continue;
+            };
+            let envelope = match self.decode_envelope(&stored) {
+                Ok(e) => e,
+                Err(e) => {
+                    warn!(message_id = %stored.message_id, error = %e, "skip corrupt deposit on load");
+                    skipped += 1;
+                    continue;
+                }
+            };
+            let key = (stored.sender_did.clone(), stored.recipient_did.clone());
+            let delivery = PendingDelivery {
+                message_id: stored.message_id.clone(),
+                envelope,
+                deposited_at: stored.deposited_at,
+                sender_did: stored.sender_did,
+                recipient_did: stored.recipient_did,
+            };
+            by_id.insert(
+                stored.message_id,
+                (delivery.sender_did.clone(), delivery.recipient_did.clone()),
+            );
+            pending.entry(key).or_insert_with(Vec::new).push(delivery);
+            loaded += 1;
         }
+
+        *self.pending.write() = pending;
+        *self.by_id.write() = by_id;
+        if loaded > 0 || skipped > 0 {
+            info!(loaded, skipped, "messaging deposits reloaded from sled");
+        }
+    }
+
+    fn decode_envelope(&self, stored: &StoredDeposit) -> Result<Vec<u8>, String> {
+        if !stored.at_rest {
+            return Ok(stored.envelope_blob.clone());
+        }
+        let key = self
+            .at_rest_key
+            .as_ref()
+            .ok_or_else(|| "deposit is at-rest encrypted but ZHTP_MSG_AT_REST_KEY is unset".to_string())?;
+        open_blob(&stored.envelope_blob, key)
+    }
+
+    fn encode_envelope(&self, plain: &[u8]) -> Result<(Vec<u8>, bool), String> {
+        if let Some(key) = &self.at_rest_key {
+            Ok((seal_blob(plain, key)?, true))
+        } else {
+            Ok((plain.to_vec(), false))
+        }
+    }
+
+    fn is_tombstoned(&self, message_id: &str) -> bool {
+        let Ok(Some(raw)) = self.tombstones.get(message_id.as_bytes()) else {
+            return false;
+        };
+        if raw.len() != 8 {
+            return true;
+        }
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&raw);
+        let expires = u64::from_le_bytes(buf);
+        if now_unix() >= expires {
+            let _ = self.tombstones.remove(message_id.as_bytes());
+            return false;
+        }
+        true
+    }
+
+    fn write_tombstone(&self, message_id: &str) {
+        let expires = now_unix().saturating_add(TOMBSTONE_TTL.as_secs());
+        let _ = self
+            .tombstones
+            .insert(message_id.as_bytes(), &expires.to_le_bytes());
+    }
+
+    fn persist_deposit(&self, delivery: &PendingDelivery) -> Result<(), String> {
+        let (blob, at_rest) = self.encode_envelope(&delivery.envelope)?;
+        let stored = StoredDeposit {
+            message_id: delivery.message_id.clone(),
+            envelope_blob: blob,
+            deposited_at: delivery.deposited_at,
+            sender_did: delivery.sender_did.clone(),
+            recipient_did: delivery.recipient_did.clone(),
+            at_rest,
+        };
+        let bytes = bincode::serialize(&stored).map_err(|e| format!("serialize deposit: {e}"))?;
+        self.deposits
+            .insert(delivery.message_id.as_bytes(), bytes)
+            .map_err(|e| format!("sled insert: {e}"))?;
+        Ok(())
+    }
+
+    fn remove_persisted(&self, message_id: &str) {
+        let _ = self.deposits.remove(message_id.as_bytes());
     }
 
     /// Deposit a single envelope. Returns `(message_id, is_new)`.
@@ -80,11 +323,26 @@ impl DepositStore {
         envelope: Vec<u8>,
     ) -> Result<(String, bool), String> {
         let message_id = message_id_for_envelope(&envelope);
+
+        if self.is_tombstoned(&message_id) {
+            metrics()
+                .tombstone_hits
+                .fetch_add(1, Ordering::Relaxed);
+            debug!(
+                message_id = %message_id,
+                "deposit: tombstoned (already acked) — ignoring mesh re-relay"
+            );
+            return Ok((message_id, false));
+        }
+
         let key = (sender_did.to_string(), recipient_did.to_string());
 
         {
             let by_id = self.by_id.read();
             if by_id.contains_key(&message_id) {
+                metrics()
+                    .deposits_duplicate
+                    .fetch_add(1, Ordering::Relaxed);
                 debug!(
                     message_id = %message_id,
                     "deposit: duplicate envelope, already stored"
@@ -96,17 +354,22 @@ impl DepositStore {
         let mut store = self.pending.write();
         let mut by_id = self.by_id.write();
 
-        // Re-check under write lock
         if by_id.contains_key(&message_id) {
+            metrics()
+                .deposits_duplicate
+                .fetch_add(1, Ordering::Relaxed);
             return Ok((message_id, false));
         }
 
         let queue = store.entry(key.clone()).or_default();
 
         if queue.len() >= MAX_PENDING_PER_PAIR {
+            metrics()
+                .deposits_rejected
+                .fetch_add(1, Ordering::Relaxed);
             warn!(
-                sender = %sender_did,
-                recipient = %recipient_did,
+                sender = %redact_did(sender_did),
+                recipient = %redact_did(recipient_did),
                 max = MAX_PENDING_PER_PAIR,
                 "deposit store full for pair — rejecting"
             );
@@ -115,19 +378,30 @@ impl DepositStore {
             ));
         }
 
-        queue.push(PendingDelivery {
+        let delivery = PendingDelivery {
             message_id: message_id.clone(),
             envelope,
             deposited_at: now_unix(),
-            deposited_instant: Instant::now(),
             sender_did: sender_did.to_string(),
             recipient_did: recipient_did.to_string(),
-        });
+        };
+
+        if let Err(e) = self.persist_deposit(&delivery) {
+            metrics()
+                .deposits_rejected
+                .fetch_add(1, Ordering::Relaxed);
+            return Err(e);
+        }
+
+        queue.push(delivery);
         by_id.insert(message_id.clone(), key);
+        metrics()
+            .deposits_accepted
+            .fetch_add(1, Ordering::Relaxed);
 
         info!(
-            sender = %sender_did,
-            recipient = %recipient_did,
+            sender = %redact_did(sender_did),
+            recipient = %redact_did(recipient_did),
             message_id = %message_id,
             pending = queue.len(),
             "message deposited"
@@ -136,7 +410,6 @@ impl DepositStore {
     }
 
     /// Deposit many envelopes. Returns `(accepted_count, message_ids)`.
-    /// Stops on first capacity error after accepting earlier envelopes.
     pub fn deposit(
         &self,
         sender_did: &str,
@@ -160,7 +433,6 @@ impl DepositStore {
                     if accepted == 0 && ids.is_empty() {
                         return Err(e);
                     }
-                    // Partial success: return what we took
                     break;
                 }
             }
@@ -179,7 +451,7 @@ impl DepositStore {
         }
         if !out.is_empty() {
             debug!(
-                recipient = %recipient_did,
+                recipient = %redact_did(recipient_did),
                 count = out.len(),
                 "peeked pending deposits (retained until ack)"
             );
@@ -189,9 +461,6 @@ impl DepositStore {
 
     /// Remove specific messages by id **only if** they are addressed to
     /// `recipient_did` (client ACK). Returns count removed.
-    ///
-    /// Ids that are unknown or belong to another recipient are ignored (not
-    /// removed). Callers must pass the authenticated caller's canonical DID.
     pub fn ack(&self, recipient_did: &str, message_ids: &[String]) -> usize {
         if message_ids.is_empty() {
             return 0;
@@ -202,18 +471,22 @@ impl DepositStore {
 
         for mid in message_ids {
             let Some((sender, recipient)) = by_id.get(mid).cloned() else {
+                // Still tombstone so mesh re-relays are dropped after local miss.
+                self.write_tombstone(mid);
                 continue;
             };
             if recipient != recipient_did {
                 debug!(
                     message_id = %mid,
-                    caller = %recipient_did,
-                    owner = %recipient,
+                    caller = %redact_did(recipient_did),
+                    owner = %redact_did(&recipient),
                     "ack ignored: message not addressed to caller"
                 );
                 continue;
             }
             by_id.remove(mid);
+            self.remove_persisted(mid);
+            self.write_tombstone(mid);
             if let Some(queue) = store.get_mut(&(sender.clone(), recipient.clone())) {
                 let before = queue.len();
                 queue.retain(|d| d.message_id != *mid);
@@ -225,9 +498,12 @@ impl DepositStore {
         }
 
         if removed > 0 {
+            metrics()
+                .acks_removed
+                .fetch_add(removed as u64, Ordering::Relaxed);
             info!(
                 count = removed,
-                recipient = %recipient_did,
+                recipient = %redact_did(recipient_did),
                 "acked and removed deposits"
             );
         }
@@ -247,11 +523,16 @@ impl DepositStore {
         let count = queue.len();
         for d in &queue {
             by_id.remove(&d.message_id);
+            self.remove_persisted(&d.message_id);
+            self.write_tombstone(&d.message_id);
         }
         if count > 0 {
+            metrics()
+                .cancels
+                .fetch_add(count as u64, Ordering::Relaxed);
             info!(
-                sender = %sender_did,
-                recipient = %recipient_did,
+                sender = %redact_did(sender_did),
+                recipient = %redact_did(recipient_did),
                 count,
                 "cancelled undelivered deposits"
             );
@@ -264,21 +545,43 @@ impl DepositStore {
         let mut store = self.pending.write();
         let mut by_id = self.by_id.write();
         let mut purged = 0;
-        let now = Instant::now();
+        let now = now_unix();
+        let ttl = DEPOSIT_TTL.as_secs();
 
         store.retain(|_, queue| {
             let before = queue.len();
             for d in queue.iter() {
-                if now.duration_since(d.deposited_instant) >= DEPOSIT_TTL {
+                if now.saturating_sub(d.deposited_at) >= ttl {
                     by_id.remove(&d.message_id);
+                    self.remove_persisted(&d.message_id);
+                    // No tombstone on TTL — allow re-send of same content later.
                 }
             }
-            queue.retain(|d| now.duration_since(d.deposited_instant) < DEPOSIT_TTL);
+            queue.retain(|d| now.saturating_sub(d.deposited_at) < ttl);
             purged += before - queue.len();
             !queue.is_empty()
         });
 
+        // GC expired tombstones
+        let mut dead_tombs = Vec::new();
+        for item in self.tombstones.iter() {
+            let Ok((k, v)) = item else { continue };
+            if v.len() == 8 {
+                let mut buf = [0u8; 8];
+                buf.copy_from_slice(&v);
+                if now >= u64::from_le_bytes(buf) {
+                    dead_tombs.push(k);
+                }
+            }
+        }
+        for k in dead_tombs {
+            let _ = self.tombstones.remove(k);
+        }
+
         if purged > 0 {
+            metrics()
+                .gc_expired
+                .fetch_add(purged as u64, Ordering::Relaxed);
             info!(purged, "GC purged expired deposits");
         }
         purged
@@ -287,6 +590,14 @@ impl DepositStore {
     /// Alias used by cleanup task (historical name).
     pub fn cleanup_expired(&self) -> usize {
         self.gc_expired()
+    }
+
+    /// Flush sled to disk (tests / graceful shutdown).
+    pub fn flush(&self) -> Result<(), String> {
+        self.db
+            .flush()
+            .map_err(|e| format!("sled flush: {e}"))
+            .map(|_| ())
     }
 
     /// Total pending envelopes across all pairs.
@@ -302,10 +613,16 @@ impl DepositStore {
     }
 }
 
+impl Default for DepositStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Shared deposit store handle.
 pub type SharedDepositStore = Arc<DepositStore>;
 
-/// Create a new shared deposit store.
+/// Create a new shared in-memory deposit store.
 pub fn new_shared_deposit_store() -> SharedDepositStore {
     Arc::new(DepositStore::new())
 }
@@ -327,7 +644,6 @@ mod tests {
         assert_eq!(peeked.len(), 1);
         assert_eq!(peeked[0].message_id, id);
 
-        // Still there
         assert_eq!(store.peek_for_recipient("did:sov:bob").len(), 1);
         assert_eq!(store.total_pending(), 1);
     }
@@ -349,7 +665,6 @@ mod tests {
         let (id, _) = store
             .deposit_one("did:sov:alice", "did:sov:bob", vec![1, 2, 3])
             .unwrap();
-        // Eve must not be able to ack Bob's mail
         assert_eq!(store.ack("did:sov:eve", &[id.clone()]), 0);
         assert_eq!(store.total_pending(), 1);
         assert_eq!(store.ack("did:sov:bob", &[id]), 1);
@@ -404,11 +719,66 @@ mod tests {
             .deposit(
                 "did:sov:a",
                 "did:sov:b",
-                vec![vec![1], vec![2], vec![1]], // third is dup of first
+                vec![vec![1], vec![2], vec![1]],
             )
             .unwrap();
         assert_eq!(n, 2);
         assert_eq!(ids.len(), 3);
         assert_eq!(store.total_pending(), 2);
+    }
+
+    #[test]
+    fn survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("deposits.sled");
+        let id = {
+            let store = DepositStore::open_with_at_rest_key(&path, None).unwrap();
+            let (id, _) = store
+                .deposit_one("did:sov:alice", "did:sov:bob", vec![42, 43, 44])
+                .unwrap();
+            store.flush().unwrap();
+            drop(store);
+            id
+        };
+        let store2 = DepositStore::open_with_at_rest_key(&path, None).unwrap();
+        let peeked = store2.peek_for_recipient("did:sov:bob");
+        assert_eq!(peeked.len(), 1);
+        assert_eq!(peeked[0].message_id, id);
+        assert_eq!(peeked[0].envelope, vec![42, 43, 44]);
+    }
+
+    #[test]
+    fn tombstone_blocks_redeposit_after_ack() {
+        let store = DepositStore::new();
+        let env = vec![1, 2, 3, 4];
+        let (id, _) = store
+            .deposit_one("did:sov:a", "did:sov:b", env.clone())
+            .unwrap();
+        assert_eq!(store.ack("did:sov:b", &[id.clone()]), 1);
+        let (id2, is_new) = store.deposit_one("did:sov:a", "did:sov:b", env).unwrap();
+        assert_eq!(id, id2);
+        assert!(!is_new);
+        assert_eq!(store.total_pending(), 0);
+    }
+
+    #[test]
+    fn at_rest_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("enc.sled");
+        let key = [0xABu8; 32];
+        let id = {
+            let store = DepositStore::open_with_at_rest_key(&path, Some(key)).unwrap();
+            assert!(store.at_rest_key.is_some());
+            let (id, _) = store
+                .deposit_one("did:sov:a", "did:sov:b", b"secret-envelope".to_vec())
+                .unwrap();
+            store.flush().unwrap();
+            drop(store);
+            id
+        };
+        let store2 = DepositStore::open_with_at_rest_key(&path, Some(key)).unwrap();
+        let peeked = store2.peek_for_recipient("did:sov:b");
+        assert_eq!(peeked[0].message_id, id);
+        assert_eq!(peeked[0].envelope, b"secret-envelope");
     }
 }

--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -4,8 +4,9 @@
 //! All crypto happens client-side — the server relays opaque ciphertext.
 
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::json;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
@@ -15,6 +16,7 @@ use lib_protocols::types::{ZhtpMethod, ZhtpRequest, ZhtpResponse, ZhtpStatus};
 use lib_protocols::zhtp::{ZhtpRequestHandler, ZhtpResult};
 
 use super::deposit::DepositStore;
+use super::metrics::{metrics, redact_did};
 use super::presence::PresenceTracker;
 
 pub struct MessagingHandler {
@@ -57,6 +59,12 @@ struct AckRequest {
     message_ids: Vec<String>,
 }
 
+#[derive(Deserialize)]
+struct CancelRequest {
+    /// Recipient DID for undelivered mail to cancel (caller must be sender).
+    recipient_did: String,
+}
+
 // ── Handler ────────────────────────────────────────────────────────
 
 fn json_response(data: serde_json::Value) -> Result<ZhtpResponse> {
@@ -70,6 +78,17 @@ fn json_response(data: serde_json::Value) -> Result<ZhtpResponse> {
 
 fn error_resp(status: ZhtpStatus, msg: &str) -> ZhtpResponse {
     ZhtpResponse::error(status, msg.to_string())
+}
+
+/// MSG-R9: when `ZHTP_MSG_VERIFY_ENVELOPES=1`, require a valid Dilithium
+/// signature on the envelope against the sender's on-chain public key.
+fn verify_envelopes_enabled() -> bool {
+    matches!(
+        std::env::var("ZHTP_MSG_VERIFY_ENVELOPES")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false),
+        true
+    )
 }
 
 impl MessagingHandler {
@@ -107,12 +126,6 @@ impl MessagingHandler {
             format!("did:zhtp:{}", req.recipient)
         };
 
-        // Get recipient's keys, sled-first (#58). The Dilithium key is the
-        // existence signal — `identity_public_key` is consensus-pinned, so it
-        // serves the durable key and refuses a metadata↔consensus drift. The
-        // Kyber key drives the encrypted-session error path. Both read durable
-        // `identity_metadata`, so a store-backed node still resolves the
-        // recipient after a restart (the in-memory registry is empty then).
         let dilithium_public_key = match blockchain.identity_public_key(&recipient_did) {
             Some(pk) => pk,
             None => return Ok(error_resp(ZhtpStatus::NotFound, "Recipient DID not found")),
@@ -127,7 +140,6 @@ impl MessagingHandler {
             }
         };
 
-        // Get username if available
         let username = blockchain.did_to_username.get(&recipient_did).cloned();
 
         json_response(json!({
@@ -137,6 +149,59 @@ impl MessagingHandler {
             "kyber_public_key": hex::encode(&kyber_public_key),
             "dilithium_public_key": hex::encode(&dilithium_public_key),
         }))
+    }
+
+    /// MSG-R8: authenticated caller DID must match claimed sender.
+    async fn bind_sender(
+        &self,
+        request: &ZhtpRequest,
+        claimed_sender: &str,
+    ) -> Result<String, String> {
+        let caller = self.resolve_caller_did(request).await?;
+        if caller != claimed_sender {
+            metrics().auth_rejects.fetch_add(1, Ordering::Relaxed);
+            return Err(format!(
+                "sender_did does not match authenticated session (claimed {}, session {})",
+                redact_did(claimed_sender),
+                redact_did(&caller)
+            ));
+        }
+        Ok(caller)
+    }
+
+    /// MSG-R9: optional Dilithium envelope verify against on-chain sender key.
+    async fn maybe_verify_envelope(
+        &self,
+        envelope: &super::envelope::MessageEnvelope,
+    ) -> Result<(), String> {
+        if !verify_envelopes_enabled() {
+            return Ok(());
+        }
+        if envelope.signature.is_empty() {
+            metrics().verify_rejects.fetch_add(1, Ordering::Relaxed);
+            return Err("envelope signature required (ZHTP_MSG_VERIFY_ENVELOPES)".to_string());
+        }
+        let blockchain = self.blockchain.read().await;
+        let pk = blockchain
+            .identity_public_key(&envelope.sender_did)
+            .ok_or_else(|| {
+                metrics().verify_rejects.fetch_add(1, Ordering::Relaxed);
+                format!(
+                    "sender DID not registered: {}",
+                    redact_did(&envelope.sender_did)
+                )
+            })?;
+        match envelope.verify_signature(&pk) {
+            Ok(true) => Ok(()),
+            Ok(false) => {
+                metrics().verify_rejects.fetch_add(1, Ordering::Relaxed);
+                Err("envelope signature invalid".to_string())
+            }
+            Err(e) => {
+                metrics().verify_rejects.fetch_add(1, Ordering::Relaxed);
+                Err(format!("envelope signature verify error: {e}"))
+            }
+        }
     }
 
     /// POST /api/v1/msg/send
@@ -149,16 +214,22 @@ impl MessagingHandler {
         let envelope_bytes = hex::decode(&req.envelope_hex)
             .map_err(|_| anyhow::anyhow!("Invalid hex in envelope"))?;
 
-        // Deserialize just enough to get the recipient DID
         let envelope: super::envelope::MessageEnvelope =
             bincode::deserialize(&envelope_bytes)
                 .map_err(|e| anyhow::anyhow!("Invalid envelope: {}", e))?;
 
+        // MSG-R8: bind sender to session
+        if let Err(e) = self.bind_sender(request, &envelope.sender_did).await {
+            return Ok(error_resp(ZhtpStatus::Forbidden, &e));
+        }
+
+        if let Err(e) = self.maybe_verify_envelope(&envelope).await {
+            return Ok(error_resp(ZhtpStatus::BadRequest, &e));
+        }
+
         let recipient_did = envelope.recipient_did.clone();
         let message_id = super::deposit::message_id_for_envelope(&envelope_bytes);
 
-        // MSG-R2 / R4: deposit first (durable on this node), then best-effort push.
-        // Local store-full is not fatal — still mesh-relay so peers can deposit.
         if let Err(e) = self.deposits.deposit_one(
             &envelope.sender_did,
             &recipient_did,
@@ -174,35 +245,68 @@ impl MessagingHandler {
         let messaging_provider =
             crate::runtime::messaging_provider::get_global_messaging_provider();
 
-        // Best-effort live push; deposit remains until client acks.
         let pushed = messaging_provider
             .try_push(&recipient_did, envelope_bytes.clone())
             .await;
+        if pushed {
+            metrics().live_pushes.fetch_add(1, Ordering::Relaxed);
+        }
 
-        // Also relay via mesh so peer nodes can deposit / push
-        if let Ok(mesh_router) = crate::runtime::mesh_router_provider::get_global_mesh_router().await {
+        // MSG-R14: presence-directed mesh — skip flood when recipient is
+        // online on this node (live subscriber or presence tracker).
+        let local_online = pushed
+            || self.presence.is_online(&recipient_did).await
+            || messaging_provider.has_subscriber(&recipient_did).await;
+
+        if !local_online {
+            self.mesh_relay(&recipient_did, envelope_bytes).await;
+        } else {
+            info!(
+                message_id = %message_id,
+                recipient = %redact_did(&recipient_did),
+                "msg/send: recipient local — skipping mesh flood"
+            );
+        }
+
+        let status = if pushed { "pushed" } else { "queued" };
+        info!(
+            message_id = %message_id,
+            status,
+            recipient = %redact_did(&recipient_did),
+            "msg/send"
+        );
+        json_response(json!({
+            "status": status,
+            "message_id": message_id,
+            "recipient_did": recipient_did,
+        }))
+    }
+
+    async fn mesh_relay(&self, recipient_did: &str, envelope_bytes: Vec<u8>) {
+        if let Ok(mesh_router) =
+            crate::runtime::mesh_router_provider::get_global_mesh_router().await
+        {
             let quic_guard = mesh_router.quic_protocol.read().await;
             if let Some(ref qp) = *quic_guard {
                 let mesh_msg = lib_network::types::mesh_message::ZhtpMeshMessage::MessageRelay {
-                    recipient_did: recipient_did.clone(),
+                    recipient_did: recipient_did.to_string(),
                     envelope: envelope_bytes,
                 };
                 let peer_ids = qp.connected_peer_ids();
                 info!(
-                    "msg/send: relaying to {} mesh peers for recipient {}",
-                    peer_ids.len(),
-                    recipient_did
+                    peers = peer_ids.len(),
+                    recipient = %redact_did(recipient_did),
+                    "msg/send: mesh relay"
                 );
                 for peer_id in &peer_ids {
                     match qp.send_to_peer(peer_id, mesh_msg.clone()).await {
-                        Ok(_) => info!(
-                            "  relay -> peer {} OK",
-                            hex::encode(&peer_id[..8.min(peer_id.len())])
-                        ),
-                        Err(e) => info!(
-                            "  relay -> peer {} FAILED: {}",
-                            hex::encode(&peer_id[..8.min(peer_id.len())]),
-                            e
+                        Ok(_) => {
+                            metrics().mesh_relays_out.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Err(e) => warn!(
+                            peer = %hex::encode(&peer_id[..8.min(peer_id.len())]),
+                            error = %e,
+                            "mesh relay failed"
                         ),
                     }
                 }
@@ -212,19 +316,6 @@ impl MessagingHandler {
         } else {
             info!("msg/send: mesh router unavailable — no mesh relay");
         }
-
-        let status = if pushed { "pushed" } else { "queued" };
-        info!(
-            message_id = %message_id,
-            status,
-            "msg/send for {}",
-            &recipient_did[..16.min(recipient_did.len())]
-        );
-        json_response(json!({
-            "status": status,
-            "message_id": message_id,
-            "recipient_did": recipient_did,
-        }))
     }
 
     /// POST /api/v1/msg/deposit
@@ -232,6 +323,10 @@ impl MessagingHandler {
     async fn handle_deposit(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
         let req: DepositRequest = serde_json::from_slice(&request.body)
             .map_err(|e| anyhow::anyhow!("Invalid request: {}", e))?;
+
+        if let Err(e) = self.bind_sender(request, &req.sender_did).await {
+            return Ok(error_resp(ZhtpStatus::Forbidden, &e));
+        }
 
         let envelopes: Vec<Vec<u8>> = req
             .envelopes_hex
@@ -241,6 +336,32 @@ impl MessagingHandler {
 
         if envelopes.is_empty() {
             return Ok(error_resp(ZhtpStatus::BadRequest, "No valid envelopes"));
+        }
+
+        // Optional verify each envelope when enabled
+        if verify_envelopes_enabled() {
+            for env_bytes in &envelopes {
+                let envelope: super::envelope::MessageEnvelope =
+                    match bincode::deserialize(env_bytes) {
+                        Ok(e) => e,
+                        Err(e) => {
+                            return Ok(error_resp(
+                                ZhtpStatus::BadRequest,
+                                &format!("Invalid envelope: {e}"),
+                            ));
+                        }
+                    };
+                if envelope.sender_did != req.sender_did {
+                    metrics().auth_rejects.fetch_add(1, Ordering::Relaxed);
+                    return Ok(error_resp(
+                        ZhtpStatus::Forbidden,
+                        "envelope sender_did does not match deposit sender_did",
+                    ));
+                }
+                if let Err(e) = self.maybe_verify_envelope(&envelope).await {
+                    return Ok(error_resp(ZhtpStatus::BadRequest, &e));
+                }
+            }
         }
 
         match self
@@ -285,6 +406,30 @@ impl MessagingHandler {
         }))
     }
 
+    /// POST /api/v1/msg/cancel (MSG-R11)
+    /// Sender cancels undelivered mail to a recipient on this node.
+    async fn handle_cancel(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
+        let req: CancelRequest = serde_json::from_slice(&request.body)
+            .map_err(|e| anyhow::anyhow!("Invalid request: {}", e))?;
+
+        let sender_did = match self.resolve_caller_did(request).await {
+            Ok(d) => d,
+            Err(e) => return Ok(error_resp(ZhtpStatus::Unauthorized, &e)),
+        };
+
+        if req.recipient_did.is_empty() {
+            return Ok(error_resp(ZhtpStatus::BadRequest, "recipient_did required"));
+        }
+
+        let cancelled = self.deposits.cancel(&sender_did, &req.recipient_did);
+        json_response(json!({
+            "status": "success",
+            "cancelled": cancelled,
+            "sender_did": sender_did,
+            "recipient_did": req.recipient_did,
+        }))
+    }
+
     /// GET /api/v1/msg/receive
     /// Peek pending messages (does not remove — client must POST /api/v1/msg/ack).
     async fn handle_receive(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
@@ -293,26 +438,18 @@ impl MessagingHandler {
             Err(e) => return Ok(error_resp(ZhtpStatus::Unauthorized, &e)),
         };
 
-        let requester_key_id = request
-            .requester
-            .as_ref()
-            .map(|id| hex::encode(&id.0))
-            .unwrap_or_default();
-
         info!(
-            "msg/receive lookup: requester_key_id={} -> recipient_did={}",
-            requester_key_id, recipient_did
+            recipient = %redact_did(&recipient_did),
+            "msg/receive lookup"
         );
 
-        // Mark as online
         self.presence.set_online(&recipient_did).await;
 
-        // Peek only — retain until explicit ack (MSG-R1)
         let deliveries = self.deposits.peek_for_recipient(&recipient_did);
         info!(
-            "msg/receive peeked {} deliveries for {}",
-            deliveries.len(),
-            recipient_did
+            count = deliveries.len(),
+            recipient = %redact_did(&recipient_did),
+            "msg/receive peeked"
         );
 
         let all_envelopes: Vec<serde_json::Value> = deliveries
@@ -334,17 +471,26 @@ impl MessagingHandler {
         }))
     }
 
-    /// GET /api/v1/msg/presence/watch
-    /// Subscribe to presence changes for specific DIDs.
+    /// POST /api/v1/msg/presence/watch
     async fn handle_presence_watch(&self, request: &ZhtpRequest) -> Result<ZhtpResponse> {
         let req: PresenceWatchRequest = serde_json::from_slice(&request.body)
             .map_err(|e| anyhow::anyhow!("Invalid request: {}", e))?;
+
+        // Bind watcher to session when possible
+        if let Ok(caller) = self.resolve_caller_did(request).await {
+            if caller != req.watcher_did {
+                metrics().auth_rejects.fetch_add(1, Ordering::Relaxed);
+                return Ok(error_resp(
+                    ZhtpStatus::Forbidden,
+                    "watcher_did does not match authenticated session",
+                ));
+            }
+        }
 
         for target in &req.target_dids {
             self.presence.watch(&req.watcher_did, target).await;
         }
 
-        // Return current status of watched DIDs
         let mut statuses = Vec::new();
         for target in &req.target_dids {
             statuses.push(json!({
@@ -356,6 +502,20 @@ impl MessagingHandler {
         json_response(json!({
             "status": "success",
             "watching": statuses,
+        }))
+    }
+
+    /// GET /api/v1/msg/stats (MSG-R12) — operator queue depth + counters.
+    async fn handle_stats(&self, _request: &ZhtpRequest) -> Result<ZhtpResponse> {
+        let mut snap = metrics().snapshot();
+        snap.pending = self.deposits.total_pending() as u64;
+        json_response(json!({
+            "status": "success",
+            "metrics": snap,
+            "at_rest_encryption": std::env::var("ZHTP_MSG_AT_REST_KEY")
+                .map(|v| !v.trim().is_empty())
+                .unwrap_or(false),
+            "envelope_verify": verify_envelopes_enabled(),
         }))
     }
 }
@@ -389,8 +549,14 @@ impl ZhtpRequestHandler for MessagingHandler {
             (ZhtpMethod::Post, "/api/v1/msg/ack") => {
                 Ok(self.handle_ack(&request).await?)
             }
+            (ZhtpMethod::Post, "/api/v1/msg/cancel") => {
+                Ok(self.handle_cancel(&request).await?)
+            }
             (ZhtpMethod::Post, "/api/v1/msg/presence/watch") => {
                 Ok(self.handle_presence_watch(&request).await?)
+            }
+            (ZhtpMethod::Get, "/api/v1/msg/stats") => {
+                Ok(self.handle_stats(&request).await?)
             }
             _ => Ok(error_resp(ZhtpStatus::NotFound, "Not found")),
         }

--- a/zhtp/src/messaging/handler.rs
+++ b/zhtp/src/messaging/handler.rs
@@ -338,29 +338,28 @@ impl MessagingHandler {
             return Ok(error_resp(ZhtpStatus::BadRequest, "No valid envelopes"));
         }
 
-        // Optional verify each envelope when enabled
-        if verify_envelopes_enabled() {
-            for env_bytes in &envelopes {
-                let envelope: super::envelope::MessageEnvelope =
-                    match bincode::deserialize(env_bytes) {
-                        Ok(e) => e,
-                        Err(e) => {
-                            return Ok(error_resp(
-                                ZhtpStatus::BadRequest,
-                                &format!("Invalid envelope: {e}"),
-                            ));
-                        }
-                    };
-                if envelope.sender_did != req.sender_did {
-                    metrics().auth_rejects.fetch_add(1, Ordering::Relaxed);
+        // MSG-R8: every envelope's embedded sender must match the deposit sender
+        // (session-bound above). Optional Dilithium verify when env is set.
+        for env_bytes in &envelopes {
+            let envelope: super::envelope::MessageEnvelope = match bincode::deserialize(env_bytes)
+            {
+                Ok(e) => e,
+                Err(e) => {
                     return Ok(error_resp(
-                        ZhtpStatus::Forbidden,
-                        "envelope sender_did does not match deposit sender_did",
+                        ZhtpStatus::BadRequest,
+                        &format!("Invalid envelope: {e}"),
                     ));
                 }
-                if let Err(e) = self.maybe_verify_envelope(&envelope).await {
-                    return Ok(error_resp(ZhtpStatus::BadRequest, &e));
-                }
+            };
+            if envelope.sender_did != req.sender_did {
+                metrics().auth_rejects.fetch_add(1, Ordering::Relaxed);
+                return Ok(error_resp(
+                    ZhtpStatus::Forbidden,
+                    "envelope sender_did does not match deposit sender_did",
+                ));
+            }
+            if let Err(e) = self.maybe_verify_envelope(&envelope).await {
+                return Ok(error_resp(ZhtpStatus::BadRequest, &e));
             }
         }
 
@@ -512,9 +511,7 @@ impl MessagingHandler {
         json_response(json!({
             "status": "success",
             "metrics": snap,
-            "at_rest_encryption": std::env::var("ZHTP_MSG_AT_REST_KEY")
-                .map(|v| !v.trim().is_empty())
-                .unwrap_or(false),
+            "at_rest_encryption": self.deposits.at_rest_enabled(),
             "envelope_verify": verify_envelopes_enabled(),
         }))
     }

--- a/zhtp/src/messaging/inbound_stream.rs
+++ b/zhtp/src/messaging/inbound_stream.rs
@@ -21,6 +21,8 @@ use quinn::SendStream;
 use tokio::io::AsyncWriteExt;
 use tracing::{info, warn};
 
+use super::metrics::redact_did;
+
 /// Write a single framed envelope to the send stream.
 async fn write_frame(send: &mut SendStream, envelope: &[u8]) -> Result<()> {
     let len = envelope.len() as u32;
@@ -40,14 +42,17 @@ pub async fn run_inbound_stream(
 
     if recipient_did.is_empty() {
         warn!(
-            "msg/inbound: empty recipient DID for key_id={}",
-            requester_key_id
+            key_id = %&requester_key_id[..16.min(requester_key_id.len())],
+            "msg/inbound: empty recipient DID"
         );
         let _ = send.finish();
         return Ok(());
     }
 
-    info!("msg/inbound: stream opened for {}", recipient_did);
+    info!(
+        recipient = %redact_did(&recipient_did),
+        "msg/inbound: stream opened"
+    );
 
     let provider = crate::runtime::messaging_provider::get_global_messaging_provider();
 
@@ -58,8 +63,8 @@ pub async fn run_inbound_stream(
         for delivery in deliveries {
             if write_frame(&mut send, &delivery.envelope).await.is_err() {
                 info!(
-                    "msg/inbound: client disconnected during initial peek for {}",
-                    recipient_did
+                    recipient = %redact_did(&recipient_did),
+                    "msg/inbound: client disconnected during initial peek"
                 );
                 // Envelopes still in store — client can reconnect or poll.
                 return Ok(());
@@ -68,8 +73,9 @@ pub async fn run_inbound_stream(
         }
         if count > 0 {
             info!(
-                "msg/inbound: peeked {} envelopes from deposit store for {}",
-                count, recipient_did
+                count,
+                recipient = %redact_did(&recipient_did),
+                "msg/inbound: peeked envelopes from deposit store"
             );
         }
     }
@@ -82,8 +88,9 @@ pub async fn run_inbound_stream(
     let (sub_id, mut rx) = provider.register_subscriber(recipient_did.clone()).await;
 
     info!(
-        "msg/inbound: subscriber registered for {} (id={})",
-        recipient_did, sub_id
+        recipient = %redact_did(&recipient_did),
+        sub_id,
+        "msg/inbound: subscriber registered"
     );
 
     // 3. Push frames until the peer disconnects or a write fails.
@@ -91,7 +98,10 @@ pub async fn run_inbound_stream(
     // does not lose mail — client acks after processing.
     while let Some(envelope) = rx.recv().await {
         if write_frame(&mut send, &envelope).await.is_err() {
-            info!("msg/inbound: write failed (client gone) for {}", recipient_did);
+            info!(
+                recipient = %redact_did(&recipient_did),
+                "msg/inbound: write failed (client gone)"
+            );
             break;
         }
     }
@@ -103,8 +113,9 @@ pub async fn run_inbound_stream(
     provider.unregister_subscriber(&recipient_did, sub_id).await;
     let _ = send.finish();
     info!(
-        "msg/inbound: stream closed for {} (id={})",
-        recipient_did, sub_id
+        recipient = %redact_did(&recipient_did),
+        sub_id,
+        "msg/inbound: stream closed"
     );
     Ok(())
 }

--- a/zhtp/src/messaging/metrics.rs
+++ b/zhtp/src/messaging/metrics.rs
@@ -5,13 +5,25 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 
-/// Redact a DID for logs: keep scheme + first 8 hex chars of identity.
+/// Redact a DID for logs: keep scheme prefix + first 8 identity chars.
+///
+/// Example: `did:zhtp:abcdef012345…` → `did:zhtp:abcdef01…`
 pub fn redact_did(did: &str) -> String {
-    const KEEP: usize = 20; // "did:zhtp:" (9) + 8 hex + "…"
-    if did.len() <= KEEP {
+    const ID_KEEP: usize = 8;
+    if let Some(last_colon) = did.rfind(':') {
+        let scheme = &did[..=last_colon];
+        let identity = &did[last_colon + 1..];
+        if identity.chars().count() <= ID_KEEP {
+            return did.to_string();
+        }
+        let kept: String = identity.chars().take(ID_KEEP).collect();
+        return format!("{scheme}{kept}…");
+    }
+    if did.chars().count() <= ID_KEEP {
         return did.to_string();
     }
-    format!("{}…", &did[..KEEP.min(did.len())])
+    let kept: String = did.chars().take(ID_KEEP).collect();
+    format!("{kept}…")
 }
 
 #[derive(Debug, Default)]
@@ -71,4 +83,20 @@ static METRICS: OnceLock<MessagingMetrics> = OnceLock::new();
 
 pub fn metrics() -> &'static MessagingMetrics {
     METRICS.get_or_init(MessagingMetrics::default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_did;
+
+    #[test]
+    fn redact_keeps_scheme_and_eight_id_chars() {
+        let full = "did:zhtp:abcdef0123456789deadbeef";
+        assert_eq!(redact_did(full), "did:zhtp:abcdef01…");
+    }
+
+    #[test]
+    fn redact_short_did_unchanged() {
+        assert_eq!(redact_did("did:zhtp:abc"), "did:zhtp:abc");
+    }
 }

--- a/zhtp/src/messaging/metrics.rs
+++ b/zhtp/src/messaging/metrics.rs
@@ -1,0 +1,74 @@
+//! Messaging operator metrics (MSG-R12).
+//!
+//! Process-local counters for deposit / ack / mesh health. No PII.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+/// Redact a DID for logs: keep scheme + first 8 hex chars of identity.
+pub fn redact_did(did: &str) -> String {
+    const KEEP: usize = 20; // "did:zhtp:" (9) + 8 hex + "…"
+    if did.len() <= KEEP {
+        return did.to_string();
+    }
+    format!("{}…", &did[..KEEP.min(did.len())])
+}
+
+#[derive(Debug, Default)]
+pub struct MessagingMetrics {
+    pub deposits_accepted: AtomicU64,
+    pub deposits_duplicate: AtomicU64,
+    pub deposits_rejected: AtomicU64,
+    pub acks_removed: AtomicU64,
+    pub cancels: AtomicU64,
+    pub gc_expired: AtomicU64,
+    pub mesh_relays_in: AtomicU64,
+    pub mesh_relays_out: AtomicU64,
+    pub live_pushes: AtomicU64,
+    pub verify_rejects: AtomicU64,
+    pub auth_rejects: AtomicU64,
+    pub tombstone_hits: AtomicU64,
+}
+
+impl MessagingMetrics {
+    pub fn snapshot(&self) -> MessagingMetricsSnapshot {
+        MessagingMetricsSnapshot {
+            deposits_accepted: self.deposits_accepted.load(Ordering::Relaxed),
+            deposits_duplicate: self.deposits_duplicate.load(Ordering::Relaxed),
+            deposits_rejected: self.deposits_rejected.load(Ordering::Relaxed),
+            acks_removed: self.acks_removed.load(Ordering::Relaxed),
+            cancels: self.cancels.load(Ordering::Relaxed),
+            gc_expired: self.gc_expired.load(Ordering::Relaxed),
+            mesh_relays_in: self.mesh_relays_in.load(Ordering::Relaxed),
+            mesh_relays_out: self.mesh_relays_out.load(Ordering::Relaxed),
+            live_pushes: self.live_pushes.load(Ordering::Relaxed),
+            verify_rejects: self.verify_rejects.load(Ordering::Relaxed),
+            auth_rejects: self.auth_rejects.load(Ordering::Relaxed),
+            tombstone_hits: self.tombstone_hits.load(Ordering::Relaxed),
+            pending: 0, // filled by caller with store depth
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MessagingMetricsSnapshot {
+    pub deposits_accepted: u64,
+    pub deposits_duplicate: u64,
+    pub deposits_rejected: u64,
+    pub acks_removed: u64,
+    pub cancels: u64,
+    pub gc_expired: u64,
+    pub mesh_relays_in: u64,
+    pub mesh_relays_out: u64,
+    pub live_pushes: u64,
+    pub verify_rejects: u64,
+    pub auth_rejects: u64,
+    pub tombstone_hits: u64,
+    pub pending: u64,
+}
+
+static METRICS: OnceLock<MessagingMetrics> = OnceLock::new();
+
+pub fn metrics() -> &'static MessagingMetrics {
+    METRICS.get_or_init(MessagingMetrics::default)
+}

--- a/zhtp/src/messaging/mod.rs
+++ b/zhtp/src/messaging/mod.rs
@@ -2,12 +2,16 @@
 //!
 //! All encryption/decryption happens client-side. The server (node) is a
 //! relay + temporary dead drop. QUIC is the only transport.
+//!
+//! Delivery model (BUBL / epic #2896): deposit first, peek on poll/inbound,
+//! delete only on client ack or 48h TTL. Deposits are sled-durable.
 
 pub mod envelope;
 pub mod session;
 pub mod ratchet;
 pub mod deposit;
 pub mod did_resolve;
+pub mod metrics;
 pub mod presence;
 pub mod handler;
 pub mod inbound_stream;

--- a/zhtp/src/messaging/presence.rs
+++ b/zhtp/src/messaging/presence.rs
@@ -9,6 +9,8 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, RwLock};
 use tracing::info;
 
+use super::metrics::redact_did;
+
 /// Grace period before marking a DID as offline (handles app backgrounding).
 const PRESENCE_GRACE_PERIOD_SECS: u64 = 30;
 
@@ -58,7 +60,7 @@ impl PresenceTracker {
         };
 
         if was_offline {
-            info!("Presence: {} online", &did[..16.min(did.len())]);
+            info!(did = %redact_did(did), "Presence: online");
             let _ = self.event_tx.send(PresenceEvent {
                 did: did.to_string(),
                 online: true,
@@ -77,7 +79,7 @@ impl PresenceTracker {
 
         let mut online = self.online.write().await;
         if online.remove(did).is_some() {
-            info!("Presence: {} offline", &did[..16.min(did.len())]);
+            info!(did = %redact_did(did), "Presence: offline");
             let _ = self.event_tx.send(PresenceEvent {
                 did: did.to_string(),
                 online: false,

--- a/zhtp/src/runtime/messaging_provider.rs
+++ b/zhtp/src/runtime/messaging_provider.rs
@@ -113,6 +113,11 @@ impl MessagingProvider {
             false
         }
     }
+
+    /// Whether a live inbound stream is registered for this DID (MSG-R14).
+    pub async fn has_subscriber(&self, recipient_did: &str) -> bool {
+        self.subscribers.read().await.contains_key(recipient_did)
+    }
 }
 
 static GLOBAL_MESSAGING_PROVIDER: OnceLock<MessagingProvider> = OnceLock::new();

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -1106,10 +1106,23 @@ impl ZhtpUnifiedServer {
                     crate::messaging::metrics::metrics()
                         .mesh_relays_in
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    let sender = bincode::deserialize::<crate::messaging::envelope::MessageEnvelope>(&envelope)
-                        .map(|env| env.sender_did)
-                        .unwrap_or_else(|_| "mesh_relay".to_string());
-                    if let Err(e) = deposits_relay.deposit_one(&sender, &recipient_did, envelope.clone()) {
+                    let sender = match bincode::deserialize::<
+                        crate::messaging::envelope::MessageEnvelope,
+                    >(&envelope)
+                    {
+                        Ok(env) => env.sender_did,
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                recipient = %crate::messaging::metrics::redact_did(&recipient_did),
+                                "dropping invalid mesh-relayed envelope"
+                            );
+                            continue;
+                        }
+                    };
+                    if let Err(e) =
+                        deposits_relay.deposit_one(&sender, &recipient_did, envelope.clone())
+                    {
                         tracing::warn!("Failed to deposit relayed message: {}", e);
                         continue;
                     }

--- a/zhtp/src/unified_server.rs
+++ b/zhtp/src/unified_server.rs
@@ -1062,7 +1062,17 @@ impl ZhtpUnifiedServer {
                     // Fallback: create a placeholder — will be replaced when blockchain is ready
                     Arc::new(tokio::sync::RwLock::new(lib_blockchain::Blockchain::default()))
                 });
-            let deposits = Arc::new(crate::messaging::deposit::DepositStore::new());
+            // MSG-R5: durable sled under node data dir (fallback to memory).
+            let deposits = match crate::messaging::deposit::DepositStore::open_default() {
+                Ok(store) => Arc::new(store),
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to open durable messaging deposits: {}. Using in-memory store.",
+                        e
+                    );
+                    Arc::new(crate::messaging::deposit::DepositStore::new())
+                }
+            };
             let presence = Arc::new(crate::messaging::presence::PresenceTracker::new());
 
             // Publish deposits to the global messaging provider so the QUIC handler
@@ -1086,13 +1096,16 @@ impl ZhtpUnifiedServer {
 
             // Wire mesh relay receiver — always deposit first (MSG-R2), then
             // best-effort live push. Deposit stays until client ack.
+            // Dedupe + tombstones (MSG-R6 / R10) drop already-acked re-relays.
             let deposits_relay = deposits.clone();
             let (relay_tx, mut relay_rx) = tokio::sync::mpsc::channel::<(String, Vec<u8>)>(256);
             tokio::spawn(async move {
                 let provider =
                     crate::runtime::messaging_provider::get_global_messaging_provider();
                 while let Some((recipient_did, envelope)) = relay_rx.recv().await {
-                    // MSG-R2: always deposit first, then best-effort live push.
+                    crate::messaging::metrics::metrics()
+                        .mesh_relays_in
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     let sender = bincode::deserialize::<crate::messaging::envelope::MessageEnvelope>(&envelope)
                         .map(|env| env.sender_did)
                         .unwrap_or_else(|_| "mesh_relay".to_string());
@@ -1101,9 +1114,12 @@ impl ZhtpUnifiedServer {
                         continue;
                     }
                     if provider.try_push(&recipient_did, envelope).await {
+                        crate::messaging::metrics::metrics()
+                            .live_pushes
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         tracing::debug!(
-                            "Relay deposited + pushed to live subscriber for {}",
-                            recipient_did
+                            "Relay deposited + pushed for {}",
+                            crate::messaging::metrics::redact_did(&recipient_did)
                         );
                     }
                 }


### PR DESCRIPTION
## Summary

Completes the [BUBL] messaging reliability epic (#2896) phases 2–4 after Phase 1 (R1–R4) already landed.

| Issue | Scope |
|-------|--------|
| #2901 | Durable sled deposits, stable `message_id`, ack-only delete |
| #2902 | Sender session bind, optional Dilithium verify, mesh tombstones, cancel API |
| #2903 | Metrics + redacted logs, at-rest option, presence-directed mesh, docs + lib-client |

## Key behavior

- Deposits at `{node_data_dir}/messaging_deposits.sled` (fallback: in-memory)
- Peek on receive/inbound; delete only on `POST /msg/ack` or 48h TTL
- Send status remains honest: `queued` | `pushed` + `message_id`
- `POST /msg/cancel`, `GET /msg/stats`
- Env: `ZHTP_MSG_AT_REST_KEY`, `ZHTP_MSG_VERIFY_ENVELOPES`

## Docs

- `docs/arch/messaging-store-and-forward.md`
- `docs/ops/messaging-bubl-operator.md`

## Test plan

- [x] `cargo test -p zhtp --lib deposit::` (10 tests incl. reopen + at-rest)
- [x] `cargo test -p lib-client messaging::`
- [x] `cargo check -p zhtp --lib`
- [ ] CI green on PR
- [ ] Deploy validators only when mobile clients use peek+ack

Closes #2901
Closes #2902
Closes #2903
Closes #2896