### PR TITLE
chore(ops): retire gateway deploy — testnet is g1–g3 only

### DIFF
--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -1,35 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Convenience wrapper — validators only (g1–g3).
+# Gateways / g4 / g5 are retired; do not add them back.
+#
 set -euo pipefail
 
-BINARY="target/debug/zhtp"
-NODES=(zhtp-g1 zhtp-g2 zhtp-g3 zhtp-gateway)
-SUDO_NODES=(zhtp-g4 zhtp-g5 zhtp-gateway-2)
-ALL_NODES=("${NODES[@]}" "${SUDO_NODES[@]}")
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+BINARY="${1:-target/dev-release/zhtp}"
 
 if [[ ! -f "$BINARY" ]]; then
-    echo "ERROR: $BINARY not found. Build first: cargo build --release -p zhtp"
+    echo "ERROR: $BINARY not found. Build first:" >&2
+    echo "  cargo build --profile dev-release -p zhtp -p zhtp-cli" >&2
     exit 1
 fi
 
-restart_node() {
-    local node="$1"
-    if [[ " ${SUDO_NODES[*]} " =~ " ${node} " ]]; then
-        ssh "$node" "sudo systemctl restart zhtp"
-        ssh "$node" "sudo systemctl is-active zhtp"
-    else
-        ssh "$node" "systemctl restart zhtp"
-        ssh "$node" "systemctl is-active zhtp"
-    fi
-}
-
-echo "=== Deploying to all nodes ==="
-for node in "${ALL_NODES[@]}"; do
-    echo "--- $node ---"
-    rsync -az --progress "$BINARY" "$node:/opt/zhtp/zhtp"
-    ssh "$node" "chmod +x /opt/zhtp/zhtp"
-    restart_node "$node"
-    echo "  $node: deployed + restarted"
-done
-
-echo ""
-echo "=== All nodes deployed ==="
+exec "$ROOT/scripts/deploy-validators.sh" "$BINARY"

--- a/scripts/backup-testnet-keystores.sh
+++ b/scripts/backup-testnet-keystores.sh
@@ -20,6 +20,7 @@ ACTIVE=(
   "g2|zhtp-g2|77.42.74.80|f37a307761b863130adb6129f16c269af4e395eb3d4b14b070a756bef282c07b"
   "g3|zhtp-g3|178.105.9.247|bf409db91ad276fa35e8af9c78a48facdfba99eb95fcbf01719310e91c558a9c"
 )
+# Offline / retired hosts — only with --include-retired. Not deploy targets.
 RETIRED=(
   "g4|zhtp-g4|148.113.140.176|14225182b8140220c2adf3e61471ba5f0117f863408ee6b2b86cff4d0f679cef"
   "g5|zhtp-g5|51.75.62.133|3218b9025f1b7c678e115c094a73d3e077801f60501452babd43c7a32ecdf284"

--- a/scripts/deploy-gateways.sh
+++ b/scripts/deploy-gateways.sh
@@ -1,169 +1,22 @@
 #!/usr/bin/env bash
 #
-# Gateway deploy wrapper. Modeled on deploy-validators.sh.
+# RETIRED — testnet has no gateway fleet.
 #
-# Gateways are observer-mode (no BFT) so no halt-consensus needed, BUT the
-# Jun-17 2026 incident proved the binary backup + verify steps are mandatory:
-# I overwrote a working gw1 binary with one that has a historical-sync bug
-# and almost bricked the node because there was no backup.
+# Live rollout surface is validators only (g1–g3):
+#   scripts/deploy-validators.sh target/dev-release/zhtp
 #
-# Usage:
-#   scripts/deploy-gateways.sh <binary-path>
-#   scripts/deploy-gateways.sh --dry-run <binary-path>
-#   scripts/deploy-gateways.sh --only gw1 <binary-path>     # one gateway only
+# Historical hosts (zhtp-gateway, zhtp-gateway-2, g4, g5) are offline /
+# out of scope. Do not rsync binaries there. Do not "finish" a deploy by
+# chasing gateway-2 SSH failures.
 #
-# What it does, in order:
-#   1. md5sum the local binary.
-#   2. For each gateway, in series (NOT parallel — bulk gateway rollout is
-#      what took mobile offline in the Jun-17 incident):
-#        a. cp /opt/zhtp/zhtp /opt/zhtp/zhtp.bak.<timestamp>
-#        b. verify backup exists with same md5 as the currently-running binary
-#        c. rsync new binary to /tmp/zhtp.new
-#        d. md5 verify the rsync
-#        e. mv into place, chmod, systemctl restart
-#        f. wait up to 60s for zhtp.service to enter active state
-#        g. attempt a QUIC CLI test against the node (blockchain status)
-#        h. if test fails → STOP, do not proceed to next gateway
-#   3. Print final cluster state.
-#
-# The script refuses to proceed past a gateway that fails its post-deploy
-# health check. This is what the user wants: never two gateways down at once.
-
 set -euo pipefail
 
-# ---- node table -------------------------------------------------------------
-#
-# Format: ssh-alias|ip|sudo
-GATEWAYS=(
-    "zhtp-gateway|91.98.113.188|sudo"
-    "zhtp-gateway-2|57.128.30.74|sudo"
-)
+cat >&2 <<'EOF'
+error: gateway deploy is retired
 
-REMOTE_BIN=/opt/zhtp/zhtp
-SERVICE=zhtp
-RESTART_WAIT_SECS=60
-HEALTH_TIMEOUT=30
+  Testnet nodes: zhtp-g1, zhtp-g2, zhtp-g3 only.
+  Use:  scripts/deploy-validators.sh target/dev-release/zhtp
 
-# ---- arg parse --------------------------------------------------------------
-
-DRY_RUN=0
-ONLY=""
-BINARY=""
-
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --dry-run) DRY_RUN=1; shift ;;
-        --only)    ONLY="$2"; shift 2 ;;
-        -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
-        -*)        echo "unknown flag: $1" >&2; exit 2 ;;
-        *)         BINARY="$1"; shift ;;
-    esac
-done
-
-[[ -z "$BINARY" ]] && { echo "usage: $0 [--dry-run] [--only <alias>] <binary-path>" >&2; exit 2; }
-[[ -f "$BINARY" ]] || { echo "binary not found: $BINARY" >&2; exit 2; }
-
-# locate zhtp-cli for post-deploy health checks
-CLI=./target/release/zhtp-cli
-[[ -x "$CLI" ]] || CLI=./target/dev-release/zhtp-cli
-[[ -x "$CLI" ]] || { echo "no zhtp-cli binary found in target/release or target/dev-release" >&2; exit 2; }
-
-# ---- helpers ----------------------------------------------------------------
-
-log()  { printf '\033[36m[%s]\033[0m %s\n' "$(date +%H:%M:%S)" "$*"; }
-ok()   { printf '\033[32m[ ok ]\033[0m %s\n' "$*"; }
-warn() { printf '\033[33m[warn]\033[0m %s\n' "$*"; }
-fail() { printf '\033[31m[fail]\033[0m %s\n' "$*"; exit 1; }
-
-# ---- step 1: local md5 ------------------------------------------------------
-
-LOCAL_MD5=$(md5sum "$BINARY" | awk '{print $1}')
-log "local binary md5: $LOCAL_MD5  ($BINARY)"
-[[ $DRY_RUN -eq 1 ]] && log "DRY RUN — printing planned actions, no changes."
-
-# ---- step 2: per-gateway serial deploy -------------------------------------
-
-for entry in "${GATEWAYS[@]}"; do
-    IFS='|' read -r alias ip sudo <<< "$entry"
-
-    if [[ -n "$ONLY" && "$alias" != "$ONLY" && "$alias" != "zhtp-$ONLY" ]]; then
-        log "skipping $alias (--only $ONLY)"
-        continue
-    fi
-
-    log "==== $alias ($ip) ===="
-
-    if [[ $DRY_RUN -eq 1 ]]; then
-        echo "  ssh $alias \"$sudo cp $REMOTE_BIN ${REMOTE_BIN}.bak.\$(date +%Y%m%d-%H%M%S)-deploy\""
-        echo "  scp $BINARY $alias:/tmp/zhtp.new"
-        echo "  ssh $alias \"$sudo md5sum /tmp/zhtp.new\"   # must equal $LOCAL_MD5"
-        echo "  ssh $alias \"$sudo mv /tmp/zhtp.new $REMOTE_BIN && $sudo chmod +x $REMOTE_BIN && $sudo systemctl restart $SERVICE\""
-        echo "  health check via $CLI -s $ip:9334 blockchain status"
-        continue
-    fi
-
-    # 2a. backup
-    BAK_NAME="${REMOTE_BIN}.bak.$(date +%Y%m%d-%H%M%S)-deploy"
-    log "backing up running binary → $BAK_NAME"
-    ssh "$alias" "${sudo} cp $REMOTE_BIN $BAK_NAME"
-
-    # 2b. verify backup
-    BAK_MD5=$(ssh "$alias" "${sudo} md5sum $BAK_NAME" | awk '{print $1}')
-    RUNNING_MD5=$(ssh "$alias" "${sudo} md5sum $REMOTE_BIN" | awk '{print $1}')
-    if [[ "$BAK_MD5" != "$RUNNING_MD5" ]]; then
-        fail "backup md5 mismatch on $alias — refusing to overwrite"
-    fi
-    ok "backup verified ($BAK_MD5)"
-
-    # 2c. rsync to /tmp
-    log "rsync new binary to $alias:/tmp/zhtp.new"
-    scp -q "$BINARY" "$alias:/tmp/zhtp.new"
-
-    # 2d. md5 verify the rsync
-    PUSHED_MD5=$(ssh "$alias" "${sudo} md5sum /tmp/zhtp.new" | awk '{print $1}')
-    if [[ "$PUSHED_MD5" != "$LOCAL_MD5" ]]; then
-        ssh "$alias" "${sudo} rm /tmp/zhtp.new"
-        fail "pushed binary md5 mismatch on $alias (got $PUSHED_MD5, expected $LOCAL_MD5)"
-    fi
-    ok "pushed binary md5 verified"
-
-    # 2e. move into place + restart
-    log "swapping binary and restarting $SERVICE"
-    ssh "$alias" "${sudo} mv /tmp/zhtp.new $REMOTE_BIN && ${sudo} chmod +x $REMOTE_BIN && ${sudo} systemctl restart $SERVICE"
-
-    # 2f. wait for active state
-    log "waiting up to ${RESTART_WAIT_SECS}s for $SERVICE to become active"
-    DEADLINE=$(( $(date +%s) + RESTART_WAIT_SECS ))
-    while (( $(date +%s) < DEADLINE )); do
-        if ssh "$alias" "${sudo} systemctl is-active $SERVICE" 2>/dev/null | grep -q '^active$'; then
-            break
-        fi
-        sleep 2
-    done
-    if ! ssh "$alias" "${sudo} systemctl is-active $SERVICE" 2>/dev/null | grep -q '^active$'; then
-        fail "$SERVICE did not reach active state on $alias — ABORTING (other gateways NOT touched)"
-    fi
-    ok "service active on $alias"
-
-    # 2g. QUIC health check
-    log "QUIC health check against $ip:9334 (timeout ${HEALTH_TIMEOUT}s)"
-    if timeout "$HEALTH_TIMEOUT" "$CLI" -s "$ip:9334" blockchain status >/dev/null 2>&1; then
-        ok "$alias responds to inbound QUIC"
-    else
-        warn "$alias does NOT respond to inbound QUIC after restart"
-        warn "ROLLBACK: restoring $BAK_NAME"
-        ssh "$alias" "${sudo} cp $BAK_NAME $REMOTE_BIN && ${sudo} systemctl restart $SERVICE"
-        sleep 10
-        if timeout "$HEALTH_TIMEOUT" "$CLI" -s "$ip:9334" blockchain status >/dev/null 2>&1; then
-            ok "$alias recovered after rollback"
-        else
-            fail "$alias still broken after rollback — manual intervention required"
-        fi
-        fail "deploy aborted on $alias — fix binary, then retry (other gateways NOT touched)"
-    fi
-
-    log "$alias deploy complete"
-    echo
-done
-
-ok "all selected gateways deployed and verified"
+  There are no gateways to upgrade. Stop.
+EOF
+exit 2

--- a/scripts/deploy-validators.sh
+++ b/scripts/deploy-validators.sh
@@ -42,7 +42,8 @@ set -euo pipefail
 # ---- node table -------------------------------------------------------------
 #
 # Format: ssh-alias|ip|sudo
-# Mirrored from CLAUDE.md deployment table. Update both together.
+# Testnet is validators ONLY (g1–g3). No gateways, no g4/g5.
+# Do not expand this table. scripts/deploy-gateways.sh is intentionally retired.
 NODES=(
     "zhtp-g1|77.42.37.161|"
     "zhtp-g2|77.42.74.80|"


### PR DESCRIPTION
## Summary
- Testnet deploy surface is **g1–g3 only**. No gateways.
- `scripts/deploy-gateways.sh` exits with a hard error (no node table).
- `deploy-all.sh` wraps `deploy-validators.sh` only.

Stops agents from “finishing” deploys by chasing gateway-2 SSH.

## Test plan
- [x] Local: scripts refuse gateways; validators script documents g1–g3 only