### PR TITLE
fix(domain): restore zhtp compile after #2919 (no zhtp_client in node)

### DIFF
--- a/lib-blockchain/src/transaction/domain.rs
+++ b/lib-blockchain/src/transaction/domain.rs
@@ -25,6 +25,32 @@ pub const DOMAIN_REGISTRATION_PREFIX_V2: &[u8] = b"DOMREG2:";
 pub const DOMAIN_REGISTRATION_PREFIX_V3: &[u8] = b"DOMREG3:";
 pub const DOMAIN_UPDATE_PREFIX: &[u8] = b"DOMUPD1:";
 
+/// Parse optional 64-char (optionally `0x`-prefixed) hex into a 32-byte asset id.
+///
+/// Shared by node API handlers and lib-client so domain_tx_signature skeletons
+/// stay byte-identical for optional DAO asset binding (M4 / Q10).
+pub fn parse_optional_asset_id_hex(
+    asset_id_hex: Option<&str>,
+) -> std::result::Result<Option<[u8; 32]>, String> {
+    let Some(raw) = asset_id_hex.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let hex_str = raw
+        .strip_prefix("0x")
+        .or_else(|| raw.strip_prefix("0X"))
+        .unwrap_or(raw);
+    if hex_str.len() != 64 {
+        return Err(format!(
+            "asset_id must be 64 hex chars (32 bytes), got {} chars",
+            hex_str.len()
+        ));
+    }
+    let bytes = hex::decode(hex_str).map_err(|e| format!("asset_id is not valid hex: {}", e))?;
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(Some(arr))
+}
+
 /// Canonical on-chain domain record — stored in `Blockchain::domain_registry`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OnChainDomainRecord {
@@ -419,6 +445,20 @@ mod tests {
             err.contains("not found in mempool"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn parse_optional_asset_id_strips_0x_and_empty() {
+        let id = [1u8; 32];
+        let hex_plain = hex::encode(id);
+        let with_prefix = format!("0x{}", hex_plain);
+        assert_eq!(
+            parse_optional_asset_id_hex(Some(&with_prefix)).unwrap(),
+            Some(id)
+        );
+        assert_eq!(parse_optional_asset_id_hex(None).unwrap(), None);
+        assert_eq!(parse_optional_asset_id_hex(Some("")).unwrap(), None);
+        assert!(parse_optional_asset_id_hex(Some("dead")).is_err());
     }
 
     #[test]

--- a/lib-blockchain/src/transaction/fee.rs
+++ b/lib-blockchain/src/transaction/fee.rs
@@ -5,10 +5,16 @@ pub const DEFAULT_TX_BYTES_PER_SOV: u64 = 100;
 pub const DEFAULT_TX_WITNESS_CAP: u32 = 500;
 pub const DEFAULT_TOKEN_CREATION_FEE: u64 = 1_000;
 
-/// Default DomainRegistration fee, in atomic SOV units (10^18 per whole SOV).
+/// Default DomainRegistration fee in whole SOV (signing message / API display).
 /// DAO launch v1 standard (epic Q10) = 100 whole SOV.
+///
+/// Clients sign `domain|timestamp|{this}`; the node verifies against live
+/// `TxFeeConfig.domain_registration_fee_atoms` (default = this × 10^18).
+pub const DEFAULT_DOMAIN_REGISTRATION_FEE_WHOLE: u64 = 100;
+
+/// Default DomainRegistration fee, in atomic SOV units (10^18 per whole SOV).
 pub const DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS: u128 =
-    100 * lib_types::TOKEN_SCALE_18;
+    (DEFAULT_DOMAIN_REGISTRATION_FEE_WHOLE as u128) * lib_types::TOKEN_SCALE_18;
 
 /// Non-refundable SOV burn applied at observer-admission registration time
 /// (observer-admission-3). Provides a small economic barrier against Sybil

--- a/lib-blockchain/src/transaction/mod.rs
+++ b/lib-blockchain/src/transaction/mod.rs
@@ -32,8 +32,8 @@ pub use reward_claim::{
     REWARD_CLAIM_MEMO, REWARD_NEW_PARTNER_ATOMS, REWARD_WELCOME_ATOMS, WEEKLY_PARTNER_CAP,
 };
 pub use domain::{
-    DomainRegistrationPayload, DomainUpdatePayload, OnChainDomainRecord,
-    DOMAIN_REGISTRATION_PREFIX, DOMAIN_UPDATE_PREFIX,
+    parse_optional_asset_id_hex, DomainRegistrationPayload, DomainUpdatePayload,
+    OnChainDomainRecord, DOMAIN_REGISTRATION_PREFIX, DOMAIN_UPDATE_PREFIX,
 };
 
 // Explicit re-exports from core module
@@ -91,7 +91,11 @@ pub use contract_execution::{
     CONTRACT_EXECUTION_MEMO_PREFIX_V1, CONTRACT_EXECUTION_MEMO_PREFIX_V2,
     MAX_CONTRACT_EXECUTION_MEMO_BYTES,
 };
-pub use fee::{required_token_creation_fee, TxFeeConfig, DEFAULT_TOKEN_CREATION_FEE};
+pub use fee::{
+    required_domain_registration_fee, required_token_creation_fee, TxFeeConfig,
+    DEFAULT_DOMAIN_REGISTRATION_FEE_ATOMS, DEFAULT_DOMAIN_REGISTRATION_FEE_WHOLE,
+    DEFAULT_TOKEN_CREATION_FEE,
+};
 pub use asset_tx::{
     build_dao_launch_manifest, build_dao_launch_manifest_bytes, manifest_cid_hash_from_bytes,
     AssetAuthorityProof, AssetAuthorityTransferCancelPayloadV1,

--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -849,28 +849,16 @@ use crate::crypto::Dilithium5;
 /// against live `TxFeeConfig.domain_registration_fee_atoms` (default matches
 /// this constant). If governance changes the fee, rebuild clients with the new
 /// whole-SOV amount (or query the node first).
-pub const DOMAIN_REGISTRATION_FEE: u64 = 100;
+///
+/// Canonical definition lives in `lib-blockchain` so node + client stay aligned.
+pub const DOMAIN_REGISTRATION_FEE: u64 =
+    lib_blockchain::transaction::DEFAULT_DOMAIN_REGISTRATION_FEE_WHOLE;
 
 /// Default chain id for domain system transactions (testnet).
 pub const DEFAULT_DOMAIN_CHAIN_ID: u8 = 0x03;
 
 /// Parse optional 64-char (optionally `0x`-prefixed) hex into a 32-byte asset id.
-pub fn parse_optional_asset_id_hex(asset_id_hex: Option<&str>) -> Result<Option<[u8; 32]>, String> {
-    let Some(raw) = asset_id_hex.map(str::trim).filter(|s| !s.is_empty()) else {
-        return Ok(None);
-    };
-    let hex_str = raw.strip_prefix("0x").or_else(|| raw.strip_prefix("0X")).unwrap_or(raw);
-    if hex_str.len() != 64 {
-        return Err(format!(
-            "asset_id must be 64 hex chars (32 bytes), got {} chars",
-            hex_str.len()
-        ));
-    }
-    let bytes = hex::decode(hex_str).map_err(|e| format!("asset_id is not valid hex: {}", e))?;
-    let mut arr = [0u8; 32];
-    arr.copy_from_slice(&bytes);
-    Ok(Some(arr))
-}
+pub use lib_blockchain::transaction::parse_optional_asset_id_hex;
 
 /// Compute the fee-payment tx hash hex the server embeds in the domain registration memo.
 pub fn fee_tx_hash_from_hex(fee_payment_tx_hex: &str) -> Result<String, String> {

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -849,9 +849,9 @@ impl Web4Handler {
                 (lib_blockchain::TransactionType::DomainUpdate, payload.encode_memo()
                     .map_err(|e| anyhow::anyhow!("Failed to encode domain update: {}", e))?)
             } else {
-                // Optional DAO asset binding (M4 / Q10): same parser as lib-client
-                // so client/server domain_tx_signature skeletons stay byte-identical.
-                let bound_asset_id = zhtp_client::token_tx::parse_optional_asset_id_hex(
+                // Optional DAO asset binding (M4 / Q10): shared parser so
+                // client/server domain_tx_signature skeletons stay byte-identical.
+                let bound_asset_id = lib_blockchain::transaction::parse_optional_asset_id_hex(
                     simple_request.asset_id.as_deref(),
                 )
                 .map_err(|e| anyhow!(e))?;
@@ -1309,7 +1309,8 @@ impl Web4Handler {
             public: api_request.public,
             economic_settings: DomainEconomicSettings {
                 // Display fee matches client/server default (TxFeeConfig / 10^18).
-                registration_fee: zhtp_client::token_tx::DOMAIN_REGISTRATION_FEE as f64,
+                registration_fee:
+                    lib_blockchain::transaction::DEFAULT_DOMAIN_REGISTRATION_FEE_WHOLE as f64,
                 renewal_fee: 5.0,
                 transfer_fee: 2.0,
                 hosting_budget: 100.0,
@@ -1327,7 +1328,8 @@ impl Web4Handler {
             deploy_manifest_cid: None, // Auto-generate for non-manifest registration
             owner_signature_hex: String::new(),
             registration_timestamp: 0,
-            registration_fee_whole: zhtp_client::token_tx::DOMAIN_REGISTRATION_FEE,
+            registration_fee_whole:
+                lib_blockchain::transaction::DEFAULT_DOMAIN_REGISTRATION_FEE_WHOLE,
         };
 
         // Process registration


### PR DESCRIPTION
## Summary
- Development fails to compile: `domains.rs` uses `zhtp_client::…` but `zhtp_client` is only a **dev-dependency** of `zhtp` (E0433 from #2919).
- Canonicalize `DEFAULT_DOMAIN_REGISTRATION_FEE_WHOLE` + `parse_optional_asset_id_hex` in **lib-blockchain**.
- Node uses lib-blockchain; lib-client re-exports the same symbols for FFI stability.

## Test plan
- [x] `cargo check -p zhtp --lib --features full-blockchain`
- [x] `cargo check -p lib-client`
- [x] `cargo test -p lib-blockchain --lib parse_optional_asset_id`

## Notes
Scoped compile fix only — does not include identity registration rollback (#2920).