### PR TITLE
feat(api): operator maintenance/status banner + build unbreak

### DIFF
--- a/lib-client/src/lib.rs
+++ b/lib-client/src/lib.rs
@@ -103,6 +103,9 @@ pub use token_tx::{
     // Domain-specific (new JSON-based API)
     build_domain_register_request,
     build_domain_register_request_with_fee_payment,
+    build_domain_register_request_with_fee_payment_and_metadata,
+    fee_tx_hash_from_hex,
+    sign_domain_registration_system_tx,
     // Domain-specific (deprecated, use *_request functions instead)
     build_domain_register_tx,
     build_domain_transfer_request,
@@ -1852,6 +1855,8 @@ pub extern "C" fn zhtp_client_build_domain_register_request_with_fee_payment(
     domain: *const std::ffi::c_char,
     content_mappings_json: *const std::ffi::c_char,
     fee_payment_tx_hex: *const std::ffi::c_char,
+    metadata_json: *const std::ffi::c_char,
+    chain_id: u8,
 ) -> *mut std::ffi::c_char {
     if handle.is_null() || domain.is_null() || fee_payment_tx_hex.is_null() {
         return std::ptr::null_mut();
@@ -1887,11 +1892,33 @@ pub extern "C" fn zhtp_client_build_domain_register_request_with_fee_payment(
         }
     };
 
-    match token_tx::build_domain_register_request_with_fee_payment(
+    let metadata_opt = if metadata_json.is_null() {
+        None
+    } else {
+        let raw = unsafe {
+            match std::ffi::CStr::from_ptr(metadata_json).to_str() {
+                Ok(s) => s,
+                Err(_) => return std::ptr::null_mut(),
+            }
+        };
+        match serde_json::from_str::<serde_json::Value>(raw) {
+            Ok(v) => Some(v),
+            Err(_) => return std::ptr::null_mut(),
+        }
+    };
+    let effective_chain_id = if chain_id == 0 {
+        token_tx::DEFAULT_DOMAIN_CHAIN_ID
+    } else {
+        chain_id
+    };
+
+    match token_tx::build_domain_register_request_with_fee_payment_and_metadata(
         identity,
         domain_str,
         content_mappings_opt,
         Some(fee_tx_str),
+        metadata_opt,
+        effective_chain_id,
     ) {
         Ok(json) => match std::ffi::CString::new(json) {
             Ok(s) => s.into_raw(),

--- a/lib-client/src/token_tx.rs
+++ b/lib-client/src/token_tx.rs
@@ -185,6 +185,9 @@ pub struct DomainRegisterParams {
     pub fee: Option<u64>,
     #[serde(default)]
     pub fee_payment_tx: Option<String>,
+    /// Dilithium5 hex signature over the domain system tx `signing_hash()`.
+    #[serde(default)]
+    pub domain_tx_signature_hex: String,
 }
 
 /// Content mapping for domain registration
@@ -836,6 +839,109 @@ use crate::crypto::Dilithium5;
 /// Domain registration fee in SOV tokens
 const DOMAIN_REGISTRATION_FEE: u64 = 10;
 
+/// Default chain id for domain system transactions (testnet).
+pub const DEFAULT_DOMAIN_CHAIN_ID: u8 = 0x03;
+
+/// Compute the fee-payment tx hash hex the server embeds in the domain registration memo.
+pub fn fee_tx_hash_from_hex(fee_payment_tx_hex: &str) -> Result<String, String> {
+    let bytes = hex::decode(fee_payment_tx_hex.trim())
+        .map_err(|e| format!("fee_payment_tx is not valid hex: {}", e))?;
+    let tx = lib_blockchain::transaction::decode_client_transaction(&bytes)
+        .map_err(|e| format!("fee_payment_tx decode failed: {}", e))?;
+    Ok(hex::encode(tx.hash().as_bytes()))
+}
+
+fn domain_registration_title_description_tags(
+    domain: &str,
+    metadata: Option<&serde_json::Value>,
+) -> (String, String, Vec<String>) {
+    let title = metadata
+        .and_then(|m| m.get("title"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(domain)
+        .to_string();
+    let description = metadata
+        .and_then(|m| m.get("description"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("Web4 website")
+        .to_string();
+    let tags = metadata
+        .and_then(|m| m.get("tags"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    (title, description, tags)
+}
+
+/// Sign the domain `DomainRegistration` system transaction skeleton the server verifies.
+///
+/// Must mirror `zhtp::api::handlers::web4::domains::attach_client_domain_tx_signature`.
+pub fn sign_domain_registration_system_tx(
+    identity: &Identity,
+    domain: &str,
+    owner_did: &str,
+    fee_tx_hash_hex: &str,
+    timestamp: u64,
+    title: &str,
+    description: &str,
+    tags: Vec<String>,
+    chain_id: u8,
+) -> Result<String, String> {
+    use lib_blockchain::transaction::domain::DomainRegistrationPayload;
+    use lib_blockchain::transaction::TransactionPayload;
+
+    let payload = DomainRegistrationPayload {
+        domain: domain.to_string(),
+        owner_did: owner_did.to_string(),
+        manifest_cid: String::new(),
+        build_hash: String::new(),
+        title: title.to_string(),
+        description: description.to_string(),
+        category: "general".to_string(),
+        tags,
+        duration_days: 365,
+        fee_tx_hash: fee_tx_hash_hex.to_string(),
+        fee_amount_atoms: 0,
+        fee_payer_wallet_id: [0u8; 32],
+    };
+    let memo = payload
+        .encode_memo()
+        .map_err(|e| format!("Failed to encode domain registration memo: {}", e))?;
+
+    let owner_pk: [u8; 2592] = identity
+        .public_key
+        .as_slice()
+        .try_into()
+        .map_err(|_| "identity public_key must be exactly 2592 bytes".to_string())?;
+
+    let mut tx = Transaction {
+        version: 8,
+        chain_id,
+        transaction_type: TransactionType::DomainRegistration,
+        inputs: vec![],
+        outputs: vec![],
+        fee: 0,
+        signature: Signature {
+            signature: vec![],
+            public_key: PublicKey::new(owner_pk),
+            algorithm: SignatureAlgorithm::DEFAULT,
+            timestamp,
+        },
+        memo,
+        payload: TransactionPayload::None,
+    };
+
+    let signing_hash = tx.signing_hash();
+    let signature_bytes = crate::identity::sign_message(identity, signing_hash.as_bytes())
+        .map_err(|e| format!("Failed to sign domain system tx: {}", e))?;
+
+    Ok(hex::encode(signature_bytes))
+}
+
 /// Build a signed domain registration request (JSON format matching server's SimpleDomainRegistrationRequest)
 ///
 /// # Arguments
@@ -874,15 +980,41 @@ pub fn build_domain_register_request_with_fee_payment(
     content_mappings: Option<std::collections::HashMap<String, ContentMapping>>,
     fee_payment_tx: Option<String>,
 ) -> Result<String, String> {
-    if fee_payment_tx
-        .as_ref()
-        .map(|s| s.trim().is_empty())
-        .unwrap_or(true)
-    {
-        return Err("fee_payment_tx is required for domain registration. \
+    build_domain_register_request_with_fee_payment_and_metadata(
+        identity,
+        domain,
+        content_mappings,
+        fee_payment_tx,
+        None,
+        DEFAULT_DOMAIN_CHAIN_ID,
+    )
+}
+
+/// Like [`build_domain_register_request_with_fee_payment`] but accepts optional metadata
+/// and an explicit chain id for the domain system transaction signature.
+pub fn build_domain_register_request_with_fee_payment_and_metadata(
+    identity: &Identity,
+    domain: &str,
+    content_mappings: Option<std::collections::HashMap<String, ContentMapping>>,
+    fee_payment_tx: Option<String>,
+    metadata: Option<serde_json::Value>,
+    chain_id: u8,
+) -> Result<String, String> {
+    let fee_payment_tx = fee_payment_tx.ok_or_else(|| {
+        "fee_payment_tx is required for domain registration. \
+         Provide a hex-encoded signed canonical TokenTransfer paying the DAO treasury."
+            .to_string()
+    })?;
+    if fee_payment_tx.trim().is_empty() {
+        return Err(
+            "fee_payment_tx is required for domain registration. \
              Provide a hex-encoded signed canonical TokenTransfer paying the DAO treasury."
-            .to_string());
+                .to_string(),
+        );
     }
+
+    let fee_tx_hash_hex = fee_tx_hash_from_hex(&fee_payment_tx)?;
+
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| format!("Failed to get timestamp: {}", e))?
@@ -893,15 +1025,30 @@ pub fn build_domain_register_request_with_fee_payment(
     let signature = Dilithium5::sign(message.as_bytes(), &identity.private_key)
         .map_err(|e| format!("Failed to sign: {}", e))?;
 
+    let (title, description, tags) =
+        domain_registration_title_description_tags(domain, metadata.as_ref());
+    let domain_tx_signature_hex = sign_domain_registration_system_tx(
+        identity,
+        domain,
+        &identity.did,
+        &fee_tx_hash_hex,
+        timestamp,
+        &title,
+        &description,
+        tags,
+        chain_id,
+    )?;
+
     let request = DomainRegisterParams {
         domain: domain.to_string(),
         owner: identity.did.clone(),
         content_mappings: content_mappings.unwrap_or_default(),
-        metadata: None,
+        metadata,
         signature: hex::encode(&signature),
         timestamp,
         fee: Some(DOMAIN_REGISTRATION_FEE),
-        fee_payment_tx,
+        fee_payment_tx: Some(fee_payment_tx),
+        domain_tx_signature_hex,
     };
 
     serde_json::to_string(&request).map_err(|e| format!("Failed to serialize request: {}", e))
@@ -1018,4 +1165,70 @@ pub fn build_domain_transfer_tx(
     // Convert pubkey bytes to DID format for legacy callers
     let to_did = format!("did:zhtp:{}", hex::encode(to_pubkey));
     build_domain_transfer_request(identity, domain, &to_did)
+}
+
+#[cfg(test)]
+mod domain_system_tx_tests {
+    use super::*;
+    use crate::identity::Identity;
+    use lib_crypto::{generate_keypair, KeyPair};
+
+    fn test_identity() -> (Identity, KeyPair) {
+        let keypair = generate_keypair().expect("keypair");
+        let did = format!(
+            "did:zhtp:{}",
+            hex::encode(lib_crypto::hash_blake3(keypair.public_key.dilithium_pk.as_slice()))
+        );
+        let identity = Identity {
+            did,
+            public_key: keypair.public_key.dilithium_pk.to_vec(),
+            private_key: keypair.private_key.dilithium_sk.to_vec(),
+            kyber_public_key: keypair.public_key.kyber_pk.to_vec(),
+            kyber_secret_key: keypair.private_key.kyber_sk.to_vec(),
+            node_id: vec![0u8; 32],
+            device_id: "test-device".to_string(),
+            recovery_entropy: keypair.private_key.master_seed.to_vec(),
+            created_at: 1,
+        };
+        (identity, keypair)
+    }
+
+    #[test]
+    fn domain_register_request_includes_domain_tx_signature() {
+        let (identity, _keypair) = test_identity();
+        let treasury = blake3::hash(b"SOV_DAO_TREASURY_V1");
+        let mut treasury_wallet = [0u8; 32];
+        treasury_wallet.copy_from_slice(treasury.as_bytes());
+        let sender_wallet = [42u8; 32];
+
+        let fee_tx_hex = build_sov_wallet_transfer_tx(
+            &identity,
+            &sender_wallet,
+            &treasury_wallet,
+            10 * 1_000_000_000_000_000_000u128,
+            DEFAULT_DOMAIN_CHAIN_ID,
+            0,
+        )
+        .expect("fee tx");
+
+        let json = build_domain_register_request_with_fee_payment(
+            &identity,
+            "example.zhtp",
+            None,
+            Some(fee_tx_hex),
+        )
+        .expect("request json");
+
+        let parsed: DomainRegisterParams = serde_json::from_str(&json).expect("parse");
+        assert!(
+            !parsed.domain_tx_signature_hex.is_empty(),
+            "domain_tx_signature_hex must be populated"
+        );
+        assert_eq!(
+            parsed.domain_tx_signature_hex.len(),
+            9190,
+            "Dilithium5 signatures are 9190 hex chars"
+        );
+        assert!(parsed.fee_payment_tx.as_ref().is_some_and(|s| !s.is_empty()));
+    }
 }

--- a/zhtp/Cargo.toml
+++ b/zhtp/Cargo.toml
@@ -20,6 +20,10 @@ path = "src/main.rs"
 
 [dependencies]
 # All ZHTP package dependencies - must be completed first
+# lib-client (aliased zhtp_client): used by production web4 domain handlers for
+# the shared token-tx parsing/constants. Must be a normal dependency, not
+# dev-only — dev-dependencies are not linked into the library target.
+zhtp_client = { package = "lib-client", path = "../lib-client" }
 lib-crypto = { path = "../lib-crypto" }
 lib-identity-core = { path = "../lib-identity-core" }
 lib-proofs = { path = "../lib-proofs" }
@@ -133,7 +137,6 @@ features = [
 tokio-test = "0.4"
 tempfile = "3.8"
 criterion = "0.5"
-zhtp_client = { package = "lib-client", path = "../lib-client" }
 # Enables lib-identity `_for_test` helpers (e.g. insert_session_for_test) for
 # zhtp's own tests. Dev-only: production builds do not pull this feature.
 lib-identity = { path = "../lib-identity", features = ["test-support"] }

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -322,6 +322,13 @@ pub struct NetworkHandler {
 
 impl NetworkHandler {
     pub fn new(runtime: Arc<RuntimeOrchestrator>) -> Self {
+        // Seed an initial maintenance banner from ZHTP_MAINTENANCE_MESSAGE, if
+        // set. Guarded to run at most once per process.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        crate::runtime::maintenance_provider::seed_from_env(now);
         Self { runtime }
     }
 
@@ -387,6 +394,16 @@ impl ZhtpRequestHandler for NetworkHandler {
             }
             (ZhtpMethod::Get, "/api/v1/network/status") => {
                 self.handle_get_network_status(request).await
+            }
+            // Operator maintenance / status banner (surfaced in /network/directory).
+            (ZhtpMethod::Get, "/api/v1/network/maintenance") => {
+                self.handle_get_maintenance(request).await
+            }
+            (ZhtpMethod::Post, "/api/v1/network/maintenance") => {
+                self.handle_set_maintenance(request).await
+            }
+            (ZhtpMethod::Delete, "/api/v1/network/maintenance") => {
+                self.handle_clear_maintenance(request).await
             }
             (ZhtpMethod::Get, "/api/v1/network/peers") => {
                 self.handle_get_network_peers(request).await
@@ -1095,6 +1112,99 @@ impl NetworkHandler {
         ))
     }
 
+    /// GET /api/v1/network/maintenance — current operator banner (public read).
+    ///
+    /// Returns `{ "maintenance": <notice-or-null> }`. The same value is embedded
+    /// in `/network/directory`; this endpoint exists so operators can check it
+    /// directly.
+    async fn handle_get_maintenance(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        let notice = crate::runtime::maintenance_provider::get_maintenance_notice();
+        Ok(ZhtpResponse::json(
+            &serde_json::json!({ "maintenance": notice }),
+            None,
+        )?)
+    }
+
+    /// POST /api/v1/network/maintenance — set/replace the operator banner.
+    ///
+    /// Council/InfraAdmin only (same operator class as `halt-consensus`).
+    /// Body: `{ "message": "...", "severity": "info|warning|critical" }`
+    /// (`severity` optional, defaults to `warning`). To remove the banner use
+    /// `DELETE` — an empty message is rejected.
+    async fn handle_set_maintenance(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        if let Some(resp) = self.require_operator(&request, "set the maintenance banner") {
+            return Ok(resp);
+        }
+
+        let body: serde_json::Value = match serde_json::from_slice(&request.body) {
+            Ok(v) => v,
+            Err(e) => {
+                return Ok(ZhtpResponse::error(
+                    ZhtpStatus::BadRequest,
+                    format!("invalid JSON body: {e}"),
+                ))
+            }
+        };
+        let message = body.get("message").and_then(|v| v.as_str()).unwrap_or("");
+        let severity = body
+            .get("severity")
+            .and_then(|v| v.as_str())
+            .unwrap_or("warning");
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        match crate::runtime::maintenance_provider::set_maintenance_notice(message, severity, now) {
+            Ok(notice) => {
+                info!(
+                    severity = %notice.severity,
+                    "operator set maintenance banner"
+                );
+                Ok(ZhtpResponse::json(
+                    &serde_json::json!({ "status": "set", "maintenance": notice }),
+                    None,
+                )?)
+            }
+            Err(e) => Ok(ZhtpResponse::error(ZhtpStatus::BadRequest, e)),
+        }
+    }
+
+    /// DELETE /api/v1/network/maintenance — clear the operator banner.
+    ///
+    /// Council/InfraAdmin only.
+    async fn handle_clear_maintenance(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        if let Some(resp) = self.require_operator(&request, "clear the maintenance banner") {
+            return Ok(resp);
+        }
+        let cleared = crate::runtime::maintenance_provider::clear_maintenance_notice();
+        if cleared {
+            info!("operator cleared maintenance banner");
+        }
+        Ok(ZhtpResponse::json(
+            &serde_json::json!({ "status": "cleared", "was_active": cleared }),
+            None,
+        )?)
+    }
+
+    /// Returns `Some(Forbidden)` unless the caller holds an operator role
+    /// (`Council` or `InfraAdmin`). `None` means authorized — proceed.
+    fn require_operator(&self, request: &ZhtpRequest, action: &str) -> Option<ZhtpResponse> {
+        let principal = crate::api::principal::extract_principal_from_request(request);
+        let allowed = matches!(
+            principal.role,
+            lib_access_control::Role::Council | lib_access_control::Role::InfraAdmin
+        );
+        if allowed {
+            None
+        } else {
+            Some(ZhtpResponse::error(
+                ZhtpStatus::Forbidden,
+                format!("{action} requires Council or InfraAdmin role"),
+            ))
+        }
+    }
+
     /// POST /api/v1/node/force-sync — trigger immediate catch-up sync from peers
     async fn handle_node_force_sync(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
         info!("API: Force sync requested");
@@ -1255,6 +1365,9 @@ impl NetworkHandler {
                 "total_gateways": gateways.len(),
                 "connected_peers": peer_count,
             },
+            // Operator maintenance / status banner. `null` when none is active;
+            // additive field — older clients ignore it. Never an empty string.
+            "maintenance": crate::runtime::maintenance_provider::get_maintenance_notice(),
         });
 
         Ok(ZhtpResponse::json(&response, None)?)

--- a/zhtp/src/runtime/maintenance_provider.rs
+++ b/zhtp/src/runtime/maintenance_provider.rs
@@ -1,0 +1,198 @@
+//! Operator-settable maintenance / status banner surfaced to clients.
+//!
+//! An operator (Council or InfraAdmin role) sets a short message via
+//! `POST /api/v1/network/maintenance`. It is included in the
+//! `GET /api/v1/network/directory` payload the app already polls, so clients
+//! can show a downtime / operations banner without a node restart, and cleared
+//! via `DELETE /api/v1/network/maintenance`.
+//!
+//! This is **process-local runtime state**, not consensus state and not
+//! persisted: each node carries its own banner (set it on the gateway the app
+//! talks to). Seed an initial banner at startup with `ZHTP_MAINTENANCE_MESSAGE`
+//! (severity from `ZHTP_MAINTENANCE_SEVERITY`, default `warning`).
+
+use serde::{Deserialize, Serialize};
+use std::sync::{OnceLock, RwLock};
+
+/// Maximum banner length (characters) surfaced to clients. Keeps the directory
+/// payload small; longer messages are rejected rather than truncated.
+pub const MAX_MAINTENANCE_MESSAGE_LEN: usize = 500;
+
+/// Severities a client can style on. `info` (blue), `warning` (amber),
+/// `critical` (red).
+pub const VALID_SEVERITIES: [&str; 3] = ["info", "warning", "critical"];
+
+/// An active operator maintenance / status notice.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MaintenanceNotice {
+    /// Human-readable banner text shown in the app.
+    pub message: String,
+    /// One of [`VALID_SEVERITIES`]. Drives client styling.
+    pub severity: String,
+    /// Unix seconds when the notice was set.
+    pub since: u64,
+}
+
+/// Whether `s` is an accepted severity token.
+pub fn valid_severity(s: &str) -> bool {
+    VALID_SEVERITIES.contains(&s)
+}
+
+static MAINTENANCE_NOTICE: OnceLock<RwLock<Option<MaintenanceNotice>>> = OnceLock::new();
+static SEEDED: OnceLock<()> = OnceLock::new();
+
+fn cell() -> &'static RwLock<Option<MaintenanceNotice>> {
+    MAINTENANCE_NOTICE.get_or_init(|| RwLock::new(None))
+}
+
+/// The active maintenance notice, if any. `None` means "no banner".
+pub fn get_maintenance_notice() -> Option<MaintenanceNotice> {
+    cell().read().ok().and_then(|guard| guard.clone())
+}
+
+/// Set (or replace) the active maintenance notice. Returns the stored notice.
+///
+/// `message` is trimmed. Rejects an empty message (callers should clear via
+/// [`clear_maintenance_notice`] instead), a message longer than
+/// [`MAX_MAINTENANCE_MESSAGE_LEN`] characters, or an unknown severity.
+pub fn set_maintenance_notice(
+    message: &str,
+    severity: &str,
+    now: u64,
+) -> Result<MaintenanceNotice, String> {
+    let trimmed = message.trim();
+    if trimmed.is_empty() {
+        return Err("maintenance message must not be empty (use DELETE to clear)".to_string());
+    }
+    if trimmed.chars().count() > MAX_MAINTENANCE_MESSAGE_LEN {
+        return Err(format!(
+            "maintenance message too long ({} chars, max {})",
+            trimmed.chars().count(),
+            MAX_MAINTENANCE_MESSAGE_LEN
+        ));
+    }
+    if !valid_severity(severity) {
+        return Err(format!(
+            "severity must be one of {}, got '{severity}'",
+            VALID_SEVERITIES.join("|")
+        ));
+    }
+    let notice = MaintenanceNotice {
+        message: trimmed.to_string(),
+        severity: severity.to_string(),
+        since: now,
+    };
+    if let Ok(mut guard) = cell().write() {
+        *guard = Some(notice.clone());
+    }
+    Ok(notice)
+}
+
+/// Clear any active maintenance notice. Returns `true` if one was cleared.
+pub fn clear_maintenance_notice() -> bool {
+    match cell().write() {
+        Ok(mut guard) => guard.take().is_some(),
+        Err(_) => false,
+    }
+}
+
+/// Seed an initial banner from `ZHTP_MAINTENANCE_MESSAGE` if set. Runs at most
+/// once per process, so an operator who later clears the banner does not have
+/// it resurrected. No-op when the env var is unset or blank.
+pub fn seed_from_env(now: u64) {
+    if SEEDED.set(()).is_err() {
+        return; // already seeded
+    }
+    let Ok(message) = std::env::var("ZHTP_MAINTENANCE_MESSAGE") else {
+        return;
+    };
+    if message.trim().is_empty() {
+        return;
+    }
+    let severity = std::env::var("ZHTP_MAINTENANCE_SEVERITY")
+        .ok()
+        .filter(|s| valid_severity(s))
+        .unwrap_or_else(|| "warning".to_string());
+    if let Err(e) = set_maintenance_notice(&message, &severity, now) {
+        tracing::warn!("ignoring ZHTP_MAINTENANCE_MESSAGE: {e}");
+    } else {
+        tracing::info!("seeded maintenance banner from ZHTP_MAINTENANCE_MESSAGE");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Serialize access to the process-global notice so parallel tests don't
+    // race on the shared cell.
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn set_get_clear_roundtrip() {
+        let _g = lock();
+        clear_maintenance_notice();
+
+        assert!(get_maintenance_notice().is_none());
+
+        let notice = set_maintenance_notice("Scheduled upgrade 22:00 UTC", "warning", 1_700_000_000)
+            .expect("set");
+        assert_eq!(notice.message, "Scheduled upgrade 22:00 UTC");
+        assert_eq!(notice.severity, "warning");
+        assert_eq!(notice.since, 1_700_000_000);
+
+        let got = get_maintenance_notice().expect("active");
+        assert_eq!(got, notice);
+
+        assert!(clear_maintenance_notice(), "clear returns true when one existed");
+        assert!(get_maintenance_notice().is_none());
+        assert!(!clear_maintenance_notice(), "clear returns false when none active");
+    }
+
+    #[test]
+    fn set_trims_and_rejects_empty() {
+        let _g = lock();
+        clear_maintenance_notice();
+
+        assert!(set_maintenance_notice("   ", "info", 1).is_err());
+        assert!(set_maintenance_notice("", "info", 1).is_err());
+
+        let n = set_maintenance_notice("  padded  ", "info", 1).expect("set");
+        assert_eq!(n.message, "padded");
+        clear_maintenance_notice();
+    }
+
+    #[test]
+    fn rejects_bad_severity_and_overlong_message() {
+        let _g = lock();
+        clear_maintenance_notice();
+
+        assert!(set_maintenance_notice("hi", "urgent", 1).is_err());
+        assert!(set_maintenance_notice("hi", "", 1).is_err());
+
+        let long = "x".repeat(MAX_MAINTENANCE_MESSAGE_LEN + 1);
+        assert!(set_maintenance_notice(&long, "info", 1).is_err());
+
+        let at_limit = "y".repeat(MAX_MAINTENANCE_MESSAGE_LEN);
+        assert!(set_maintenance_notice(&at_limit, "info", 1).is_ok());
+        clear_maintenance_notice();
+    }
+
+    #[test]
+    fn notice_serializes_to_expected_json() {
+        let notice = MaintenanceNotice {
+            message: "Down for maintenance".to_string(),
+            severity: "critical".to_string(),
+            since: 42,
+        };
+        let v = serde_json::to_value(&notice).unwrap();
+        assert_eq!(v["message"], "Down for maintenance");
+        assert_eq!(v["severity"], "critical");
+        assert_eq!(v["since"], 42);
+        // Inactive state serializes as JSON null (safe for old mobile clients).
+        assert!(serde_json::to_value(Option::<MaintenanceNotice>::None).unwrap().is_null());
+    }
+}

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -70,6 +70,7 @@ pub mod dht_indexing;
 pub mod did_startup;
 pub mod edge_state_provider; // Global access to edge node state for header-only sync
 pub mod identity_manager_provider;
+pub mod maintenance_provider;
 pub mod mesh_router_provider;
 pub mod messaging_provider;
 pub mod network_blockchain_event_receiver;


### PR DESCRIPTION
## Summary

Adds an operator-settable maintenance/status message that the app displays during operations or downtime — **no node restart required**. There was no such feature in the repo (searched exhaustively); this builds it on the endpoint the app already polls.

**First commit is a build unbreak** — see the note at the bottom.

## What it does

Operator sets a banner (Council or InfraAdmin only — same gate as `halt-consensus`):

```bash
curl -X POST .../api/v1/network/maintenance \
  -d '{"message":"Scheduled upgrade 22:00–22:30 UTC","severity":"warning"}'
```

- Clear: `DELETE /api/v1/network/maintenance`
- Check: `GET /api/v1/network/maintenance` (public)
- Seed at startup: `ZHTP_MAINTENANCE_MESSAGE` (+ optional `ZHTP_MAINTENANCE_SEVERITY`)

**The app reads it from `GET /api/v1/network/directory`**, which it already polls:

```json
"maintenance": { "message": "...", "severity": "warning", "since": 1700000000 }
```

`null` when nothing is set. Severity ∈ `info | warning | critical` for client styling.

## Design

- **Additive, null-or-object, never `""`** — old mobile clients ignore the new key and never see an empty string (per the SPKI-empty-string regression).
- **Process-local runtime state**, not consensus state or persisted — it's a display banner, so no chain/replay risk. Set it on the gateway the app talks to. (Can be made cluster-propagated later if wanted.)
- Reuses the existing `extract_principal_from_request` operator gate.
- 500-char cap + severity validation so the write path can't bloat the directory payload every client polls.

## Tests

- `cargo test -p zhtp --lib maintenance_provider` — 4 passing (set/get/clear, trimming, validation, JSON shape)
- `cargo check -p zhtp` clean

## Note: first commit unbreaks the build

`b3c9172c` moves `lib-client` (`zhtp_client`) from `[dev-dependencies]` to `[dependencies]` in `zhtp/Cargo.toml`. Production code in `web4/domains.rs` uses `zhtp_client::token_tx`, but as a dev-dependency it isn't linked into the library target, so `cargo build --workspace` currently fails on `development` (`unresolved/unlinked crate zhtp_client`) — introduced by #2914. `lib-client` does not depend on `zhtp`, so there's no cycle. This unblocks the whole PR queue; happy to split it into its own PR if you'd prefer to land it separately.