### PR TITLE
feat(zhtp-auth): Phase 2 identity projection + reward-claim admit safety

### DIFF
--- a/docs/ops/blockchain-authoritative-registration-plan.md
+++ b/docs/ops/blockchain-authoritative-registration-plan.md
@@ -1,0 +1,90 @@
+# Blockchain-Authoritative Registration — Implementation Plan
+
+Parent epic: **#1982**. Phase 1 parent: **#1984**.
+
+Goal: committed blocks are the only authority for identity, wallet, and token
+state. API/runtime may only validate and enqueue; projections update after
+block processing.
+
+## Invariants
+
+1. No canonical identity/wallet/token mutation outside block process/commit.
+2. API success does not imply finality before inclusion (`queued` vs `confirmed`).
+3. One registration path: system inject → mempool → block → process_* / executor.
+4. Pending registration txs are durable (sled pending tree) and reloaded on restart.
+5. DHT / identity_manager / local indexes are projections, rebuildable from chain.
+
+## Ordered work (do not skip)
+
+| Order | Work | Issue | Status in tree (pre-cutover) |
+|------:|------|-------|------------------------------|
+| 0 | Audit divergence | #1983 | Done historically; residual ghost paths remain |
+| 1A | `register_wallet()` enqueue-only | #1989 | **Done in tree** — enqueue only; pending occupies id |
+| 1B | Identity handler: no pre-block authority | #1990 | **Done in tree** — no shadow; events + wait option |
+| 1C | Peer welcome uses same path | #1991 | **Done via 1A** (no direct registry insert in quic) |
+| 1D | Pending tx durability + restart gates | #1992 | **Done** (`put_pending` + recover); unit coverage exists |
+| B | Kill startup SOV backfill | #1993 | **Still present** (`collect_sov_backfill_entries`) |
+| 2 | Replay rebuild identity projection | #1985 | **In progress** — rebuild + telemetry + restart tests |
+| 3 | Wallet sled projection | #1986 | Partial (executor put_wallet_projection) |
+| 4 | DHT post-confirmation only | #1987 | Listener exists; **events never emitted** |
+| 5 | Cleanup legacy fixups | #1988 | Open |
+
+## Phase 1 cutover design (this PR series)
+
+### 1A — `register_wallet`
+
+- Enqueue `WalletRegistration` only (`add_system_transaction`).
+- Do **not** insert `wallet_registry` / `wallet_blocks`.
+- Do **not** mint SOV (genesis or otherwise). Welcome SOV = separate `TokenMint`.
+- Existence checks include **pending** wallet registrations (not only sled/shadow).
+
+Canonical wallet materialization remains in:
+
+- `process_wallet_transactions` (in-mem registry + height index)
+- executor `put_wallet_projection` (sled)
+
+### 1B — Identity register API
+
+- Validate proof, username, conflicts (committed **or** pending).
+- Enqueue identity + wallets + welcome mint only.
+- Do **not** `insert_identity_shadow` / pre-fill `identity_blocks`.
+- Return `status: "queued"` + `blockchain_tx` immediately by default.
+- Optional `wait_for_inclusion` (body flag): poll until DID exists from committed
+  state (or timeout → still `queued` with timeout note).
+- Local `identity_manager` citizen create is a **provisional cache** for wallet
+  id derivation only; roll back on enqueue failure. Not chain authority.
+- DHT / storage identity index writes only from post-commit projection listener.
+
+### Event emission (unlocks 1B projections / #1987)
+
+Publish from block processing:
+
+- `BlockchainEvent::IdentityRegistered` in `process_identity_transactions`
+- `BlockchainEvent::WalletRegistered` in `process_wallet_transactions`
+
+### 1D — Durability
+
+Already: `add_system_transaction` → `store.put_pending_transaction`;
+`set_store` → `recover_pending_transactions_from_store`.
+
+Add regression tests: restart before mine keeps registration txs; after commit
+they are gone and state matches process_*.
+
+### Blocker after Phase 1
+
+#1993 — remove `collect_sov_backfill_entries` / load-time mint paths so restart
+cannot invent supply.
+
+## Rollout
+
+1. Land Phase 1 code + unit/integration tests.
+2. Deploy to GENESIS-3 only after binary includes empty-sig fix **and** this cutover.
+3. Clients: treat `queued` as pending; poll `GET /identity/get/{did}` or use
+   `wait_for_inclusion` for sync UX.
+4. Do not wipe chain unless explicitly ordered.
+
+## Non-goals (this plan)
+
+- BFT redesign, new tx types, rewriting BlockExecutor.
+- Making DHT authoritative.
+- Patch-only “return success and hope” behavior.

--- a/docs/ops/genesis3-dev-node-connect.md
+++ b/docs/ops/genesis3-dev-node-connect.md
@@ -1,0 +1,204 @@
+# GENESIS-3 — Developer node connect guide
+
+**Audience:** External / team developers connecting a **client or full node** to the live GENESIS-3 testnet.  
+**Network role model:** **Three validators only** (g1, g2, g3). There is **no gateway layer**. Clients talk to validators on port **9334**.
+
+**Status (as of 2026-07-21):** Chain is **active and producing blocks**. If you hit a stuck or unreachable network earlier today, retry now — consensus recovered and is advancing.
+
+---
+
+## 1. Can you connect now?
+
+**Yes**, for normal client / non-validator use:
+
+| Check | Expected |
+|-------|----------|
+| Chain status | `"status": "active"` |
+| Height | advancing (seconds between blocks) |
+| Consensus epoch | `6` on all three validators |
+| Your role | **not** a BFT validator unless operators add you to the set |
+
+You do **not** need a gateway. Point tools and node config at any of the three validators below.
+
+---
+
+## 2. Public endpoints (validators only)
+
+| Name | Host / IP | QUIC / API port |
+|------|-----------|-----------------|
+| g1 | `g1.thesovereignnetwork.org` → `77.42.37.161` | **9334** |
+| g2 | `g2.thesovereignnetwork.org` → `77.42.74.80` | **9334** |
+| g3 | `g3.thesovereignnetwork.org` → `178.105.9.247` | **9334** |
+
+Bootstrap list (same as `tools/node-configs/shared.toml`):
+
+```text
+77.42.37.161:9334
+77.42.74.80:9334
+178.105.9.247:9334
+```
+
+**Firewall on your machine / VPS:** allow **outbound UDP/TCP 9334** to those three IPs (QUIC control plane). If you run a reachable full node, open **inbound 9334** (and mesh **9333** if you use mesh) for peer traffic.
+
+---
+
+## 3. Prove the network is up (do this first)
+
+Build CLI from a recent tree (or use a release binary that matches testnet):
+
+```bash
+cargo build --profile dev-release -p zhtp-cli
+```
+
+### 3.1 Consensus epoch (must be 6)
+
+```bash
+./target/dev-release/zhtp-cli -s g1.thesovereignnetwork.org:9334 version --remote --build-id-only
+./target/dev-release/zhtp-cli -s g2.thesovereignnetwork.org:9334 version --remote --build-id-only
+./target/dev-release/zhtp-cli -s g3.thesovereignnetwork.org:9334 version --remote --build-id-only
+```
+
+All three should print:
+
+```text
+6
+```
+
+If a node is unreachable or reports a different epoch, use another of the three. Do not mix epoch-mismatched binaries if you run a consensus-aware full node.
+
+### 3.2 Chain tip / status
+
+```bash
+./target/dev-release/zhtp-cli -s g1.thesovereignnetwork.org:9334 blockchain status
+```
+
+Expect something like:
+
+- `status` → `"active"`
+- `height` → a number that **increases** if you run the command twice ~15–30s apart
+
+Example (height will be higher by the time you read this):
+
+```text
+height               3334
+status               "active"
+```
+
+---
+
+## 4. What kind of node are you running?
+
+### A) Client / CLI only (recommended first step)
+
+Use `zhtp-cli` against a validator. No local chain required.
+
+```bash
+# always pass -s <validator>:9334
+./target/dev-release/zhtp-cli -s g1.thesovereignnetwork.org:9334 blockchain status
+./target/dev-release/zhtp-cli -s g1.thesovereignnetwork.org:9334 identity register --display-name YourName
+```
+
+Identity registration:
+
+- Success often returns **`queued`** (tx in mempool), not “already final”.
+- Final when the DID is queryable after a block includes the registration txs.
+- Optional: poll identity get, or use API `wait_for_inclusion` if your client supports it.
+
+### B) Local full node (sync / mesh), **not** a validator
+
+1. Build:
+
+   ```bash
+   cargo build --release -p zhtp
+   ```
+
+2. Config: start from `tools/node-configs/shared.toml` and set:
+
+   - `network_id = "testnet"`
+   - `bootstrap_peers` = the three IPs above on **9334**
+   - **`validator_enabled = false`** (unless operators have explicitly onboarded you as a validator)
+   - Fresh data dir (do not reuse an old mainnet or pre–GENESIS-3 sled)
+
+3. Start with testnet flags matching operators (typical pattern):
+
+   ```bash
+   ./target/release/zhtp --testnet --config /path/to/your.toml --data-dir /path/to/data
+   ```
+
+4. Confirm you sync: local height should catch up toward validator height from `blockchain status`.
+
+### C) Joining as a BFT validator
+
+**Not self-service.** Validators are the fixed set g1–g3 for GENESIS-3. Contact operators; do not enable validator mode hoping to join quorum.
+
+---
+
+## 5. Config snippet (non-validator)
+
+Minimal network section:
+
+```toml
+[network]
+network_id = "testnet"
+mesh_port = 9333
+bootstrap_peers = [
+  "77.42.37.161:9334",
+  "77.42.74.80:9334",
+  "178.105.9.247:9334",
+]
+max_peers = 50
+
+[protocol_settings]
+enable_quic = true
+quic_port = 9334
+
+[consensus_config]
+# Client / follower: do not propose
+validator_enabled = false
+```
+
+Copy full bootstrap validator identity rows from `tools/node-configs/shared.toml` if your binary requires them for peer trust.
+
+---
+
+## 6. Common failures and fixes
+
+| Symptom | Likely cause | What to do |
+|---------|--------------|------------|
+| Connection timeout to `:9334` | Firewall / wrong host | Use IPs in §2; open outbound 9334; try all three validators |
+| Looking for a “gateway” host | Gateways are **retired** | Connect **only** to g1/g2/g3 |
+| `status` not active / height stuck | Your process only, or old binary | Re-check §3 against g1; rebuild from current `development` |
+| Identity returns `queued` forever | Tx not included or rejected | Check node logs / mempool; re-query tip height; ensure registration path is current |
+| Reward claim errors (`token_contract_not_found` etc.) | Claim token has rewards module but no token contract on chain | Do **not** spam claim against incomplete asset setup; ask operators for supported reward token |
+| Mixed consensus epoch vs peers | Binary too old/new | Align build; epoch must be **6** on GENESIS-3 right now |
+
+---
+
+## 7. What operators fixed recently (why it may have failed earlier)
+
+Earlier today GENESIS-3 briefly **stopped producing blocks** after a bad reward-claim path. That was recovered without wiping the chain, and validators were upgraded so invalid reward claims are **rejected at admission** instead of halting apply.
+
+For you as a connecting developer:
+
+- **Retry connect and status checks now.**
+- Prefer **current** `zhtp` / `zhtp-cli` from the repo.
+- Still **no gateways** — same three validators as always for GENESIS-3.
+
+---
+
+## 8. Success checklist (send this back to operators)
+
+When it works, you should be able to report:
+
+1. `version --remote --build-id-only` → **6** on at least one of g1/g2/g3  
+2. `blockchain status` → **`active`**, height **N** (and N increases on a second poll)  
+3. (If registering) identity **`queued`** or **`confirmed`**, then DID visible via identity get  
+4. (If full node) local height within a few blocks of N  
+
+---
+
+## 9. Contact / scope
+
+- **Testnet:** GENESIS-3 only (g1–g3).  
+- **Docs nearby:** `docs/protocol/genesis-3-testnet-reset.md` (topology), `tools/node-configs/shared.toml` (canonical peer list).  
+- **Not covered here:** becoming a council/validator member, mainnet, or gateway-style reverse proxies (not part of this network).

--- a/docs/ops/legacy-fixup-removal-gate.md
+++ b/docs/ops/legacy-fixup-removal-gate.md
@@ -1,0 +1,50 @@
+# Legacy fixup removal gate (#1985 / #2000)
+
+Startup/replay still contains a few **non-canonical repair** paths. They are
+instrumented so operators can prove they are idle before Phase 5 deletes them.
+
+## Instrumented paths
+
+| Path | Code | Log target / fields |
+|------|------|---------------------|
+| SOV key→wallet balance migrate | `migrate_sov_key_balances_to_wallets` | `target=legacy_fixup` `path=migrate_sov_key_balances_to_wallets` |
+| Backfill inflation repair | `repair_backfill_inflation` | `target=legacy_fixup` `path=repair_backfill_inflation` |
+| Contract blob → `token_balances` | `backfill_token_balances_from_contract` | `target=legacy_fixup` `path=backfill_token_balances_from_contract` |
+| Identity projection rebuild (canonical) | `rebuild_identity_projections_from_registry` | `target=legacy_fixup` `path=rebuild_identity_projections` |
+
+Identity rebuild is **not** a ghost-mint path; it only rewrites projections from
+block-derived registry. Track it to confirm rebuild frequency after upgrades.
+
+## How to measure (validators g1–g3)
+
+```bash
+# Last 14 days of fixup firings (any non-zero entity counts matter)
+for h in zhtp-g1 zhtp-g2 zhtp-g3; do
+  echo "=== $h ==="
+  ssh "$h" "journalctl -u zhtp --since '14 days ago' --no-pager \
+    | grep 'legacy_fixup' \
+    | grep -E 'migrate_sov_key_balances|repair_backfill_inflation|backfill_token_balances' \
+    | wc -l"
+done
+```
+
+Parse structured fields when present:
+
+- `amount_atomic` / `entries_written` / `wallets_corrected` — **must be 0** for
+  the removal window (or log lines must not appear at all).
+
+## Removal gate (Phase 5)
+
+**Ready to remove** a fixup when **all** of:
+
+1. **Zero firings** of that path with non-zero effect for **≥ 14 consecutive days**
+   on every GENESIS-3 validator (g1–g3).
+2. Restart/replay suites green:
+   - `identity_projection_restart_tests`
+   - `wallet_projection_restart_tests`
+   - `token_snapshot_restart_tests`
+3. No open incident requiring the fixup as a recovery tool.
+4. Parent epic checklist updated (#1988).
+
+Until then: leave the path in place; do not “delete because it looks unused”
+without the two-week evidence window.

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -333,13 +333,10 @@ impl Blockchain {
                                     );
                                 }
                             } else {
-                                // Transparent migration: wallet not in registry and no legacy
-                                // match found. Auto-register using the dilithium_pk from the
-                                // transaction signature — the signature itself proves ownership.
-                                // This handles wallets from a previous chain without requiring
-                                // users to re-register. All nodes execute this at the same block
-                                // height so state stays consistent across the network.
-                                const SOV_WELCOME_BONUS: u128 = lib_types::sov::atoms(5_000);
+                                // Same-block deterministic wallet materialization for legacy
+                                // senders (signature proves ownership). No welcome SOV mint —
+                                // inventing supply here was a #1983 / #1993 divergence source.
+                                // initial_balance stays 0; funding must be TokenMint history.
                                 let wallet_data = crate::transaction::WalletTransactionData {
                                     wallet_id: Hash::new(transfer.from),
                                     owner_identity_id: None,
@@ -350,26 +347,16 @@ impl Blockchain {
                                     capabilities: 0xFFFFFFFF,
                                     created_at: 0,
                                     registration_fee: 0,
-                                    initial_balance: SOV_WELCOME_BONUS,
+                                    initial_balance: 0,
                                     seed_commitment: crate::types::hash::blake3_hash(
                                         format!("migrated:{}", from_wallet_id).as_bytes(),
                                     ),
                                 };
-                                match self.register_wallet(wallet_data) {
-                                    Ok(_) => {
-                                        info!(
-                                            "🔄 Transparent migration: auto-registered wallet {} with {} SOV at block execution",
-                                            &from_wallet_id[..16],
-                                            SOV_WELCOME_BONUS / lib_types::sov::SCALE,
-                                        );
-                                    }
-                                    Err(e) => {
-                                        return Err(anyhow::anyhow!(
-                                            "TokenTransfer SOV sender wallet not found and auto-registration failed: {}",
-                                            e
-                                        ));
-                                    }
-                                }
+                                self.insert_wallet_shadow(from_wallet_id.clone(), wallet_data);
+                                info!(
+                                    "🔄 Transparent migration: materialised wallet {} at block execution (0 SOV; no mint)",
+                                    &from_wallet_id[..16.min(from_wallet_id.len())],
+                                );
                             }
                         }
 

--- a/lib-blockchain/src/blockchain/identity.rs
+++ b/lib-blockchain/src/blockchain/identity.rs
@@ -240,12 +240,42 @@ impl Blockchain {
         if let Some(store) = self.get_store() {
             let did_hash = crate::storage::did_to_hash(did);
             match store.get_identity(&did_hash) {
-                Ok(found) => return found.is_some(),
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
                 Err(e) => {
                     tracing::warn!(
                         did = %did,
                         error = %e,
                         "identity_exists: sled read failed; treating as not-in-sled"
+                    );
+                }
+            }
+        }
+        // Pending IdentityRegistration occupies the DID until commit or abort (#1990).
+        self.pending_transactions.iter().any(|tx| {
+            tx.transaction_type == TransactionType::IdentityRegistration
+                && tx
+                    .identity_data()
+                    .map(|d| d.did == did)
+                    .unwrap_or(false)
+        })
+    }
+
+    /// True when the DID is present in committed state (in-mem registry or sled),
+    /// ignoring the pending mempool. Used for inclusion wait / confirmation.
+    pub fn identity_committed(&self, did: &str) -> bool {
+        if self.identity_registry.contains_key(did) {
+            return true;
+        }
+        if let Some(store) = self.get_store() {
+            let did_hash = crate::storage::did_to_hash(did);
+            match store.get_identity(&did_hash) {
+                Ok(found) => return found.is_some(),
+                Err(e) => {
+                    tracing::warn!(
+                        did = %did,
+                        error = %e,
+                        "identity_committed: sled read failed; treating as not committed"
                     );
                 }
             }
@@ -728,8 +758,18 @@ impl Blockchain {
                 }
             }
         }
-        self.identity_registry.values().any(|id| {
+        if self.identity_registry.values().any(|id| {
             id.display_name.to_lowercase() == display_name_lower
+        }) {
+            return true;
+        }
+        // Pending registrations reserve the display name until commit/abort (#1990).
+        self.pending_transactions.iter().any(|tx| {
+            tx.transaction_type == TransactionType::IdentityRegistration
+                && tx
+                    .identity_data()
+                    .map(|d| d.display_name.to_lowercase() == display_name_lower)
+                    .unwrap_or(false)
         })
     }
 
@@ -891,6 +931,16 @@ impl Blockchain {
                                     block.height(),
                                 )?;
                             }
+
+                            // Post-commit projection listeners (DHT / local index) (#1990).
+                            let tx_hash_arr = transaction.hash().as_array();
+                            self.event_publisher.publish(
+                                crate::events::BlockchainEvent::IdentityRegistered {
+                                    tx_hash: tx_hash_arr,
+                                    block_height: block.height(),
+                                    identity_data: new_identity_data.clone(),
+                                },
+                            );
 
                             if identity_data.identity_type == "verified_citizen"
                                 || identity_data.identity_type == "citizen"

--- a/lib-blockchain/src/blockchain/init.rs
+++ b/lib-blockchain/src/blockchain/init.rs
@@ -426,6 +426,7 @@ impl Blockchain {
                 ownership_proof,
                 controlled_nodes,
                 owned_wallets,
+                kyber_public_key,
             ) = match metadata {
                 Some(m) => {
                     let did = if m.did.is_empty() {
@@ -440,11 +441,13 @@ impl Blockchain {
                         m.ownership_proof,
                         m.controlled_nodes,
                         m.owned_wallets,
+                        m.kyber_public_key,
                     )
                 }
                 None => (
                     hex::encode(consensus.did_hash),
                     String::new(),
+                    Vec::new(),
                     Vec::new(),
                     Vec::new(),
                     Vec::new(),
@@ -467,7 +470,7 @@ impl Blockchain {
                     dao_fee: consensus.dao_fee,
                     controlled_nodes,
                     owned_wallets,
-                    kyber_public_key: Vec::new(),
+                    kyber_public_key,
                 },
             );
         }
@@ -793,11 +796,18 @@ impl Blockchain {
                 match store.backfill_token_balances_from_contract(&token_id, &entries) {
                     Ok(0) => {}
                     Ok(n) => info!(
+                        target: "legacy_fixup",
+                        path = "backfill_token_balances_from_contract",
+                        token = %hex::encode(&token_id.0[..8]),
+                        entries_written = n,
                         "💰 Backfilled {} balances for token {} into token_balances tree",
                         n,
                         hex::encode(&token_id.0[..8])
                     ),
                     Err(e) => warn!(
+                        target: "legacy_fixup",
+                        path = "backfill_token_balances_from_contract",
+                        token = %hex::encode(&token_id.0[..8]),
                         "⚠️ Failed to backfill token_balances for {}: {}",
                         hex::encode(&token_id.0[..8]),
                         e
@@ -1030,6 +1040,10 @@ impl Blockchain {
                     e
                 ),
             }
+
+            // #1985 / #1999: same for identities — sled trees must match
+            // block-derived registry, not pre-existing projection content.
+            blockchain.rebuild_identity_projections_from_registry();
         }
 
         match blockchain.repair_missing_token_creation_balances(store.as_ref()) {
@@ -1047,8 +1061,6 @@ impl Blockchain {
         // #56: backfill durable validators tree on normal startup (not replay-only).
         // Gated by schema version; regenerates from the loaded/replayed registry.
         blockchain.migrate_validator_records_schema();
-        blockchain.backfill_genesis_identities_to_store();
-        blockchain.migrate_identity_metadata_schema();
 
         // Genesis allocations are direct inserts in build_block0(), not block txs.
         // After executor-only block-0 import the in-memory registries are empty until
@@ -1062,21 +1074,8 @@ impl Blockchain {
             }
         }
 
-        blockchain.backfill_genesis_identities_to_store();
-        blockchain.migrate_identity_metadata_schema();
-
-        // Genesis allocations are direct inserts in build_block0(), not block txs.
-        // After executor-only block-0 import the in-memory registries are empty until
-        // we re-apply embedded genesis metadata (replay determinism / g4 bootstrap).
-        if let Ok(cfg) = crate::genesis::GenesisConfig::from_embedded() {
-            if let Err(e) = cfg.apply_genesis_state(&mut blockchain) {
-                warn!(
-                    "apply_genesis_state during load_from_store failed (non-fatal): {}",
-                    e
-                );
-            }
-        }
-
+        // Fill any genesis identities still missing from sled, then regenerate
+        // metadata schema if needed. (Replay path already rewrote projections.)
         blockchain.backfill_genesis_identities_to_store();
         blockchain.migrate_identity_metadata_schema();
 

--- a/lib-blockchain/src/blockchain/replay.rs
+++ b/lib-blockchain/src/blockchain/replay.rs
@@ -237,7 +237,9 @@ impl Blockchain {
                     );
                 }
             }
-            let (consensus, metadata) = crate::storage::convert_legacy_identity(data);
+            let height = self.identity_blocks.get(did).copied().unwrap_or(0);
+            let (mut consensus, metadata) = crate::storage::convert_legacy_identity(data);
+            consensus.registered_at_height = height;
             if let Err(e) = store.put_identity_direct(&did_hash, &consensus) {
                 tracing::warn!("backfill: put_identity_direct({}): {}", did, e);
                 continue;
@@ -246,12 +248,84 @@ impl Blockchain {
                 tracing::warn!("backfill: put_identity_metadata_direct({}): {}", did, e);
                 continue;
             }
+            if let Err(e) = store.put_identity_owner_index_direct(&consensus.owner, &did_hash) {
+                tracing::warn!("backfill: put_identity_owner_index_direct({}): {}", did, e);
+                continue;
+            }
             written += 1;
         }
         if written > 0 {
             tracing::info!(
                 "Backfilled {} genesis identities into sled identity store",
                 written
+            );
+        }
+    }
+
+    /// Rebuild sled identity trees from the in-memory registry after
+    /// block-scan replay (#1985 / #1999).
+    ///
+    /// Mirrors wallet `replace_wallet_projections`: when the scan path rebuilt
+    /// `identity_registry` / `identity_blocks` from committed blocks, write the
+    /// full projection (consensus + metadata + owner index) so stale sled rows
+    /// cannot remain implicit authority. Uses direct (non-tx) store APIs only.
+    pub(crate) fn rebuild_identity_projections_from_registry(&self) {
+        let Some(ref store) = self.store else {
+            return;
+        };
+
+        let mut written = 0usize;
+        let mut errors = 0usize;
+        for (did, data) in &self.identity_registry {
+            // Skip revocation tombstones kept under `{did}_revoked` keys.
+            if did.ends_with("_revoked") {
+                continue;
+            }
+            let height = self.identity_blocks.get(did).copied().unwrap_or(0);
+            let did_hash = crate::storage::did_to_hash(did);
+            let (mut consensus, metadata) = crate::storage::convert_legacy_identity(data);
+            consensus.registered_at_height = height;
+
+            if let Err(e) = store.put_identity_direct(&did_hash, &consensus) {
+                tracing::warn!(
+                    target: "legacy_fixup",
+                    path = "rebuild_identity_projections",
+                    did = %did,
+                    "put_identity_direct failed: {e}"
+                );
+                errors += 1;
+                continue;
+            }
+            if let Err(e) = store.put_identity_metadata_direct(&did_hash, &metadata) {
+                tracing::warn!(
+                    target: "legacy_fixup",
+                    path = "rebuild_identity_projections",
+                    did = %did,
+                    "put_identity_metadata_direct failed: {e}"
+                );
+                errors += 1;
+                continue;
+            }
+            if let Err(e) = store.put_identity_owner_index_direct(&consensus.owner, &did_hash) {
+                tracing::warn!(
+                    target: "legacy_fixup",
+                    path = "rebuild_identity_projections",
+                    did = %did,
+                    "put_identity_owner_index_direct failed: {e}"
+                );
+                errors += 1;
+                continue;
+            }
+            written += 1;
+        }
+
+        if written > 0 || errors > 0 {
+            tracing::info!(
+                target: "legacy_fixup",
+                path = "rebuild_identity_projections",
+                identities_written = written,
+                errors,
+                "🔁 Rebuilt identity sled projection from block-scan replay"
             );
         }
     }

--- a/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
@@ -303,6 +303,38 @@ fn system_injection_accepts_valid_client_identity_registration() {
 }
 
 #[test]
+fn register_wallet_is_enqueue_only_no_registry_or_mint() {
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    let pk = [0xABu8; 2592];
+    let wallet_id = [0x42u8; 32];
+    let wallet_hex = hex::encode(wallet_id);
+    let wallet_data = crate::transaction::WalletTransactionData {
+        wallet_id: crate::types::Hash::from_slice(&wallet_id),
+        wallet_type: "Primary".to_string(),
+        wallet_name: "Primary".to_string(),
+        alias: Some("primary".to_string()),
+        public_key: pk.to_vec(),
+        owner_identity_id: None,
+        seed_commitment: crate::types::Hash::default(),
+        created_at: 1,
+        registration_fee: 0,
+        capabilities: 0,
+        initial_balance: 0,
+    };
+    let shadow_before = bc.wallet_registry_shadow_len();
+    let hash = bc.register_wallet(wallet_data).expect("enqueue");
+    assert_eq!(bc.pending_transactions.len(), 1);
+    assert_eq!(bc.pending_transactions[0].hash(), hash);
+    assert_eq!(
+        bc.wallet_registry_shadow_len(),
+        shadow_before,
+        "register_wallet must not grow wallet_registry (enqueue-only)"
+    );
+    assert!(bc.wallet_exists(&wallet_hex), "pending occupies wallet id");
+    assert!(!bc.identity_committed("did:zhtp:none"));
+}
+
+#[test]
 fn abort_pending_client_registration_clears_mempool_and_shadows() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     let pk = [0xABu8; 2592];
@@ -348,6 +380,7 @@ fn abort_pending_client_registration_clears_mempool_and_shadows() {
         .expect("wallet tx in mempool");
 
     assert_eq!(bc.pending_transactions.len(), 2);
+    // Pending occupies DID / wallet id without committed wallet shadow (#1989 / #1990).
     assert!(bc.identity_exists(&did));
     assert!(bc.wallet_exists(&wallet_hex));
 
@@ -363,11 +396,11 @@ fn abort_pending_client_registration_clears_mempool_and_shadows() {
     );
     assert!(
         !bc.identity_exists(&did),
-        "abort must clear identity shadow so retries are not blocked"
+        "abort must clear identity pending/shadow so retries are not blocked"
     );
     assert!(
         !bc.wallet_exists(&wallet_hex),
-        "abort must clear wallet shadow"
+        "abort must clear wallet pending/shadow"
     );
 }
 

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -355,6 +355,9 @@ impl Blockchain {
 
         if migrated_total > 0 {
             info!(
+                target: "legacy_fixup",
+                path = "migrate_sov_key_balances_to_wallets",
+                amount_atomic = migrated_total,
                 "🪙 Migrated {} SOV from key-based balances to Primary wallets",
                 migrated_total
             );
@@ -690,8 +693,19 @@ impl Blockchain {
         let count = corrections.len();
         if count > 0 {
             match store.force_set_token_balances(&corrections) {
-                Ok(_) => info!("🔧 Repaired backfill inflation for {} wallets", count),
-                Err(e) => warn!("⚠️ Failed to write backfill corrections: {}", e),
+                Ok(_) => info!(
+                    target: "legacy_fixup",
+                    path = "repair_backfill_inflation",
+                    wallets_corrected = count,
+                    "🔧 Repaired backfill inflation for {} wallets",
+                    count
+                ),
+                Err(e) => warn!(
+                    target: "legacy_fixup",
+                    path = "repair_backfill_inflation",
+                    "⚠️ Failed to write backfill corrections: {}",
+                    e
+                ),
             }
         }
         count
@@ -735,7 +749,11 @@ impl Blockchain {
             .collect()
     }
 
-    /// Register a wallet via the trusted system-injection path.
+    /// Register a wallet via the trusted system-injection path (**enqueue only**).
+    ///
+    /// Canonical wallet state is materialised only when a committed block is
+    /// processed (`process_wallet_transactions` + executor `put_wallet_projection`).
+    /// This method must not insert `wallet_registry` / mint SOV (#1989 / #1982).
     ///
     /// **Trusted callers** (in-process only — not mempool-admitted):
     /// - `zhtp` citizenship / identity handlers (`identity/mod.rs`)
@@ -744,9 +762,9 @@ impl Blockchain {
     /// - `zhtp` wallet provisioning handler (`api/handlers/wallet/mod.rs`)
     /// - Genesis allocation replay (`blockchain/contracts.rs`)
     ///
-    /// Welcome-bonus SOV (`initial_balance > 0`) is only minted in-memory during
-    /// `apply_genesis_state`. At `height > 0`, callers must set `initial_balance = 0`
-    /// and submit a separate treasury-signed [`TransactionType::TokenMint`].
+    /// Welcome-bonus SOV must be a separate treasury-signed
+    /// [`TransactionType::TokenMint`]. `initial_balance` on the registration
+    /// payload is forced to 0 (executor rejects non-zero).
     pub fn register_wallet(
         &mut self,
         wallet_data: crate::transaction::WalletTransactionData,
@@ -758,18 +776,30 @@ impl Blockchain {
                 wallet_id_str
             ));
         }
+        if wallet_data.initial_balance > 0 {
+            return Err(anyhow::anyhow!(
+                "register_wallet initial_balance={} rejected: \
+                 submit a treasury-signed TokenMint instead of embedding balance \
+                 (block-authoritative path #1989)",
+                wallet_data.initial_balance,
+            ));
+        }
 
         // Never embed SOV mint amount in the WalletRegistration tx — executor and
-        // mempool reject initial_balance > 0 unless treasury-authorized. Bonus
-        // SOV is credited via the trusted in-memory mint path below.
+        // mempool reject initial_balance > 0 unless treasury-authorized.
         let mut registration_data = wallet_data.clone();
         registration_data.initial_balance = 0;
 
+        // Empty Dilithium signature: AutoWalletRegistration is authenticated at
+        // system-injection time; commit validation allows empty sig for
+        // zero-balance WalletRegistration (see allows_empty_system_signature).
+        // Do NOT put the public key bytes in `signature` — that is not a valid
+        // Dilithium sig and poisons block commit (InvalidSignature).
         let registration_tx = Transaction::new_wallet_registration(
             registration_data,
             vec![],
             Signature {
-                signature: wallet_data.public_key.clone(),
+                signature: Vec::new(),
                 public_key: PublicKey::new(
                     wallet_data.public_key.as_slice().try_into().unwrap_or([0u8; 2592])
                 ),
@@ -783,44 +813,7 @@ impl Blockchain {
             registration_tx.clone(),
             super::SystemOriginator::AutoWalletRegistration,
         )?;
-        self.wallet_registry
-            .insert(wallet_id_str.clone(), wallet_data.clone());
-        self.wallet_blocks
-            .insert(wallet_id_str.clone(), self.height + 1);
-
-        if wallet_data.initial_balance > 0 {
-            if !self.is_applying_genesis_state() {
-                return Err(anyhow::anyhow!(
-                    "register_wallet initial_balance={} rejected at height {}: \
-                     submit a treasury-signed TokenMint instead of in-memory mint",
-                    wallet_data.initial_balance,
-                    self.height
-                ));
-            }
-            let sov_token_id = crate::contracts::utils::generate_lib_token_id();
-            self.ensure_sov_token_contract();
-            let mut wallet_id_bytes_arr = [0u8; 32];
-            wallet_id_bytes_arr.copy_from_slice(wallet_data.wallet_id.as_bytes());
-            let recipient_pk = Self::wallet_key_for_sov(&wallet_id_bytes_arr);
-            if let Some(token) = self.token_contracts.get_mut(&sov_token_id) {
-                if token.balance_of(&recipient_pk) == 0 {
-                    if let Err(e) = token.mint(&recipient_pk, wallet_data.initial_balance as u128) {
-                        warn!(
-                            "register_wallet: genesis bootstrap mint failed {} SOV for {}: {}",
-                            wallet_data.initial_balance,
-                            &wallet_id_str[..16.min(wallet_id_str.len())],
-                            e
-                        );
-                    } else {
-                        info!(
-                            "💰 register_wallet: genesis bootstrap minted {} SOV for wallet {}",
-                            wallet_data.initial_balance,
-                            &wallet_id_str[..16.min(wallet_id_str.len())]
-                        );
-                    }
-                }
-            }
-        }
+        // No wallet_registry / wallet_blocks / token mint here — block commit only.
 
         Ok(registration_tx.hash())
     }
@@ -888,7 +881,8 @@ impl Blockchain {
                 return false;
             };
             match store.get_wallet_projection(&wallet_id_bytes) {
-                Ok(found) => return found.is_some(),
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
                 Err(e) => {
                     tracing::warn!(
                         wallet_id = %wallet_id,
@@ -898,7 +892,17 @@ impl Blockchain {
                 }
             }
         }
-        false
+        // Pending (not yet committed) registrations occupy the id so a second
+        // enqueue cannot race (#1989).
+        self.pending_transactions.iter().any(|tx| {
+            matches!(
+                tx.transaction_type,
+                TransactionType::WalletRegistration | TransactionType::WalletUpdate
+            ) && tx
+                .wallet_data()
+                .map(|w| hex::encode(w.wallet_id.as_bytes()) == wallet_id)
+                .unwrap_or(false)
+        })
     }
 
     /// Sled-first wallet record for handlers needing full `WalletTransactionData` (#2639).
@@ -1005,6 +1009,17 @@ impl Blockchain {
                         .insert(wallet_id_str.clone(), wallet_data.clone());
                     self.wallet_blocks
                         .insert(wallet_id_str.clone(), block.height());
+
+                    if transaction.transaction_type == TransactionType::WalletRegistration {
+                        let tx_hash_arr = transaction.hash().as_array();
+                        self.event_publisher.publish(
+                            crate::events::BlockchainEvent::WalletRegistered {
+                                tx_hash: tx_hash_arr,
+                                block_height: block.height(),
+                                wallet_data: wallet_data.clone(),
+                            },
+                        );
+                    }
 
                     // Executor mode mints initial SOV to sled in apply_block; in-memory
                     // mint here would be a second write source (#2641).

--- a/lib-blockchain/src/execution/errors.rs
+++ b/lib-blockchain/src/execution/errors.rs
@@ -148,6 +148,16 @@ pub enum TxApplyError {
     #[error("Replay nonce dropped: expected {expected}, got {actual} (replay protection)")]
     ReplayDropped { expected: u64, actual: u64 },
 
+    /// RewardClaim ineligible or invalid at apply height. Soft-dropped like
+    /// [`Self::ReplayDropped`]: skip the tx, keep the block valid.
+    ///
+    /// Stateful eligibility (welcome/daily/partner already claimed, tip moved)
+    /// cannot be closed by mempool mirroring alone — admission and apply see
+    /// different heights. Fatal apply would halt consensus after BFT finality
+    /// (GENESIS-3 class). Mempool checks remain best-effort early reject.
+    #[error("RewardClaim dropped at apply: {0}")]
+    RewardClaimDropped(String),
+
     #[error("Account not found: {0}")]
     AccountNotFound(Address),
 

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -949,9 +949,37 @@ impl BlockExecutor {
             }
 
             // apply_tx (writes)
-            let tx_result = self
-                .apply_tx(&mutator, tx, block_height, block_timestamp)
-                .map_err(|e| BlockApplyError::TxFailed { index, reason: e })?;
+            // Soft-drop RewardClaim ineligibility / nonce-replay races so a
+            // finalized block never halts on apply rejects that mempool cannot
+            // fully prevent (stateful eligibility at different heights).
+            let tx_result = match self.apply_tx(&mutator, tx, block_height, block_timestamp) {
+                Ok(outcome) => outcome,
+                Err(TxApplyError::ReplayDropped {
+                    expected,
+                    actual,
+                }) => {
+                    tracing::warn!(
+                        index = index,
+                        height = block_height,
+                        expected_nonce = expected,
+                        actual_nonce = actual,
+                        "dropping replay tx during apply_tx (soft drop)"
+                    );
+                    continue;
+                }
+                Err(TxApplyError::RewardClaimDropped(reason)) => {
+                    tracing::warn!(
+                        index = index,
+                        height = block_height,
+                        reason = %reason,
+                        "RewardClaim dropped during apply (soft drop; block continues)"
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    return Err(BlockApplyError::TxFailed { index, reason: e });
+                }
+            };
 
             // Accumulate results
             match tx_result {
@@ -3548,9 +3576,13 @@ impl BlockExecutor {
                     block_timestamp,
                     &fee_sink,
                 )?;
-                Ok(TxOutcome::TokenTransfer(
-                    outcome.expect("apply_reward_claim returns Err on ineligibility"),
-                ))
+                // Ineligibility returns Err(RewardClaimDropped) → soft-dropped
+                // in the apply loop. Ok(None) is not used for rejects.
+                Ok(TxOutcome::TokenTransfer(outcome.ok_or_else(|| {
+                    TxApplyError::RewardClaimDropped(
+                        "apply_reward_claim returned Ok(None)".to_string(),
+                    )
+                })?))
             }
             TransactionType::TokenMint => {
                 let mint_data = tx.token_mint_data().ok_or_else(|| {

--- a/lib-blockchain/src/execution/reward_claim.rs
+++ b/lib-blockchain/src/execution/reward_claim.rs
@@ -28,13 +28,13 @@ fn resolve_rewards_policy(
     if let Some(state) = mutator.get_rewards_module_state(&token_id)? {
         if let Some(doc) = mutator.get_rewards_policy_document(&state.policy_hash)? {
             let policy = validate_rewards_policy(&doc).map_err(|e| {
-                TxApplyError::InvalidType(format!("invalid stored rewards policy: {e}"))
+                TxApplyError::RewardClaimDropped(format!("invalid stored rewards policy: {e}"))
             })?;
             let hash = policy_hash(&policy).map_err(|e| {
-                TxApplyError::InvalidType(format!("rewards policy hash failed: {e}"))
+                TxApplyError::RewardClaimDropped(format!("rewards policy hash failed: {e}"))
             })?;
             if hash.as_array() != state.policy_hash {
-                return Err(TxApplyError::InvalidType(
+                return Err(TxApplyError::RewardClaimDropped(
                     "stored rewards policy hash mismatch".to_string(),
                 ));
             }
@@ -44,19 +44,20 @@ fn resolve_rewards_policy(
             "RewardClaim: rewards module present but policy document missing for token {}",
             hex::encode(token_id)
         );
-        return Err(TxApplyError::InvalidType(
+        return Err(TxApplyError::RewardClaimDropped(
             "rewards module present but policy document missing".to_string(),
         ));
     }
     if is_legacy_bubl_token(token_id) {
         return Ok(legacy_bubl_policy());
     }
-    Err(TxApplyError::InvalidType(
+    Err(TxApplyError::RewardClaimDropped(
         "rewards module state required for reward claims".to_string(),
     ))
 }
 fn reject_claim(msg: impl Into<String>) -> TxApplyResult<Option<TokenTransferOutcome>> {
-    Err(TxApplyError::InvalidType(msg.into()))
+    // Soft-drop at block apply (executor maps this to skip-tx, not halt).
+    Err(TxApplyError::RewardClaimDropped(msg.into()))
 }
 
 /// Apply a `RewardClaim` inside the executor block window.
@@ -131,9 +132,10 @@ pub fn apply_reward_claim(
     // 2h) and enforces monotonicity, so a validated block cannot reach the
     // ~8.2e12 chrono ceiling. Safety is therefore coupled to that config staying
     // far below chrono's range — not to these helpers being infallible.
-    let date = utc_date_from_ts(block_timestamp).map_err(TxApplyError::InvalidType)?;
-    let week = iso_week_from_ts(block_timestamp).map_err(TxApplyError::InvalidType)?;
-    let today_ord = utc_day_ordinal_from_ts(block_timestamp).map_err(TxApplyError::InvalidType)?;
+    let date = utc_date_from_ts(block_timestamp).map_err(TxApplyError::RewardClaimDropped)?;
+    let week = iso_week_from_ts(block_timestamp).map_err(TxApplyError::RewardClaimDropped)?;
+    let today_ord =
+        utc_day_ordinal_from_ts(block_timestamp).map_err(TxApplyError::RewardClaimDropped)?;
     let token_id = &data.token_id;
 
     let mut streak_day = 1u32;
@@ -248,10 +250,10 @@ pub fn apply_reward_claim(
         });
     }
     if data.nonce > expected_nonce {
-        return Err(TxApplyError::InvalidType(format!(
+        return reject_claim(format!(
             "RewardClaim nonce gap: expected {}, got {}",
             expected_nonce, data.nonce
-        )));
+        ));
     }
 
     let cbe_token_id_arr = crate::Blockchain::derive_cbe_token_id_pub();
@@ -273,7 +275,9 @@ pub fn apply_reward_claim(
                 fee_sink,
             )
         {
-            return Err(TxApplyError::InsufficientRewardLiquidity { have, need });
+            return reject_claim(format!(
+                "insufficient reward liquidity: have {have}, need {need}"
+            ));
         }
     } else {
         tx_apply::apply_token_transfer(

--- a/lib-blockchain/src/storage/mod.rs
+++ b/lib-blockchain/src/storage/mod.rs
@@ -912,6 +912,18 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
     /// - Block hash MUST be unique
     fn append_block(&self, block: &crate::block::Block) -> StorageResult<()>;
 
+    /// Replace an already-committed block at the same height (hash may change).
+    ///
+    /// Used after genesis funding mutates block 0 in memory so the sled body and
+    /// height index match the tip hash proposers use. Not a general reorg API.
+    ///
+    /// Default: unsupported.
+    fn replace_block(&self, _block: &crate::block::Block) -> StorageResult<()> {
+        Err(StorageError::Database(
+            "replace_block not implemented for this BlockchainStore backend".into(),
+        ))
+    }
+
     /// Get a block by its height.
     ///
     /// Returns None if no block exists at that height.
@@ -1715,6 +1727,20 @@ pub trait BlockchainStore: Send + Sync + fmt::Debug {
         let _ = (did_hash, metadata);
         Err(StorageError::Database(
             "put_identity_metadata_direct not supported by this backend".to_string(),
+        ))
+    }
+
+    /// Write owner → did_hash index outside begin_block/commit_block.
+    ///
+    /// Used by projection rebuild after block-scan replay (#1985 / #1999).
+    fn put_identity_owner_index_direct(
+        &self,
+        addr: &Address,
+        did_hash: &[u8; 32],
+    ) -> StorageResult<()> {
+        let _ = (addr, did_hash);
+        Err(StorageError::Database(
+            "put_identity_owner_index_direct not supported by this backend".to_string(),
         ))
     }
 

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1194,6 +1194,44 @@ impl BlockchainStore for SledStore {
     // Block Operations
     // =========================================================================
 
+    fn replace_block(&self, block: &Block) -> StorageResult<()> {
+        // Must not run inside an open begin_block/commit_block transaction —
+        // this is a post-commit repair of an already-written height.
+        if self.tx_active.load(Ordering::SeqCst) {
+            return Err(StorageError::TransactionAlreadyActive);
+        }
+
+        let height = block.header.height;
+        let height_key = keys::block_height_key(height);
+        let new_hash_bytes: [u8; 32] = block.header.block_hash.as_array();
+        let new_hash = BlockHash::new(new_hash_bytes);
+        let block_bytes = Self::serialize(block)?;
+
+        if let Some(old_hash_bytes) = self
+            .blocks_by_height
+            .get(height_key)
+            .map_err(|e| StorageError::Database(e.to_string()))?
+        {
+            if old_hash_bytes.as_ref() != new_hash_bytes.as_ref() {
+                self.blocks_by_hash
+                    .remove(old_hash_bytes.as_ref())
+                    .map_err(|e| StorageError::Database(e.to_string()))?;
+            }
+        }
+
+        self.blocks_by_height
+            .insert(height_key, new_hash_bytes.as_ref())
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        self.blocks_by_hash
+            .insert(keys::block_hash_key(&new_hash).as_ref(), block_bytes)
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        self.db
+            .flush()
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
     fn append_block(&self, block: &Block) -> StorageResult<()> {
         self.require_transaction()?;
 
@@ -2743,6 +2781,21 @@ impl BlockchainStore for SledStore {
             .insert(did_hash.as_ref(), value)
             .map_err(|e| StorageError::Database(e.to_string()))?;
         self.identity_metadata
+            .flush()
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    fn put_identity_owner_index_direct(
+        &self,
+        addr: &Address,
+        did_hash: &[u8; 32],
+    ) -> StorageResult<()> {
+        let key = keys::identity_by_owner_key(addr);
+        self.identity_by_owner
+            .insert(key.as_ref(), did_hash.as_ref())
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+        self.identity_by_owner
             .flush()
             .map_err(|e| StorageError::Database(e.to_string()))?;
         Ok(())

--- a/lib-blockchain/src/transaction/system_tx_signature.rs
+++ b/lib-blockchain/src/transaction/system_tx_signature.rs
@@ -102,6 +102,46 @@ pub fn requires_system_tx_signature(transaction: &Transaction) -> bool {
     system_tx_signature_policy(transaction.transaction_type) == SystemTxSignaturePolicy::Required
 }
 
+/// Client / auto-bootstrap system txs that are intentionally unsigned at the
+/// Dilithium tx layer. Authentication is elsewhere:
+/// - [`TransactionType::IdentityRegistration`]: API verifies `ZHTP_REGISTER`
+///   proof; payload carries `ownership_proof` + DID/pk binding (see
+///   `SystemOriginator::ClientIdentityRegistration`).
+/// - [`TransactionType::WalletRegistration`]: zero-balance auto wallets from
+///   the same registration path (`SystemOriginator::AutoWalletRegistration`).
+///
+/// Non-empty signatures still always go through full crypto verify.
+pub fn allows_empty_system_signature(transaction: &Transaction) -> bool {
+    if !transaction.signature.signature.is_empty() {
+        return false;
+    }
+    match transaction.transaction_type {
+        TransactionType::IdentityRegistration => {
+            let Some(data) = transaction.identity_data() else {
+                return false;
+            };
+            if data.ownership_proof.is_empty() || data.public_key.len() != 2592 {
+                return false;
+            }
+            let Ok(identity_pk): Result<[u8; 2592], _> = data.public_key.as_slice().try_into()
+            else {
+                return false;
+            };
+            if transaction.signature.public_key.dilithium_pk != identity_pk {
+                return false;
+            }
+            let key_id = crate::types::hash::blake3_hash(identity_pk.as_slice());
+            let expected_did = format!("did:zhtp:{}", hex::encode(key_id.as_bytes()));
+            data.did == expected_did
+        }
+        TransactionType::WalletRegistration => transaction
+            .wallet_data()
+            .map(|w| w.initial_balance == 0)
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -150,5 +190,43 @@ mod tests {
                 SystemTxSignaturePolicy::Required
             );
         }
+    }
+
+    #[test]
+    fn client_identity_registration_allows_empty_sig_when_bound() {
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+        use crate::transaction::core::IdentityTransactionData;
+        use crate::types::Hash;
+
+        let dilithium_pk = [0xABu8; 2592];
+        let key_id = crate::types::hash::blake3_hash(&dilithium_pk);
+        let did = format!("did:zhtp:{}", hex::encode(key_id.as_bytes()));
+        let identity_data = IdentityTransactionData {
+            did,
+            display_name: "test_user".to_string(),
+            public_key: dilithium_pk.to_vec(),
+            ownership_proof: vec![0x01, 0x02],
+            identity_type: "human".to_string(),
+            did_document_hash: Hash::default(),
+            created_at: 1,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_nodes: vec![],
+            owned_wallets: vec![],
+            kyber_public_key: vec![],
+        };
+        let tx = Transaction::new_identity_registration(
+            identity_data,
+            vec![],
+            Signature {
+                signature: Vec::new(),
+                public_key: PublicKey::new(dilithium_pk),
+                algorithm: SignatureAlgorithm::DEFAULT,
+                timestamp: 1,
+            },
+            b"client-identity-register:test".to_vec(),
+        );
+        assert!(allows_empty_system_signature(&tx));
+        assert!(requires_system_tx_signature(&tx));
     }
 }

--- a/lib-blockchain/src/transaction/system_tx_signature.rs
+++ b/lib-blockchain/src/transaction/system_tx_signature.rs
@@ -134,10 +134,25 @@ pub fn allows_empty_system_signature(transaction: &Transaction) -> bool {
             let expected_did = format!("did:zhtp:{}", hex::encode(key_id.as_bytes()));
             data.did == expected_did
         }
-        TransactionType::WalletRegistration => transaction
-            .wallet_data()
-            .map(|w| w.initial_balance == 0)
-            .unwrap_or(false),
+        TransactionType::WalletRegistration => {
+            // Zero-balance auto wallets only. Bind wallet_id + tx.signature.pk
+            // to the payload public key so an empty signature cannot admit a
+            // forged WalletRegistration with arbitrary wallet_id (Copilot #2924).
+            let Some(w) = transaction.wallet_data() else {
+                return false;
+            };
+            if w.initial_balance != 0 || w.public_key.len() != 2592 {
+                return false;
+            }
+            let Ok(wallet_pk): Result<[u8; 2592], _> = w.public_key.as_slice().try_into() else {
+                return false;
+            };
+            if transaction.signature.public_key.dilithium_pk != wallet_pk {
+                return false;
+            }
+            let key_id = crate::types::hash::blake3_hash(wallet_pk.as_slice());
+            w.wallet_id.as_bytes() == key_id.as_bytes()
+        }
         _ => false,
     }
 }
@@ -228,5 +243,61 @@ mod tests {
         );
         assert!(allows_empty_system_signature(&tx));
         assert!(requires_system_tx_signature(&tx));
+    }
+
+    #[test]
+    fn wallet_registration_empty_sig_requires_wallet_id_pk_binding() {
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+        use crate::transaction::core::WalletTransactionData;
+        use crate::types::Hash;
+
+        let dilithium_pk = [0xCDu8; 2592];
+        let key_id = crate::types::hash::blake3_hash(&dilithium_pk);
+        let good = WalletTransactionData {
+            wallet_id: key_id,
+            wallet_type: "Primary".to_string(),
+            wallet_name: "p".to_string(),
+            alias: None,
+            public_key: dilithium_pk.to_vec(),
+            owner_identity_id: None,
+            seed_commitment: Hash::default(),
+            created_at: 1,
+            registration_fee: 0,
+            capabilities: 0,
+            initial_balance: 0,
+        };
+        let good_tx = Transaction::new_wallet_registration(
+            good,
+            vec![],
+            Signature {
+                signature: Vec::new(),
+                public_key: PublicKey::new(dilithium_pk),
+                algorithm: SignatureAlgorithm::DEFAULT,
+                timestamp: 1,
+            },
+            b"wallet-reg".to_vec(),
+        );
+        assert!(allows_empty_system_signature(&good_tx));
+
+        let mut forged = good_tx.clone();
+        if let Some(w) = forged.wallet_data().cloned() {
+            let mut bad = w;
+            bad.wallet_id = Hash::new([0x11; 32]);
+            forged = Transaction::new_wallet_registration(
+                bad,
+                vec![],
+                Signature {
+                    signature: Vec::new(),
+                    public_key: PublicKey::new(dilithium_pk),
+                    algorithm: SignatureAlgorithm::DEFAULT,
+                    timestamp: 1,
+                },
+                b"wallet-reg".to_vec(),
+            );
+        }
+        assert!(
+            !allows_empty_system_signature(&forged),
+            "empty sig must not allow wallet_id unbound from public_key"
+        );
     }
 }

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -2554,18 +2554,35 @@ impl<'a> StatefulTransactionValidator<'a> {
             tracing::debug!("[BREADCRUMB] validate_zk_proofs OK");
         }
 
-        // RewardClaim: must match apply (`reward_claim::apply_reward_claim`) so a
-        // claim that cannot execute never enters the mempool or a BFT proposal.
-        // Order is intentional and identical to apply:
-        //   1) owner_did registered in sled
-        //   2) token_contract MUST exist (rewards-module alone is not enough —
-        //      AssetLaunch can write rewards state without a token_contracts row;
-        //      admitting such claims caused the GENESIS-3 H=1920 halt)
-        //   3) spend-delegate (if rewards module) else legacy token-creator
+        // RewardClaim mempool filter (best-effort early reject).
+        // Stateless / tip-stable checks mirror apply. Stateful eligibility
+        // (welcome/daily/partner already claimed) can race tip vs apply height
+        // and is soft-dropped at apply (`TxApplyError::RewardClaimDropped`)
+        // so unmirrored rejects cannot halt consensus after BFT finality.
+        //
+        // Order for tip-stable checks (matches apply):
+        //   0) amount > 0
+        //   1) recipient_key_id == key_id_from_did(owner_did)
+        //   2) owner_did registered in sled
+        //   3) token_contract exists (GENESIS-3 H=1920: rewards-module alone
+        //      is not enough — pure AssetLaunch has no token_contracts row)
+        //   4) spend-delegate (if rewards module) else legacy token-creator
         if transaction.transaction_type == TransactionType::RewardClaim {
             let data = transaction
                 .reward_claim_data()
                 .ok_or(ValidationError::MissingRequiredData)?;
+            if data.amount == 0 {
+                tracing::warn!("[REWARD_CLAIM] amount must be greater than 0");
+                return Err(ValidationError::InvalidTransaction);
+            }
+            if crate::transaction::reward_claim::key_id_from_did(&data.owner_did)
+                != Some(data.recipient_key_id)
+            {
+                tracing::warn!(
+                    "[REWARD_CLAIM] recipient_key_id does not match owner_did"
+                );
+                return Err(ValidationError::InvalidTransaction);
+            }
             let blockchain = self
                 .blockchain
                 .ok_or(ValidationError::InvalidTransaction)?;
@@ -2582,10 +2599,6 @@ impl<'a> StatefulTransactionValidator<'a> {
                 );
                 return Err(ValidationError::InvalidTransaction);
             }
-            // Apply hard-requires token_contract first. Checking rewards_module
-            // before contract previously admitted pure-AssetLaunch BUBL claims
-            // that then failed apply with "token contract not found" and halted
-            // consensus after BFT finality.
             let Some(contract) = blockchain.get_token_contract(&data.token_id) else {
                 tracing::warn!(
                     "[REWARD_CLAIM] token contract not found for claim token_id={}",

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -9,7 +9,9 @@ use crate::transaction::core::{
     IdentityTransactionData, Transaction, TransactionInput, TransactionOutput,
 };
 use crate::transaction::mint_authorization::validate_token_mint_authorization;
-use crate::transaction::system_tx_signature::requires_system_tx_signature;
+use crate::transaction::system_tx_signature::{
+    allows_empty_system_signature, requires_system_tx_signature,
+};
 use crate::transaction::asset_tx::{
     AssetLaunchPayloadV1, AssetManifestUpdatePayloadV1, AssetModuleUpgradePayloadV1,
     AssetBurnBpsUpdatePayloadV1, AssetRewardsDelegateRotatePayloadV1,
@@ -682,7 +684,8 @@ impl TransactionValidator {
             transaction.transaction_type,
             TransactionType::RecordOnRampTrade | TransactionType::TreasuryAllocation
         );
-        if !is_threshold_only && (require_signature || has_nonempty_sig) {
+        let allow_empty = allows_empty_system_signature(transaction);
+        if !is_threshold_only && !allow_empty && (require_signature || has_nonempty_sig) {
             self.validate_signature(transaction)?;
         }
 
@@ -1004,7 +1007,8 @@ impl TransactionValidator {
             transaction.transaction_type,
             TransactionType::RecordOnRampTrade | TransactionType::TreasuryAllocation
         );
-        if !is_threshold_only_sflag && (require_signature || has_nonempty_sig) {
+        let allow_empty = allows_empty_system_signature(transaction);
+        if !is_threshold_only_sflag && !allow_empty && (require_signature || has_nonempty_sig) {
             self.validate_signature(transaction)?;
         }
 
@@ -2525,6 +2529,9 @@ impl<'a> StatefulTransactionValidator<'a> {
         if is_threshold_type {
             skip_signature = true;
         }
+        if allows_empty_system_signature(transaction) {
+            skip_signature = true;
+        }
         if transaction.transaction_type == TransactionType::TokenMint {
             if let Some(blockchain) = self.blockchain {
                 if blockchain.is_applying_genesis_state()
@@ -2547,11 +2554,14 @@ impl<'a> StatefulTransactionValidator<'a> {
             tracing::debug!("[BREADCRUMB] validate_zk_proofs OK");
         }
 
-        // RewardClaim: signer is the spend delegate (system tx), but beneficiary
-        // `owner_did` must exist in durable sled — same oracle as executor apply.
-        // Spend-delegate (or legacy token-creator) authorization must also match
-        // apply (`reward_claim.rs`) so a non-delegate claim is rejected at
-        // mempool admission instead of halting block apply (#2859 class).
+        // RewardClaim: must match apply (`reward_claim::apply_reward_claim`) so a
+        // claim that cannot execute never enters the mempool or a BFT proposal.
+        // Order is intentional and identical to apply:
+        //   1) owner_did registered in sled
+        //   2) token_contract MUST exist (rewards-module alone is not enough —
+        //      AssetLaunch can write rewards state without a token_contracts row;
+        //      admitting such claims caused the GENESIS-3 H=1920 halt)
+        //   3) spend-delegate (if rewards module) else legacy token-creator
         if transaction.transaction_type == TransactionType::RewardClaim {
             let data = transaction
                 .reward_claim_data()
@@ -2572,6 +2582,17 @@ impl<'a> StatefulTransactionValidator<'a> {
                 );
                 return Err(ValidationError::InvalidTransaction);
             }
+            // Apply hard-requires token_contract first. Checking rewards_module
+            // before contract previously admitted pure-AssetLaunch BUBL claims
+            // that then failed apply with "token contract not found" and halted
+            // consensus after BFT finality.
+            let Some(contract) = blockchain.get_token_contract(&data.token_id) else {
+                tracing::warn!(
+                    "[REWARD_CLAIM] token contract not found for claim token_id={}",
+                    hex::encode(data.token_id)
+                );
+                return Err(ValidationError::InvalidTransaction);
+            };
             if let Some(rewards_state) = blockchain.get_rewards_module_state(&data.token_id) {
                 if data.from != rewards_state.spend_delegate_key_id {
                     tracing::warn!(
@@ -2581,21 +2602,13 @@ impl<'a> StatefulTransactionValidator<'a> {
                     );
                     return Err(ValidationError::Unauthorized);
                 }
-            } else if let Some(contract) = blockchain.get_token_contract(&data.token_id) {
-                if contract.creator.key_id != data.from {
-                    tracing::warn!(
-                        "[REWARD_CLAIM] signer is not token creator (legacy path): from={} creator={}",
-                        hex::encode(data.from),
-                        hex::encode(contract.creator.key_id)
-                    );
-                    return Err(ValidationError::Unauthorized);
-                }
-            } else {
+            } else if contract.creator.key_id != data.from {
                 tracing::warn!(
-                    "[REWARD_CLAIM] token contract not found for claim token_id={}",
-                    hex::encode(data.token_id)
+                    "[REWARD_CLAIM] signer is not token creator (legacy path): from={} creator={}",
+                    hex::encode(data.from),
+                    hex::encode(contract.creator.key_id)
                 );
-                return Err(ValidationError::InvalidTransaction);
+                return Err(ValidationError::Unauthorized);
             }
             return Ok(());
         }

--- a/lib-blockchain/tests/common/reward_claim_harness.rs
+++ b/lib-blockchain/tests/common/reward_claim_harness.rs
@@ -124,6 +124,41 @@ fn install_bubl_mempool_fixtures(blockchain: &mut Blockchain, actors: &RewardCla
     );
 }
 
+/// Identities + rewards-module state for `token_id`, but **no** `token_contracts`
+/// row — mirrors pure AssetLaunch (discoverable rewards, un-applyable claims).
+pub fn mempool_blockchain_rewards_module_without_token_contract(
+    actors: &RewardClaimActors,
+) -> Blockchain {
+    use lib_blockchain::contracts::sovereign_asset::RewardsModuleState;
+
+    let mut blockchain = Blockchain::new().expect("blockchain construct");
+    let store = attach_ephemeral_store(&mut blockchain);
+    register_actor_identities_store(store.as_ref(), actors);
+    register_actor_identities_shadow(&mut blockchain, actors);
+    // put_rewards_module_state requires an active block transaction.
+    // Empty store expects height 0 (genesis slot) for the first begin_block.
+    store.begin_block(0).expect("begin rewards fixture block");
+    store
+        .put_rewards_module_state(
+            &actors.token_id,
+            &RewardsModuleState {
+                spend_delegate_key_id: actors.treasury.public_key.key_id,
+                policy_cid: [0u8; 32],
+                policy_hash: [0u8; 32],
+                nonce: 0,
+                pending_policy: None,
+            },
+        )
+        .expect("seed rewards module without token contract");
+    store.commit_block().expect("commit rewards fixture block");
+    blockchain.insert_token_nonce_shadow(
+        actors.token_id,
+        actors.treasury.public_key.key_id,
+        0,
+    );
+    blockchain
+}
+
 /// In-memory blockchain with treasury identity + BUBL contract, but beneficiary
 /// `owner_did` deliberately absent from the registry (halt regression harness).
 pub fn mempool_blockchain_unregistered_beneficiary(actors: &RewardClaimActors) -> Blockchain {

--- a/lib-blockchain/tests/identity_projection_restart_tests.rs
+++ b/lib-blockchain/tests/identity_projection_restart_tests.rs
@@ -1,0 +1,158 @@
+//! #1985 / #1999 / #2002 — identity projection rebuild equivalence after restart.
+//!
+//! After block-scan replay, sled identity trees must match the registry derived
+//! from committed blocks (not stale pre-existing projection content).
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use lib_blockchain::block::{Block, BlockHeader};
+use lib_blockchain::integration::crypto_integration::PublicKey;
+use lib_blockchain::storage::{
+    did_to_hash, BlockchainStore, IdentityMetadata, SledStore,
+};
+use lib_blockchain::transaction::{IdentityTransactionData, Transaction, TransactionPayload};
+use lib_blockchain::types::{Hash, TransactionType};
+use lib_crypto::types::signatures::Signature;
+
+mod common;
+
+fn test_pubkey(seed: u8) -> PublicKey {
+    common::crypto_fixtures::seeded_public_key(seed)
+}
+
+fn test_signature(pubkey: &PublicKey) -> Signature {
+    common::crypto_fixtures::signature_for(pubkey)
+}
+
+fn identity_data(did: &str, owner: &PublicKey, display_name: &str, kyber: Vec<u8>) -> IdentityTransactionData {
+    IdentityTransactionData {
+        did: did.to_string(),
+        display_name: display_name.to_string(),
+        public_key: owner.dilithium_pk.to_vec(),
+        ownership_proof: vec![],
+        identity_type: "human".to_string(),
+        did_document_hash: Hash::zero(),
+        created_at: 1_700_000_000,
+        registration_fee: 0,
+        dao_fee: 0,
+        controlled_nodes: vec![],
+        owned_wallets: vec![],
+        kyber_public_key: kyber,
+    }
+}
+
+fn identity_tx(data: IdentityTransactionData, owner: &PublicKey) -> Transaction {
+    Transaction {
+        version: 2,
+        chain_id: 0x03,
+        transaction_type: TransactionType::IdentityRegistration,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: test_signature(owner),
+        memo: Vec::new(),
+        payload: TransactionPayload::Identity(data),
+    }
+}
+
+fn block(height: u64, txs: Vec<Transaction>) -> Block {
+    let header = BlockHeader {
+        version: 1,
+        previous_hash: Hash::zero().into(),
+        data_helix_root: Hash::zero().into(),
+        timestamp: 1_700_000_000 + height,
+        height,
+        verification_helix_root: [0u8; 32],
+        state_root: Hash::default().into(),
+        bft_quorum_root: [0u8; 32],
+        block_hash: Hash::zero(),
+    };
+    Block::new(header, txs)
+}
+
+#[test]
+fn test_identity_projection_rebuilt_from_blocks_after_stale_sled() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let store: Arc<dyn BlockchainStore> = Arc::new(SledStore::open(tmp.path())?);
+
+    let owner = test_pubkey(7);
+    let did = "did:zhtp:phase2-identity-rebuild";
+    let kyber = vec![0xAB; 32];
+    let data = identity_data(did, &owner, "Canonical Name", kyber.clone());
+    let did_hash = did_to_hash(did);
+
+    store.begin_block(0)?;
+    store.append_block(&block(
+        0,
+        vec![identity_tx(data.clone(), &owner)],
+    ))?;
+    store.commit_block()?;
+
+    // Stale projection: wrong display name / empty kyber, missing owner index.
+    let stale = IdentityMetadata {
+        did: did.to_string(),
+        display_name: "STALE NAME".to_string(),
+        public_key: owner.dilithium_pk.to_vec(),
+        kyber_public_key: Vec::new(),
+        ownership_proof: vec![],
+        controlled_nodes: vec![],
+        owned_wallets: vec![],
+        attributes: vec![],
+    };
+    store.put_identity_metadata_direct(&did_hash, &stale)?;
+
+    let loaded =
+        lib_blockchain::Blockchain::load_from_store(store.clone())?.expect("load after replay");
+
+    assert_eq!(
+        loaded.identity_display_name(did).as_deref(),
+        Some("Canonical Name")
+    );
+    assert_eq!(loaded.identity_kyber_public_key(did), Some(kyber.clone()));
+    assert_eq!(loaded.identity_blocks.get(did), Some(&0));
+
+    let meta = store
+        .get_identity_metadata(&did_hash)?
+        .expect("metadata rebuilt");
+    assert_eq!(meta.display_name, "Canonical Name");
+    assert_eq!(meta.kyber_public_key, kyber);
+
+    let consensus = store.get_identity(&did_hash)?.expect("consensus rebuilt");
+    assert_eq!(consensus.registered_at_height, 0);
+
+    let owner_addr = lib_blockchain::storage::derive_address_from_public_key(&owner.dilithium_pk);
+    assert_eq!(
+        store.get_identity_by_owner(&owner_addr)?,
+        Some(did_hash),
+        "owner index must be rebuilt"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_identity_registry_matches_across_two_load_from_store_passes() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let store: Arc<dyn BlockchainStore> = Arc::new(SledStore::open(tmp.path())?);
+
+    let owner = test_pubkey(9);
+    let did = "did:zhtp:phase2-identity-equiv";
+    let data = identity_data(did, &owner, "Equivalence", vec![0xCD; 16]);
+
+    store.begin_block(0)?;
+    store.append_block(&block(0, vec![identity_tx(data, &owner)]))?;
+    store.commit_block()?;
+
+    let a = lib_blockchain::Blockchain::load_from_store(store.clone())?.expect("load A");
+    let b = lib_blockchain::Blockchain::load_from_store(store)?.expect("load B");
+
+    assert_eq!(
+        a.identity_transaction_data(did),
+        b.identity_transaction_data(did)
+    );
+    assert_eq!(a.identity_blocks.get(did), b.identity_blocks.get(did));
+    assert_eq!(a.height, b.height);
+
+    Ok(())
+}

--- a/lib-blockchain/tests/reward_claim_mempool_tests.rs
+++ b/lib-blockchain/tests/reward_claim_mempool_tests.rs
@@ -14,9 +14,10 @@ mod common;
 
 use common::block_builders;
 use common::reward_claim_harness::{
-    mempool_blockchain, mempool_blockchain_shadow_phantom_beneficiary,
-    mempool_blockchain_unregistered_beneficiary, mempool_blockchain_unregistered_treasury,
-    seed_executor_store, welcome_claim_tx, welcome_claim_tx_from, RewardClaimActors,
+    mempool_blockchain, mempool_blockchain_rewards_module_without_token_contract,
+    mempool_blockchain_shadow_phantom_beneficiary, mempool_blockchain_unregistered_beneficiary,
+    mempool_blockchain_unregistered_treasury, seed_executor_store, welcome_claim_tx,
+    welcome_claim_tx_from, RewardClaimActors,
 };
 
 #[test]
@@ -63,6 +64,37 @@ fn non_delegate_signer_rejected_from_mempool() {
     assert!(
         blockchain.get_pending_transactions().is_empty(),
         "non-delegate claim must not enter mempool"
+    );
+}
+
+#[test]
+fn rewards_module_without_token_contract_rejected_from_mempool() {
+    // GENESIS-3 H=1920 halt: pure AssetLaunch writes rewards_module_state but
+    // no token_contracts row. Old mempool order checked rewards_module first and
+    // admitted the claim; apply then failed and halted consensus after BFT.
+    let actors = RewardClaimActors::generate();
+    let mut blockchain = mempool_blockchain_rewards_module_without_token_contract(&actors);
+
+    assert!(
+        blockchain.get_rewards_module_state(&actors.token_id).is_some(),
+        "fixture must expose rewards module (AssetLaunch path)"
+    );
+    assert!(
+        blockchain.get_token_contract(&actors.token_id).is_none(),
+        "fixture must omit token_contracts row"
+    );
+
+    let err = blockchain
+        .add_pending_transaction(welcome_claim_tx(&actors, 0))
+        .expect_err("RewardClaim without token contract must not enter mempool");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("verification failed") || msg.contains("Invalid"),
+        "expected mempool rejection for missing token contract, got: {msg}"
+    );
+    assert!(
+        blockchain.get_pending_transactions().is_empty(),
+        "unapplyable RewardClaim must not enter mempool"
     );
 }
 

--- a/lib-blockchain/tests/reward_claim_mempool_tests.rs
+++ b/lib-blockchain/tests/reward_claim_mempool_tests.rs
@@ -68,6 +68,53 @@ fn non_delegate_signer_rejected_from_mempool() {
 }
 
 #[test]
+fn recipient_key_id_mismatch_rejected_from_mempool() {
+    // Apply rejects recipient_key_id != key_id_from_did(owner_did). Must not
+    // admit at mempool (halt vector #2924 review).
+    use lib_blockchain::transaction::reward_claim::{
+        expected_amount_for_event, RewardClaimData, RewardEventKind, REWARD_CLAIM_MEMO,
+    };
+    use lib_blockchain::transaction::signing::sign_transaction;
+    use lib_blockchain::transaction::Transaction;
+    use lib_crypto::SignatureAlgorithm;
+
+    let actors = RewardClaimActors::generate();
+    let mut blockchain = mempool_blockchain(&actors);
+    let data = RewardClaimData {
+        event: RewardEventKind::Welcome,
+        owner_did: actors.owner_did.clone(),
+        recipient_key_id: [0xABu8; 32], // deliberately not key_id of owner_did
+        token_id: actors.token_id,
+        from: actors.treasury.public_key.key_id,
+        amount: expected_amount_for_event(RewardEventKind::Welcome, 1),
+        nonce: 0,
+        peer_did: None,
+    };
+    let mut tx = Transaction::new_reward_claim_with_chain_id(
+        0x03,
+        data,
+        lib_crypto::Signature {
+            signature: Vec::new(),
+            public_key: actors.treasury.public_key.clone(),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp: 0,
+        },
+        REWARD_CLAIM_MEMO.to_vec(),
+    );
+    sign_transaction(&mut tx, &actors.treasury.private_key).expect("sign");
+
+    let err = blockchain
+        .add_pending_transaction(tx)
+        .expect_err("mismatched recipient_key_id must not enter mempool");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("verification failed") || msg.contains("Invalid"),
+        "expected mempool rejection for recipient_key_id binding, got: {msg}"
+    );
+    assert!(blockchain.get_pending_transactions().is_empty());
+}
+
+#[test]
 fn rewards_module_without_token_contract_rejected_from_mempool() {
     // GENESIS-3 H=1920 halt: pure AssetLaunch writes rewards_module_state but
     // no token_contracts row. Old mempool order checked rewards_module first and
@@ -176,7 +223,9 @@ fn duplicate_welcome_claim_rejected_from_mempool() {
 }
 
 #[test]
-fn executor_rejects_duplicate_welcome_claim_after_first_applied() {
+fn executor_soft_drops_duplicate_welcome_claim_after_first_applied() {
+    // #2924 review / #2908 option b: stateful eligibility fails at apply must
+    // soft-drop the tx (block stays valid), not halt consensus.
     let actors = RewardClaimActors::generate();
     let temp = tempdir().expect("tempdir");
     let store: Arc<dyn BlockchainStore> = Arc::new(
@@ -208,24 +257,26 @@ fn executor_rejects_duplicate_welcome_claim_after_first_applied() {
         "welcome claim must be recorded on-chain after first apply"
     );
 
-    // Nonce 1 so stateful validation reaches apply_reward_claim (nonce 0 would
-    // be soft-dropped as ReplayDropped after the first claim increments treasury nonce).
+    // Nonce 1 so we reach eligibility (nonce 0 would soft-drop as ReplayDropped).
     let duplicate_block = block_builders::block_at_height_with_txs(
         3,
         welcome_block.header.block_hash,
         vec![welcome_claim_tx(&actors, 1)],
     );
-    let err = executor
+    executor
         .apply_block(&duplicate_block)
-        .expect_err("duplicate welcome claim must fail block apply");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("welcome already claimed"),
-        "expected hard rejection, not silent no-op; got: {msg}"
-    );
+        .expect("duplicate welcome must soft-drop — block remains valid");
     assert_eq!(
         store.latest_height().unwrap(),
-        2,
-        "failed duplicate must roll back — chain stays at first committed claim"
+        3,
+        "soft-dropped claim still advances height (tx in block, no state write)"
+    );
+    // Welcome marker set once; soft-drop must not re-write / double-pay.
+    assert!(
+        store
+            .get_bubl_reward_welcome(&welcome_key)
+            .expect("read welcome marker")
+            .is_some(),
+        "welcome marker must still be present after soft-dropped duplicate"
     );
 }

--- a/tools/drop_pending_tx.rs
+++ b/tools/drop_pending_tx.rs
@@ -1,34 +1,64 @@
-//! Remove a pending transaction from sled recovery storage (operator tool).
+//! Remove pending transaction(s) from sled recovery storage (operator tool).
 //!
-//! Usage: drop_pending_tx <sled-dir> <tx-hash-hex>
+//! Non-consensus only — does not touch chain blocks/state.
+//!
+//! Usage:
+//!   drop_pending_tx <sled-dir> <tx-hash-hex>
+//!   drop_pending_tx <sled-dir> --all
+//!   drop_pending_tx <sled-dir> --list
 
 use std::path::PathBuf;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 3 {
-        eprintln!("Usage: drop_pending_tx <sled-dir> <tx-hash-hex>");
+        eprintln!("Usage: drop_pending_tx <sled-dir> <tx-hash-hex|--all|--list>");
         std::process::exit(1);
     }
     let sled_path = PathBuf::from(&args[1]);
-    let hash_bytes = hex::decode(&args[2]).expect("invalid tx hash hex");
-    if hash_bytes.len() != 32 {
-        eprintln!("tx hash must be 32 bytes (64 hex chars)");
-        std::process::exit(1);
-    }
-    let mut key = [0u8; 32];
-    key.copy_from_slice(&hash_bytes);
+    let action = args[2].as_str();
 
     let db = sled::open(&sled_path).expect("open sled");
     let tree = db
         .open_tree("pending_transactions")
         .expect("open pending_transactions tree");
     let before = tree.len();
-    let removed = tree.remove(&key).expect("remove pending tx");
-    db.flush().expect("flush sled");
-    println!(
-        "pending_transactions: {} entries before, removed={}",
-        before,
-        removed.is_some()
-    );
+
+    match action {
+        "--list" => {
+            println!("pending_transactions: {} entries", before);
+            for item in tree.iter() {
+                let (k, v) = item.expect("iter");
+                println!(
+                    "  key={} bytes={}",
+                    hex::encode(k.as_ref()),
+                    v.len()
+                );
+            }
+        }
+        "--all" => {
+            tree.clear().expect("clear pending_transactions");
+            db.flush().expect("flush sled");
+            println!(
+                "pending_transactions: cleared {} entries (non-consensus mempool only)",
+                before
+            );
+        }
+        hash_hex => {
+            let hash_bytes = hex::decode(hash_hex).expect("invalid tx hash hex");
+            if hash_bytes.len() != 32 {
+                eprintln!("tx hash must be 32 bytes (64 hex chars)");
+                std::process::exit(1);
+            }
+            let mut key = [0u8; 32];
+            key.copy_from_slice(&hash_bytes);
+            let removed = tree.remove(&key).expect("remove pending tx");
+            db.flush().expect("flush sled");
+            println!(
+                "pending_transactions: {} entries before, removed={}",
+                before,
+                removed.is_some()
+            );
+        }
+    }
 }

--- a/zhtp-cli/src/commands/identity.rs
+++ b/zhtp-cli/src/commands/identity.rs
@@ -589,8 +589,17 @@ async fn register_identity_on_chain(
     let result: serde_json::Value = ZhtpClient::parse_json(&response)
         .map_err(|e| CliError::ConfigError(format!("Failed to parse response: {}", e)))?;
 
-    if result.get("status").and_then(|s| s.as_str()) == Some("success") {
-        output.success("Identity registered on-chain")?;
+    let status = result.get("status").and_then(|s| s.as_str()).unwrap_or("");
+    // API returns "queued" when txs are in the mempool, "confirmed" when
+    // wait_for_inclusion saw block commit. Both are operator success paths.
+    if status == "success" || status == "queued" || status == "confirmed" {
+        if status == "queued" {
+            output.success("Identity registration queued on-chain (pending block inclusion)")?;
+        } else if status == "confirmed" {
+            output.success("Identity confirmed on-chain (block-committed)")?;
+        } else {
+            output.success("Identity registered on-chain")?;
+        }
         if let Some(did) = result.get("did").and_then(|d| d.as_str()) {
             output.print(&format!("DID: {}", did))?;
         }
@@ -602,6 +611,9 @@ async fn register_identity_on_chain(
         }
         if let Some(savings) = result.get("savings_wallet_id").and_then(|w| w.as_str()) {
             output.print(&format!("Savings wallet: {}", savings))?;
+        }
+        if let Some(tx) = result.get("blockchain_tx").and_then(|t| t.as_str()) {
+            output.print(&format!("Tx: {}", tx))?;
         }
     } else {
         let err = result

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -1954,6 +1954,15 @@ impl IdentityHandler {
 
             /// Timestamp when signature was created (Unix seconds)
             timestamp: u64,
+
+            /// When true, hold the response until the identity is committed
+            /// (or timeout). Default false → immediate `status: "queued"`.
+            #[serde(default)]
+            wait_for_inclusion: bool,
+
+            /// Max seconds to wait when `wait_for_inclusion` is true (default 30, max 120).
+            #[serde(default)]
+            wait_timeout_secs: Option<u64>,
         }
 
         fn default_identity_type() -> String {
@@ -2168,7 +2177,8 @@ impl IdentityHandler {
             if on_chain {
                 return Ok(ZhtpResponse::error(
                     ZhtpStatus::Conflict,
-                    "Identity already exists on chain; retry with the same keys or contact support"
+                    "Identity already exists or registration is already pending; \
+                     retry with the same keys after inclusion, or contact support"
                         .to_string(),
                 ));
             }
@@ -2186,12 +2196,19 @@ impl IdentityHandler {
             drop(identity_manager);
         }
 
+        let wait_for_inclusion = req_data.wait_for_inclusion;
+        let wait_timeout = req_data
+            .wait_timeout_secs
+            .unwrap_or(30)
+            .clamp(1, 120);
+
         // Create identity record (without private key - client keeps it)
         let created_at = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs();
 
-        // Register identity with full citizenship (creates 3 wallets)
+        // Provisional identity_manager entry for wallet-id derivation only.
+        // Canonical chain state is only written on block commit (#1990 / #1982).
         let citizenship_result = {
             let mut identity_manager = self.identity_manager.write().await;
             let mut economic_model = lib_identity::economics::EconomicModel::new();
@@ -2288,7 +2305,8 @@ impl IdentityHandler {
             if blockchain.identity_exists(&did_string) {
                 return Err((
                     ZhtpStatus::Conflict,
-                    "Identity already exists on chain; retry with the same keys or contact support"
+                    "Identity already exists or registration is already pending; \
+                     retry with the same keys after inclusion, or contact support"
                         .to_string(),
                 ));
             }
@@ -2345,11 +2363,8 @@ impl IdentityHandler {
                 ));
             }
             queued_txs.push(identity_tx);
-            let pending_height = blockchain.get_height() + 1;
-            blockchain.insert_identity_shadow(did_string.clone(), identity_transaction_data);
-            blockchain
-                .identity_blocks
-                .insert(did_string.clone(), pending_height);
+            // No insert_identity_shadow / identity_blocks — committed block
+            // processing is the only authority (#1990 / #1982).
             tracing::info!(
                 "⛓️ Identity registration queued on blockchain: {}",
                 &identity_tx_hash[..16.min(identity_tx_hash.len())]
@@ -2487,10 +2502,40 @@ impl IdentityHandler {
             &did[..32.min(did.len())]
         );
 
-        // Return success response with server-derived DID, node_id, and wallet IDs
-        // IMPORTANT: Client must use the DID and node_id from this response (server-derived)
+        // Optional: wait until process_identity_transactions has committed the DID.
+        let mut status = "queued";
+        let mut committed_height: Option<u64> = None;
+        if wait_for_inclusion {
+            let deadline = std::time::Instant::now()
+                + std::time::Duration::from_secs(wait_timeout);
+            loop {
+                if let Ok(blockchain_arc) =
+                    crate::runtime::blockchain_provider::get_global_blockchain().await
+                {
+                    let blockchain = blockchain_arc.read().await;
+                    if blockchain.identity_committed(&did) {
+                        status = "confirmed";
+                        committed_height = blockchain.identity_blocks.get(&did).copied();
+                        break;
+                    }
+                }
+                if std::time::Instant::now() >= deadline {
+                    tracing::warn!(
+                        did = %&did[..did.len().min(32)],
+                        wait_timeout_secs = wait_timeout,
+                        "identity register wait_for_inclusion timed out; returning queued"
+                    );
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            }
+        }
+
+        // Return queue-aware response with server-derived DID, node_id, and wallet IDs.
+        // IMPORTANT: Client must use the DID and node_id from this response (server-derived).
+        // `status: "queued"` means mempool only; `"confirmed"` means committed on-chain.
         let response_body = json!({
-            "status": "queued",
+            "status": status,
             "identity_id": identity_id.to_string(),
             "did": did,
             "node_id": hex::encode(&node_id_bytes),
@@ -2502,7 +2547,8 @@ impl IdentityHandler {
             "pqc_enabled": req_data.kyber_public_key.is_some(),
             "primary_wallet_id": primary_wallet_id,
             "ubi_wallet_id": ubi_wallet_id,
-            "savings_wallet_id": savings_wallet_id
+            "savings_wallet_id": savings_wallet_id,
+            "committed_height": committed_height,
         });
 
         Ok(ZhtpResponse::json(&response_body, None)?)

--- a/zhtp/src/api/handlers/rewards/settlement.rs
+++ b/zhtp/src/api/handlers/rewards/settlement.rs
@@ -105,6 +105,12 @@ pub fn plan_reward_claim(
         Ok(false) => return Err("owner_did_not_registered".into()),
         Err(_) => return Err("owner_did_not_registered".into()),
     }
+    // Apply requires a token_contracts row; rewards-module state alone is not
+    // enough (pure AssetLaunch). Fail closed here so the API never signs a claim
+    // that would pass mempool and halt consensus on block apply.
+    if bc.get_token_contract(token_id).is_none() {
+        return Err("token_contract_not_found".into());
+    }
     let ts = claim_unix_ts();
     // Map conversion failures to a stable snake_case reason for clients /
     // soft_fail matching — do not surface the raw numeric error string.

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -973,7 +973,6 @@ async fn bootstrap_identities_from_dht(
                                 if !bc.wallet_exists(wid) {
                                     let wallet_bytes = hex::decode(wid).unwrap_or_default();
                                     if wallet_bytes.len() >= 32 {
-                                        const WELCOME_BONUS: u128 = SOV_WELCOME_BONUS;
                                         let wallet_data =
                                             lib_blockchain::transaction::WalletTransactionData {
                                                 wallet_id: lib_blockchain::Hash::from_slice(
@@ -995,16 +994,14 @@ async fn bootstrap_identities_from_dht(
                                                 created_at,
                                                 registration_fee: 0,
                                                 capabilities: 0xFF,
-                                                initial_balance: WELCOME_BONUS,
+                                                // Enqueue-only (#1989): no embedded balance / UTXO mint.
+                                                initial_balance: 0,
                                             };
                                         if bc.register_wallet(wallet_data).is_ok() {
-                                            // Create spendable UTXO (not just registry entry)
-                                            bc.create_funding_utxo(
-                                                wid,
-                                                &identity_hash.0,
-                                                WELCOME_BONUS,
+                                            info!(
+                                                "💰 MIGRATED primary wallet {} queued (0 SOV; TokenMint required for funding)",
+                                                &wid[..16.min(wid.len())]
                                             );
-                                            info!("💰 MIGRATED primary wallet {} with {} SOV (spendable)", &wid[..16], SOV_WELCOME_BONUS_SOV);
                                         }
                                     }
                                 }

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -314,10 +314,31 @@ impl GenesisFundingService {
             );
         genesis_block.header.data_helix_root = updated_merkle_root.as_array();
         genesis_block.header.block_hash = genesis_block.header.calculate_hash();
+        let funded_genesis_hash = genesis_block.header.block_hash;
         info!(
             "Genesis block merkle root updated: {}",
             hex::encode(updated_merkle_root.as_bytes())
         );
+        info!(
+            "Genesis block hash after funding: {}",
+            hex::encode(funded_genesis_hash.as_bytes())
+        );
+
+        // Empty genesis was already persisted before funding. Re-write height 0 so
+        // the store tip hash matches the in-memory block proposers use as previous_hash.
+        // Without this, observers apply store-genesis (pre-funding hash) then reject
+        // block 1 (parents the post-funding hash).
+        if let Some(store) = blockchain.store.as_ref() {
+            store.replace_block(genesis_block).map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to re-persist funded genesis block to store: {e}"
+                )
+            })?;
+            info!(
+                "💾 Re-persisted funded genesis (height 0) to SledStore: {}",
+                hex::encode(funded_genesis_hash.as_bytes())
+            );
+        }
 
         // Create UTXOs from genesis transaction outputs and add to UTXO set
         let genesis_tx_id =


### PR DESCRIPTION
## Stack (bottom — review first)
```
development
  └── #2924 (this) Phase 2 identity projection rebuild
        └── #2925 DHT cache-only + chain-first PoUW
```

## Summary
- Rebuild sled identity projections from block-scan registry on `load_from_store` (#1985/#1999)
- Legacy fixup telemetry `target=legacy_fixup` for Phase 5 removal gate (#2000)
- Identity projection restart equivalence tests (#2002)
- RewardClaim mempool/API admit requires token contract (consensus halt safety)
- Phase 1 queue-only registration / pending-tx durability pieces in tree

## Related
- Epic #1982 · `docs/ops/legacy-fixup-removal-gate.md`
- Stacked child: #2925

## Test plan (local after your review)
- `cargo test -p lib-blockchain --test identity_projection_restart_tests`
- focused mempool admit tests
- Then `cargo clean`