### PR TITLE
chore: bump CONSENSUS_BUILD_ID to 7 for ZHTP-AUTH deploy

### DIFF
--- a/lib-consensus-core/src/build_id.rs
+++ b/lib-consensus-core/src/build_id.rs
@@ -20,9 +20,10 @@
 /// - Consensus admission rules change in a way that requires homogeneous binaries
 ///
 /// Do **not** bump for docs-only, CLI-only, or unrelated crate changes.
-// Epoch 6: RewardClaim mempool gates (UnregisteredSender fix + spend-delegate
-// admission). Homogeneous cluster required so nodes agree on mempool admits.
-pub const CONSENSUS_BUILD_ID: &str = "6";
+// Epoch 7: ZHTP-AUTH Phase 2+4 (#2924/#2925) — identity projection rebuild,
+// RewardClaim soft-drop, DHT cache-only warm, chain-first PoUW, ownership_proof
+// verify. Homogeneous cluster required for mempool/apply parity.
+pub const CONSENSUS_BUILD_ID: &str = "7";
 
 /// Marker assigned when decoding codec v1 frames (no epoch field on wire).
 pub const LEGACY_BUILD_ID: &str = "";


### PR DESCRIPTION
## Summary
- Bump `CONSENSUS_BUILD_ID` **6 → 7** for coordinated g1–g3 deploy of #2924/#2925 ZHTP-AUTH work.

## Test plan
- [x] Deploy via `scripts/deploy-validators.sh` after merge
- [ ] g1–g3 homogeneous epoch 7 + active consensus