### PR TITLE
feat(lib-client): AssetLaunch C FFI + domain 100 SOV / asset_id V3 (mobile M1/M4)

### DIFF
--- a/lib-client/src/asset_launch_tx.rs
+++ b/lib-client/src/asset_launch_tx.rs
@@ -204,6 +204,48 @@ mod tests {
         assert_eq!(payload.treasury_bps, DaoClass::Fp.treasury_bps());
     }
 
+    /// Mirrors `zhtp_client_build_asset_launch` defaults: local manifest derive,
+    /// Fixed supply, no rewards/governance, transfer_authority false.
+    #[test]
+    fn ffi_defaults_local_manifest_round_trip() {
+        use crate::identity::generate_identity;
+
+        let identity = generate_identity("ffi-launch".to_string()).unwrap();
+        let (cid, hash) = build_dao_launch_manifest("Mobile DAO", "MDAO", 18).unwrap();
+        let signed = build_asset_launch_tx(
+            &identity,
+            &AssetLaunchBuildParams {
+                name: "Mobile DAO".to_string(),
+                symbol: "MDAO".to_string(),
+                initial_supply: 1_000_000_000_000_000_000_000,
+                decimals: 18,
+                treasury_key_id: [0xABu8; 32],
+                dao_class: DaoClass::Fp,
+                burn_bps: 100,
+                supply_mode: SupplyMode::Fixed,
+                manifest_cid: cid,
+                manifest_hash: hash,
+                chain_id: 3,
+                rewards: None,
+                governance: None,
+                transfer_authority: false,
+            },
+        )
+        .expect("ffi-default builder");
+
+        let tx: Transaction =
+            bincode::deserialize(&hex::decode(signed).expect("hex")).expect("tx");
+        assert_eq!(tx.transaction_type, TransactionType::AssetLaunch);
+        let payload = AssetLaunchPayloadV1::decode_memo(&tx.memo).expect("memo");
+        assert_eq!(payload.manifest_cid, cid);
+        assert_eq!(payload.manifest_hash, hash);
+        assert_eq!(payload.burn_bps, 100);
+        assert_eq!(payload.supply_mode, SupplyMode::Fixed);
+        assert!(payload.rewards.is_none());
+        assert!(payload.governance.is_none());
+        assert!(!payload.transfer_authority);
+    }
+
     #[test]
     fn np_launch_uses_full_treasury_split() {
         use crate::identity::generate_identity;

--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -1541,19 +1541,28 @@ pub extern "C" fn zhtp_client_build_token_create(
 /// # Parameters
 /// - `handle`: Creator identity handle
 /// - `name` / `symbol`: Null-terminated C strings
-/// - `initial_supply`: Atomic units (u128; mobile ABI: two u64 halves)
+/// - `initial_supply_atoms_lo` / `initial_supply_atoms_hi`: Atomic supply as two
+///   little-endian u64 halves (`hi << 64 | lo` → u128). Same pattern as
+///   `zhtp_client_build_domain_fee_payment_tx` (Swift/Kotlin-safe; bare `u128`
+///   is not a portable C ABI).
 /// - `decimals`: Decimal places
 /// - `treasury_key_id`: 32-byte key_id (must be non-zero and ≠ creator)
 /// - `dao_class`: 0 = Fp (for-profit), 1 = Np (non-profit); other values → NULL
 /// - `burn_bps`: Transfer burn in basis points (max 1000 = 10%)
 /// - `chain_id`: Network chain ID
-/// - `manifest_cid` / `manifest_hash`: Optional 32-byte pointers; NULL → local derive
+/// - `manifest_cid` / `manifest_hash`: Optional 32-byte pointers. Both NULL →
+///   local derive via `build_dao_launch_manifest`. Both non-null → copy.
+///   Mixed (one null, one set) → NULL (fail closed).
+///
+/// M1 defaults (not overridable via this ABI): `SupplyMode::Fixed`,
+/// `rewards`/`governance` none, `transfer_authority` false.
 #[no_mangle]
 pub extern "C" fn zhtp_client_build_asset_launch(
     handle: *const IdentityHandle,
     name: *const std::ffi::c_char,
     symbol: *const std::ffi::c_char,
-    initial_supply: u128,
+    initial_supply_atoms_lo: u64,
+    initial_supply_atoms_hi: u64,
     decimals: u8,
     treasury_key_id: *const u8,
     dao_class: u8,
@@ -1580,6 +1589,9 @@ pub extern "C" fn zhtp_client_build_asset_launch(
         }
     };
 
+    let initial_supply: u128 =
+        (initial_supply_atoms_hi as u128) << 64 | (initial_supply_atoms_lo as u128);
+
     let mut treasury_arr = [0u8; 32];
     unsafe {
         std::ptr::copy_nonoverlapping(treasury_key_id, treasury_arr.as_mut_ptr(), 32);
@@ -1592,19 +1604,22 @@ pub extern "C" fn zhtp_client_build_asset_launch(
         _ => return std::ptr::null_mut(),
     };
 
-    let (cid, hash) = if manifest_cid.is_null() || manifest_hash.is_null() {
-        match build_dao_launch_manifest(name_str, symbol_str, decimals) {
+    // Fail closed: both null (derive) or both non-null (copy). Never half-set.
+    let (cid, hash) = match (manifest_cid.is_null(), manifest_hash.is_null()) {
+        (true, true) => match build_dao_launch_manifest(name_str, symbol_str, decimals) {
             Ok(v) => v,
             Err(_) => return std::ptr::null_mut(),
+        },
+        (false, false) => {
+            let mut c = [0u8; 32];
+            let mut h = [0u8; 32];
+            unsafe {
+                std::ptr::copy_nonoverlapping(manifest_cid, c.as_mut_ptr(), 32);
+                std::ptr::copy_nonoverlapping(manifest_hash, h.as_mut_ptr(), 32);
+            }
+            (c, h)
         }
-    } else {
-        let mut c = [0u8; 32];
-        let mut h = [0u8; 32];
-        unsafe {
-            std::ptr::copy_nonoverlapping(manifest_cid, c.as_mut_ptr(), 32);
-            std::ptr::copy_nonoverlapping(manifest_hash, h.as_mut_ptr(), 32);
-        }
-        (c, h)
+        _ => return std::ptr::null_mut(),
     };
 
     match build_asset_launch_tx(
@@ -1858,10 +1873,9 @@ pub extern "C" fn zhtp_client_build_domain_update(
 //
 // The web4 server now requires every new-domain registration to carry a
 // `fee_payment_tx` field: a hex-encoded, user-signed TokenTransfer paying the
-// 10 SOV registration fee from the owner's Primary wallet to the DAO
-// treasury wallet. The two FFI exports below give the mobile SDK the same
-// surface the Rust CLI already uses (`build_domain_fee_payment_tx` +
-// `build_domain_register_request_with_fee_payment`).
+// domain registration fee (default **100 SOV** = `100 * 10^18` atoms; must
+// match live `TxFeeConfig.domain_registration_fee_atoms`) from the owner's
+// Primary wallet to the DAO treasury wallet.
 //
 // Mobile flow:
 //   1. Fetch owner's Primary `wallet_id` (32 bytes) via the existing
@@ -1871,6 +1885,9 @@ pub extern "C" fn zhtp_client_build_domain_update(
 //   3. Call `zhtp_client_build_domain_fee_payment_tx` to get the hex tx.
 //   4. Call `zhtp_client_build_domain_register_request_with_fee_payment`
 //      with the hex from step 3 to get the JSON body to POST.
+//
+// **ABI note (M4):** step 4 gained a trailing `asset_id_hex` parameter.
+// Mobile must regenerate headers and pass NULL for non-DAO domains.
 //
 // The DAO treasury wallet id is deterministic and may be hard-coded or
 // computed by the caller — see Blockchain::deterministic_treasury_wallet_id
@@ -1967,6 +1984,10 @@ pub extern "C" fn zhtp_client_build_domain_fee_payment_tx(
 /// - `asset_id_hex`: Optional 64-char hex sovereign asset id (optional
 ///   `0x` prefix). Pass NULL or empty for unbound (V2) domains; when set
 ///   the domain system tx is V3-bound to the asset (DAO M4).
+///
+/// **Breaking C ABI (M4):** this export added `asset_id_hex` as the last
+/// argument. Existing mobile binaries must be rebuilt against the new
+/// header; old arity will crash or mis-parse.
 ///
 /// Returns NULL on missing inputs, JSON parse failure, or signing failure.
 #[no_mangle]

--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -1525,6 +1525,113 @@ pub extern "C" fn zhtp_client_build_token_create(
     }
 }
 
+/// Build a signed Sovereign Asset `AssetLaunch` transaction.
+///
+/// Returns hex-encoded bincode `Transaction` ready to POST to
+/// `POST /api/v1/assets/launch` as
+/// `{"signed_tx": "<hex>", "enforce_dao_launch_constraints": true}`.
+/// Caller must free with `zhtp_client_string_free`. Returns NULL on error.
+///
+/// When `manifest_cid` / `manifest_hash` are NULL, a deterministic local
+/// DAO launch manifest is derived via `build_dao_launch_manifest` (non-zero
+/// cid/hash). Full Web4 pin is a separate step.
+///
+/// # Parameters
+/// - `handle`: Creator identity handle
+/// - `name` / `symbol`: Null-terminated C strings
+/// - `initial_supply`: Atomic units (u128; mobile ABI: two u64 halves)
+/// - `decimals`: Decimal places
+/// - `treasury_key_id`: 32-byte key_id (must be non-zero and ≠ creator)
+/// - `dao_class`: 0 = Fp (for-profit), 1 = Np (non-profit); other values → NULL
+/// - `burn_bps`: Transfer burn in basis points (max 1000 = 10%)
+/// - `chain_id`: Network chain ID
+/// - `manifest_cid` / `manifest_hash`: Optional 32-byte pointers; NULL → local derive
+#[no_mangle]
+pub extern "C" fn zhtp_client_build_asset_launch(
+    handle: *const IdentityHandle,
+    name: *const std::ffi::c_char,
+    symbol: *const std::ffi::c_char,
+    initial_supply: u128,
+    decimals: u8,
+    treasury_key_id: *const u8,
+    dao_class: u8,
+    burn_bps: u16,
+    chain_id: u8,
+    manifest_cid: *const u8,
+    manifest_hash: *const u8,
+) -> *mut std::ffi::c_char {
+    if handle.is_null() || name.is_null() || symbol.is_null() || treasury_key_id.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let identity = unsafe { &(*handle).inner };
+    let name_str = unsafe {
+        match std::ffi::CStr::from_ptr(name).to_str() {
+            Ok(s) => s,
+            Err(_) => return std::ptr::null_mut(),
+        }
+    };
+    let symbol_str = unsafe {
+        match std::ffi::CStr::from_ptr(symbol).to_str() {
+            Ok(s) => s,
+            Err(_) => return std::ptr::null_mut(),
+        }
+    };
+
+    let mut treasury_arr = [0u8; 32];
+    unsafe {
+        std::ptr::copy_nonoverlapping(treasury_key_id, treasury_arr.as_mut_ptr(), 32);
+    }
+
+    use lib_blockchain::contracts::sovereign_asset::{DaoClass, SupplyMode};
+    let dao = match dao_class {
+        0 => DaoClass::Fp,
+        1 => DaoClass::Np,
+        _ => return std::ptr::null_mut(),
+    };
+
+    let (cid, hash) = if manifest_cid.is_null() || manifest_hash.is_null() {
+        match build_dao_launch_manifest(name_str, symbol_str, decimals) {
+            Ok(v) => v,
+            Err(_) => return std::ptr::null_mut(),
+        }
+    } else {
+        let mut c = [0u8; 32];
+        let mut h = [0u8; 32];
+        unsafe {
+            std::ptr::copy_nonoverlapping(manifest_cid, c.as_mut_ptr(), 32);
+            std::ptr::copy_nonoverlapping(manifest_hash, h.as_mut_ptr(), 32);
+        }
+        (c, h)
+    };
+
+    match build_asset_launch_tx(
+        identity,
+        &AssetLaunchBuildParams {
+            name: name_str.to_string(),
+            symbol: symbol_str.to_string(),
+            initial_supply,
+            decimals,
+            treasury_key_id: treasury_arr,
+            dao_class: dao,
+            burn_bps,
+            supply_mode: SupplyMode::Fixed,
+            manifest_cid: cid,
+            manifest_hash: hash,
+            chain_id,
+            rewards: None,
+            governance: None,
+            transfer_authority: false,
+        },
+    ) {
+        Ok(hex_tx) => match std::ffi::CString::new(hex_tx) {
+            Ok(s) => s.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        },
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
 /// Build a signed token burn transaction.
 /// Returns hex-encoded transaction ready to POST to /api/v1/token/burn
 /// Caller must free with `zhtp_client_string_free`.

--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -110,7 +110,9 @@ pub use token_tx::{
     build_domain_register_request_with_fee_payment,
     build_domain_register_request_with_fee_payment_and_metadata,
     fee_tx_hash_from_hex,
+    parse_optional_asset_id_hex,
     sign_domain_registration_system_tx,
+    DOMAIN_REGISTRATION_FEE,
     // Domain-specific (deprecated, use *_request functions instead)
     build_domain_register_tx,
     build_domain_transfer_request,
@@ -1889,8 +1891,8 @@ pub extern "C" fn zhtp_client_build_domain_update(
 /// - `treasury_wallet_id`: 32-byte raw DAO treasury wallet id. If NULL,
 ///   the deterministic `blake3("SOV_DAO_TREASURY_V1")` value is used.
 /// - `amount_atoms`: Fee amount in atomic SOV units (18-decimals;
-///   10 SOV = `10_000_000_000_000_000_000`). The server enforces a
-///   minimum of 10 SOV.
+///   100 SOV = `100_000_000_000_000_000_000`). The server enforces the
+///   governance-tunable domain fee (default 100 SOV).
 /// - `nonce`: Sender's current SOV nonce (fetch from
 ///   `GET /api/v1/token/nonce/<sov_token_id_hex>/<sender_wallet_id_hex>`).
 /// - `chain_id`: Network chain id (3 for the current testnet).
@@ -1959,6 +1961,12 @@ pub extern "C" fn zhtp_client_build_domain_fee_payment_tx(
 ///   record). Invalid JSON returns NULL.
 /// - `fee_payment_tx_hex`: Null-terminated hex string produced by
 ///   `zhtp_client_build_domain_fee_payment_tx`. REQUIRED.
+/// - `metadata_json`: Optional null-terminated metadata JSON. Pass NULL
+///   for none.
+/// - `chain_id`: Network chain id (0 → default testnet 0x03).
+/// - `asset_id_hex`: Optional 64-char hex sovereign asset id (optional
+///   `0x` prefix). Pass NULL or empty for unbound (V2) domains; when set
+///   the domain system tx is V3-bound to the asset (DAO M4).
 ///
 /// Returns NULL on missing inputs, JSON parse failure, or signing failure.
 #[no_mangle]
@@ -1969,6 +1977,7 @@ pub extern "C" fn zhtp_client_build_domain_register_request_with_fee_payment(
     fee_payment_tx_hex: *const std::ffi::c_char,
     metadata_json: *const std::ffi::c_char,
     chain_id: u8,
+    asset_id_hex: *const std::ffi::c_char,
 ) -> *mut std::ffi::c_char {
     if handle.is_null() || domain.is_null() || fee_payment_tx_hex.is_null() {
         return std::ptr::null_mut();
@@ -2018,6 +2027,21 @@ pub extern "C" fn zhtp_client_build_domain_register_request_with_fee_payment(
             Err(_) => return std::ptr::null_mut(),
         }
     };
+    let asset_id_opt: Option<&str> = if asset_id_hex.is_null() {
+        None
+    } else {
+        let raw = unsafe {
+            match std::ffi::CStr::from_ptr(asset_id_hex).to_str() {
+                Ok(s) => s,
+                Err(_) => return std::ptr::null_mut(),
+            }
+        };
+        if raw.trim().is_empty() {
+            None
+        } else {
+            Some(raw)
+        }
+    };
     let effective_chain_id = if chain_id == 0 {
         token_tx::DEFAULT_DOMAIN_CHAIN_ID
     } else {
@@ -2031,6 +2055,7 @@ pub extern "C" fn zhtp_client_build_domain_register_request_with_fee_payment(
         Some(fee_tx_str),
         metadata_opt,
         effective_chain_id,
+        asset_id_opt,
     ) {
         Ok(json) => match std::ffi::CString::new(json) {
             Ok(s) => s.into_raw(),

--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -841,8 +841,14 @@ pub fn build_burn_tx(
 use crate::crypto::Dilithium5;
 
 /// Domain registration fee in whole SOV tokens.
+///
 /// DAO launch v1 standard (epic Q10 / M4) = 100 SOV native → protocol treasury.
 /// Atomic amount = 100 * 10^18 = `100000000000000000000`.
+///
+/// **Coupling:** clients sign `domain|timestamp|{this}` while the node verifies
+/// against live `TxFeeConfig.domain_registration_fee_atoms` (default matches
+/// this constant). If governance changes the fee, rebuild clients with the new
+/// whole-SOV amount (or query the node first).
 pub const DOMAIN_REGISTRATION_FEE: u64 = 100;
 
 /// Default chain id for domain system transactions (testnet).
@@ -1305,6 +1311,37 @@ mod domain_system_tx_tests {
         let parsed: DomainRegisterParams = serde_json::from_str(&json).expect("parse");
         assert_eq!(parsed.asset_id.as_deref(), Some(asset_hex.as_str()));
         assert!(!parsed.domain_tx_signature_hex.is_empty());
+
+        // Memo must be DOMREG3 with the same asset_id the client signed.
+        use lib_blockchain::transaction::domain::{
+            DomainRegistrationPayload, DOMAIN_REGISTRATION_PREFIX_V3,
+        };
+        let fee_tx_hash_hex = fee_tx_hash_from_hex(parsed.fee_payment_tx.as_ref().unwrap())
+            .expect("fee hash");
+        let (title, description, tags) =
+            domain_registration_title_description_tags("dao.example.sov", None);
+        let payload = DomainRegistrationPayload {
+            domain: "dao.example.sov".to_string(),
+            owner_did: identity.did.clone(),
+            manifest_cid: String::new(),
+            build_hash: String::new(),
+            title,
+            description,
+            category: "general".to_string(),
+            tags,
+            duration_days: 365,
+            fee_tx_hash: fee_tx_hash_hex,
+            fee_amount_atoms: 0,
+            fee_payer_wallet_id: [0u8; 32],
+            asset_id: Some(asset_id),
+        };
+        let memo = payload.encode_memo().expect("encode");
+        assert!(
+            memo.starts_with(DOMAIN_REGISTRATION_PREFIX_V3),
+            "DAO-bound register must encode DOMREG3"
+        );
+        let decoded = DomainRegistrationPayload::decode_memo(&memo).expect("decode");
+        assert_eq!(decoded.asset_id, Some(asset_id));
     }
 
     #[test]

--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -188,6 +188,10 @@ pub struct DomainRegisterParams {
     /// Dilithium5 hex signature over the domain system tx `signing_hash()`.
     #[serde(default)]
     pub domain_tx_signature_hex: String,
+    /// Optional 64-char hex sovereign `asset_id` for DAO-scoped domains (V3 memo).
+    /// When set, the domain system tx encodes as DOMREG3 with `asset_id: Some`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_id: Option<String>,
 }
 
 /// Content mapping for domain registration
@@ -836,11 +840,31 @@ pub fn build_burn_tx(
 
 use crate::crypto::Dilithium5;
 
-/// Domain registration fee in SOV tokens
-const DOMAIN_REGISTRATION_FEE: u64 = 10;
+/// Domain registration fee in whole SOV tokens.
+/// DAO launch v1 standard (epic Q10 / M4) = 100 SOV native → protocol treasury.
+/// Atomic amount = 100 * 10^18 = `100000000000000000000`.
+pub const DOMAIN_REGISTRATION_FEE: u64 = 100;
 
 /// Default chain id for domain system transactions (testnet).
 pub const DEFAULT_DOMAIN_CHAIN_ID: u8 = 0x03;
+
+/// Parse optional 64-char (optionally `0x`-prefixed) hex into a 32-byte asset id.
+pub fn parse_optional_asset_id_hex(asset_id_hex: Option<&str>) -> Result<Option<[u8; 32]>, String> {
+    let Some(raw) = asset_id_hex.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let hex_str = raw.strip_prefix("0x").or_else(|| raw.strip_prefix("0X")).unwrap_or(raw);
+    if hex_str.len() != 64 {
+        return Err(format!(
+            "asset_id must be 64 hex chars (32 bytes), got {} chars",
+            hex_str.len()
+        ));
+    }
+    let bytes = hex::decode(hex_str).map_err(|e| format!("asset_id is not valid hex: {}", e))?;
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(Some(arr))
+}
 
 /// Compute the fee-payment tx hash hex the server embeds in the domain registration memo.
 pub fn fee_tx_hash_from_hex(fee_payment_tx_hex: &str) -> Result<String, String> {
@@ -880,6 +904,7 @@ fn domain_registration_title_description_tags(
 /// Sign the domain `DomainRegistration` system transaction skeleton the server verifies.
 ///
 /// Must mirror `zhtp::api::handlers::web4::domains::attach_client_domain_tx_signature`.
+/// When `asset_id` is `Some`, the memo is V3 (DOMREG3); otherwise V2.
 pub fn sign_domain_registration_system_tx(
     identity: &Identity,
     domain: &str,
@@ -890,6 +915,7 @@ pub fn sign_domain_registration_system_tx(
     description: &str,
     tags: Vec<String>,
     chain_id: u8,
+    asset_id: Option<[u8; 32]>,
 ) -> Result<String, String> {
     use lib_blockchain::transaction::domain::DomainRegistrationPayload;
     use lib_blockchain::transaction::TransactionPayload;
@@ -907,7 +933,7 @@ pub fn sign_domain_registration_system_tx(
         fee_tx_hash: fee_tx_hash_hex.to_string(),
         fee_amount_atoms: 0,
         fee_payer_wallet_id: [0u8; 32],
-        asset_id: None,
+        asset_id,
     };
     let memo = payload
         .encode_memo()
@@ -919,7 +945,7 @@ pub fn sign_domain_registration_system_tx(
         .try_into()
         .map_err(|_| "identity public_key must be exactly 2592 bytes".to_string())?;
 
-    let mut tx = Transaction {
+    let tx = Transaction {
         version: 8,
         chain_id,
         transaction_type: TransactionType::DomainRegistration,
@@ -988,11 +1014,15 @@ pub fn build_domain_register_request_with_fee_payment(
         fee_payment_tx,
         None,
         DEFAULT_DOMAIN_CHAIN_ID,
+        None,
     )
 }
 
 /// Like [`build_domain_register_request_with_fee_payment`] but accepts optional metadata
 /// and an explicit chain id for the domain system transaction signature.
+///
+/// `asset_id_hex`: optional 64-char hex (optional `0x` prefix) sovereign asset id.
+/// When present, the domain system tx is V3-bound to that asset (DAO M4).
 pub fn build_domain_register_request_with_fee_payment_and_metadata(
     identity: &Identity,
     domain: &str,
@@ -1000,6 +1030,7 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
     fee_payment_tx: Option<String>,
     metadata: Option<serde_json::Value>,
     chain_id: u8,
+    asset_id_hex: Option<&str>,
 ) -> Result<String, String> {
     let fee_payment_tx = fee_payment_tx.ok_or_else(|| {
         "fee_payment_tx is required for domain registration. \
@@ -1014,6 +1045,9 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
         );
     }
 
+    let asset_id = parse_optional_asset_id_hex(asset_id_hex)?;
+    let asset_id_hex_out = asset_id.map(|id| hex::encode(id));
+
     let fee_tx_hash_hex = fee_tx_hash_from_hex(&fee_payment_tx)?;
 
     let timestamp = std::time::SystemTime::now()
@@ -1021,7 +1055,7 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
         .map_err(|e| format!("Failed to get timestamp: {}", e))?
         .as_secs();
 
-    // Sign: domain|timestamp|fee_amount
+    // Sign: domain|timestamp|fee_amount (whole SOV; must match server TxFeeConfig)
     let message = format!("{}|{}|{}", domain, timestamp, DOMAIN_REGISTRATION_FEE);
     let signature = Dilithium5::sign(message.as_bytes(), &identity.private_key)
         .map_err(|e| format!("Failed to sign: {}", e))?;
@@ -1038,6 +1072,7 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
         &description,
         tags,
         chain_id,
+        asset_id,
     )?;
 
     let request = DomainRegisterParams {
@@ -1050,6 +1085,7 @@ pub fn build_domain_register_request_with_fee_payment_and_metadata(
         fee: Some(DOMAIN_REGISTRATION_FEE),
         fee_payment_tx: Some(fee_payment_tx),
         domain_tx_signature_hex,
+        asset_id: asset_id_hex_out,
     };
 
     serde_json::to_string(&request).map_err(|e| format!("Failed to serialize request: {}", e))
@@ -1206,7 +1242,7 @@ mod domain_system_tx_tests {
             &identity,
             &sender_wallet,
             &treasury_wallet,
-            10 * 1_000_000_000_000_000_000u128,
+            100 * 1_000_000_000_000_000_000u128,
             DEFAULT_DOMAIN_CHAIN_ID,
             0,
         )
@@ -1231,5 +1267,56 @@ mod domain_system_tx_tests {
             "Dilithium5 signatures are 9190 hex chars"
         );
         assert!(parsed.fee_payment_tx.as_ref().is_some_and(|s| !s.is_empty()));
+        assert_eq!(parsed.fee, Some(DOMAIN_REGISTRATION_FEE));
+        assert!(parsed.asset_id.is_none());
+    }
+
+    #[test]
+    fn domain_register_request_binds_asset_id_v3() {
+        let (identity, _keypair) = test_identity();
+        let treasury = blake3::hash(b"SOV_DAO_TREASURY_V1");
+        let mut treasury_wallet = [0u8; 32];
+        treasury_wallet.copy_from_slice(treasury.as_bytes());
+        let sender_wallet = [42u8; 32];
+        let asset_id = [7u8; 32];
+        let asset_hex = hex::encode(asset_id);
+
+        let fee_tx_hex = build_sov_wallet_transfer_tx(
+            &identity,
+            &sender_wallet,
+            &treasury_wallet,
+            100 * 1_000_000_000_000_000_000u128,
+            DEFAULT_DOMAIN_CHAIN_ID,
+            0,
+        )
+        .expect("fee tx");
+
+        let json = build_domain_register_request_with_fee_payment_and_metadata(
+            &identity,
+            "dao.example.sov",
+            None,
+            Some(fee_tx_hex),
+            None,
+            DEFAULT_DOMAIN_CHAIN_ID,
+            Some(&asset_hex),
+        )
+        .expect("request json");
+
+        let parsed: DomainRegisterParams = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed.asset_id.as_deref(), Some(asset_hex.as_str()));
+        assert!(!parsed.domain_tx_signature_hex.is_empty());
+    }
+
+    #[test]
+    fn parse_optional_asset_id_strips_0x() {
+        let id = [1u8; 32];
+        let hex_plain = hex::encode(id);
+        let with_prefix = format!("0x{}", hex_plain);
+        assert_eq!(
+            parse_optional_asset_id_hex(Some(&with_prefix)).unwrap(),
+            Some(id)
+        );
+        assert_eq!(parse_optional_asset_id_hex(None).unwrap(), None);
+        assert_eq!(parse_optional_asset_id_hex(Some("")).unwrap(), None);
     }
 }

--- a/zhtp-cli/src/commands/domain.rs
+++ b/zhtp-cli/src/commands/domain.rs
@@ -307,6 +307,7 @@ async fn register_domain_impl(
         created_at: loaded.identity.created_at,
     };
 
+    // asset_id_hex: None — plain domain registration (not DAO-scoped V3).
     let body_json = zhtp_client::token_tx::build_domain_register_request_with_fee_payment_and_metadata(
         &identity,
         domain,
@@ -314,6 +315,7 @@ async fn register_domain_impl(
         Some(fee_payment_tx_hex),
         metadata_json,
         3,
+        None,
     )
     .map_err(|e| CliError::ConfigError(format!("Failed to build registration request: {}", e)))?;
 

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -169,7 +169,7 @@ pub struct SimpleDomainRegistrationRequest {
     pub signature: String,
     /// Request timestamp (Unix seconds) - for replay protection
     pub timestamp: u64,
-    /// Fee amount in SOV tokens (fixed: 10 SOV for domain registration)
+    /// Fee amount in whole SOV tokens (must match live TxFeeConfig; default 100 SOV).
     #[serde(default)]
     pub fee: Option<u64>,
     /// CONS-516: hex-encoded canonical signed TokenTransfer paying the
@@ -183,6 +183,11 @@ pub struct SimpleDomainRegistrationRequest {
     /// Dilithium5 hex signature over the domain system tx `signing_hash()` (client-signed).
     #[serde(default)]
     pub domain_tx_signature_hex: String,
+    /// Optional 64-char hex sovereign `asset_id` for DAO-scoped domains (V3 memo).
+    /// Client and server must both include this in the DomainRegistrationPayload
+    /// so `domain_tx_signature_hex` verifies.
+    #[serde(default)]
+    pub asset_id: Option<String>,
 }
 
 /// Content mapping for simple registration
@@ -844,6 +849,34 @@ impl Web4Handler {
                 (lib_blockchain::TransactionType::DomainUpdate, payload.encode_memo()
                     .map_err(|e| anyhow::anyhow!("Failed to encode domain update: {}", e))?)
             } else {
+                // Optional DAO asset binding (M4 / Q10): 64-char hex → V3 memo.
+                // Must match what the client signed into domain_tx_signature_hex.
+                let bound_asset_id: Option<[u8; 32]> =
+                    if let Some(raw) = simple_request.asset_id.as_deref() {
+                        let hex_str = raw
+                            .trim()
+                            .strip_prefix("0x")
+                            .or_else(|| raw.trim().strip_prefix("0X"))
+                            .unwrap_or(raw.trim());
+                        if hex_str.is_empty() {
+                            None
+                        } else {
+                            let bytes = hex::decode(hex_str).map_err(|e| {
+                                anyhow!("asset_id is not valid hex: {}", e)
+                            })?;
+                            if bytes.len() != 32 {
+                                return Err(anyhow!(
+                                    "asset_id must be 32 bytes (64 hex chars), got {}",
+                                    bytes.len()
+                                ));
+                            }
+                            let mut arr = [0u8; 32];
+                            arr.copy_from_slice(&bytes);
+                            Some(arr)
+                        }
+                    } else {
+                        None
+                    };
                 let payload = lib_blockchain::transaction::DomainRegistrationPayload {
                     domain: simple_request.domain.clone(),
                     owner_did: owner_did.clone(),
@@ -855,12 +888,12 @@ impl Web4Handler {
                     tags,
                     duration_days: 365,
                     fee_tx_hash: fee_tx_hash_hex.clone(),
-                    // CONS-516: fee paid by companion TokenTransfer; V2 memo
+                    // CONS-516: fee paid by companion TokenTransfer; V2/V3 memo
                     // carries fee_tx_hash binding only. Inline fee fields zeroed
                     // so client/server skeletons stay byte-identical.
                     fee_amount_atoms: 0,
                     fee_payer_wallet_id: [0u8; 32],
-                    asset_id: None,
+                    asset_id: bound_asset_id,
                 };
                 (lib_blockchain::TransactionType::DomainRegistration, payload.encode_memo()
                     .map_err(|e| anyhow::anyhow!("Failed to encode domain registration: {}", e))?)
@@ -2627,9 +2660,11 @@ mod tests {
                     "content_type": "text/html"
                 }
             },
-            "signature": sign_simple_registration(owner_identity, domain, timestamp, 10),
+            // Fee must match live TxFeeConfig.domain_registration_fee_atoms / 10^18
+            // (default 100 SOV for DAO launch v1 / M4).
+            "signature": sign_simple_registration(owner_identity, domain, timestamp, 100),
             "timestamp": timestamp,
-            "fee": 10
+            "fee": 100
         }))
     }
 

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -760,7 +760,7 @@ impl Web4Handler {
                 .unwrap_or_default(),
             public: true,
             economic_settings: DomainEconomicSettings {
-                registration_fee: 10.0,
+                registration_fee: registration_fee_whole as f64,
                 renewal_fee: 5.0,
                 transfer_fee: 2.0,
                 hosting_budget: 100.0,
@@ -849,34 +849,12 @@ impl Web4Handler {
                 (lib_blockchain::TransactionType::DomainUpdate, payload.encode_memo()
                     .map_err(|e| anyhow::anyhow!("Failed to encode domain update: {}", e))?)
             } else {
-                // Optional DAO asset binding (M4 / Q10): 64-char hex → V3 memo.
-                // Must match what the client signed into domain_tx_signature_hex.
-                let bound_asset_id: Option<[u8; 32]> =
-                    if let Some(raw) = simple_request.asset_id.as_deref() {
-                        let hex_str = raw
-                            .trim()
-                            .strip_prefix("0x")
-                            .or_else(|| raw.trim().strip_prefix("0X"))
-                            .unwrap_or(raw.trim());
-                        if hex_str.is_empty() {
-                            None
-                        } else {
-                            let bytes = hex::decode(hex_str).map_err(|e| {
-                                anyhow!("asset_id is not valid hex: {}", e)
-                            })?;
-                            if bytes.len() != 32 {
-                                return Err(anyhow!(
-                                    "asset_id must be 32 bytes (64 hex chars), got {}",
-                                    bytes.len()
-                                ));
-                            }
-                            let mut arr = [0u8; 32];
-                            arr.copy_from_slice(&bytes);
-                            Some(arr)
-                        }
-                    } else {
-                        None
-                    };
+                // Optional DAO asset binding (M4 / Q10): same parser as lib-client
+                // so client/server domain_tx_signature skeletons stay byte-identical.
+                let bound_asset_id = zhtp_client::token_tx::parse_optional_asset_id_hex(
+                    simple_request.asset_id.as_deref(),
+                )
+                .map_err(|e| anyhow!(e))?;
                 let payload = lib_blockchain::transaction::DomainRegistrationPayload {
                     domain: simple_request.domain.clone(),
                     owner_did: owner_did.clone(),
@@ -1127,7 +1105,7 @@ impl Web4Handler {
             tags: vec!["web4".to_string(), "manifest".to_string()],
             public: true,
             economic_settings: DomainEconomicSettings {
-                registration_fee: 10.0,
+                registration_fee: registration_fee_whole as f64,
                 renewal_fee: 5.0,
                 transfer_fee: 2.0,
                 hosting_budget: 100.0,
@@ -1330,7 +1308,8 @@ impl Web4Handler {
             tags: api_request.tags,
             public: api_request.public,
             economic_settings: DomainEconomicSettings {
-                registration_fee: 10.0, // Will be calculated properly
+                // Display fee matches client/server default (TxFeeConfig / 10^18).
+                registration_fee: zhtp_client::token_tx::DOMAIN_REGISTRATION_FEE as f64,
                 renewal_fee: 5.0,
                 transfer_fee: 2.0,
                 hosting_budget: 100.0,
@@ -1348,7 +1327,7 @@ impl Web4Handler {
             deploy_manifest_cid: None, // Auto-generate for non-manifest registration
             owner_signature_hex: String::new(),
             registration_timestamp: 0,
-            registration_fee_whole: 10,
+            registration_fee_whole: zhtp_client::token_tx::DOMAIN_REGISTRATION_FEE,
         };
 
         // Process registration
@@ -2601,8 +2580,8 @@ mod tests {
             kyber_pk: [0u8; 1568],
             key_id: owner_wallet_id,
         };
-        // 11 SOV — enough to cover the 10 SOV domain registration fee (atoms).
-        sov.mint(&owner_wallet_key, lib_types::sov::atoms(11)).unwrap();
+        // 101 SOV — enough to cover the 100 SOV domain registration fee (atoms).
+        sov.mint(&owner_wallet_key, lib_types::sov::atoms(101)).unwrap();
         blockchain.insert_token_contract(generate_lib_token_id(), sov);
 
         let blockchain = Arc::new(RwLock::new(blockchain));
@@ -2666,6 +2645,130 @@ mod tests {
             "timestamp": timestamp,
             "fee": 100
         }))
+    }
+
+    /// M4 / V3: `domain_tx_signature_hex` must be over the memo that includes
+    /// the same `asset_id` the server will encode. Mismatch (wrong id or V2)
+    /// must fail closed so DAO-scoped registration cannot silently drift.
+    #[test]
+    fn v3_domain_tx_signature_requires_matching_asset_id() {
+        use lib_blockchain::integration::crypto_integration::{
+            PublicKey as BcPublicKey, Signature as BcSignature, SignatureAlgorithm,
+        };
+        use lib_blockchain::transaction::domain::DomainRegistrationPayload;
+        use lib_identity::types::IdentityType;
+
+        let owner = lib_identity::ZhtpIdentity::new_unified(
+            IdentityType::Human,
+            Some(30),
+            Some("US".to_string()),
+            "v3-asset-id-sig-test",
+            None,
+        )
+        .expect("identity");
+        let owner_pk = owner.public_key.dilithium_pk.as_slice();
+        let private = owner
+            .private_key
+            .clone()
+            .expect("test identity private key");
+        let keypair = lib_crypto::KeyPair {
+            public_key: owner.public_key.clone(),
+            private_key: private,
+        };
+
+        let asset_id = [0xABu8; 32];
+        let timestamp = 1_700_000_000u64;
+        let fee_tx_hash = "aa".repeat(32);
+
+        let make_memo = |aid: Option<[u8; 32]>| {
+            DomainRegistrationPayload {
+                domain: "dao.example.sov".to_string(),
+                owner_did: owner.did.clone(),
+                manifest_cid: String::new(),
+                build_hash: String::new(),
+                title: "dao.example.sov".to_string(),
+                description: String::new(),
+                category: "general".to_string(),
+                tags: vec![],
+                duration_days: 365,
+                fee_tx_hash: fee_tx_hash.clone(),
+                fee_amount_atoms: 0,
+                fee_payer_wallet_id: [0u8; 32],
+                asset_id: aid,
+            }
+            .encode_memo()
+            .expect("encode memo")
+        };
+
+        let memo_v3 = make_memo(Some(asset_id));
+        assert!(
+            memo_v3.starts_with(lib_blockchain::transaction::domain::DOMAIN_REGISTRATION_PREFIX_V3),
+            "DAO-bound payload must encode DOMREG3"
+        );
+
+        let owner_pk_arr: [u8; 2592] = owner_pk.try_into().expect("pk len");
+        let skeleton = lib_blockchain::Transaction {
+            version: 8,
+            chain_id: domain_chain_id(),
+            transaction_type: lib_blockchain::TransactionType::DomainRegistration,
+            inputs: vec![],
+            outputs: vec![],
+            fee: 0,
+            signature: BcSignature {
+                signature: vec![],
+                public_key: BcPublicKey::new(owner_pk_arr),
+                algorithm: SignatureAlgorithm::Dilithium5,
+                timestamp,
+            },
+            memo: memo_v3.clone(),
+            payload: lib_blockchain::transaction::TransactionPayload::None,
+        };
+        let sig = lib_crypto::sign_message(&keypair, skeleton.signing_hash().as_bytes())
+            .expect("sign");
+        let sig_hex = hex::encode(&sig.signature);
+
+        attach_client_domain_tx_signature(
+            owner_pk,
+            &sig_hex,
+            lib_blockchain::TransactionType::DomainRegistration,
+            memo_v3,
+            timestamp,
+        )
+        .expect("matching V3 asset_id must verify");
+
+        // Same signature over a V2 memo (no asset_id) must fail.
+        let err_v2 = attach_client_domain_tx_signature(
+            owner_pk,
+            &sig_hex,
+            lib_blockchain::TransactionType::DomainRegistration,
+            make_memo(None),
+            timestamp,
+        )
+        .expect_err("V2 memo must not verify V3 signature");
+        assert!(
+            err_v2
+                .to_string()
+                .contains("does not match the domain system transaction"),
+            "got: {}",
+            err_v2
+        );
+
+        // Same signature over a different asset_id must fail.
+        let err_wrong = attach_client_domain_tx_signature(
+            owner_pk,
+            &sig_hex,
+            lib_blockchain::TransactionType::DomainRegistration,
+            make_memo(Some([0xCDu8; 32])),
+            timestamp,
+        )
+        .expect_err("wrong asset_id must not verify");
+        assert!(
+            err_wrong
+                .to_string()
+                .contains("does not match the domain system transaction"),
+            "got: {}",
+            err_wrong
+        );
     }
 
     /// CONS-516: a new-domain registration without `fee_payment_tx` must be


### PR DESCRIPTION
## Summary

Mobile M1/M4 surface for DAO launch:

- **`zhtp_client_build_asset_launch`** C FFI wraps `build_asset_launch_tx` (hex tx for `POST /api/v1/assets/launch`).
- Domain registration fee client constant **10 → 100 SOV** (matches `DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS` / live `TxFeeConfig`).
- Optional **`asset_id`** threads client → system-tx memo → server so V3 (`DOMREG3`) + `domain_tx_signature_hex` stay byte-identical.

### Review follow-ups

- Manifest pointers fail closed (both null → derive; both set → copy; mixed → NULL).
- AssetLaunch supply uses **`initial_supply_atoms_lo` / `_hi`** (Swift/Kotlin-safe; not bare `u128`).
- Shared `parse_optional_asset_id_hex` on server; fee-display paths use live whole-SOV fee / `DOMAIN_REGISTRATION_FEE`.
- Tests: FFI-default launch round-trip, client V3 memo decode, server V3 signature match/mismatch.
- Documented **C ABI break** on domain-register FFI trailing `asset_id_hex` and **client fee coupling** to governance-tunable `TxFeeConfig`.

### Mobile / release notes

- **Breaking C ABI (M4):** `zhtp_client_build_domain_register_request_with_fee_payment` gained trailing `asset_id_hex` — regenerate headers; pass `NULL` for non-DAO domains.
- **New AssetLaunch ABI:** supply is two `u64` halves (`hi << 64 | lo`).
- Fee signing still uses whole-SOV `DOMAIN_REGISTRATION_FEE` (100); if governance changes the fee, rebuild clients or query the node first.

## Test plan

- [x] `cargo test -p lib-client --lib domain_system_tx_tests`
- [x] `cargo test -p lib-client --lib ffi_defaults_local_manifest`
- [x] `cargo test -p zhtp --lib v3_domain_tx_signature`
- [ ] CI green on PR