### PR TITLE
fix(rewards): AssetLaunch BUBL claims + chain wallet hydrate

### DIFF
--- a/lib-blockchain/src/execution/reward_claim.rs
+++ b/lib-blockchain/src/execution/reward_claim.rs
@@ -96,40 +96,29 @@ pub fn apply_reward_claim(
 
     let token = TokenId::new(data.token_id);
 
-    // Authorization:
-    // - Rewards-module assets (pure AssetLaunch): require spend-delegate match.
-    //   These have no `token_contracts` row; balances live in sled alone and
-    //   `apply_token_transfer` does not need a contract object.
-    // - Legacy TokenContract path: require token_contracts row + creator signer.
-    if let Some(rewards_state) = mutator.get_rewards_module_state(&data.token_id)? {
-        if data.from != rewards_state.spend_delegate_key_id {
-            warn!(
-                "RewardClaim rejected at height {}: signer {} is not spend delegate {} for token {}",
-                block_height,
-                hex::encode(data.from),
-                hex::encode(rewards_state.spend_delegate_key_id),
-                hex::encode(data.token_id)
-            );
-            return reject_claim("signer is not on-chain spend delegate");
-        }
-    } else {
-        let contract = match mutator.get_token_contract(&token)? {
-            Some(c) => c,
-            None => {
-                warn!(
-                    "RewardClaim rejected at height {}: token contract not found",
-                    block_height
-                );
-                return reject_claim("token contract not found");
-            }
-        };
-        if contract.creator.key_id != data.from {
-            warn!(
-                "RewardClaim rejected at height {}: signer is not token creator (legacy path)",
-                block_height
-            );
-            return reject_claim("signer is not authorized token creator");
-        }
+    // Authorization ladder — shared with mempool + settlement
+    // (`transaction::reward_claim::authorize_reward_claim`). Do not re-inline.
+    let spend_delegate = mutator
+        .get_rewards_module_state(&data.token_id)?
+        .map(|s| s.spend_delegate_key_id);
+    let token_creator = match mutator.get_token_contract(&token)? {
+        Some(c) => Some(c.creator.key_id),
+        None => None,
+    };
+    if let Err(auth_err) =
+        crate::transaction::reward_claim::authorize_reward_claim(
+            data.from,
+            spend_delegate,
+            token_creator,
+        )
+    {
+        warn!(
+            "RewardClaim rejected at height {}: {} (token={})",
+            block_height,
+            auth_err.as_str(),
+            hex::encode(data.token_id)
+        );
+        return reject_claim(auth_err.as_str());
     }
 
     // Day/week bucketing rejects chrono-unrepresentable timestamps. On the apply

--- a/lib-blockchain/src/execution/reward_claim.rs
+++ b/lib-blockchain/src/execution/reward_claim.rs
@@ -96,17 +96,11 @@ pub fn apply_reward_claim(
 
     let token = TokenId::new(data.token_id);
 
-    let contract = match mutator.get_token_contract(&token)? {
-        Some(c) => c,
-        None => {
-            warn!(
-                "RewardClaim rejected at height {}: token contract not found",
-                block_height
-            );
-            return reject_claim("token contract not found");
-        }
-    };
-
+    // Authorization:
+    // - Rewards-module assets (pure AssetLaunch): require spend-delegate match.
+    //   These have no `token_contracts` row; balances live in sled alone and
+    //   `apply_token_transfer` does not need a contract object.
+    // - Legacy TokenContract path: require token_contracts row + creator signer.
     if let Some(rewards_state) = mutator.get_rewards_module_state(&data.token_id)? {
         if data.from != rewards_state.spend_delegate_key_id {
             warn!(
@@ -118,12 +112,24 @@ pub fn apply_reward_claim(
             );
             return reject_claim("signer is not on-chain spend delegate");
         }
-    } else if contract.creator.key_id != data.from {
-        warn!(
-            "RewardClaim rejected at height {}: signer is not token creator (legacy path)",
-            block_height
-        );
-        return reject_claim("signer is not authorized token creator");
+    } else {
+        let contract = match mutator.get_token_contract(&token)? {
+            Some(c) => c,
+            None => {
+                warn!(
+                    "RewardClaim rejected at height {}: token contract not found",
+                    block_height
+                );
+                return reject_claim("token contract not found");
+            }
+        };
+        if contract.creator.key_id != data.from {
+            warn!(
+                "RewardClaim rejected at height {}: signer is not token creator (legacy path)",
+                block_height
+            );
+            return reject_claim("signer is not authorized token creator");
+        }
     }
 
     // Day/week bucketing rejects chrono-unrepresentable timestamps. On the apply

--- a/lib-blockchain/src/transaction/reward_claim.rs
+++ b/lib-blockchain/src/transaction/reward_claim.rs
@@ -238,9 +238,167 @@ pub fn partner_count_key(token_id: &[u8; 32], week: &str, did: &str) -> String {
     format!("{}|{}|{}", token_key_prefix(token_id), week, did)
 }
 
+// ── Shared authorization ladder (apply / mempool / settlement) ─────────────
+//
+// Keep these three surfaces byte-aligned forever: module present → spend
+// delegate; else token_contract + creator. Do not re-inline this ladder.
+
+/// Which authorization path authorized a `RewardClaim` signer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RewardClaimAuthPath {
+    /// Pure AssetLaunch / rewards-module asset (may have no `token_contracts` row).
+    RewardsModuleSpendDelegate,
+    /// Legacy TokenContract creator path.
+    LegacyTokenCreator,
+}
+
+/// Resolved authority for a claim token (before signer check).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RewardClaimAuthSource {
+    RewardsModule { spend_delegate_key_id: [u8; 32] },
+    LegacyToken { creator_key_id: [u8; 32] },
+}
+
+/// Authorization failures shared across mempool, apply, and settlement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RewardClaimAuthError {
+    /// Neither rewards module nor token contract for this token_id.
+    TokenContractNotFound,
+    /// Module path: `data.from` is not the on-chain spend delegate.
+    NotSpendDelegate {
+        expected: [u8; 32],
+        got: [u8; 32],
+    },
+    /// Legacy path: `data.from` is not the token contract creator.
+    NotTokenCreator {
+        expected: [u8; 32],
+        got: [u8; 32],
+    },
+}
+
+impl RewardClaimAuthError {
+    /// Stable human message (apply soft-drop / logs).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::TokenContractNotFound => "token contract not found",
+            Self::NotSpendDelegate { .. } => "signer is not on-chain spend delegate",
+            Self::NotTokenCreator { .. } => "signer is not authorized token creator",
+        }
+    }
+}
+
+impl std::fmt::Display for RewardClaimAuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Resolve which authority governs claims for this asset.
+///
+/// Rewards-module presence wins over a legacy token contract when both exist
+/// (AssetLaunch path).
+pub fn resolve_reward_claim_auth(
+    spend_delegate_key_id: Option<[u8; 32]>,
+    token_creator_key_id: Option<[u8; 32]>,
+) -> Result<RewardClaimAuthSource, RewardClaimAuthError> {
+    if let Some(spend_delegate_key_id) = spend_delegate_key_id {
+        return Ok(RewardClaimAuthSource::RewardsModule {
+            spend_delegate_key_id,
+        });
+    }
+    if let Some(creator_key_id) = token_creator_key_id {
+        return Ok(RewardClaimAuthSource::LegacyToken { creator_key_id });
+    }
+    Err(RewardClaimAuthError::TokenContractNotFound)
+}
+
+/// Check that `from` is the authorized signer for a resolved auth source.
+pub fn authorize_reward_claim_signer(
+    from: [u8; 32],
+    source: RewardClaimAuthSource,
+) -> Result<RewardClaimAuthPath, RewardClaimAuthError> {
+    match source {
+        RewardClaimAuthSource::RewardsModule {
+            spend_delegate_key_id,
+        } => {
+            if from != spend_delegate_key_id {
+                return Err(RewardClaimAuthError::NotSpendDelegate {
+                    expected: spend_delegate_key_id,
+                    got: from,
+                });
+            }
+            Ok(RewardClaimAuthPath::RewardsModuleSpendDelegate)
+        }
+        RewardClaimAuthSource::LegacyToken { creator_key_id } => {
+            if from != creator_key_id {
+                return Err(RewardClaimAuthError::NotTokenCreator {
+                    expected: creator_key_id,
+                    got: from,
+                });
+            }
+            Ok(RewardClaimAuthPath::LegacyTokenCreator)
+        }
+    }
+}
+
+/// Full ladder: resolve module/contract → require signer match.
+///
+/// **Single source of truth** for apply, mempool validation, and settlement.
+pub fn authorize_reward_claim(
+    from: [u8; 32],
+    spend_delegate_key_id: Option<[u8; 32]>,
+    token_creator_key_id: Option<[u8; 32]>,
+) -> Result<RewardClaimAuthPath, RewardClaimAuthError> {
+    let source = resolve_reward_claim_auth(spend_delegate_key_id, token_creator_key_id)?;
+    authorize_reward_claim_signer(from, source)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn authorize_module_path_requires_spend_delegate() {
+        let delegate = [0x11; 32];
+        let creator = [0x22; 32];
+        assert_eq!(
+            authorize_reward_claim(delegate, Some(delegate), Some(creator)).unwrap(),
+            RewardClaimAuthPath::RewardsModuleSpendDelegate
+        );
+        assert!(matches!(
+            authorize_reward_claim(creator, Some(delegate), Some(creator)),
+            Err(RewardClaimAuthError::NotSpendDelegate { .. })
+        ));
+    }
+
+    #[test]
+    fn authorize_legacy_path_when_no_module() {
+        let creator = [0x22; 32];
+        assert_eq!(
+            authorize_reward_claim(creator, None, Some(creator)).unwrap(),
+            RewardClaimAuthPath::LegacyTokenCreator
+        );
+        assert!(matches!(
+            authorize_reward_claim([0x33; 32], None, Some(creator)),
+            Err(RewardClaimAuthError::NotTokenCreator { .. })
+        ));
+        assert!(matches!(
+            authorize_reward_claim(creator, None, None),
+            Err(RewardClaimAuthError::TokenContractNotFound)
+        ));
+    }
+
+    #[test]
+    fn resolve_prefers_module_over_contract() {
+        let delegate = [0x11; 32];
+        let creator = [0x22; 32];
+        assert_eq!(
+            resolve_reward_claim_auth(Some(delegate), Some(creator)).unwrap(),
+            RewardClaimAuthSource::RewardsModule {
+                spend_delegate_key_id: delegate
+            }
+        );
+    }
 
     #[test]
     fn checkin_amount_streak_schedule() {

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -2564,9 +2564,8 @@ impl<'a> StatefulTransactionValidator<'a> {
         //   0) amount > 0
         //   1) recipient_key_id == key_id_from_did(owner_did)
         //   2) owner_did registered in sled
-        //   3) token_contract exists (GENESIS-3 H=1920: rewards-module alone
-        //      is not enough — pure AssetLaunch has no token_contracts row)
-        //   4) spend-delegate (if rewards module) else legacy token-creator
+        //   3) rewards-module present → spend-delegate; else token_contract
+        //      + creator (AssetLaunch has rewards module without token_contracts)
         if transaction.transaction_type == TransactionType::RewardClaim {
             let data = transaction
                 .reward_claim_data()
@@ -2599,13 +2598,6 @@ impl<'a> StatefulTransactionValidator<'a> {
                 );
                 return Err(ValidationError::InvalidTransaction);
             }
-            let Some(contract) = blockchain.get_token_contract(&data.token_id) else {
-                tracing::warn!(
-                    "[REWARD_CLAIM] token contract not found for claim token_id={}",
-                    hex::encode(data.token_id)
-                );
-                return Err(ValidationError::InvalidTransaction);
-            };
             if let Some(rewards_state) = blockchain.get_rewards_module_state(&data.token_id) {
                 if data.from != rewards_state.spend_delegate_key_id {
                     tracing::warn!(
@@ -2615,13 +2607,22 @@ impl<'a> StatefulTransactionValidator<'a> {
                     );
                     return Err(ValidationError::Unauthorized);
                 }
-            } else if contract.creator.key_id != data.from {
-                tracing::warn!(
-                    "[REWARD_CLAIM] signer is not token creator (legacy path): from={} creator={}",
-                    hex::encode(data.from),
-                    hex::encode(contract.creator.key_id)
-                );
-                return Err(ValidationError::Unauthorized);
+            } else {
+                let Some(contract) = blockchain.get_token_contract(&data.token_id) else {
+                    tracing::warn!(
+                        "[REWARD_CLAIM] token contract not found for claim token_id={}",
+                        hex::encode(data.token_id)
+                    );
+                    return Err(ValidationError::InvalidTransaction);
+                };
+                if contract.creator.key_id != data.from {
+                    tracing::warn!(
+                        "[REWARD_CLAIM] signer is not token creator (legacy path): from={} creator={}",
+                        hex::encode(data.from),
+                        hex::encode(contract.creator.key_id)
+                    );
+                    return Err(ValidationError::Unauthorized);
+                }
             }
             return Ok(());
         }

--- a/lib-blockchain/src/transaction/validation.rs
+++ b/lib-blockchain/src/transaction/validation.rs
@@ -2598,28 +2598,49 @@ impl<'a> StatefulTransactionValidator<'a> {
                 );
                 return Err(ValidationError::InvalidTransaction);
             }
-            if let Some(rewards_state) = blockchain.get_rewards_module_state(&data.token_id) {
-                if data.from != rewards_state.spend_delegate_key_id {
-                    tracing::warn!(
-                        "[REWARD_CLAIM] signer is not on-chain spend delegate: from={} expected={}",
-                        hex::encode(data.from),
-                        hex::encode(rewards_state.spend_delegate_key_id)
-                    );
-                    return Err(ValidationError::Unauthorized);
-                }
-            } else {
-                let Some(contract) = blockchain.get_token_contract(&data.token_id) else {
+            // Shared ladder with apply + settlement (authorize_reward_claim).
+            let spend_delegate = blockchain
+                .get_rewards_module_state(&data.token_id)
+                .map(|s| s.spend_delegate_key_id);
+            let token_creator = blockchain
+                .get_token_contract(&data.token_id)
+                .map(|c| c.creator.key_id);
+            match crate::transaction::reward_claim::authorize_reward_claim(
+                data.from,
+                spend_delegate,
+                token_creator,
+            ) {
+                Ok(_) => {}
+                Err(crate::transaction::reward_claim::RewardClaimAuthError::TokenContractNotFound) => {
                     tracing::warn!(
                         "[REWARD_CLAIM] token contract not found for claim token_id={}",
                         hex::encode(data.token_id)
                     );
                     return Err(ValidationError::InvalidTransaction);
-                };
-                if contract.creator.key_id != data.from {
+                }
+                Err(
+                    crate::transaction::reward_claim::RewardClaimAuthError::NotSpendDelegate {
+                        expected,
+                        got,
+                    },
+                ) => {
+                    tracing::warn!(
+                        "[REWARD_CLAIM] signer is not on-chain spend delegate: from={} expected={}",
+                        hex::encode(got),
+                        hex::encode(expected)
+                    );
+                    return Err(ValidationError::Unauthorized);
+                }
+                Err(
+                    crate::transaction::reward_claim::RewardClaimAuthError::NotTokenCreator {
+                        expected,
+                        got,
+                    },
+                ) => {
                     tracing::warn!(
                         "[REWARD_CLAIM] signer is not token creator (legacy path): from={} creator={}",
-                        hex::encode(data.from),
-                        hex::encode(contract.creator.key_id)
+                        hex::encode(got),
+                        hex::encode(expected)
                     );
                     return Err(ValidationError::Unauthorized);
                 }

--- a/lib-blockchain/tests/common/reward_claim_harness.rs
+++ b/lib-blockchain/tests/common/reward_claim_harness.rs
@@ -125,7 +125,7 @@ fn install_bubl_mempool_fixtures(blockchain: &mut Blockchain, actors: &RewardCla
 }
 
 /// Identities + rewards-module state for `token_id`, but **no** `token_contracts`
-/// row — mirrors pure AssetLaunch (discoverable rewards, un-applyable claims).
+/// row — mirrors pure AssetLaunch (discoverable rewards, applyable via module).
 pub fn mempool_blockchain_rewards_module_without_token_contract(
     actors: &RewardClaimActors,
 ) -> Blockchain {

--- a/lib-blockchain/tests/common/reward_claim_harness.rs
+++ b/lib-blockchain/tests/common/reward_claim_harness.rs
@@ -124,39 +124,119 @@ fn install_bubl_mempool_fixtures(blockchain: &mut Blockchain, actors: &RewardCla
     );
 }
 
-/// Identities + rewards-module state for `token_id`, but **no** `token_contracts`
-/// row — mirrors pure AssetLaunch (discoverable rewards, applyable via module).
-pub fn mempool_blockchain_rewards_module_without_token_contract(
+/// Seed rewards module + policy document (legacy BUBL policy) with no token contract.
+fn put_rewards_module_with_legacy_policy(
+    store: &dyn BlockchainStore,
     actors: &RewardClaimActors,
-) -> Blockchain {
+    block_height: u64,
+) {
     use lib_blockchain::contracts::sovereign_asset::RewardsModuleState;
+    use lib_blockchain::rewards_policy::{legacy_bubl_policy, policy_hash, validate_rewards_policy_value};
 
-    let mut blockchain = Blockchain::new().expect("blockchain construct");
-    let store = attach_ephemeral_store(&mut blockchain);
-    register_actor_identities_store(store.as_ref(), actors);
-    register_actor_identities_shadow(&mut blockchain, actors);
-    // put_rewards_module_state requires an active block transaction.
-    // Empty store expects height 0 (genesis slot) for the first begin_block.
-    store.begin_block(0).expect("begin rewards fixture block");
+    let policy = legacy_bubl_policy();
+    validate_rewards_policy_value(&policy).expect("legacy policy valid");
+    let policy_hash_arr = policy_hash(&policy).expect("policy hash").as_array();
+    let policy_document = serde_json::to_vec(&policy).expect("policy json");
+    let mut policy_cid_input = b"zhtp/rewards-policy/cid/v1\0".to_vec();
+    policy_cid_input.extend_from_slice(&policy_document);
+    let policy_cid = lib_crypto::hash_blake3(&policy_cid_input);
+
+    store
+        .begin_block(block_height)
+        .expect("begin rewards fixture block");
     store
         .put_rewards_module_state(
             &actors.token_id,
             &RewardsModuleState {
                 spend_delegate_key_id: actors.treasury.public_key.key_id,
-                policy_cid: [0u8; 32],
-                policy_hash: [0u8; 32],
+                policy_cid,
+                policy_hash: policy_hash_arr,
                 nonce: 0,
                 pending_policy: None,
             },
         )
         .expect("seed rewards module without token contract");
+    store
+        .put_rewards_policy_document(&policy_hash_arr, &policy_document)
+        .expect("seed rewards policy document");
     store.commit_block().expect("commit rewards fixture block");
+}
+
+/// Identities + rewards-module state for `token_id`, but **no** `token_contracts`
+/// row — mirrors pure AssetLaunch (discoverable rewards, applyable via module).
+pub fn mempool_blockchain_rewards_module_without_token_contract(
+    actors: &RewardClaimActors,
+) -> Blockchain {
+    let mut blockchain = Blockchain::new().expect("blockchain construct");
+    let store = attach_ephemeral_store(&mut blockchain);
+    register_actor_identities_store(store.as_ref(), actors);
+    register_actor_identities_shadow(&mut blockchain, actors);
+    // Empty store expects height 0 (genesis slot) for the first begin_block.
+    put_rewards_module_with_legacy_policy(store.as_ref(), actors, 0);
     blockchain.insert_token_nonce_shadow(
         actors.token_id,
         actors.treasury.public_key.key_id,
         0,
     );
     blockchain
+}
+
+/// Executor fixture: identities + rewards module + policy + treasury balance,
+/// **no** `token_contracts` row. Returns the setup block at height 1.
+pub fn seed_executor_store_rewards_module_without_token_contract(
+    store: &Arc<dyn BlockchainStore>,
+    genesis: &Block,
+    actors: &RewardClaimActors,
+) -> Block {
+    register_actor_identities_store(store.as_ref(), actors);
+
+    let treasury_addr = Address::new(actors.treasury.public_key.key_id);
+    let welcome_amount = expected_amount_for_event(RewardEventKind::Welcome, 1);
+
+    // Height 1: fund treasury balances (no TokenContract object).
+    store.begin_block(1).expect("begin setup block");
+    store
+        .set_token_balance(
+            &TokenId::new(actors.token_id),
+            &treasury_addr,
+            welcome_amount.saturating_mul(2),
+        )
+        .expect("fund treasury");
+    // Install rewards module + policy inside same block window.
+    {
+        use lib_blockchain::contracts::sovereign_asset::RewardsModuleState;
+        use lib_blockchain::rewards_policy::{
+            legacy_bubl_policy, policy_hash, validate_rewards_policy_value,
+        };
+
+        let policy = legacy_bubl_policy();
+        validate_rewards_policy_value(&policy).expect("legacy policy valid");
+        let policy_hash_arr = policy_hash(&policy).expect("policy hash").as_array();
+        let policy_document = serde_json::to_vec(&policy).expect("policy json");
+        let mut policy_cid_input = b"zhtp/rewards-policy/cid/v1\0".to_vec();
+        policy_cid_input.extend_from_slice(&policy_document);
+        let policy_cid = lib_crypto::hash_blake3(&policy_cid_input);
+
+        store
+            .put_rewards_module_state(
+                &actors.token_id,
+                &RewardsModuleState {
+                    spend_delegate_key_id: actors.treasury.public_key.key_id,
+                    policy_cid,
+                    policy_hash: policy_hash_arr,
+                    nonce: 0,
+                    pending_policy: None,
+                },
+            )
+            .expect("seed rewards module");
+        store
+            .put_rewards_policy_document(&policy_hash_arr, &policy_document)
+            .expect("seed policy document");
+    }
+    let setup_block = block_builders::block_at_height(1, genesis.header.block_hash);
+    store.append_block(&setup_block).expect("append setup block");
+    store.commit_block().expect("commit setup block");
+    setup_block
 }
 
 /// In-memory blockchain with treasury identity + BUBL contract, but beneficiary

--- a/lib-blockchain/tests/reward_claim_mempool_tests.rs
+++ b/lib-blockchain/tests/reward_claim_mempool_tests.rs
@@ -16,8 +16,13 @@ use common::block_builders;
 use common::reward_claim_harness::{
     mempool_blockchain, mempool_blockchain_rewards_module_without_token_contract,
     mempool_blockchain_shadow_phantom_beneficiary, mempool_blockchain_unregistered_beneficiary,
-    mempool_blockchain_unregistered_treasury, seed_executor_store, welcome_claim_tx,
+    mempool_blockchain_unregistered_treasury, seed_executor_store,
+    seed_executor_store_rewards_module_without_token_contract, welcome_claim_tx,
     welcome_claim_tx_from, RewardClaimActors,
+};
+use lib_blockchain::storage::{Address, TokenId};
+use lib_blockchain::transaction::reward_claim::{
+    expected_amount_for_event, RewardEventKind,
 };
 
 #[test]
@@ -134,7 +139,73 @@ fn rewards_module_without_token_contract_admitted_to_mempool() {
     blockchain
         .add_pending_transaction(welcome_claim_tx(&actors, 0))
         .expect("RewardClaim with rewards module + spend delegate must enter mempool");
-    assert_eq!(blockchain.get_pending_transactions().len(), 1);
+    assert_eq!(
+        blockchain.get_pending_transactions().len(),
+        1,
+        "structurally valid module-only claim must be admitted"
+    );
+}
+
+#[test]
+fn rewards_module_without_token_contract_apply_moves_beneficiary_balance() {
+    // Positive apply path for the headline BUBL AssetLaunch fix: no
+    // token_contracts row, rewards module + policy present, spend-delegate
+    // signed welcome claim credits the beneficiary.
+    let actors = RewardClaimActors::generate();
+    let temp = tempdir().expect("tempdir");
+    let store: Arc<dyn BlockchainStore> = Arc::new(
+        SledStore::open(temp.path().join("reward_claim_module_only")).expect("sled store"),
+    );
+    let executor = BlockExecutor::with_store(store.clone());
+
+    let genesis = block_builders::genesis_block();
+    executor.apply_block(&genesis).expect("apply genesis");
+
+    let setup_block =
+        seed_executor_store_rewards_module_without_token_contract(&store, &genesis, &actors);
+
+    assert!(
+        store
+            .get_token_contract(&TokenId::new(actors.token_id))
+            .expect("read contract")
+            .is_none(),
+        "fixture must omit token_contracts row"
+    );
+    assert!(
+        store
+            .get_rewards_module_state(&actors.token_id)
+            .expect("read module")
+            .is_some(),
+        "fixture must expose rewards module"
+    );
+
+    let welcome_amount = expected_amount_for_event(RewardEventKind::Welcome, 1);
+    let welcome_block = block_builders::block_at_height_with_txs(
+        2,
+        setup_block.header.block_hash,
+        vec![welcome_claim_tx(&actors, 0)],
+    );
+    executor
+        .apply_block(&welcome_block)
+        .expect("module-only welcome claim must apply");
+
+    let beneficiary = Address::new(actors.beneficiary.public_key.key_id);
+    let bal = store
+        .get_token_balance(&TokenId::new(actors.token_id), &beneficiary)
+        .expect("read beneficiary balance");
+    assert_eq!(
+        bal, welcome_amount,
+        "beneficiary must receive policy welcome amount after apply"
+    );
+
+    let welcome_key = welcome_claim_key(&actors.token_id, &actors.owner_did);
+    assert!(
+        store
+            .get_bubl_reward_welcome(&welcome_key)
+            .expect("read welcome marker")
+            .is_some(),
+        "welcome claim marker must be recorded"
+    );
 }
 
 #[test]

--- a/lib-blockchain/tests/reward_claim_mempool_tests.rs
+++ b/lib-blockchain/tests/reward_claim_mempool_tests.rs
@@ -115,10 +115,10 @@ fn recipient_key_id_mismatch_rejected_from_mempool() {
 }
 
 #[test]
-fn rewards_module_without_token_contract_rejected_from_mempool() {
-    // GENESIS-3 H=1920 halt: pure AssetLaunch writes rewards_module_state but
-    // no token_contracts row. Old mempool order checked rewards_module first and
-    // admitted the claim; apply then failed and halted consensus after BFT.
+fn rewards_module_without_token_contract_admitted_to_mempool() {
+    // Pure AssetLaunch writes rewards_module_state without a token_contracts
+    // row. Apply authorizes via spend-delegate + balance transfer (no contract
+    // object needed), so mempool must admit matching claims.
     let actors = RewardClaimActors::generate();
     let mut blockchain = mempool_blockchain_rewards_module_without_token_contract(&actors);
 
@@ -131,18 +131,10 @@ fn rewards_module_without_token_contract_rejected_from_mempool() {
         "fixture must omit token_contracts row"
     );
 
-    let err = blockchain
+    blockchain
         .add_pending_transaction(welcome_claim_tx(&actors, 0))
-        .expect_err("RewardClaim without token contract must not enter mempool");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("verification failed") || msg.contains("Invalid"),
-        "expected mempool rejection for missing token contract, got: {msg}"
-    );
-    assert!(
-        blockchain.get_pending_transactions().is_empty(),
-        "unapplyable RewardClaim must not enter mempool"
-    );
+        .expect("RewardClaim with rewards module + spend delegate must enter mempool");
+    assert_eq!(blockchain.get_pending_transactions().len(), 1);
 }
 
 #[test]

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -458,12 +458,15 @@ impl RewardsHandler {
 
         let bc = self.blockchain.read().await;
 
-        // Settlement requires a hot treasury keystore AND either a rewards
-        // module or legacy token contract. Do not advertise claimable events
-        // when plan_reward_claim / apply would fail closed.
+        // Settlement requires a hot treasury keystore, a rewards module or
+        // legacy token contract, AND a resolvable rewards policy (so amounts
+        // are non-zero and plan_reward_claim will not fail closed).
         let claims_settleable = self.treasury.is_some()
             && (bc.get_rewards_module_state(&token_id).is_some()
-                || bc.get_token_contract(&token_id).is_some());
+                || bc.get_token_contract(&token_id).is_some())
+            && bc
+                .reward_expected_amount(&token_id, RewardEventKind::Welcome, 1)
+                .is_some_and(|amt| amt > 0);
 
         let welcome_available =
             claims_settleable && !bc.reward_welcome_claimed(&token_id, did);

--- a/zhtp/src/api/handlers/rewards/mod.rs
+++ b/zhtp/src/api/handlers/rewards/mod.rs
@@ -458,7 +458,15 @@ impl RewardsHandler {
 
         let bc = self.blockchain.read().await;
 
-        let welcome_available = !bc.reward_welcome_claimed(&token_id, did);
+        // Settlement requires a hot treasury keystore AND either a rewards
+        // module or legacy token contract. Do not advertise claimable events
+        // when plan_reward_claim / apply would fail closed.
+        let claims_settleable = self.treasury.is_some()
+            && (bc.get_rewards_module_state(&token_id).is_some()
+                || bc.get_token_contract(&token_id).is_some());
+
+        let welcome_available =
+            claims_settleable && !bc.reward_welcome_claimed(&token_id, did);
         let checkin_done =
             bc.reward_daily_claimed(&token_id, &date, did, RewardEventKind::DailyCheckin);
         let streak = bc.reward_streak(&token_id, did);
@@ -497,13 +505,13 @@ impl RewardsHandler {
                     "amount_display": (welcome_amount / ATOM_18).to_string(),
                 },
                 "daily_checkin": {
-                    "available": !checkin_done,
+                    "available": claims_settleable && !checkin_done,
                     "amount_display": (checkin_amount / ATOM_18).to_string(),
                     "next_streak_day": next_streak,
                     "next_eligible_at": if checkin_done { Some(next_midnight) } else { None },
                 },
                 "active_session": {
-                    "available": !session_done,
+                    "available": claims_settleable && !session_done,
                     "amount_display": (session_amount / ATOM_18).to_string(),
                     "next_eligible_at": if session_done { Some(next_midnight) } else { None },
                 },

--- a/zhtp/src/api/handlers/rewards/settlement.rs
+++ b/zhtp/src/api/handlers/rewards/settlement.rs
@@ -105,10 +105,12 @@ pub fn plan_reward_claim(
         Ok(false) => return Err("owner_did_not_registered".into()),
         Err(_) => return Err("owner_did_not_registered".into()),
     }
-    // Apply requires a token_contracts row; rewards-module state alone is not
-    // enough (pure AssetLaunch). Fail closed here so the API never signs a claim
-    // that would pass mempool and halt consensus on block apply.
-    if bc.get_token_contract(token_id).is_none() {
+    // Apply accepts either a rewards-module asset (AssetLaunch / pure sovereign
+    // asset — no token_contracts row) or a legacy TokenContract. Fail closed
+    // only when neither is present so we never sign an un-applyable claim.
+    let has_rewards_module = bc.get_rewards_module_state(token_id).is_some();
+    let has_token_contract = bc.get_token_contract(token_id).is_some();
+    if !has_rewards_module && !has_token_contract {
         return Err("token_contract_not_found".into());
     }
     let ts = claim_unix_ts();

--- a/zhtp/src/api/handlers/rewards/settlement.rs
+++ b/zhtp/src/api/handlers/rewards/settlement.rs
@@ -105,13 +105,26 @@ pub fn plan_reward_claim(
         Ok(false) => return Err("owner_did_not_registered".into()),
         Err(_) => return Err("owner_did_not_registered".into()),
     }
-    // Apply accepts either a rewards-module asset (AssetLaunch / pure sovereign
-    // asset — no token_contracts row) or a legacy TokenContract. Fail closed
-    // only when neither is present so we never sign an un-applyable claim.
-    let has_rewards_module = bc.get_rewards_module_state(token_id).is_some();
-    let has_token_contract = bc.get_token_contract(token_id).is_some();
-    if !has_rewards_module && !has_token_contract {
-        return Err("token_contract_not_found".into());
+    // Shared ladder with apply + mempool: asset must resolve to module or
+    // legacy token contract (signer checked at submit with treasury key).
+    let spend_delegate = bc
+        .get_rewards_module_state(token_id)
+        .map(|s| s.spend_delegate_key_id);
+    let token_creator = bc
+        .get_token_contract(token_id)
+        .map(|c| c.creator.key_id);
+    if let Err(e) =
+        lib_blockchain::transaction::reward_claim::resolve_reward_claim_auth(
+            spend_delegate,
+            token_creator,
+        )
+    {
+        return Err(match e {
+            lib_blockchain::transaction::reward_claim::RewardClaimAuthError::TokenContractNotFound => {
+                "token_contract_not_found".into()
+            }
+            other => other.as_str().into(),
+        });
     }
     let ts = claim_unix_ts();
     // Map conversion failures to a stable snake_case reason for clients /
@@ -252,6 +265,20 @@ async fn submit_reward_claim(
 ) -> Result<String> {
     let nonce = {
         let bc = blockchain.read().await;
+        // Same authorize_reward_claim ladder as apply/mempool — refuse to sign
+        // if this treasury key would be soft-dropped on-chain.
+        let spend_delegate = bc
+            .get_rewards_module_state(&treasury.rewards_asset_id)
+            .map(|s| s.spend_delegate_key_id);
+        let token_creator = bc
+            .get_token_contract(&treasury.rewards_asset_id)
+            .map(|c| c.creator.key_id);
+        lib_blockchain::transaction::reward_claim::authorize_reward_claim(
+            treasury.signer_key_id,
+            spend_delegate,
+            token_creator,
+        )
+        .map_err(|e| anyhow!("reward claim signer not authorized: {}", e.as_str()))?;
         bc.token_nonce(&treasury.rewards_asset_id, &treasury.signer_key_id)
             .map_err(|e| anyhow!("nonce lookup failed: {e}"))?
     };

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -996,14 +996,16 @@ impl WalletHandler {
     }
 
     /// Reconstruct a single identity + owned wallets from chain snapshots.
+    ///
+    /// Fails closed on malformed public keys (no zero-key fallback). Wallet
+    /// balances are synced from authoritative sled/token balances (not
+    /// `initial_balance`).
     async fn hydrate_identity_from_chain(&self, identity_id: &[u8; 32]) -> Option<Identity> {
         let identity_hash = Hash(*identity_id);
-        let owner_hex = hex::encode(identity_id);
 
         let blockchain = self.blockchain.read().await;
         let identity_registry = blockchain.identity_registry_snapshot();
         let wallet_registry = blockchain.wallet_registry_snapshot();
-        drop(blockchain);
 
         let identity_data = identity_registry.values().find(|data| {
             lib_identity::did::parse_did_to_identity_id(&data.did)
@@ -1023,13 +1025,15 @@ impl WalletHandler {
             return None;
         }
 
-        let public_key = lib_crypto::PublicKey::new(
-            identity_data
-                .public_key
-                .as_slice()
-                .try_into()
-                .unwrap_or([0u8; 2592]),
-        );
+        // Fail closed: never cache a zero/forged Dilithium key.
+        let dilithium_pk: [u8; 2592] = identity_data.public_key.as_slice().try_into().ok()?;
+        let public_key = if identity_data.kyber_public_key.len() == 1568 {
+            let kyber_pk: [u8; 1568] = identity_data.kyber_public_key.as_slice().try_into().ok()?;
+            lib_crypto::PublicKey::new_with_kyber(dilithium_pk, kyber_pk)
+        } else {
+            lib_crypto::PublicKey::new(dilithium_pk)
+        };
+
         let display_name = if identity_data.display_name.is_empty() {
             None
         } else {
@@ -1053,10 +1057,12 @@ impl WalletHandler {
         identity.wallet_manager.wallets.clear();
         identity.wallet_manager.total_balance = 0;
 
+        let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
+
         for wallet_data in wallet_registry.values() {
             let owned = wallet_data
                 .owner_identity_id
-                .map(|owner| hex::encode(owner.as_bytes()) == owner_hex)
+                .map(|owner| owner.as_bytes() == identity_id.as_slice())
                 .unwrap_or(false);
             if !owned {
                 continue;
@@ -1087,10 +1093,17 @@ impl WalletHandler {
                     wallet.public_key = wallet_data.public_key.clone();
                     wallet.seed_commitment =
                         Some(hex::encode(wallet_data.seed_commitment.as_bytes()));
-                    wallet.balance = wallet_data.initial_balance;
+                    // Authoritative balance: sled/token tree for native SOV.
+                    // Do not use wallet_data.initial_balance (registration-time only).
+                    let key_id = wallet_data.wallet_id.as_array();
+                    wallet.balance = blockchain
+                        .token_balance(&sov_token_id, &key_id)
+                        .unwrap_or(0);
                 }
             }
         }
+        identity.wallet_manager.calculate_total_balance();
+        drop(blockchain);
 
         // Cache only if still missing — never overwrite live registration state.
         {

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -974,14 +974,135 @@ impl WalletHandler {
 
     // Helper functions
 
-    /// Get identity by ID from the identity manager
+    /// Get identity by ID from the identity manager, with chain-backed hydrate.
+    ///
+    /// The in-memory IdentityManager is only populated on the node that handled
+    /// registration (or a live handshake). Other validators still have the DID
+    /// in sled / wallet_registry after block apply — hydrate a read-only view
+    /// for wallet balance/list when the manager misses. Never overwrites an
+    /// existing manager entry (avoids the wallet-ownership migration bug that
+    /// forced full startup backfill to stay disabled).
     async fn get_identity_by_id(&self, identity_id: &[u8; 32]) -> Option<Identity> {
-        // Convert bytes to Hash for identity lookup
         let identity_hash = Hash(*identity_id);
 
-        // Look up in identity manager
-        let identity_manager = self.identity_manager.read().await;
-        identity_manager.get_identity(&identity_hash).cloned()
+        {
+            let identity_manager = self.identity_manager.read().await;
+            if let Some(identity) = identity_manager.get_identity(&identity_hash).cloned() {
+                return Some(identity);
+            }
+        }
+
+        self.hydrate_identity_from_chain(identity_id).await
+    }
+
+    /// Reconstruct a single identity + owned wallets from chain snapshots.
+    async fn hydrate_identity_from_chain(&self, identity_id: &[u8; 32]) -> Option<Identity> {
+        let identity_hash = Hash(*identity_id);
+        let owner_hex = hex::encode(identity_id);
+
+        let blockchain = self.blockchain.read().await;
+        let identity_registry = blockchain.identity_registry_snapshot();
+        let wallet_registry = blockchain.wallet_registry_snapshot();
+        drop(blockchain);
+
+        let identity_data = identity_registry.values().find(|data| {
+            lib_identity::did::parse_did_to_identity_id(&data.did)
+                .map(|id| id.as_bytes() == identity_id.as_slice())
+                .unwrap_or(false)
+        })?;
+
+        let identity_type = match identity_data.identity_type.to_ascii_lowercase().as_str() {
+            "human" => lib_identity::IdentityType::Human,
+            "device" => lib_identity::IdentityType::Device,
+            "organization" => lib_identity::IdentityType::Organization,
+            "agent" => lib_identity::IdentityType::Agent,
+            "contract" => lib_identity::IdentityType::Contract,
+            _ => lib_identity::IdentityType::Human,
+        };
+        if matches!(identity_type, lib_identity::IdentityType::Device) {
+            return None;
+        }
+
+        let public_key = lib_crypto::PublicKey::new(
+            identity_data
+                .public_key
+                .as_slice()
+                .try_into()
+                .unwrap_or([0u8; 2592]),
+        );
+        let display_name = if identity_data.display_name.is_empty() {
+            None
+        } else {
+            Some(identity_data.display_name.clone())
+        };
+        let mut identity = lib_identity::ZhtpIdentity::new_external(
+            identity_data.did.clone(),
+            public_key,
+            identity_type,
+            identity_data
+                .did
+                .trim_start_matches("did:zhtp:")
+                .to_string(),
+            display_name,
+            identity_data.created_at,
+        )
+        .ok()?;
+        identity.did_document_hash = Some(lib_crypto::Hash::from_bytes(
+            identity_data.did_document_hash.as_bytes(),
+        ));
+        identity.wallet_manager.wallets.clear();
+        identity.wallet_manager.total_balance = 0;
+
+        for wallet_data in wallet_registry.values() {
+            let owned = wallet_data
+                .owner_identity_id
+                .map(|owner| hex::encode(owner.as_bytes()) == owner_hex)
+                .unwrap_or(false);
+            if !owned {
+                continue;
+            }
+            let wallet_type = match wallet_data.wallet_type.to_ascii_lowercase().as_str() {
+                "primary" => lib_identity::wallets::WalletType::Primary,
+                "ubi" => lib_identity::wallets::WalletType::UBI,
+                "savings" => lib_identity::wallets::WalletType::Savings,
+                "business" => lib_identity::wallets::WalletType::Business,
+                "stealth" => lib_identity::wallets::WalletType::Stealth,
+                "dao" | "nonprofitdao" | "non_profit_dao" | "non-profit-dao" => {
+                    lib_identity::wallets::WalletType::NonProfitDAO
+                }
+                "forprofitdao" | "for_profit_dao" | "for-profit-dao" => {
+                    lib_identity::wallets::WalletType::ForProfitDAO
+                }
+                "standard" => lib_identity::wallets::WalletType::Standard,
+                _ => lib_identity::wallets::WalletType::Primary,
+            };
+            if let Ok(wallet_id) = identity.wallet_manager.add_restored_wallet(
+                &hex::encode(wallet_data.wallet_id.as_bytes()),
+                wallet_type,
+                wallet_data.created_at,
+            ) {
+                if let Some(wallet) = identity.wallet_manager.get_wallet_mut(&wallet_id) {
+                    wallet.name = wallet_data.wallet_name.clone();
+                    wallet.alias = wallet_data.alias.clone();
+                    wallet.public_key = wallet_data.public_key.clone();
+                    wallet.seed_commitment =
+                        Some(hex::encode(wallet_data.seed_commitment.as_bytes()));
+                    wallet.balance = wallet_data.initial_balance;
+                }
+            }
+        }
+
+        // Cache only if still missing — never overwrite live registration state.
+        {
+            let mut identity_manager = self.identity_manager.write().await;
+            if identity_manager.get_identity(&identity_hash).is_none() {
+                identity_manager.add_identity(identity.clone());
+            } else if let Some(existing) = identity_manager.get_identity(&identity_hash).cloned() {
+                return Some(existing);
+            }
+        }
+
+        Some(identity)
     }
 
     /// Parse wallet type string to WalletType enum


### PR DESCRIPTION
## Summary
- Allow `RewardClaim` for pure AssetLaunch assets that have a rewards module but no `token_contracts` row (apply, mempool validation, and settlement plan).
- Stop advertising claimable rewards in status when the treasury/settlement path cannot run.
- Hydrate missing identities into the wallet API from chain registry so g2/g3 return balances after registration (add-only; no overwrite of live manager state).

## Context
Live BUBL welcome claims returned `503 token_contract_not_found` because GENESIS-3 AssetLaunch never wrote a legacy token contract. Registration finalized on all validators, but wallet balance endpoints only consulted the in-memory IdentityManager on the node that handled registration.

## Test plan
- [x] `cargo test -p lib-blockchain --test reward_claim_mempool_tests` (includes rewards-module-without-contract admission)
- [x] `cargo check -p zhtp`
- [ ] Deploy binary to g1–g3 and claim BUBL welcome for a registered DID
- [ ] Confirm wallet balance for same DID on g2 and g3 after registration