### PR TITLE
fix(identity): real per-IP rate limit on register (#2773)

### DIFF
--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1960,14 +1960,37 @@ impl IdentityHandler {
             "human".to_string()
         }
 
+        // #2773: Per-IP admission limit BEFORE body parse / Dilithium verify.
+        // Prefer mesh `peer_addr` (not spoofable X-Forwarded-For) — same as migrate.
+        // check_and_consume counts every attempt (success or fail) so valid spam
+        // still burns slots and cannot flood the mempool.
+        const REGISTER_MAX_PER_HOUR: usize = 10;
+        const REGISTER_WINDOW_SECS: u64 = 3600;
+        let reported_ip = login_handlers::extract_client_ip(&request);
+        let rate_key = request
+            .headers
+            .get("peer_addr")
+            .unwrap_or_else(|| reported_ip.clone());
+        if self
+            .rate_limiter
+            .check_and_consume(&rate_key, REGISTER_MAX_PER_HOUR, REGISTER_WINDOW_SECS)
+            .await
+            .is_err()
+        {
+            tracing::warn!(
+                "identity/register rate limited key={} reported_ip={}",
+                rate_key,
+                reported_ip
+            );
+            return Ok(ZhtpResponse::error(
+                ZhtpStatus::TooManyRequests,
+                "Too many registration attempts. Please try again later.".to_string(),
+            ));
+        }
+
         // Parse request
         let req_data: RegisterIdentityRequest = serde_json::from_slice(&request.body)
             .map_err(|e| anyhow::anyhow!("Invalid register request: {}", e))?;
-
-        let client_ip = login_handlers::extract_client_ip(&request);
-        if let Err(response) = self.rate_limiter.check_rate_limit(&client_ip).await {
-            return Ok(response);
-        }
 
         tracing::info!(
             "📱 Client-side identity registration (device: {})",

--- a/zhtp/src/api/middleware/rate_limiter.rs
+++ b/zhtp/src/api/middleware/rate_limiter.rs
@@ -63,6 +63,33 @@ impl RateLimiter {
         max_attempts: usize,
         window_seconds: u64,
     ) -> Result<(), ZhtpResponse> {
+        self.check_window(ip, max_attempts, window_seconds, false)
+            .await
+    }
+
+    /// Admission rate limit: every call consumes a slot (success or failure).
+    ///
+    /// Use for expensive unauthenticated endpoints (e.g. identity/register) where
+    /// valid spam still costs Dilithium verification and mempool pressure. Unlike
+    /// [`check_rate_limit`] / [`check_rate_limit_aggressive`], this does not wait
+    /// for a later `record_failed_attempt` — the attempt is counted immediately.
+    pub async fn check_and_consume(
+        &self,
+        ip: &str,
+        max_attempts: usize,
+        window_seconds: u64,
+    ) -> Result<(), ZhtpResponse> {
+        self.check_window(ip, max_attempts, window_seconds, true)
+            .await
+    }
+
+    async fn check_window(
+        &self,
+        ip: &str,
+        max_attempts: usize,
+        window_seconds: u64,
+        consume: bool,
+    ) -> Result<(), ZhtpResponse> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -75,23 +102,26 @@ impl RateLimiter {
                 failed_attempts: Vec::new(),
             });
 
-        // Remove old attempts outside the window
         entry
             .failed_attempts
             .retain(|&timestamp| now - timestamp < window_seconds);
 
-        // Check if limit exceeded
         if entry.failed_attempts.len() >= max_attempts {
             tracing::warn!(
-                "Aggressive rate limit exceeded for IP {} ({} failed attempts in window)",
+                "Rate limit exceeded for IP {} ({} attempts in {}s window)",
                 ip,
-                entry.failed_attempts.len()
+                entry.failed_attempts.len(),
+                window_seconds
             );
 
             return Err(ZhtpResponse::error(
                 ZhtpStatus::TooManyRequests,
-                format!("Too many failed attempts. Please try again later."),
+                "Too many failed attempts. Please try again later.".to_string(),
             ));
+        }
+
+        if consume {
+            entry.failed_attempts.push(now);
         }
 
         Ok(())
@@ -311,5 +341,18 @@ mod tests {
         limiter.cleanup().await;
         let stats = limiter.stats().await;
         assert_eq!(stats.tracked_ips, 1);
+    }
+
+    #[tokio::test]
+    async fn test_check_and_consume_counts_every_attempt() {
+        let limiter = RateLimiter::new();
+
+        for _ in 0..3 {
+            assert!(limiter.check_and_consume("reg_ip", 3, 3600).await.is_ok());
+        }
+        // Fourth attempt in the window is denied
+        assert!(limiter.check_and_consume("reg_ip", 3, 3600).await.is_err());
+        // Other IPs unaffected
+        assert!(limiter.check_and_consume("other_ip", 3, 3600).await.is_ok());
     }
 }

--- a/zhtp/src/runtime/test_api_integration.rs
+++ b/zhtp/src/runtime/test_api_integration.rs
@@ -433,4 +433,64 @@ mod api_integration_tests {
 
         let _ = std::fs::remove_dir_all(db_path);
     }
+
+    /// #2773: unauthenticated register admits at most 10 attempts / hour / IP.
+    #[tokio::test]
+    async fn test_register_identity_rate_limits_per_ip() {
+        let mut storage_config = UnifiedStorageConfig::default();
+        let db_path =
+            std::env::temp_dir().join(format!("zhtp-test-rl-{}", rand::random::<u64>()));
+        storage_config.storage_config.dht_persist_path = Some(db_path.clone());
+        let storage = UnifiedStorageSystem::new_persistent(storage_config, db_path.clone())
+            .expect("failed to create storage");
+        let (handler, db_path) = build_identity_handler(storage, db_path);
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        // 10 attempts (any status) from the same IP must be admitted into the handler.
+        // 11th is rejected before crypto / parse side effects matter.
+        for i in 0..10 {
+            let keypair = lib_crypto::KeyPair::generate().expect("keypair");
+            // Far-future timestamp → cheap BadRequest after rate-limit consume
+            let mut request =
+                build_register_request(&keypair, &format!("device-rl-{}", i), now + 120, None);
+            request.headers.set("peer_addr", "203.0.113.50".into());
+            let response = handler
+                .handle_request(request)
+                .await
+                .expect("handler failed");
+            assert_ne!(
+                response.status,
+                ZhtpStatus::TooManyRequests,
+                "attempt {} should not be rate-limited yet",
+                i + 1
+            );
+        }
+
+        let keypair = lib_crypto::KeyPair::generate().expect("keypair");
+        let mut request =
+            build_register_request(&keypair, "device-rl-blocked", now + 120, None);
+        request.headers.set("peer_addr", "203.0.113.50".into());
+        let response = handler
+            .handle_request(request)
+            .await
+            .expect("handler failed");
+        assert_eq!(response.status, ZhtpStatus::TooManyRequests);
+
+        // Different peer is unaffected
+        let keypair = lib_crypto::KeyPair::generate().expect("keypair");
+        let mut request =
+            build_register_request(&keypair, "device-rl-other", now + 120, None);
+        request.headers.set("peer_addr", "203.0.113.99".into());
+        let response = handler
+            .handle_request(request)
+            .await
+            .expect("handler failed");
+        assert_ne!(response.status, ZhtpStatus::TooManyRequests);
+
+        let _ = std::fs::remove_dir_all(db_path);
+    }
 }


### PR DESCRIPTION
## Summary
- Closes #2773: unauthenticated `POST /api/v1/identity/register` was effectively unlimited (check without consume).
- New `RateLimiter::check_and_consume` counts every attempt (success or fail).
- Register: **10 attempts / hour / IP**, before parse/crypto; key prefers `peer_addr`.

## Test plan
- [x] `cargo test -p zhtp --lib -- check_and_consume register_identity_rate_limits`