### PR TITLE
feat(auth): Phase 1 wallet read privacy + principal hardening (#2935)

### DIFF
--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -2591,28 +2591,28 @@ mod principal_extraction_tests {
     }
 
     #[test]
-    fn test_extract_principal_bearer_returns_citizen() {
+    fn test_extract_principal_bearer_without_did_is_public() {
+        // #2935 Phase 1: bare Bearer must not elevate to Citizen.
         let request = request_with_header("authorization", "Bearer token123");
         let principal = extract_principal_from_request(&request);
-        assert_eq!(principal.role, Role::Citizen);
-        assert_eq!(principal.did, "did:zhtp:session");
+        assert_eq!(principal.role, Role::Public);
+        assert_eq!(principal.did, "did:zhtp:public");
     }
 
     #[test]
-    fn test_extract_principal_node_type_returns_node() {
+    fn test_extract_principal_node_type_header_not_trusted() {
+        // #2935 Phase 1: client-declared x-node-type must not yield Role::Node.
         let request = request_with_header("x-node-type", "validator");
         let principal = extract_principal_from_request(&request);
-        assert_eq!(principal.role, Role::Node);
-        assert_eq!(principal.did, "did:zhtp:node");
-        assert_eq!(principal.node_type, NodeType::Validator);
+        assert_eq!(principal.role, Role::Public);
+        assert_eq!(principal.did, "did:zhtp:public");
     }
 
     #[test]
-    fn test_extract_principal_relay_node_type() {
+    fn test_extract_principal_relay_node_type_header_not_trusted() {
         let request = request_with_header("x-node-type", "relay");
         let principal = extract_principal_from_request(&request);
-        assert_eq!(principal.role, Role::Node);
-        assert_eq!(principal.did, "did:zhtp:node");
-        assert_eq!(principal.node_type, NodeType::Relay);
+        assert_eq!(principal.role, Role::Public);
+        assert_eq!(principal.did, "did:zhtp:public");
     }
 }

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -25,7 +25,8 @@ use lib_identity::{identity::ZhtpIdentity as Identity, IdentityManager};
 
 // Access control imports
 use crate::api::principal::{
-    extract_principal_from_request, identity_id_matches_caller, parse_identity_id_bytes,
+    extract_principal_from_request, identity_id_matches_caller, may_read_wallet_subject,
+    parse_identity_id_bytes,
 };
 use lib_access_control::{AccessDomain, AccessOperation, SecurityPrincipal};
 
@@ -254,6 +255,73 @@ struct TransactionRecord {
 }
 
 impl WalletHandler {
+    /// Soft-privacy empty list when principal may not read subject wallets (#2935 Phase 1).
+    fn denied_wallet_list_response(identity_id: &str) -> Result<ZhtpResponse> {
+        create_json_response(json!({
+            "status": "success",
+            "identity_id": identity_id,
+            "total_wallets": 0,
+            "total_balance": "0",
+            "wallets": []
+        }))
+    }
+
+    /// Soft-privacy zero balance when principal may not read subject wallets.
+    fn denied_wallet_balance_response(
+        wallet_type_str: &str,
+        identity_id: &str,
+    ) -> Result<ZhtpResponse> {
+        create_json_response(json!({
+            "status": "success",
+            "wallet_type": wallet_type_str,
+            "identity_id": identity_id,
+            "balance": {
+                "available_balance": "0",
+                "staked_balance": "0",
+                "pending_rewards": "0",
+                "total_balance": "0"
+            },
+            "permissions": {
+                "can_transfer_external": false,
+                "can_vote": false,
+                "can_stake": false,
+                "can_receive_rewards": false,
+                "daily_transaction_limit": 0,
+                "requires_multisig_threshold": null
+            },
+            "created_at": 0
+        }))
+    }
+
+    /// Soft-privacy empty statistics when principal may not read subject wallets.
+    fn denied_wallet_statistics_response(identity_id: &str) -> Result<ZhtpResponse> {
+        create_json_response(json!({
+            "status": "success",
+            "identity_id": identity_id,
+            "statistics": {
+                "identity": null,
+                "total_balance": "0",
+                "wallet_count": 0,
+                "wallet_statistics": {},
+                "cross_wallet_transactions": 0,
+                "blockchain_context": {
+                    "current_height": 0,
+                    "is_synced": true,
+                    "peer_count": 0
+                }
+            }
+        }))
+    }
+
+    /// Soft-privacy empty history when principal may not read subject wallets.
+    fn denied_wallet_transactions_response(identity_id: &str) -> Result<ZhtpResponse> {
+        create_json_response(json!({
+            "identity_id": identity_id,
+            "total_transactions": 0,
+            "transactions": []
+        }))
+    }
+
     /// List all wallets for an identity
     async fn handle_list_wallets(
         &self,
@@ -266,8 +334,20 @@ impl WalletHandler {
         };
         let identity_hash = Hash(identity_id_bytes);
 
-        // TODO: Gate cross-identity wallet list once mobile app is updated.
-        // For now, return full data to maintain backward compatibility.
+        // #2935 Phase 1: cross-identity wallet list is soft-denied (200 + empty).
+        let principal = self.extract_principal(request);
+        if !may_read_wallet_subject(&principal, identity_id) {
+            tracing::info!(
+                target: "access_control",
+                principal_did = %principal.did,
+                principal_role = ?principal.role,
+                subject = %identity_id,
+                domain = "WalletGraph",
+                op = "Enumerate",
+                "wallet list denied (soft privacy)"
+            );
+            return Self::denied_wallet_list_response(identity_id);
+        }
 
         // The in-memory identity_manager is an optional fast-path for the rich
         // Identity object (it carries the WalletManager with staked/pending
@@ -468,8 +548,20 @@ impl WalletHandler {
         };
         let identity_hash = Hash(identity_id_bytes);
 
-        // TODO: Gate cross-identity balance once mobile app is updated.
-        // For now, return full data to maintain backward compatibility.
+        // #2935 Phase 1: cross-identity balance is soft-denied (200 + zeros).
+        let principal = self.extract_principal(request);
+        if !may_read_wallet_subject(&principal, identity_id) {
+            tracing::info!(
+                target: "access_control",
+                principal_did = %principal.did,
+                principal_role = ?principal.role,
+                subject = %identity_id,
+                domain = "WalletGraph",
+                op = "Read",
+                "wallet balance denied (soft privacy)"
+            );
+            return Self::denied_wallet_balance_response(wallet_type_str, identity_id);
+        }
 
         // Get the identity from stored state
         let identity = match self.get_identity_by_id(&identity_id_bytes).await {
@@ -603,8 +695,20 @@ impl WalletHandler {
         };
         let identity_hash = Hash(identity_id_bytes);
 
-        // TODO: Gate cross-identity statistics once mobile app is updated.
-        // For now, return full data to maintain backward compatibility.
+        // #2935 Phase 1: cross-identity statistics soft-denied (200 + empty).
+        let principal = self.extract_principal(request);
+        if !may_read_wallet_subject(&principal, identity_id) {
+            tracing::info!(
+                target: "access_control",
+                principal_did = %principal.did,
+                principal_role = ?principal.role,
+                subject = %identity_id,
+                domain = "WalletGraph",
+                op = "Read",
+                "wallet statistics denied (soft privacy)"
+            );
+            return Self::denied_wallet_statistics_response(identity_id);
+        }
 
         // Get the identity from stored state
         let identity = match self.get_identity_by_id(&identity_id_bytes).await {
@@ -1362,9 +1466,21 @@ impl WalletHandler {
         };
         let identity_hash = Hash(identity_id_bytes);
 
-        // Graph-traversal guard: WalletGraph / Read
-        // TODO: Gate cross-identity transaction history once mobile app is updated.
-        // For now, return full data to maintain backward compatibility.
+        // #2935 Phase 1: cross-identity history soft-denied (200 + empty).
+        // Tx-involvement expansion for non-owners is deferred (no balance leak).
+        let principal = self.extract_principal(request);
+        if !may_read_wallet_subject(&principal, identity_id) {
+            tracing::info!(
+                target: "access_control",
+                principal_did = %principal.did,
+                principal_role = ?principal.role,
+                subject = %identity_id,
+                domain = "WalletGraph",
+                op = "Read",
+                "wallet transactions denied (soft privacy)"
+            );
+            return Self::denied_wallet_transactions_response(identity_id);
+        }
 
         // The in-memory identity_manager is an optional fast-path only; a miss
         // must not hide on-chain transaction history. Fall through to the

--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -3,7 +3,12 @@
 /// Parse `identity_id` from API paths or JSON — accepts canonical `did:zhtp:<64-hex>` or raw 64-char hex.
 #[cfg(test)]
 mod tests {
-    use super::parse_identity_id_bytes;
+    use super::{
+        identity_id_matches_caller, may_read_wallet_subject, parse_identity_id_bytes,
+        wallet_read_privacy_enforced,
+    };
+    use lib_access_control::{Role, SecurityPrincipal};
+    use lib_types::NodeType;
 
     #[test]
     fn parse_raw_hex_identity() {
@@ -18,6 +23,48 @@ mod tests {
         let did = format!("did:zhtp:{hex}");
         let bytes = parse_identity_id_bytes(&did).unwrap();
         assert_eq!(hex::encode(bytes), hex);
+    }
+
+    #[test]
+    fn identity_id_matches_did_prefix() {
+        let hex = "59e07e17556e2955581443538839d576974e4f8a9af424c0a2cc7df79c995c9d";
+        assert!(identity_id_matches_caller(hex, &format!("did:zhtp:{hex}")));
+        assert!(identity_id_matches_caller(
+            &format!("did:zhtp:{hex}"),
+            &format!("did:zhtp:{hex}")
+        ));
+        assert!(!identity_id_matches_caller(hex, "did:zhtp:deadbeef"));
+    }
+
+    #[test]
+    fn wallet_read_privacy_default_on() {
+        // Default when env unset: enforced. Do not mutate process env in parallel tests.
+        let _ = wallet_read_privacy_enforced();
+    }
+
+    #[test]
+    fn may_read_wallet_self_and_council() {
+        let hex = "59e07e17556e2955581443538839d576974e4f8a9af424c0a2cc7df79c995c9d";
+        let self_p = SecurityPrincipal::new(
+            format!("did:zhtp:{hex}"),
+            Role::Citizen,
+            NodeType::FullNode,
+        );
+        let other = SecurityPrincipal::new(
+            "did:zhtp:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            Role::Citizen,
+            NodeType::FullNode,
+        );
+        let council = SecurityPrincipal::new("did:zhtp:council", Role::Council, NodeType::FullNode);
+        let public = SecurityPrincipal::public();
+
+        // When privacy is on (default), self OK, other denied, council OK, public denied.
+        if wallet_read_privacy_enforced() {
+            assert!(may_read_wallet_subject(&self_p, hex));
+            assert!(!may_read_wallet_subject(&other, hex));
+            assert!(may_read_wallet_subject(&council, hex));
+            assert!(!may_read_wallet_subject(&public, hex));
+        }
     }
 }
 
@@ -54,29 +101,24 @@ use lib_types::NodeType;
 ///
 /// This is the canonical integration point used across all API handlers.
 /// Authenticated DIDs are checked against the on-chain council member list
-/// to assign `Role::Council` vs `Role::Citizen`. The membership check reads a
-/// sync-warmed council cache first (see `BlockchainProvider::is_council_member_blocking`),
-/// so it is safe to call **before** acquiring a `blockchain.read()` guard.
+/// (and optional ops allowlist) to assign `Role::Council` / `InfraAdmin` /
+/// `Citizen`. The membership check reads a sync-warmed council cache first
+/// (see `BlockchainProvider::is_council_member_blocking`), so it is safe to
+/// call **before** acquiring a `blockchain.read()` guard.
 ///
 /// **Handler invariant (deadlock):** `extract_principal_from_request` must run
 /// before any `blockchain.read().await` / `write().await` on the global chain.
 /// Tokio `RwLock` is not re-entrant; a nested read on the same task deadlocks.
-/// Council-gated handlers audited in this PR (all extract principal first):
-/// - `network/mod.rs` — halt-consensus
-/// - `notifications/mod.rs` — subscriber list
-/// - `blockchain/mod.rs` — export/import chain, list wallets (Council bypass paths)
-/// - `dao/mod.rs` — council register, entity-registry init
-/// - `wallet/mod.rs` — cross-wallet transfer, stake/unstake, simple send (Council bypass)
+///
+/// **Phase 1 (#2935):** do not trust client-declared `x-node-type` or elevate
+/// bare Bearer tokens to `Role::Citizen`. Without a bound DID, the principal
+/// is `Public`.
 ///
 /// Mobile clients sign QUIC bytes with a per-device Dilithium key
 /// (`53c47662…`) which is *different by design* from the user's canonical
 /// chain DID (`e0b97576…`); the OPAQUE login flow binds the two in the
-/// in-memory `SessionManager` map (see PR #2626). The previous version of
-/// this function turned `request.requester.0` directly into
-/// `did:zhtp:<device-key-hex>` — the device-DID — which made every
-/// owner-gated endpoint 403 even immediately after a successful OPAQUE
-/// login. We now consult the binding first and only fall back to the raw
-/// device DID when no binding exists (i.e. pre-OPAQUE-login traffic).
+/// in-memory `SessionManager` map (see PR #2626). We consult the binding
+/// first and only fall back to the raw device DID when no binding exists.
 pub fn extract_principal_from_request(request: &ZhtpRequest) -> SecurityPrincipal {
     // If the transport/session layer has already authenticated the caller
     // and set request.requester, use that DID directly.
@@ -87,46 +129,98 @@ pub fn extract_principal_from_request(request: &ZhtpRequest) -> SecurityPrincipa
         return SecurityPrincipal::new(&did, role, NodeType::FullNode);
     }
 
-    // Node-to-node calls may declare their node type.
-    // TODO: in production this should come from authenticated UHP context,
-    // not from caller-controlled headers.
-    if let Some(node_type_str) = request.headers.get("x-node-type") {
-        let node_type = NodeType::from_config(Some(&node_type_str));
-        return SecurityPrincipal::new("did:zhtp:node", Role::Node, node_type);
-    }
+    // Client-declared NodeType is spoofable. Fail closed: treat as Public
+    // until node attestation / authenticated UHP context is wired (Phase 3).
+    // Do not assign Role::Node from x-node-type alone.
+    let _ignored_spoofable_node_type = request.headers.get("x-node-type");
 
-    // Authenticated sessions (placeholder: any bearer token is treated as
-    // a citizen session until full session-to-principal mapping is wired).
-    if let Some(auth) = request.headers.get("authorization") {
-        if auth.to_lowercase().starts_with("bearer ") {
-            return SecurityPrincipal::new(
-                "did:zhtp:session",
-                Role::Citizen,
-                NodeType::FullNode,
-            );
-        }
-    }
+    // Bearer without a bound DID must not become a fake Citizen session.
+    // Session→DID mapping is the requester path above (or future session map).
+    let _ignored_unbound_bearer = request
+        .headers
+        .get("authorization")
+        .map(|a| a.to_lowercase().starts_with("bearer "))
+        .unwrap_or(false);
 
     // Default: unauthenticated public caller.
     SecurityPrincipal::public()
 }
 
-/// Determine the role for an authenticated DID by checking on-chain state.
+/// Env-configured ops allowlist for `Role::InfraAdmin` (comma-separated DIDs).
+/// Example: `ZHTP_INFRA_ADMIN_DIDS=did:zhtp:abc...,did:zhtp:def...`
+pub fn infra_admin_dids_from_env() -> Vec<String> {
+    std::env::var("ZHTP_INFRA_ADMIN_DIDS")
+        .ok()
+        .map(|s| {
+            s.split(',')
+                .map(str::trim)
+                .filter(|d| !d.is_empty())
+                .map(|d| d.to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// True when wallet read privacy filters are enforced (default: on).
+/// Set `ZHTP_ENFORCE_WALLET_READ_PRIVACY=0` / `false` / `off` to disable
+/// (emergency rollback only).
+pub fn wallet_read_privacy_enforced() -> bool {
+    match std::env::var("ZHTP_ENFORCE_WALLET_READ_PRIVACY") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+        Err(_) => true,
+    }
+}
+
+/// Whether `principal` may read wallet graph data for `subject_identity_id`
+/// (raw hex or `did:zhtp:`). Soft-privacy path: callers return empty/zero
+/// bodies on deny rather than 403.
+pub fn may_read_wallet_subject(principal: &SecurityPrincipal, subject_identity_id: &str) -> bool {
+    use lib_access_control::Role;
+    if !wallet_read_privacy_enforced() {
+        return true;
+    }
+    match principal.role {
+        Role::Council | Role::InfraAdmin | Role::System => true,
+        Role::Citizen | Role::Device | Role::PolicyAdmin | Role::Emergency | Role::Node => {
+            identity_id_matches_caller(subject_identity_id, &principal.did)
+        }
+        Role::Public => false,
+    }
+}
+
+/// Determine the role for an authenticated DID by checking on-chain state
+/// and the optional ops allowlist.
 ///
-/// Council members get `Role::Council`, everyone else gets `Role::Citizen`.
+/// Priority: Council > InfraAdmin (env) > Citizen.
 /// Checks canonical and transport DIDs — council config uses `did:zhtp:…` while
 /// QUIC `requester` may encode only the 32-byte key id.
 fn resolve_role_for_dids(dids: &[&str]) -> Role {
-    let provider = match crate::runtime::blockchain_provider::get_global_blockchain_provider() {
-        Some(p) => p,
-        None => return Role::Citizen,
-    };
+    let provider = crate::runtime::blockchain_provider::get_global_blockchain_provider();
 
-    for did in dids {
-        if provider.is_council_member_blocking(did) == Some(true) {
-            return Role::Council;
+    if let Some(ref provider) = provider {
+        for did in dids {
+            if provider.is_council_member_blocking(did) == Some(true) {
+                return Role::Council;
+            }
         }
     }
+
+    let infra = infra_admin_dids_from_env();
+    if !infra.is_empty() {
+        for did in dids {
+            let did_hex = did.strip_prefix("did:zhtp:").unwrap_or(did);
+            if infra.iter().any(|admin| {
+                let admin_hex = admin.strip_prefix("did:zhtp:").unwrap_or(admin);
+                admin == *did || admin_hex == did_hex
+            }) {
+                return Role::InfraAdmin;
+            }
+        }
+    }
+
     Role::Citizen
 }
 

--- a/zhtp/src/server/mesh/identity_api.rs
+++ b/zhtp/src/server/mesh/identity_api.rs
@@ -22,7 +22,6 @@ use crate::api::handlers::constants::SOV_WELCOME_BONUS;
 use crate::session_manager::SessionManager;
 use lib_access_control::{Role, SecurityPrincipal};
 use lib_identity::IdentityManager;
-use lib_types::NodeType;
 
 /// Safe string truncation for display (avoids panic on short strings)
 #[inline]
@@ -46,29 +45,11 @@ pub fn parse_mesh_request(mesh_data: &serde_json::Value) -> Result<MeshZhtpReque
 
 /// Extract a SecurityPrincipal from a mesh request context.
 ///
-/// Mesh requests default to Node role since they traverse the peer mesh.
-/// If the wrapped ZHTP request contains an authorization bearer token,
-/// we treat it as a citizen session (placeholder until full cert parsing).
+/// #2935 Phase 1: do not elevate bare Bearer to Citizen or trust client
+/// `x-node-type` alone. Unauthenticated mesh traffic is `Public` until
+/// peer attestation / bound DID is available.
 fn extract_mesh_principal(zhtp_request: &serde_json::Value) -> SecurityPrincipal {
-    if let Some(headers) = zhtp_request.get("headers") {
-        if let Some(auth) = headers.get("authorization").and_then(|v| v.as_str()) {
-            if auth.to_lowercase().starts_with("bearer ") {
-                return SecurityPrincipal::new(
-                    "did:zhtp:session",
-                    Role::Citizen,
-                    NodeType::FullNode,
-                );
-            }
-        }
-        if let Some(node_type) = headers.get("x-node-type").and_then(|v| v.as_str()) {
-            return SecurityPrincipal::new(
-                "did:zhtp:node",
-                Role::Node,
-                NodeType::from_config(Some(node_type)),
-            );
-        }
-    }
-    // Default: unauthenticated mesh traffic is treated as public.
+    let _ = zhtp_request; // headers intentionally not trusted for role elevation
     SecurityPrincipal::public()
 }
 


### PR DESCRIPTION
## Summary

Implements **#2935 Phase 1** (stacked on ADR PR #2936).

- **Wallet read soft-privacy**: list / balance / statistics / transactions return 200 + empty/zero for non-self, non-Council/InfraAdmin callers (no balance leak).
- **Principal hardening**: bare Bearer no longer elevates to `Role::Citizen`; client `x-node-type` no longer yields `Role::Node`.
- **Helpers**: `may_read_wallet_subject`, `wallet_read_privacy_enforced` (`ZHTP_ENFORCE_WALLET_READ_PRIVACY`, default on), early `ZHTP_INFRA_ADMIN_DIDS` role assignment.
- Mesh identity principal path aligned (no spoof elevation).

## Stack

1. #2936 ADR (base)
2. **This PR** — Phase 1
3. Phase 2 → Phase 3 (follow-on)

## Test plan

- [x] `cargo test -p zhtp --lib principal_extraction_tests`
- [x] `cargo test -p zhtp --lib api::principal::tests`
- [x] `cargo check -p zhtp --lib`
- [ ] Reviewer: self-DID still sees own wallets; cross-identity empty; Council full; send still owner-gated 403

## Do not merge until

Morning review of the full epic stack. **Do not merge this PR alone without ADR base.**

Implements #2935 Phase 1.