### PR TITLE
feat(zhtp-auth): DHT cache-only + chain-first PoUW + admit/nullifier harden

### DIFF
--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -1228,6 +1228,13 @@ impl BlockchainStore for SledStore {
         self.db
             .flush()
             .map_err(|e| StorageError::Database(e.to_string()))?;
+        // If we change an already-indexed block hash (notably genesis funding),
+        // keep the nullifier index checkpoint consistent so it can advance.
+        // Checkpoint value includes (height, block_hash); leaving the pre-replace
+        // hash makes subsequent append_block treat the index as "not current".
+        if height == 0 {
+            self.mark_nullifier_index_current(height, &new_hash)?;
+        }
 
         Ok(())
     }
@@ -5235,6 +5242,56 @@ mod tests {
         store.append_block(&block1).unwrap();
         store.commit_block().unwrap();
         assert!(store.nullifier_index_is_current(1, &block1_hash).unwrap());
+    }
+
+    /// Genesis funding rewrites block 0 via `replace_block`. Without refreshing
+    /// the nullifier checkpoint (height, hash), the next `append_block` sees a
+    /// stale (0, old_hash) pair and never advances the index again.
+    #[test]
+    fn test_replace_block_updates_nullifier_checkpoint_at_genesis() {
+        let store = SledStore::open_temporary().unwrap();
+        let mut genesis = create_test_block_with_transactions(
+            0,
+            Hash::default(),
+            vec![transaction_with_nullifier(Hash::new([0xA1; 32]))],
+        );
+        let old_hash = BlockHash::new(genesis.header.block_hash.as_array());
+
+        store.begin_block(0).unwrap();
+        store.append_block(&genesis).unwrap();
+        store.commit_block().unwrap();
+        assert!(store.nullifier_index_is_current(0, &old_hash).unwrap());
+
+        // Simulate genesis funding rewrite: same height, new block hash.
+        let mut new_hash_bytes = [0u8; 32];
+        new_hash_bytes[0] = 0xFF;
+        new_hash_bytes[1] = 0xEE;
+        genesis.header.block_hash = Hash::new(new_hash_bytes);
+        let new_hash = BlockHash::new(new_hash_bytes);
+        store.replace_block(&genesis).unwrap();
+
+        assert!(
+            store.nullifier_index_is_current(0, &new_hash).unwrap(),
+            "replace_block must retarget NULLIFIER_INDEX_CHECKPOINT to the new genesis hash"
+        );
+        assert!(
+            !store.nullifier_index_is_current(0, &old_hash).unwrap(),
+            "checkpoint must not remain pinned to the pre-replace genesis hash"
+        );
+
+        let block1 = create_test_block_with_transactions(
+            1,
+            genesis.header.block_hash,
+            vec![transaction_with_nullifier(Hash::new([0xA2; 32]))],
+        );
+        let block1_hash = BlockHash::new(block1.header.block_hash.as_array());
+        store.begin_block(1).unwrap();
+        store.append_block(&block1).unwrap();
+        store.commit_block().unwrap();
+        assert!(
+            store.nullifier_index_is_current(1, &block1_hash).unwrap(),
+            "append after genesis replace must advance the nullifier checkpoint"
+        );
     }
 
     #[test]

--- a/lib-blockchain/src/transaction/system_tx_signature.rs
+++ b/lib-blockchain/src/transaction/system_tx_signature.rs
@@ -103,12 +103,13 @@ pub fn requires_system_tx_signature(transaction: &Transaction) -> bool {
 }
 
 /// Client / auto-bootstrap system txs that are intentionally unsigned at the
-/// Dilithium tx layer. Authentication is elsewhere:
-/// - [`TransactionType::IdentityRegistration`]: API verifies `ZHTP_REGISTER`
-///   proof; payload carries `ownership_proof` + DID/pk binding (see
-///   `SystemOriginator::ClientIdentityRegistration`).
-/// - [`TransactionType::WalletRegistration`]: zero-balance auto wallets from
-///   the same registration path (`SystemOriginator::AutoWalletRegistration`).
+/// Dilithium tx layer. Authentication is carried in the payload:
+/// - [`TransactionType::IdentityRegistration`]: Dilithium verify of
+///   `ownership_proof` over `ZHTP_REGISTER:{created_at}` (same message the
+///   registration API signs), plus DID/pk binding. Consensus must not trust
+///   arbitrary proof bytes when skipping tx-level signature verification.
+/// - [`TransactionType::WalletRegistration`]: zero-balance auto wallets with
+///   wallet_id + pk binding (`SystemOriginator::AutoWalletRegistration`).
 ///
 /// Non-empty signatures still always go through full crypto verify.
 pub fn allows_empty_system_signature(transaction: &Transaction) -> bool {
@@ -128,6 +129,18 @@ pub fn allows_empty_system_signature(transaction: &Transaction) -> bool {
                 return false;
             };
             if transaction.signature.public_key.dilithium_pk != identity_pk {
+                return false;
+            }
+            // Cryptographic ownership (not just non-empty bytes): client signs
+            // "ZHTP_REGISTER:{timestamp}" with the identity private key.
+            let ownership_msg = format!("ZHTP_REGISTER:{}", data.created_at);
+            if !lib_crypto::verify_signature(
+                ownership_msg.as_bytes(),
+                &data.ownership_proof,
+                &data.public_key,
+            )
+            .unwrap_or(false)
+            {
                 return false;
             }
             let key_id = crate::types::hash::blake3_hash(identity_pk.as_slice());
@@ -213,17 +226,63 @@ mod tests {
         use crate::transaction::core::IdentityTransactionData;
         use crate::types::Hash;
 
-        let dilithium_pk = [0xABu8; 2592];
+        let keypair = lib_crypto::generate_keypair().expect("keypair");
+        let dilithium_pk = keypair.public_key.dilithium_pk;
+        let created_at = 1_700_000_000u64;
+        let ownership_msg = format!("ZHTP_REGISTER:{}", created_at);
+        let ownership_proof = lib_crypto::sign_message(&keypair, ownership_msg.as_bytes())
+            .expect("sign ownership")
+            .signature;
         let key_id = crate::types::hash::blake3_hash(&dilithium_pk);
         let did = format!("did:zhtp:{}", hex::encode(key_id.as_bytes()));
         let identity_data = IdentityTransactionData {
             did,
             display_name: "test_user".to_string(),
             public_key: dilithium_pk.to_vec(),
-            ownership_proof: vec![0x01, 0x02],
+            ownership_proof,
             identity_type: "human".to_string(),
             did_document_hash: Hash::default(),
-            created_at: 1,
+            created_at,
+            registration_fee: 0,
+            dao_fee: 0,
+            controlled_nodes: vec![],
+            owned_wallets: vec![],
+            kyber_public_key: vec![],
+        };
+        let tx = Transaction::new_identity_registration(
+            identity_data,
+            vec![],
+            Signature {
+                signature: Vec::new(),
+                public_key: PublicKey::new(dilithium_pk),
+                algorithm: SignatureAlgorithm::DEFAULT,
+                timestamp: created_at,
+            },
+            b"client-identity-register:test".to_vec(),
+        );
+        assert!(allows_empty_system_signature(&tx));
+        assert!(requires_system_tx_signature(&tx));
+    }
+
+    #[test]
+    fn client_identity_registration_rejects_forged_ownership_proof() {
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+        use crate::transaction::core::IdentityTransactionData;
+        use crate::types::Hash;
+
+        let keypair = lib_crypto::generate_keypair().expect("keypair");
+        let dilithium_pk = keypair.public_key.dilithium_pk;
+        let key_id = crate::types::hash::blake3_hash(&dilithium_pk);
+        let did = format!("did:zhtp:{}", hex::encode(key_id.as_bytes()));
+        let identity_data = IdentityTransactionData {
+            did,
+            display_name: "squatter".to_string(),
+            public_key: dilithium_pk.to_vec(),
+            // Non-empty garbage — previously admitted under empty tx-sig bypass.
+            ownership_proof: vec![0xDE, 0xAD, 0xBE, 0xEF],
+            identity_type: "human".to_string(),
+            did_document_hash: Hash::default(),
+            created_at: 1_700_000_000,
             registration_fee: 0,
             dao_fee: 0,
             controlled_nodes: vec![],
@@ -239,10 +298,12 @@ mod tests {
                 algorithm: SignatureAlgorithm::DEFAULT,
                 timestamp: 1,
             },
-            b"client-identity-register:test".to_vec(),
+            b"client-identity-register:forged".to_vec(),
         );
-        assert!(allows_empty_system_signature(&tx));
-        assert!(requires_system_tx_signature(&tx));
+        assert!(
+            !allows_empty_system_signature(&tx),
+            "empty tx-sig must not admit IdentityRegistration with unverified ownership_proof"
+        );
     }
 
     #[test]

--- a/zhtp/src/api/handlers/pouw/mod.rs
+++ b/zhtp/src/api/handlers/pouw/mod.rs
@@ -168,68 +168,41 @@ impl PouwHandler {
         "did:zhtp:anonymous".to_string()
     }
 
-    /// Validate client DID against identity registry
+    /// Validate client DID against chain identity projection (manager only if chain down).
     async fn validate_client_identity(&self, client_did: &str) -> Result<(), String> {
-        // Check DID format (currently only did:zhtp:... is supported by identity registry)
-        if !client_did.starts_with("did:zhtp:") {
-            return Err("Invalid DID format: must start with 'did:zhtp:'".to_string());
+        let view = crate::runtime::resolve_pouw_client_identity(
+            client_did,
+            &self.identity_manager,
+        )
+        .await?;
+
+        // Identity age check: reject DIDs registered less than MIN_IDENTITY_AGE_SECS ago.
+        // created_at is chain-authoritative when the blockchain is available.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let age_secs = now.saturating_sub(view.created_at);
+        if age_secs < MIN_IDENTITY_AGE_SECS {
+            warn!(
+                did = %client_did,
+                age_secs = age_secs,
+                required_secs = MIN_IDENTITY_AGE_SECS,
+                source = ?view.source,
+                "PoUW reward rejected: identity too new"
+            );
+            return Err(format!(
+                "Identity too new for reward eligibility: {} seconds old, minimum {} seconds required",
+                age_secs, MIN_IDENTITY_AGE_SECS
+            ));
         }
 
-        // Check if identity exists in registry, ensuring exact DID match.
-        let identity_manager = self.identity_manager.read().await;
-        match identity_manager.get_identity_by_did(client_did) {
-            Some(identity) => {
-                if identity.did != client_did {
-                    return Err(format!(
-                        "Client DID mismatch: requested {}, found {}",
-                        client_did, identity.did
-                    ));
-                }
-
-                // Identity age check: reject DIDs registered less than MIN_IDENTITY_AGE_SECS ago.
-                // Prevents Sybil attacks from freshly created identities.
-                // Use on-chain created_at (persisted in blocks) instead of in-memory
-                // identity manager timestamp, which resets on node restart.
-                let now = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
-                let chain_created_at = match
-                    crate::runtime::blockchain_provider::get_global_blockchain().await
-                {
-                    Ok(blockchain_arc) => {
-                        let blockchain = blockchain_arc.read().await;
-                        // #2639: sled-first — durable created_at survives restart
-                        // (in-mem registry is empty on a store-backed node then).
-                        blockchain
-                            .identity_consensus_by_did(client_did)
-                            .map(|c| c.created_at)
-                            .unwrap_or(identity.created_at)
-                    }
-                    Err(_) => identity.created_at,
-                };
-                let age_secs = now.saturating_sub(chain_created_at);
-                if age_secs < MIN_IDENTITY_AGE_SECS {
-                    warn!(
-                        did = %client_did,
-                        age_secs = age_secs,
-                        required_secs = MIN_IDENTITY_AGE_SECS,
-                        "PoUW reward rejected: identity too new"
-                    );
-                    return Err(format!(
-                        "Identity too new for reward eligibility: {} seconds old, minimum {} seconds required",
-                        age_secs, MIN_IDENTITY_AGE_SECS
-                    ));
-                }
-
-                debug!("Client identity validated: {}", client_did);
-                Ok(())
-            }
-            None => Err(format!(
-                "Client DID not found in identity registry: {}",
-                client_did
-            )),
-        }
+        debug!(
+            did = %client_did,
+            source = ?view.source,
+            "Client identity validated"
+        );
+        Ok(())
     }
 
     fn payout_status_str(status: crate::pouw::rewards::PayoutStatus) -> &'static str {

--- a/zhtp/src/pouw/validation.rs
+++ b/zhtp/src/pouw/validation.rs
@@ -551,18 +551,21 @@ impl ReceiptValidator {
             return Ok(()); // Age check disabled
         };
 
-        let mgr = self.identity_manager.read().await;
-        let identity = mgr
-            .get_identity_by_did(client_did)
-            .ok_or(RejectionReason::ClientInvalid)?;
+        let view = crate::runtime::resolve_pouw_client_identity(
+            client_did,
+            &self.identity_manager,
+        )
+        .await
+        .map_err(|_| RejectionReason::ClientInvalid)?;
 
         let now = self.now_secs();
-        let age_secs = now.saturating_sub(identity.created_at);
+        let age_secs = now.saturating_sub(view.created_at);
         if age_secs < min_age {
             warn!(
                 client = %client_did,
                 age_secs = age_secs,
                 min_age_secs = min_age,
+                source = ?view.source,
                 "Receipt rejected: identity too new for reward eligibility"
             );
             return Err(RejectionReason::ClientInvalid);
@@ -616,13 +619,15 @@ impl ReceiptValidator {
         bincode::serialize(receipt).context("Failed to serialize receipt")
     }
 
-    /// Get client's Dilithium5 public key from DID
+    /// Get client's Dilithium5 public key from DID (chain-first).
     async fn get_client_pubkey_dilithium(&self, client_did: &str) -> Result<Vec<u8>> {
-        let mgr = self.identity_manager.read().await;
-        let identity = mgr
-            .get_identity_by_did(client_did)
-            .ok_or_else(|| anyhow::anyhow!("DID not registered: {}", client_did))?;
-        Ok(identity.public_key.dilithium_pk.to_vec())
+        let view = crate::runtime::resolve_pouw_client_identity(
+            client_did,
+            &self.identity_manager,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+        Ok(view.dilithium_pk)
     }
 
     /// Parse Web4 context fields from receipt aux JSON

--- a/zhtp/src/runtime/blockchain_provider.rs
+++ b/zhtp/src/runtime/blockchain_provider.rs
@@ -48,6 +48,12 @@ impl BlockchainProvider {
         Ok(())
     }
 
+    /// Drop the blockchain instance (tests that need a deterministic "chain down" path).
+    #[cfg(test)]
+    pub async fn clear_blockchain_for_tests(&self) {
+        *self.blockchain.write().await = None;
+    }
+
     /// Refresh the sync council cache from live `blockchain.council_members`.
     ///
     /// Council membership is in-memory only (not sled-persisted). A
@@ -554,6 +560,14 @@ pub fn initialize_global_blockchain_provider() -> &'static BlockchainProvider {
 /// Get the global blockchain provider
 pub fn get_global_blockchain_provider() -> Option<&'static BlockchainProvider> {
     GLOBAL_BLOCKCHAIN_PROVIDER.get()
+}
+
+/// Clear the global blockchain instance (unit tests only).
+#[cfg(test)]
+pub async fn clear_global_blockchain_for_tests() {
+    if let Some(provider) = get_global_blockchain_provider() {
+        provider.clear_blockchain_for_tests().await;
+    }
 }
 
 /// Set the global blockchain instance

--- a/zhtp/src/runtime/chain_identity_resolve.rs
+++ b/zhtp/src/runtime/chain_identity_resolve.rs
@@ -1,0 +1,143 @@
+//! Chain-first identity resolution for reward / PoUW paths.
+//!
+//! Committed blockchain projections are authoritative. IdentityManager is only
+//! a fallback when the global blockchain is unavailable (unit tests / early
+//! boot). When the chain is available, a DID present only in the manager is
+//! treated as missing so stale local cache cannot authorize rewards.
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use lib_identity::IdentityManager;
+
+/// Where a PoUW client identity was resolved from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PouwIdentitySource {
+    /// Durable / in-block projection via blockchain facades.
+    Chain,
+    /// IdentityManager only — blockchain provider unavailable.
+    ManagerFallback,
+}
+
+/// Minimal identity view needed for PoUW eligibility and signature checks.
+#[derive(Debug, Clone)]
+pub struct PouwClientIdentity {
+    pub did: String,
+    pub created_at: u64,
+    /// Dilithium5 public key bytes (2592).
+    pub dilithium_pk: Vec<u8>,
+    pub source: PouwIdentitySource,
+}
+
+/// Resolve a client DID for PoUW: chain first, manager only if chain is down.
+///
+/// # Errors
+/// Returns a human-readable error for API / rejection mapping.
+pub async fn resolve_pouw_client_identity(
+    client_did: &str,
+    identity_manager: &Arc<RwLock<IdentityManager>>,
+) -> Result<PouwClientIdentity, String> {
+    if !client_did.starts_with("did:zhtp:") {
+        return Err("Invalid DID format: must start with 'did:zhtp:'".to_string());
+    }
+
+    match crate::runtime::blockchain_provider::get_global_blockchain().await {
+        Ok(bc_arc) => {
+            let bc = bc_arc.read().await;
+            if !bc.identity_exists(client_did) {
+                return Err(format!(
+                    "Client DID not found on chain identity projection: {}",
+                    client_did
+                ));
+            }
+
+            let created_at = bc
+                .identity_consensus_by_did(client_did)
+                .map(|c| c.created_at)
+                .or_else(|| {
+                    bc.identity_transaction_data(client_did)
+                        .map(|d| d.created_at)
+                })
+                .unwrap_or(0);
+
+            let dilithium_pk = bc.identity_public_key(client_did).ok_or_else(|| {
+                format!(
+                    "Client DID on chain but Dilithium public key missing: {}",
+                    client_did
+                )
+            })?;
+
+            Ok(PouwClientIdentity {
+                did: client_did.to_string(),
+                created_at,
+                dilithium_pk,
+                source: PouwIdentitySource::Chain,
+            })
+        }
+        Err(_) => {
+            // Chain unavailable: manager is the only option (tests / early boot).
+            let mgr = identity_manager.read().await;
+            let identity = mgr.get_identity_by_did(client_did).ok_or_else(|| {
+                format!(
+                    "Client DID not found in identity registry (chain unavailable): {}",
+                    client_did
+                )
+            })?;
+            if identity.did != client_did {
+                return Err(format!(
+                    "Client DID mismatch: requested {}, found {}",
+                    client_did, identity.did
+                ));
+            }
+            Ok(PouwClientIdentity {
+                did: client_did.to_string(),
+                created_at: identity.created_at,
+                dilithium_pk: identity.public_key.dilithium_pk.to_vec(),
+                source: PouwIdentitySource::ManagerFallback,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lib_identity::IdentityType;
+
+    #[tokio::test]
+    async fn manager_fallback_when_chain_unavailable() {
+        let did = "did:zhtp:1111111111111111111111111111111111111111111111111111111111111111";
+        let keypair = lib_crypto::generate_keypair().expect("keypair");
+        let identity_id = lib_identity::did::parse_did_to_identity_id(did).expect("did");
+        let mgr = Arc::new(RwLock::new(IdentityManager::new()));
+        mgr.write()
+            .await
+            .register_external_identity(
+                identity_id,
+                did.to_string(),
+                keypair.public_key,
+                IdentityType::Human,
+                "test-device".to_string(),
+                Some("test".to_string()),
+                1_700_000_000,
+            )
+            .expect("register");
+
+        // Do not set global blockchain — fallback path.
+        let view = resolve_pouw_client_identity(did, &mgr)
+            .await
+            .expect("manager fallback");
+        assert_eq!(view.source, PouwIdentitySource::ManagerFallback);
+        assert_eq!(view.created_at, 1_700_000_000);
+        assert_eq!(view.dilithium_pk.len(), 2592);
+    }
+
+    #[tokio::test]
+    async fn rejects_bad_did_format() {
+        let mgr = Arc::new(RwLock::new(IdentityManager::new()));
+        let err = resolve_pouw_client_identity("not-a-did", &mgr)
+            .await
+            .unwrap_err();
+        assert!(err.contains("Invalid DID format"));
+    }
+}

--- a/zhtp/src/runtime/chain_identity_resolve.rs
+++ b/zhtp/src/runtime/chain_identity_resolve.rs
@@ -44,13 +44,18 @@ pub async fn resolve_pouw_client_identity(
     match crate::runtime::blockchain_provider::get_global_blockchain().await {
         Ok(bc_arc) => {
             let bc = bc_arc.read().await;
-            if !bc.identity_exists(client_did) {
+            // Committed projection only — never treat pure mempool pending as
+            // PoUW-eligible (matches module doc; identity_exists includes pending).
+            if !bc.identity_committed(client_did) {
                 return Err(format!(
                     "Client DID not found on chain identity projection: {}",
                     client_did
                 ));
             }
 
+            // Fail closed on age: created_at=0 (Unix epoch) would pass any
+            // min_identity_age_secs gate. Missing projection fields must not
+            // become age-exempt (#2925 review).
             let created_at = bc
                 .identity_consensus_by_did(client_did)
                 .map(|c| c.created_at)
@@ -58,7 +63,13 @@ pub async fn resolve_pouw_client_identity(
                     bc.identity_transaction_data(client_did)
                         .map(|d| d.created_at)
                 })
-                .unwrap_or(0);
+                .filter(|&ts| ts > 0)
+                .ok_or_else(|| {
+                    format!(
+                        "Client DID on chain but created_at unresolvable: {}",
+                        client_did
+                    )
+                })?;
 
             let dilithium_pk = bc.identity_public_key(client_did).ok_or_else(|| {
                 format!(
@@ -102,11 +113,29 @@ pub async fn resolve_pouw_client_identity(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lib_blockchain::Blockchain;
     use lib_identity::IdentityType;
+    use std::sync::{Mutex, OnceLock};
 
-    #[tokio::test]
-    async fn manager_fallback_when_chain_unavailable() {
-        let did = "did:zhtp:1111111111111111111111111111111111111111111111111111111111111111";
+    /// Serialise tests that touch the process-global blockchain provider.
+    fn global_blockchain_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn install_empty_global_blockchain() {
+        crate::runtime::blockchain_provider::initialize_global_blockchain_provider();
+        let bc = Blockchain::new().expect("genesis");
+        crate::runtime::blockchain_provider::set_global_blockchain(Arc::new(RwLock::new(bc)))
+            .await
+            .expect("set global blockchain");
+    }
+
+    async fn clear_global_blockchain() {
+        crate::runtime::blockchain_provider::clear_global_blockchain_for_tests().await;
+    }
+
+    async fn register_manager_did(did: &str, created_at: u64) -> Arc<RwLock<IdentityManager>> {
         let keypair = lib_crypto::generate_keypair().expect("keypair");
         let identity_id = lib_identity::did::parse_did_to_identity_id(did).expect("did");
         let mgr = Arc::new(RwLock::new(IdentityManager::new()));
@@ -119,17 +148,102 @@ mod tests {
                 IdentityType::Human,
                 "test-device".to_string(),
                 Some("test".to_string()),
-                1_700_000_000,
+                created_at,
             )
             .expect("register");
+        mgr
+    }
 
-        // Do not set global blockchain — fallback path.
+    #[tokio::test]
+    async fn manager_fallback_when_chain_unavailable() {
+        let _guard = global_blockchain_test_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Ensure chain path is closed so this test is deterministic under
+        // parallel workers that may have set the global provider.
+        clear_global_blockchain().await;
+
+        let did = "did:zhtp:1111111111111111111111111111111111111111111111111111111111111111";
+        let mgr = register_manager_did(did, 1_700_000_000).await;
+
         let view = resolve_pouw_client_identity(did, &mgr)
             .await
             .expect("manager fallback");
         assert_eq!(view.source, PouwIdentitySource::ManagerFallback);
         assert_eq!(view.created_at, 1_700_000_000);
         assert_eq!(view.dilithium_pk.len(), 2592);
+    }
+
+    #[tokio::test]
+    async fn rejects_manager_only_did_when_chain_available() {
+        let _guard = global_blockchain_test_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let did = "did:zhtp:2222222222222222222222222222222222222222222222222222222222222222";
+        let mgr = register_manager_did(did, 1_700_000_000).await;
+
+        // Chain up, empty projection: DID exists only in IdentityManager.
+        install_empty_global_blockchain().await;
+
+        let err = resolve_pouw_client_identity(did, &mgr)
+            .await
+            .expect_err("stale manager DID must not authorize when chain is up");
+        assert!(
+            err.contains("not found on chain identity projection"),
+            "expected chain rejection, got: {err}"
+        );
+        assert!(
+            !err.contains("chain unavailable"),
+            "must not take manager-fallback path: {err}"
+        );
+
+        clear_global_blockchain().await;
+    }
+
+    #[tokio::test]
+    async fn rejects_chain_identity_with_unresolvable_created_at() {
+        let _guard = global_blockchain_test_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let did = "did:zhtp:3333333333333333333333333333333333333333333333333333333333333333";
+        let mgr = Arc::new(RwLock::new(IdentityManager::new()));
+
+        crate::runtime::blockchain_provider::initialize_global_blockchain_provider();
+        let mut bc = Blockchain::new().expect("genesis");
+        // Shadow-only identity with created_at=0: committed for existence, but
+        // age must fail closed (never treat epoch as "old enough").
+        bc.insert_identity_shadow(
+            did.to_string(),
+            lib_blockchain::transaction::IdentityTransactionData {
+                did: did.to_string(),
+                did_document_hash: lib_blockchain::Hash::default(),
+                public_key: vec![0xAB; 2592],
+                ownership_proof: vec![],
+                identity_type: "Human".to_string(),
+                display_name: "zero-age".to_string(),
+                registration_fee: 0,
+                dao_fee: 0,
+                created_at: 0,
+                controlled_nodes: vec![],
+                owned_wallets: vec![],
+                kyber_public_key: vec![],
+            },
+        );
+        crate::runtime::blockchain_provider::set_global_blockchain(Arc::new(RwLock::new(bc)))
+            .await
+            .expect("set global blockchain");
+
+        let err = resolve_pouw_client_identity(did, &mgr)
+            .await
+            .expect_err("created_at=0 must fail closed");
+        assert!(
+            err.contains("created_at unresolvable"),
+            "expected created_at failure, got: {err}"
+        );
+
+        clear_global_blockchain().await;
     }
 
     #[tokio::test]

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -144,33 +144,36 @@ impl Component for IdentityComponent {
         crate::runtime::set_global_identity_manager(identity_manager_arc.clone()).await?;
         info!(" Identity manager registered globally for component access");
 
-        // Phase 4 (#1987/#2007): DHT/local storage is cache only. When the
-        // chain already has identity projections, do not treat DHT bootstrap
-        // as an authority source for IdentityManager or mempool injection.
+        // Phase 4 (#1987/#2007–#2009): local DHT/storage bootstrap only warms
+        // IdentityManager as a cache. It must not invent chain authority
+        // (wallet registration / welcome-bonus mint are gated or removed
+        // inside bootstrap). Do NOT skip the warm path when the chain already
+        // has identities — IdentityManager is still needed for PoUW/API paths
+        // that read the manager, and chain backfill into the manager is
+        // intentionally disabled (wallet ownership migration hazard below).
         let canonical_identities = canonical_identity_projection_count().await;
-        if should_skip_dht_identity_bootstrap(canonical_identities) {
+        if canonical_identities > 0 {
             info!(
-                "Canonical identity projection present ({} identities) — skipping DHT identity bootstrap (cache-only)",
+                "Canonical identity projection present ({} identities) — DHT bootstrap is cache-only (no authority mutations without ZHTP_MIGRATE_IDENTITIES)",
                 canonical_identities
             );
-        } else {
-            info!("🔄 Bootstrapping identities from local DHT storage (no canonical projection yet)...");
-            match bootstrap_identities_from_dht(&identity_manager_arc).await {
-                Ok(result) => {
-                    info!(
-                        "✅ Bootstrap complete: {} identities, {} wallets loaded",
-                        result.identities_loaded, result.wallets_loaded
-                    );
-                    if !result.errors.is_empty() {
-                        for err in &result.errors {
-                            debug!("  Bootstrap warning: {}", err);
-                        }
+        }
+        info!("🔄 Warming IdentityManager from local DHT/storage cache...");
+        match bootstrap_identities_from_dht(&identity_manager_arc).await {
+            Ok(result) => {
+                info!(
+                    "✅ Cache warm complete: {} identities, {} wallets loaded",
+                    result.identities_loaded, result.wallets_loaded
+                );
+                if !result.errors.is_empty() {
+                    for err in &result.errors {
+                        debug!("  Bootstrap warning: {}", err);
                     }
                 }
-                Err(e) => {
-                    // Non-fatal - log and continue
-                    info!("⚠️ DHT bootstrap skipped (non-fatal): {}", e);
-                }
+            }
+            Err(e) => {
+                // Non-fatal - log and continue
+                info!("⚠️ DHT cache warm skipped (non-fatal): {}", e);
             }
         }
 
@@ -329,12 +332,14 @@ pub struct DhtBootstrapResult {
     pub errors: Vec<String>,
 }
 
-/// Prefer canonical chain identity projection over DHT on startup (#2007).
+/// Whether DHT bootstrap may enqueue chain-mutating registration work (#2008).
 ///
-/// When any committed identity projection exists, DHT must not act as an
-/// authoritative bootstrap source for IdentityManager or registration enqueue.
-pub(crate) fn should_skip_dht_identity_bootstrap(canonical_identity_count: usize) -> bool {
-    canonical_identity_count > 0
+/// Authority mutations from local DHT/storage require an explicit ops opt-in.
+/// Cache warm (IdentityManager population) is always allowed and is not gated.
+pub(crate) fn dht_authority_mutations_enabled() -> bool {
+    std::env::var("ZHTP_MIGRATE_IDENTITIES")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
 }
 
 /// Count identities already present in the blockchain projection (sled + shadow).
@@ -995,9 +1000,7 @@ async fn bootstrap_identities_from_dht(
                                 .await
                                 .ok();
 
-                        let migrate_wallets = std::env::var("ZHTP_MIGRATE_IDENTITIES")
-                            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                            .unwrap_or(false);
+                        let migrate_wallets = dht_authority_mutations_enabled();
 
                         if migrate_wallets {
                             if let Some(ref bc_arc) = blockchain_arc {
@@ -1284,13 +1287,19 @@ mod tests {
     use lib_blockchain::Hash;
 
     #[test]
-    fn dht_identity_bootstrap_skipped_when_canonical_projection_exists() {
-        assert!(should_skip_dht_identity_bootstrap(1));
-        assert!(should_skip_dht_identity_bootstrap(42));
+    fn dht_authority_mutations_default_off() {
+        // Default: no env → cache warm only, no register_wallet / mint from DHT.
+        // (Do not set ZHTP_MIGRATE_IDENTITIES in this process for the assertion.)
+        let previous = std::env::var_os("ZHTP_MIGRATE_IDENTITIES");
+        std::env::remove_var("ZHTP_MIGRATE_IDENTITIES");
         assert!(
-            !should_skip_dht_identity_bootstrap(0),
-            "empty chain may still warm IdentityManager from local cache"
+            !dht_authority_mutations_enabled(),
+            "DHT must not mutate chain authority without ZHTP_MIGRATE_IDENTITIES"
         );
+        match previous {
+            Some(v) => std::env::set_var("ZHTP_MIGRATE_IDENTITIES", v),
+            None => std::env::remove_var("ZHTP_MIGRATE_IDENTITIES"),
+        }
     }
 
     #[test]

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -966,6 +966,22 @@ async fn bootstrap_identities_from_dht(
                         _ => lib_identity::IdentityType::Human,
                     };
 
+                    // When the chain projection is available, only warm the manager
+                    // for DIDs that exist on-chain. Stale local DHT rows must not
+                    // invent IdentityManager entries that diverge from authority.
+                    if let Ok(bc_arc) =
+                        crate::runtime::blockchain_provider::get_global_blockchain().await
+                    {
+                        let bc = bc_arc.read().await;
+                        if !bc.identity_exists(did_str) {
+                            debug!(
+                                "Skipping DHT cache warm for {} — not in chain identity projection",
+                                id_preview
+                            );
+                            continue;
+                        }
+                    }
+
                     // Register into IdentityManager
                     let mut mgr = identity_manager.write().await;
                     if let Err(e) = mgr.register_external_identity(

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -144,23 +144,33 @@ impl Component for IdentityComponent {
         crate::runtime::set_global_identity_manager(identity_manager_arc.clone()).await?;
         info!(" Identity manager registered globally for component access");
 
-        // Bootstrap identities from DHT storage
-        info!("🔄 Bootstrapping identities from DHT storage...");
-        match bootstrap_identities_from_dht(&identity_manager_arc).await {
-            Ok(result) => {
-                info!(
-                    "✅ Bootstrap complete: {} identities, {} wallets loaded",
-                    result.identities_loaded, result.wallets_loaded
-                );
-                if !result.errors.is_empty() {
-                    for err in &result.errors {
-                        debug!("  Bootstrap warning: {}", err);
+        // Phase 4 (#1987/#2007): DHT/local storage is cache only. When the
+        // chain already has identity projections, do not treat DHT bootstrap
+        // as an authority source for IdentityManager or mempool injection.
+        let canonical_identities = canonical_identity_projection_count().await;
+        if should_skip_dht_identity_bootstrap(canonical_identities) {
+            info!(
+                "Canonical identity projection present ({} identities) — skipping DHT identity bootstrap (cache-only)",
+                canonical_identities
+            );
+        } else {
+            info!("🔄 Bootstrapping identities from local DHT storage (no canonical projection yet)...");
+            match bootstrap_identities_from_dht(&identity_manager_arc).await {
+                Ok(result) => {
+                    info!(
+                        "✅ Bootstrap complete: {} identities, {} wallets loaded",
+                        result.identities_loaded, result.wallets_loaded
+                    );
+                    if !result.errors.is_empty() {
+                        for err in &result.errors {
+                            debug!("  Bootstrap warning: {}", err);
+                        }
                     }
                 }
-            }
-            Err(e) => {
-                // Non-fatal - log and continue
-                info!("⚠️ DHT bootstrap skipped (non-fatal): {}", e);
+                Err(e) => {
+                    // Non-fatal - log and continue
+                    info!("⚠️ DHT bootstrap skipped (non-fatal): {}", e);
+                }
             }
         }
 
@@ -317,6 +327,25 @@ pub struct DhtBootstrapResult {
     pub identities_loaded: u32,
     pub wallets_loaded: u32,
     pub errors: Vec<String>,
+}
+
+/// Prefer canonical chain identity projection over DHT on startup (#2007).
+///
+/// When any committed identity projection exists, DHT must not act as an
+/// authoritative bootstrap source for IdentityManager or registration enqueue.
+pub(crate) fn should_skip_dht_identity_bootstrap(canonical_identity_count: usize) -> bool {
+    canonical_identity_count > 0
+}
+
+/// Count identities already present in the blockchain projection (sled + shadow).
+async fn canonical_identity_projection_count() -> usize {
+    match crate::runtime::blockchain_provider::get_global_blockchain().await {
+        Ok(bc_arc) => {
+            let bc = bc_arc.read().await;
+            bc.identity_count()
+        }
+        Err(_) => 0,
+    }
 }
 
 /// Safe string truncation for display (avoids panic on short strings)
@@ -958,117 +987,121 @@ async fn bootstrap_identities_from_dht(
                             .get("savings_wallet_id")
                             .and_then(|v| v.as_str());
 
-                        // Get blockchain for balance lookup and migration
+                        // Balance lookup only by default. DHT must not invent
+                        // wallet registration / funding outside opt-in migration
+                        // (#2008 post-confirmation; #2009 cache-only reads).
                         let blockchain_arc =
                             crate::runtime::blockchain_provider::get_global_blockchain()
                                 .await
                                 .ok();
 
-                        // Migrate missing wallets to blockchain (for identities created before fix)
-                        if let Some(ref bc_arc) = blockchain_arc {
-                            let mut bc = bc_arc.write().await;
+                        let migrate_wallets = std::env::var("ZHTP_MIGRATE_IDENTITIES")
+                            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                            .unwrap_or(false);
 
-                            // Migrate primary wallet if missing
-                            if let Some(wid) = primary_wallet_id {
-                                if !bc.wallet_exists(wid) {
-                                    let wallet_bytes = hex::decode(wid).unwrap_or_default();
-                                    if wallet_bytes.len() >= 32 {
-                                        let wallet_data =
-                                            lib_blockchain::transaction::WalletTransactionData {
-                                                wallet_id: lib_blockchain::Hash::from_slice(
-                                                    &wallet_bytes[..32],
-                                                ),
-                                                wallet_type: "Primary".to_string(),
-                                                wallet_name: "Primary Wallet".to_string(),
-                                                alias: Some("primary".to_string()),
-                                                public_key: pk_bytes_for_migration.clone(),
-                                                owner_identity_id: Some(
-                                                    lib_blockchain::Hash::from_slice(
-                                                        &identity_hash.0,
+                        if migrate_wallets {
+                            if let Some(ref bc_arc) = blockchain_arc {
+                                let mut bc = bc_arc.write().await;
+
+                                // Enqueue-only (#1989): no embedded balance / UTXO mint.
+                                if let Some(wid) = primary_wallet_id {
+                                    if !bc.wallet_exists(wid) {
+                                        let wallet_bytes = hex::decode(wid).unwrap_or_default();
+                                        if wallet_bytes.len() >= 32 {
+                                            let wallet_data =
+                                                lib_blockchain::transaction::WalletTransactionData {
+                                                    wallet_id: lib_blockchain::Hash::from_slice(
+                                                        &wallet_bytes[..32],
                                                     ),
-                                                ),
-                                                seed_commitment:
-                                                    lib_blockchain::types::hash::blake3_hash(
-                                                        b"migrated_wallet",
+                                                    wallet_type: "Primary".to_string(),
+                                                    wallet_name: "Primary Wallet".to_string(),
+                                                    alias: Some("primary".to_string()),
+                                                    public_key: pk_bytes_for_migration.clone(),
+                                                    owner_identity_id: Some(
+                                                        lib_blockchain::Hash::from_slice(
+                                                            &identity_hash.0,
+                                                        ),
                                                     ),
-                                                created_at,
-                                                registration_fee: 0,
-                                                capabilities: 0xFF,
-                                                // Enqueue-only (#1989): no embedded balance / UTXO mint.
-                                                initial_balance: 0,
-                                            };
-                                        if bc.register_wallet(wallet_data).is_ok() {
-                                            info!(
-                                                "💰 MIGRATED primary wallet {} queued (0 SOV; TokenMint required for funding)",
-                                                &wid[..16.min(wid.len())]
-                                            );
+                                                    seed_commitment:
+                                                        lib_blockchain::types::hash::blake3_hash(
+                                                            b"migrated_wallet",
+                                                        ),
+                                                    created_at,
+                                                    registration_fee: 0,
+                                                    capabilities: 0xFF,
+                                                    initial_balance: 0,
+                                                };
+                                            if bc.register_wallet(wallet_data).is_ok() {
+                                                info!(
+                                                    "💰 MIGRATED primary wallet {} queued (0 SOV; TokenMint required for funding)",
+                                                    &wid[..16.min(wid.len())]
+                                                );
+                                            }
                                         }
                                     }
                                 }
-                            }
 
-                            // Migrate UBI wallet if missing
-                            if let Some(wid) = ubi_wallet_id {
-                                if !bc.wallet_exists(wid) {
-                                    let wallet_bytes = hex::decode(wid).unwrap_or_default();
-                                    if wallet_bytes.len() >= 32 {
-                                        let wallet_data =
-                                            lib_blockchain::transaction::WalletTransactionData {
-                                                wallet_id: lib_blockchain::Hash::from_slice(
-                                                    &wallet_bytes[..32],
-                                                ),
-                                                wallet_type: "UBI".to_string(),
-                                                wallet_name: "UBI Wallet".to_string(),
-                                                alias: Some("ubi".to_string()),
-                                                public_key: pk_bytes_for_migration.clone(),
-                                                owner_identity_id: Some(
-                                                    lib_blockchain::Hash::from_slice(
-                                                        &identity_hash.0,
+                                if let Some(wid) = ubi_wallet_id {
+                                    if !bc.wallet_exists(wid) {
+                                        let wallet_bytes = hex::decode(wid).unwrap_or_default();
+                                        if wallet_bytes.len() >= 32 {
+                                            let wallet_data =
+                                                lib_blockchain::transaction::WalletTransactionData {
+                                                    wallet_id: lib_blockchain::Hash::from_slice(
+                                                        &wallet_bytes[..32],
                                                     ),
-                                                ),
-                                                seed_commitment:
-                                                    lib_blockchain::types::hash::blake3_hash(
-                                                        b"migrated_wallet",
+                                                    wallet_type: "UBI".to_string(),
+                                                    wallet_name: "UBI Wallet".to_string(),
+                                                    alias: Some("ubi".to_string()),
+                                                    public_key: pk_bytes_for_migration.clone(),
+                                                    owner_identity_id: Some(
+                                                        lib_blockchain::Hash::from_slice(
+                                                            &identity_hash.0,
+                                                        ),
                                                     ),
-                                                created_at,
-                                                registration_fee: 0,
-                                                capabilities: 0x01,
-                                                initial_balance: 0,
-                                            };
-                                        let _ = bc.register_wallet(wallet_data);
+                                                    seed_commitment:
+                                                        lib_blockchain::types::hash::blake3_hash(
+                                                            b"migrated_wallet",
+                                                        ),
+                                                    created_at,
+                                                    registration_fee: 0,
+                                                    capabilities: 0x01,
+                                                    initial_balance: 0,
+                                                };
+                                            let _ = bc.register_wallet(wallet_data);
+                                        }
                                     }
                                 }
-                            }
 
-                            // Migrate savings wallet if missing
-                            if let Some(wid) = savings_wallet_id {
-                                if !bc.wallet_exists(wid) {
-                                    let wallet_bytes = hex::decode(wid).unwrap_or_default();
-                                    if wallet_bytes.len() >= 32 {
-                                        let wallet_data =
-                                            lib_blockchain::transaction::WalletTransactionData {
-                                                wallet_id: lib_blockchain::Hash::from_slice(
-                                                    &wallet_bytes[..32],
-                                                ),
-                                                wallet_type: "Savings".to_string(),
-                                                wallet_name: "Savings Wallet".to_string(),
-                                                alias: Some("savings".to_string()),
-                                                public_key: pk_bytes_for_migration.clone(),
-                                                owner_identity_id: Some(
-                                                    lib_blockchain::Hash::from_slice(
-                                                        &identity_hash.0,
+                                if let Some(wid) = savings_wallet_id {
+                                    if !bc.wallet_exists(wid) {
+                                        let wallet_bytes = hex::decode(wid).unwrap_or_default();
+                                        if wallet_bytes.len() >= 32 {
+                                            let wallet_data =
+                                                lib_blockchain::transaction::WalletTransactionData {
+                                                    wallet_id: lib_blockchain::Hash::from_slice(
+                                                        &wallet_bytes[..32],
                                                     ),
-                                                ),
-                                                seed_commitment:
-                                                    lib_blockchain::types::hash::blake3_hash(
-                                                        b"migrated_wallet",
+                                                    wallet_type: "Savings".to_string(),
+                                                    wallet_name: "Savings Wallet".to_string(),
+                                                    alias: Some("savings".to_string()),
+                                                    public_key: pk_bytes_for_migration.clone(),
+                                                    owner_identity_id: Some(
+                                                        lib_blockchain::Hash::from_slice(
+                                                            &identity_hash.0,
+                                                        ),
                                                     ),
-                                                created_at,
-                                                registration_fee: 0,
-                                                capabilities: 0x02,
-                                                initial_balance: 0,
-                                            };
-                                        let _ = bc.register_wallet(wallet_data);
+                                                    seed_commitment:
+                                                        lib_blockchain::types::hash::blake3_hash(
+                                                            b"migrated_wallet",
+                                                        ),
+                                                    created_at,
+                                                    registration_fee: 0,
+                                                    capabilities: 0x02,
+                                                    initial_balance: 0,
+                                                };
+                                            let _ = bc.register_wallet(wallet_data);
+                                        }
                                     }
                                 }
                             }
@@ -1249,6 +1282,16 @@ mod tests {
     use super::*;
     use lib_blockchain::transaction::{IdentityTransactionData, WalletTransactionData};
     use lib_blockchain::Hash;
+
+    #[test]
+    fn dht_identity_bootstrap_skipped_when_canonical_projection_exists() {
+        assert!(should_skip_dht_identity_bootstrap(1));
+        assert!(should_skip_dht_identity_bootstrap(42));
+        assert!(
+            !should_skip_dht_identity_bootstrap(0),
+            "empty chain may still warm IdentityManager from local cache"
+        );
+    }
 
     #[test]
     fn reconstruct_identity_manager_from_blockchain_state_restores_wallets() {

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -151,12 +151,22 @@ impl Component for IdentityComponent {
         // has identities — IdentityManager is still needed for PoUW/API paths
         // that read the manager, and chain backfill into the manager is
         // intentionally disabled (wallet ownership migration hazard below).
-        let canonical_identities = canonical_identity_projection_count().await;
-        if canonical_identities > 0 {
-            info!(
+        //
+        // IdentityComponent starts before BlockchainComponent, so the provider
+        // is often unset here; count is informational only. Chain-aligned warm
+        // filters inside bootstrap when the provider is available; PoUW uses
+        // chain-first resolve regardless of what was warmed.
+        match canonical_identity_projection_count().await {
+            Some(n) if n > 0 => info!(
                 "Canonical identity projection present ({} identities) — DHT bootstrap is cache-only (no authority mutations without ZHTP_MIGRATE_IDENTITIES)",
-                canonical_identities
-            );
+                n
+            ),
+            Some(_) => info!(
+                "Canonical identity projection empty — DHT cache warm may seed manager from local rows (still non-authoritative for PoUW)"
+            ),
+            None => info!(
+                "Blockchain provider not ready at identity warm — DHT cache warm without chain filter; PoUW re-checks when chain is up"
+            ),
         }
         info!("🔄 Warming IdentityManager from local DHT/storage cache...");
         match bootstrap_identities_from_dht(&identity_manager_arc).await {
@@ -343,13 +353,16 @@ pub(crate) fn dht_authority_mutations_enabled() -> bool {
 }
 
 /// Count identities already present in the blockchain projection (sled + shadow).
-async fn canonical_identity_projection_count() -> usize {
+///
+/// Returns `None` when the global provider is not ready yet (Identity starts
+/// before Blockchain). Callers must not treat "provider down" as "zero identities".
+async fn canonical_identity_projection_count() -> Option<usize> {
     match crate::runtime::blockchain_provider::get_global_blockchain().await {
         Ok(bc_arc) => {
             let bc = bc_arc.read().await;
-            bc.identity_count()
+            Some(bc.identity_count())
         }
-        Err(_) => 0,
+        Err(_) => None,
     }
 }
 
@@ -536,12 +549,7 @@ async fn rebuild_index_from_backup(
 async fn migrate_identities_to_blockchain() -> Result<(u32, u32)> {
     use std::io::BufReader;
 
-    // Check if migration is enabled
-    let migrate_enabled = std::env::var("ZHTP_MIGRATE_IDENTITIES")
-        .map(|v| v == "1" || v.to_lowercase() == "true")
-        .unwrap_or(false);
-
-    if !migrate_enabled {
+    if !dht_authority_mutations_enabled() {
         return Ok((0, 0));
     }
 
@@ -871,6 +879,14 @@ async fn bootstrap_identities_from_dht(
 
     info!("📋 Found {} identities in DHT index", identity_ids.len());
 
+    // Fetch chain handle once for the whole warm (exists filter + wallet restore).
+    // Committed projection only — pending mempool registrations must not make a
+    // stale DHT row look chain-backed.
+    let blockchain_arc = crate::runtime::blockchain_provider::get_global_blockchain()
+        .await
+        .ok();
+    let migrate_wallets = dht_authority_mutations_enabled();
+
     // 2. For each identity, load record and verify
     for identity_id in &identity_ids {
         let id_preview = truncate_for_display(identity_id, 16);
@@ -969,13 +985,11 @@ async fn bootstrap_identities_from_dht(
                     // When the chain projection is available, only warm the manager
                     // for DIDs that exist on-chain. Stale local DHT rows must not
                     // invent IdentityManager entries that diverge from authority.
-                    if let Ok(bc_arc) =
-                        crate::runtime::blockchain_provider::get_global_blockchain().await
-                    {
+                    if let Some(ref bc_arc) = blockchain_arc {
                         let bc = bc_arc.read().await;
-                        if !bc.identity_exists(did_str) {
+                        if !bc.identity_committed(did_str) {
                             debug!(
-                                "Skipping DHT cache warm for {} — not in chain identity projection",
+                                "Skipping DHT cache warm for {} — not in committed chain identity projection",
                                 id_preview
                             );
                             continue;
@@ -1011,13 +1025,6 @@ async fn bootstrap_identities_from_dht(
                         // Balance lookup only by default. DHT must not invent
                         // wallet registration / funding outside opt-in migration
                         // (#2008 post-confirmation; #2009 cache-only reads).
-                        let blockchain_arc =
-                            crate::runtime::blockchain_provider::get_global_blockchain()
-                                .await
-                                .ok();
-
-                        let migrate_wallets = dht_authority_mutations_enabled();
-
                         if migrate_wallets {
                             if let Some(ref bc_arc) = blockchain_arc {
                                 let mut bc = bc_arc.write().await;
@@ -1301,11 +1308,20 @@ mod tests {
     use super::*;
     use lib_blockchain::transaction::{IdentityTransactionData, WalletTransactionData};
     use lib_blockchain::Hash;
+    use std::sync::{Mutex, OnceLock};
+
+    fn migrate_env_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn dht_authority_mutations_default_off() {
         // Default: no env → cache warm only, no register_wallet / mint from DHT.
-        // (Do not set ZHTP_MIGRATE_IDENTITIES in this process for the assertion.)
+        // Serialise env mutation: parallel tests may also read/write this var.
+        let _guard = migrate_env_test_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let previous = std::env::var_os("ZHTP_MIGRATE_IDENTITIES");
         std::env::remove_var("ZHTP_MIGRATE_IDENTITIES");
         assert!(

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -69,6 +69,7 @@ pub mod components;
 pub mod dht_indexing;
 pub mod did_startup;
 pub mod edge_state_provider; // Global access to edge node state for header-only sync
+pub mod chain_identity_resolve;
 pub mod identity_manager_provider;
 pub mod manifest_pin_bridge;
 pub mod mesh_router_provider;
@@ -98,6 +99,9 @@ pub use blockchain_provider::{
     set_global_catchup_trigger, trigger_global_catchup,
 };
 pub use components::*;
+pub use chain_identity_resolve::{
+    resolve_pouw_client_identity, PouwClientIdentity, PouwIdentitySource,
+};
 pub use identity_manager_provider::{
     get_global_identity_manager, initialize_global_identity_manager_provider,
     set_global_identity_manager,


### PR DESCRIPTION
## Summary

ZHTP-AUTH residual work on **development** (after #2924 merge):

- DHT identity bootstrap is **cache-only** (`ZHTP_MIGRATE_IDENTITIES` gates authority mutations)
- Always warm IdentityManager (do not skip when chain has identities)
- Chain-first PoUW identity resolve (`identity_committed`, fail-closed `created_at`)
- **From closed #2924 review leftovers:**
  - `replace_block` updates nullifier index checkpoint on genesis hash rewrite
  - IdentityRegistration empty-sig path verifies Dilithium `ownership_proof` over `ZHTP_REGISTER:{created_at}`

## Test plan

- [x] `cargo test -p lib-blockchain --lib system_tx_signature`
- [x] `cargo test -p lib-blockchain --lib test_replace_block_updates_nullifier`
- [x] `cargo test -p zhtp --lib chain_identity_resolve`
- [ ] Re-review after conflict resolution (rebased onto `development` post-#2924)