### PR TITLE
Fix/add updated domain prefix

### DIFF
--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -1065,10 +1065,6 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
 ///
 /// # Returns
 /// JSON string ready to POST to /api/v1/web4/domains/update
-/// Domain separation prefix for domain update signatures.
-/// Mirrors the `ZHTP-identity-sig-v1\0` pattern used in identity attestations.
-const ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN: &[u8] = b"ZHTP-domain-update-v1\0";
-
 pub fn build_domain_update_request(
     identity: &Identity,
     domain: &str,
@@ -1080,14 +1076,12 @@ pub fn build_domain_update_request(
         .map_err(|e| format!("Failed to get timestamp: {}", e))?
         .as_secs();
 
-    // Sign: ZHTP-domain-update-v1\0domain|expected_previous_manifest_cid|new_manifest_cid|timestamp
-    let mut message = ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN.to_vec();
-    message.extend_from_slice(
-        format!(
-            "{}|{}|{}|{}",
-            domain, expected_previous_manifest_cid, new_manifest_cid, timestamp
-        )
-        .as_bytes(),
+    // Canonical message from lib-network (includes ZHTP-domain-update-v1\0 prefix).
+    let message = lib_network::web4::domain_update_signing_message(
+        domain,
+        expected_previous_manifest_cid,
+        new_manifest_cid,
+        timestamp,
     );
     let signature = Dilithium5::sign(&message, &identity.private_key)
         .map_err(|e| format!("Failed to sign: {}", e))?;

--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -1065,6 +1065,10 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
 ///
 /// # Returns
 /// JSON string ready to POST to /api/v1/web4/domains/update
+/// Domain separation prefix for domain update signatures.
+/// Mirrors the `ZHTP-identity-sig-v1\0` pattern used in identity attestations.
+const ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN: &[u8] = b"ZHTP-domain-update-v1\0";
+
 pub fn build_domain_update_request(
     identity: &Identity,
     domain: &str,
@@ -1076,12 +1080,16 @@ pub fn build_domain_update_request(
         .map_err(|e| format!("Failed to get timestamp: {}", e))?
         .as_secs();
 
-    // Sign: domain|expected_previous_manifest_cid|new_manifest_cid|timestamp
-    let message = format!(
-        "{}|{}|{}|{}",
-        domain, expected_previous_manifest_cid, new_manifest_cid, timestamp
+    // Sign: ZHTP-domain-update-v1\0domain|expected_previous_manifest_cid|new_manifest_cid|timestamp
+    let mut message = ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN.to_vec();
+    message.extend_from_slice(
+        format!(
+            "{}|{}|{}|{}",
+            domain, expected_previous_manifest_cid, new_manifest_cid, timestamp
+        )
+        .as_bytes(),
     );
-    let signature = Dilithium5::sign(message.as_bytes(), &identity.private_key)
+    let signature = Dilithium5::sign(&message, &identity.private_key)
         .map_err(|e| format!("Failed to sign: {}", e))?;
 
     let request = DomainUpdateParams {

--- a/lib-network/src/web4/domain_signing.rs
+++ b/lib-network/src/web4/domain_signing.rs
@@ -1,13 +1,17 @@
 //! Canonical domain-update signing and Dilithium5 verification.
 //!
-//! Wire format matches zhtp-cli and lib-client:
-//!   `domain|expected_previous_manifest_cid|new_manifest_cid|timestamp`
+//! Wire format (with domain separation prefix):
+//!   `ZHTP-domain-update-v1\0domain|expected_previous_manifest_cid|new_manifest_cid|timestamp`
 
 use anyhow::{anyhow, Result};
 use lib_crypto::verify_signature;
 
 /// Hex-encoded Dilithium5 detached signatures are 4595 bytes → 9190 hex chars.
 pub const DILITHIUM5_HEX_SIGNATURE_LEN: usize = 9190;
+
+/// Domain separation prefix for domain update signatures.
+/// Mirrors the `ZHTP-identity-sig-v1\0` pattern used in identity attestations.
+pub const ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN: &[u8] = b"ZHTP-domain-update-v1\0";
 
 /// Returns true when a stored owner public key is present (full Dilithium5 size, non-zero).
 pub fn has_owner_signing_key(owner_dilithium_pk: &[u8]) -> bool {
@@ -23,18 +27,24 @@ fn owner_pk_array(owner_dilithium_pk: &[u8]) -> Result<[u8; 2592]> {
     Ok(arr)
 }
 
-/// Build the canonical domain-update signing message.
+/// Build the canonical domain-update signing message with domain separation prefix.
+///
+/// Format: `ZHTP-domain-update-v1\0domain|expected_previous_manifest_cid|new_manifest_cid|timestamp`
 pub fn domain_update_signing_message(
     domain: &str,
     expected_previous_manifest_cid: &str,
     new_manifest_cid: &str,
     timestamp: u64,
 ) -> Vec<u8> {
-    format!(
-        "{}|{}|{}|{}",
-        domain, expected_previous_manifest_cid, new_manifest_cid, timestamp
-    )
-    .into_bytes()
+    let mut message = ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN.to_vec();
+    message.extend_from_slice(
+        format!(
+            "{}|{}|{}|{}",
+            domain, expected_previous_manifest_cid, new_manifest_cid, timestamp
+        )
+        .as_bytes(),
+    );
+    message
 }
 
 /// Reject missing or malformed owner signatures before mutating domain state.
@@ -249,5 +259,67 @@ mod tests {
         )
         .expect("verify runs");
         assert!(!bad);
+    }
+
+    #[test]
+    fn domain_update_message_contains_prefix() {
+        let domain = "app.zhtp";
+        let prev = "bafkabc123";
+        let new_cid = "bafkdef456";
+        let timestamp = 1_700_000_000u64;
+
+        let message = domain_update_signing_message(domain, prev, new_cid, timestamp);
+
+        // Verify the prefix is present at the start of the message
+        assert!(
+            message.starts_with(ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN),
+            "Message must start with domain separation prefix"
+        );
+
+        // Verify the payload follows the prefix correctly
+        let payload = &message[ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN.len()..];
+        let expected_payload = format!(
+            "{}|{}|{}|{}",
+            domain, prev, new_cid, timestamp
+        );
+        assert_eq!(
+            payload,
+            expected_payload.as_bytes(),
+            "Payload after prefix must match pipe-delimited format"
+        );
+    }
+
+    #[test]
+    fn domain_update_signature_fails_without_prefix() {
+        // A signature created over the raw (unprefixed) message must fail verification
+        // against the canonical helper that expects the prefix.
+        let keypair = generate_keypair().expect("keypair");
+        let domain = "app.zhtp";
+        let prev = "bafkabc123";
+        let new_cid = "bafkdef456";
+        let timestamp = 1_700_000_000u64;
+
+        // Sign the OLD raw format (without prefix)
+        let raw_message = format!(
+            "{}|{}|{}|{}",
+            domain, prev, new_cid, timestamp
+        );
+        let sig = sign_message(&keypair, raw_message.as_bytes()).expect("sign");
+        let sig_hex = hex::encode(&sig.signature);
+
+        // Verify using the canonical helper (which expects the prefix) should FAIL
+        let ok = verify_domain_update_signature(
+            keypair.public_key.dilithium_pk.as_slice(),
+            domain,
+            prev,
+            new_cid,
+            timestamp,
+            &sig_hex,
+        )
+        .expect("verify runs");
+        assert!(
+            !ok,
+            "Signature over raw unprefixed message must fail verification with canonical helper"
+        );
     }
 }

--- a/lib-network/src/web4/domain_signing.rs
+++ b/lib-network/src/web4/domain_signing.rs
@@ -1,7 +1,13 @@
 //! Canonical domain-update signing and Dilithium5 verification.
 //!
-//! Wire format (with domain separation prefix):
-//!   `ZHTP-domain-update-v1\0domain|expected_previous_manifest_cid|new_manifest_cid|timestamp`
+//! ## Current wire format (signers must produce this)
+//! `ZHTP-domain-update-v1\0domain|expected_previous_manifest_cid|new_manifest_cid|timestamp`
+//!
+//! ## Transition (one release)
+//! Verifiers also accept the legacy unprefixed form
+//! `domain|expected_previous_manifest_cid|new_manifest_cid|timestamp` so older
+//! mobile/CLI clients can still update domains. Signers must not emit legacy.
+//! Drop legacy accept in a follow-up release.
 
 use anyhow::{anyhow, Result};
 use lib_crypto::verify_signature;
@@ -27,9 +33,22 @@ fn owner_pk_array(owner_dilithium_pk: &[u8]) -> Result<[u8; 2592]> {
     Ok(arr)
 }
 
+/// Pipe-delimited payload shared by current and legacy formats.
+fn domain_update_payload(
+    domain: &str,
+    expected_previous_manifest_cid: &str,
+    new_manifest_cid: &str,
+    timestamp: u64,
+) -> String {
+    format!(
+        "{}|{}|{}|{}",
+        domain, expected_previous_manifest_cid, new_manifest_cid, timestamp
+    )
+}
+
 /// Build the canonical domain-update signing message with domain separation prefix.
 ///
-/// Format: `ZHTP-domain-update-v1\0domain|expected_previous_manifest_cid|new_manifest_cid|timestamp`
+/// **Signers must use this** (CLI, lib-client, mobile). Do not reimplement the prefix.
 pub fn domain_update_signing_message(
     domain: &str,
     expected_previous_manifest_cid: &str,
@@ -38,13 +57,56 @@ pub fn domain_update_signing_message(
 ) -> Vec<u8> {
     let mut message = ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN.to_vec();
     message.extend_from_slice(
-        format!(
-            "{}|{}|{}|{}",
-            domain, expected_previous_manifest_cid, new_manifest_cid, timestamp
+        domain_update_payload(
+            domain,
+            expected_previous_manifest_cid,
+            new_manifest_cid,
+            timestamp,
         )
         .as_bytes(),
     );
     message
+}
+
+/// Legacy unprefixed signing message (pre domain-separation).
+///
+/// Used only by verifiers during the dual-accept window. Do not sign with this.
+pub fn domain_update_signing_message_legacy(
+    domain: &str,
+    expected_previous_manifest_cid: &str,
+    new_manifest_cid: &str,
+    timestamp: u64,
+) -> Vec<u8> {
+    domain_update_payload(
+        domain,
+        expected_previous_manifest_cid,
+        new_manifest_cid,
+        timestamp,
+    )
+    .into_bytes()
+}
+
+/// Messages accepted during verification: current (prefixed) first, then legacy.
+pub fn domain_update_verify_candidates(
+    domain: &str,
+    expected_previous_manifest_cid: &str,
+    new_manifest_cid: &str,
+    timestamp: u64,
+) -> [Vec<u8>; 2] {
+    [
+        domain_update_signing_message(
+            domain,
+            expected_previous_manifest_cid,
+            new_manifest_cid,
+            timestamp,
+        ),
+        domain_update_signing_message_legacy(
+            domain,
+            expected_previous_manifest_cid,
+            new_manifest_cid,
+            timestamp,
+        ),
+    ]
 }
 
 /// Reject missing or malformed owner signatures before mutating domain state.
@@ -149,6 +211,10 @@ pub fn verify_domain_transfer_signature(
 }
 
 /// Verify a domain update signature against the stored owner Dilithium5 public key.
+///
+/// Accepts the current prefixed message, then falls back to the legacy unprefixed
+/// form for one release (mobile/CLI lag). Prefer signing with
+/// [`domain_update_signing_message`] only.
 pub fn verify_domain_update_signature(
     owner_dilithium_pk: &[u8],
     domain: &str,
@@ -162,19 +228,38 @@ pub fn verify_domain_update_signature(
     }
 
     let owner_pk = owner_pk_array(owner_dilithium_pk)?;
+    let signature_bytes = hex::decode(signature_hex)
+        .map_err(|e| anyhow!("Invalid signature hex: {}", e))?;
 
-    let message = domain_update_signing_message(
+    let candidates = domain_update_verify_candidates(
         domain,
         expected_previous_manifest_cid,
         new_manifest_cid,
         timestamp,
     );
 
-    let signature_bytes = hex::decode(signature_hex)
-        .map_err(|e| anyhow!("Invalid signature hex: {}", e))?;
+    let mut last_err: Option<String> = None;
+    for (idx, message) in candidates.iter().enumerate() {
+        match verify_signature(message, &signature_bytes, owner_pk.as_slice()) {
+            Ok(true) => {
+                if idx > 0 {
+                    // Legacy path hit — remove dual-accept after one release.
+                    tracing::info!(
+                        domain = %domain,
+                        "domain update accepted via legacy unprefixed signature"
+                    );
+                }
+                return Ok(true);
+            }
+            Ok(false) => continue,
+            Err(e) => last_err = Some(e.to_string()),
+        }
+    }
 
-    verify_signature(&message, &signature_bytes, owner_pk.as_slice())
-        .map_err(|e| anyhow!("Domain update signature verification failed: {}", e))
+    if let Some(e) = last_err {
+        return Err(anyhow!("Domain update signature verification failed: {e}"));
+    }
+    Ok(false)
 }
 
 #[cfg(test)]
@@ -290,24 +375,19 @@ mod tests {
     }
 
     #[test]
-    fn domain_update_signature_fails_without_prefix() {
-        // A signature created over the raw (unprefixed) message must fail verification
-        // against the canonical helper that expects the prefix.
+    fn domain_update_signature_accepts_legacy_unprefixed_during_transition() {
+        // Dual-accept window: old clients still sign without the prefix.
         let keypair = generate_keypair().expect("keypair");
         let domain = "app.zhtp";
         let prev = "bafkabc123";
         let new_cid = "bafkdef456";
         let timestamp = 1_700_000_000u64;
 
-        // Sign the OLD raw format (without prefix)
-        let raw_message = format!(
-            "{}|{}|{}|{}",
-            domain, prev, new_cid, timestamp
-        );
-        let sig = sign_message(&keypair, raw_message.as_bytes()).expect("sign");
+        let raw_message =
+            domain_update_signing_message_legacy(domain, prev, new_cid, timestamp);
+        let sig = sign_message(&keypair, &raw_message).expect("sign");
         let sig_hex = hex::encode(&sig.signature);
 
-        // Verify using the canonical helper (which expects the prefix) should FAIL
         let ok = verify_domain_update_signature(
             keypair.public_key.dilithium_pk.as_slice(),
             domain,
@@ -318,8 +398,16 @@ mod tests {
         )
         .expect("verify runs");
         assert!(
-            !ok,
-            "Signature over raw unprefixed message must fail verification with canonical helper"
+            ok,
+            "legacy unprefixed signatures must verify during dual-accept window"
         );
+    }
+
+    #[test]
+    fn domain_update_verify_candidates_order_prefixed_first() {
+        let c = domain_update_verify_candidates("d.zhtp", "prev", "next", 1);
+        assert!(c[0].starts_with(ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN));
+        assert!(!c[1].starts_with(ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN));
+        assert_eq!(c[1], b"d.zhtp|prev|next|1".as_slice());
     }
 }

--- a/lib-network/src/web4/mod.rs
+++ b/lib-network/src/web4/mod.rs
@@ -34,9 +34,10 @@ pub use content_service::*;
 pub use domain_registry::*;
 pub use domain_signing::{
     domain_registration_signing_message, domain_transfer_signing_candidates,
-    domain_update_signing_message, has_owner_signing_key, verify_domain_registration_signature,
-    verify_domain_transfer_signature, verify_domain_update_signature,
-    validate_domain_owner_signature_hex, DILITHIUM5_HEX_SIGNATURE_LEN,
+    domain_update_signing_message, domain_update_signing_message_legacy,
+    domain_update_verify_candidates, has_owner_signing_key, validate_domain_owner_signature_hex,
+    verify_domain_registration_signature, verify_domain_transfer_signature,
+    verify_domain_update_signature, DILITHIUM5_HEX_SIGNATURE_LEN, ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN,
 };
 pub use name_resolver::NameResolver;
 #[cfg(feature = "quic")]

--- a/zhtp-cli/src/commands/deploy.rs
+++ b/zhtp-cli/src/commands/deploy.rs
@@ -863,15 +863,24 @@ async fn deploy_update_impl(
         ))?;
     }
 
+    // Domain separation prefix for domain update signatures.
+    // Mirrors the `ZHTP-identity-sig-v1\0` pattern used in identity attestations.
+    const ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN: &[u8] = b"ZHTP-domain-update-v1\0";
+
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| CliError::ConfigError(format!("Time error: {}", e)))?
         .as_secs();
-    let update_message = format!(
-        "{}|{}|{}|{}",
-        domain, previous_cid, manifest_hash, timestamp
+    // Sign: ZHTP-domain-update-v1\0domain|expected_previous_manifest_cid|new_manifest_cid|timestamp
+    let mut update_message = ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN.to_vec();
+    update_message.extend_from_slice(
+        format!(
+            "{}|{}|{}|{}",
+            domain, previous_cid, manifest_hash, timestamp
+        )
+        .as_bytes(),
     );
-    let update_signature = lib_crypto::sign_message(&loaded.keypair, update_message.as_bytes())
+    let update_signature = lib_crypto::sign_message(&loaded.keypair, &update_message)
         .map_err(|e| CliError::ConfigError(format!("Failed to sign update: {}", e)))?;
 
     let update_body = serde_json::json!({

--- a/zhtp-cli/src/commands/deploy.rs
+++ b/zhtp-cli/src/commands/deploy.rs
@@ -863,22 +863,16 @@ async fn deploy_update_impl(
         ))?;
     }
 
-    // Domain separation prefix for domain update signatures.
-    // Mirrors the `ZHTP-identity-sig-v1\0` pattern used in identity attestations.
-    const ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN: &[u8] = b"ZHTP-domain-update-v1\0";
-
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| CliError::ConfigError(format!("Time error: {}", e)))?
         .as_secs();
-    // Sign: ZHTP-domain-update-v1\0domain|expected_previous_manifest_cid|new_manifest_cid|timestamp
-    let mut update_message = ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN.to_vec();
-    update_message.extend_from_slice(
-        format!(
-            "{}|{}|{}|{}",
-            domain, previous_cid, manifest_hash, timestamp
-        )
-        .as_bytes(),
+    // Canonical message from lib-network (includes ZHTP-domain-update-v1\0 prefix).
+    let update_message = lib_network::web4::domain_update_signing_message(
+        domain,
+        &previous_cid,
+        &manifest_hash,
+        timestamp,
     );
     let update_signature = lib_crypto::sign_message(&loaded.keypair, &update_message)
         .map_err(|e| CliError::ConfigError(format!("Failed to sign update: {}", e)))?;

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -1836,21 +1836,7 @@ impl Web4Handler {
         // - Web4Manifest CID = derived deterministically from DeployManifest, used for resolution
         // - The transform from DeployManifest → Web4Manifest is deterministic and auditable
         // - Both CIDs are stored: DeployManifest for audit, Web4Manifest for runtime
-        // Reconstruct the signed message with domain separation prefix and verify
-        let signed_message = {
-            let mut msg = b"ZHTP-domain-update-v1\0".to_vec();
-            msg.extend_from_slice(
-                format!(
-                    "{}|{}|{}|{}",
-                    update_request.domain,
-                    update_request.expected_previous_manifest_cid,
-                    update_request.new_manifest_cid,
-                    update_request.timestamp
-                )
-                .as_bytes(),
-            );
-            msg
-        };
+        // Verify via canonical candidates (prefixed first, legacy unprefixed dual-accept).
         let signature_bytes = hex::decode(&update_request.signature)
             .map_err(|e| anyhow!("Invalid update signature hex encoding: {}", e))?;
 
@@ -1859,12 +1845,32 @@ impl Web4Handler {
             .get_identity_by_did(owner_did)
             .ok_or_else(|| anyhow!("Owner identity not found: {}", owner_did))?;
 
-        let is_valid = lib_crypto::verify_signature(
-            &signed_message,
-            &signature_bytes,
-            &owner_identity.public_key.as_bytes(),
-        )
-        .map_err(|e| anyhow!("Signature verification error: {}", e))?;
+        let pk = owner_identity.public_key.as_bytes();
+        let candidates = lib_network::web4::domain_update_verify_candidates(
+            &update_request.domain,
+            &update_request.expected_previous_manifest_cid,
+            &update_request.new_manifest_cid,
+            update_request.timestamp,
+        );
+        let mut is_valid = false;
+        for (idx, signed_message) in candidates.iter().enumerate() {
+            match lib_crypto::verify_signature(signed_message, &signature_bytes, &pk) {
+                Ok(true) => {
+                    if idx > 0 {
+                        info!(
+                            domain = %update_request.domain,
+                            "domain update accepted via legacy unprefixed signature"
+                        );
+                    }
+                    is_valid = true;
+                    break;
+                }
+                Ok(false) => continue,
+                Err(e) => {
+                    return Err(anyhow!("Signature verification error: {}", e));
+                }
+            }
+        }
 
         if !is_valid {
             return Err(anyhow!("Invalid update signature"));

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -1836,13 +1836,21 @@ impl Web4Handler {
         // - Web4Manifest CID = derived deterministically from DeployManifest, used for resolution
         // - The transform from DeployManifest → Web4Manifest is deterministic and auditable
         // - Both CIDs are stored: DeployManifest for audit, Web4Manifest for runtime
-        let signed_message = format!(
-            "{}|{}|{}|{}",
-            update_request.domain,
-            update_request.expected_previous_manifest_cid,
-            update_request.new_manifest_cid,
-            update_request.timestamp
-        );
+        // Reconstruct the signed message with domain separation prefix and verify
+        let signed_message = {
+            let mut msg = b"ZHTP-domain-update-v1\0".to_vec();
+            msg.extend_from_slice(
+                format!(
+                    "{}|{}|{}|{}",
+                    update_request.domain,
+                    update_request.expected_previous_manifest_cid,
+                    update_request.new_manifest_cid,
+                    update_request.timestamp
+                )
+                .as_bytes(),
+            );
+            msg
+        };
         let signature_bytes = hex::decode(&update_request.signature)
             .map_err(|e| anyhow!("Invalid update signature hex encoding: {}", e))?;
 
@@ -1852,7 +1860,7 @@ impl Web4Handler {
             .ok_or_else(|| anyhow!("Owner identity not found: {}", owner_did))?;
 
         let is_valid = lib_crypto::verify_signature(
-            signed_message.as_bytes(),
+            &signed_message,
             &signature_bytes,
             &owner_identity.public_key.as_bytes(),
         )


### PR DESCRIPTION

## Summary

Added `ZHTP-domain-update-v1\0` domain separation prefix to all domain update signing and verification paths. Domain update messages are now signed as `ZHTP-domain-update-v1\0domain|expected_previous_manifest_cid|new_manifest_cid|timestamp` instead of the raw pipe-delimited format. This prevents cross-protocol signature collisions, mirroring the existing `ZHTP-identity-sig-v1\0` pattern used in identity attestations.

## Linked issues

Closes #2746

## Architecture compliance

n/a

## Test plan

- [x] Unit tests added/updated (`lib-network/src/web4/domain_signing.rs`):
  - `domain_update_message_contains_prefix` — asserts message starts with `ZHTP_DOMAIN_UPDATE_SIGN_DOMAIN`
  - `domain_update_signature_fails_without_prefix` — asserts old unprefixed signatures are rejected by the canonical verifier
  - `domain_update_roundtrip_sign_and_verify` — end-to-end sign + verify with prefix
- [x] `cargo check --workspace` passes (exit code 0)

## Risk and reversibility

**Breaking change:** old signatures (without the prefix) will fail verification. All nodes (signers in `lib-network`, `lib-client`, `zhtp-cli`; verifier in `zhtp` API handler) must be deployed together in the same release — no coordinated network restart needed, but rolling deployments will have a brief window where old signatures are rejected.