### PR TITLE
feat(auth): Phase 2 InfraAdmin ops, audit logs, CI matrix (#2935)

### DIFF
--- a/docs/arch/authorization-bootstrap-adr.md
+++ b/docs/arch/authorization-bootstrap-adr.md
@@ -83,6 +83,15 @@ Device QUIC key → canonical DID binding remains required for owner-gated endpo
 3. Structured access-decision logging (denies INFO).
 4. Subset of E2E matrix in CI.
 
+**Ops note — `ZHTP_INFRA_ADMIN_DIDS` is consensus-critical.** Comma-separated
+DIDs that receive `Role::InfraAdmin`. Blast radius after Phase 2: halt consensus
+(network DoS), full chain export (exfiltration), chain import, wallet provision,
+and cross-user wallet read (Phase 1). Treat the variable as secret-grade
+allowlist config; log the granted DIDs at node startup (`access_control` target).
+Bootstrap keeps **export under Council | InfraAdmin** so ops can recover nodes
+without Council keys; Phase 3 may tighten export to Council-only or ScopedGrant
+if product policy requires a higher bar.
+
 #### Phase 3 — Mature access
 
 1. **ScopedGrant**: council-issued, scoped, expiring; remove `Role::System` bypass.

--- a/lib-access-control/src/lib.rs
+++ b/lib-access-control/src/lib.rs
@@ -15,6 +15,9 @@ pub mod policy;
 pub mod principal;
 pub mod types;
 
+#[cfg(test)]
+mod matrix_tests;
+
 pub use decision::{AccessDecision, ReasonCode};
 pub use policy::AccessPolicy;
 pub use principal::SecurityPrincipal;

--- a/lib-access-control/src/matrix_tests.rs
+++ b/lib-access-control/src/matrix_tests.rs
@@ -1,0 +1,335 @@
+//! CI policy matrix: Role × SubjectRelation × AccessDomain × AccessOperation.
+//!
+//! Snapshot expectations so policy changes are intentional (#2935 Phase 2).
+//! Default DENY for unmatched combinations is covered by the matrix rows that
+//! assert denial.
+
+#![cfg(test)]
+
+use crate::policy::AccessPolicy;
+use crate::principal::SecurityPrincipal;
+use crate::types::{
+    AccessDomain, AccessOperation, Capability, Role, SubjectRelation,
+};
+use lib_types::NodeType;
+
+fn p(role: Role) -> SecurityPrincipal {
+    SecurityPrincipal::new("did:zhtp:matrix", role, NodeType::FullNode)
+}
+
+fn allow(
+    policy: &AccessPolicy,
+    role: Role,
+    rel: SubjectRelation,
+    domain: AccessDomain,
+    op: AccessOperation,
+) {
+    assert!(
+        policy.check_access(&p(role), rel, domain, op).is_allowed(),
+        "expected Allow for {:?} {:?} {:?} {:?}",
+        role,
+        rel,
+        domain,
+        op
+    );
+}
+
+fn deny(
+    policy: &AccessPolicy,
+    role: Role,
+    rel: SubjectRelation,
+    domain: AccessDomain,
+    op: AccessOperation,
+) {
+    assert!(
+        policy.check_access(&p(role), rel, domain, op).is_denied(),
+        "expected Deny for {:?} {:?} {:?} {:?}",
+        role,
+        rel,
+        domain,
+        op
+    );
+}
+
+#[test]
+fn matrix_citizen_self_wallet_and_core() {
+    let policy = AccessPolicy;
+    allow(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::Self_,
+        AccessDomain::WalletGraph,
+        AccessOperation::Read,
+    );
+    allow(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::Self_,
+        AccessDomain::WalletGraph,
+        AccessOperation::Enumerate,
+    );
+    allow(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::Self_,
+        AccessDomain::CoreIdentity,
+        AccessOperation::Read,
+    );
+    deny(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::Self_,
+        AccessDomain::ZkProofPrivate,
+        AccessOperation::Read,
+    );
+}
+
+#[test]
+fn matrix_citizen_external_no_wallet() {
+    let policy = AccessPolicy;
+    allow(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::External,
+        AccessDomain::CoreIdentity,
+        AccessOperation::Read,
+    );
+    deny(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::External,
+        AccessDomain::WalletGraph,
+        AccessOperation::Read,
+    );
+    deny(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::External,
+        AccessDomain::WalletGraph,
+        AccessOperation::Enumerate,
+    );
+    deny(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::External,
+        AccessDomain::WalletGraph,
+        AccessOperation::Traverse,
+    );
+    deny(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::External,
+        AccessDomain::UbiData,
+        AccessOperation::Read,
+    );
+    deny(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::External,
+        AccessDomain::Governance,
+        AccessOperation::Read,
+    );
+}
+
+#[test]
+fn matrix_public_minimal() {
+    let policy = AccessPolicy;
+    allow(
+        &policy,
+        Role::Public,
+        SubjectRelation::Public,
+        AccessDomain::CoreIdentity,
+        AccessOperation::Resolve,
+    );
+    deny(
+        &policy,
+        Role::Public,
+        SubjectRelation::Public,
+        AccessDomain::WalletGraph,
+        AccessOperation::Read,
+    );
+    deny(
+        &policy,
+        Role::Public,
+        SubjectRelation::Public,
+        AccessDomain::Governance,
+        AccessOperation::Read,
+    );
+    deny(
+        &policy,
+        Role::Public,
+        SubjectRelation::Public,
+        AccessDomain::NodeGraph,
+        AccessOperation::Traverse,
+    );
+}
+
+#[test]
+fn matrix_council_bootstrap_audit() {
+    let policy = AccessPolicy;
+    allow(
+        &policy,
+        Role::Council,
+        SubjectRelation::External,
+        AccessDomain::WalletGraph,
+        AccessOperation::Read,
+    );
+    allow(
+        &policy,
+        Role::Council,
+        SubjectRelation::External,
+        AccessDomain::Governance,
+        AccessOperation::Read,
+    );
+    allow(
+        &policy,
+        Role::Council,
+        SubjectRelation::External,
+        AccessDomain::NodeGraph,
+        AccessOperation::Traverse,
+    );
+    deny(
+        &policy,
+        Role::Council,
+        SubjectRelation::External,
+        AccessDomain::ZkProofPrivate,
+        AccessOperation::Read,
+    );
+}
+
+#[test]
+fn matrix_infra_admin_not_god_mode() {
+    let policy = AccessPolicy;
+    allow(
+        &policy,
+        Role::InfraAdmin,
+        SubjectRelation::Self_,
+        AccessDomain::WalletGraph,
+        AccessOperation::Read,
+    );
+    allow(
+        &policy,
+        Role::InfraAdmin,
+        SubjectRelation::External,
+        AccessDomain::NodeGraph,
+        AccessOperation::Traverse,
+    );
+    allow(
+        &policy,
+        Role::InfraAdmin,
+        SubjectRelation::External,
+        AccessDomain::CoreIdentity,
+        AccessOperation::Read,
+    );
+    deny(
+        &policy,
+        Role::InfraAdmin,
+        SubjectRelation::External,
+        AccessDomain::WalletGraph,
+        AccessOperation::Read,
+    );
+    deny(
+        &policy,
+        Role::InfraAdmin,
+        SubjectRelation::External,
+        AccessDomain::ZkProofPrivate,
+        AccessOperation::Read,
+    );
+}
+
+#[test]
+fn matrix_policy_admin_governance_only() {
+    let policy = AccessPolicy;
+    allow(
+        &policy,
+        Role::PolicyAdmin,
+        SubjectRelation::External,
+        AccessDomain::Governance,
+        AccessOperation::Read,
+    );
+    deny(
+        &policy,
+        Role::PolicyAdmin,
+        SubjectRelation::External,
+        AccessDomain::WalletGraph,
+        AccessOperation::Read,
+    );
+    deny(
+        &policy,
+        Role::PolicyAdmin,
+        SubjectRelation::External,
+        AccessDomain::NodeGraph,
+        AccessOperation::Traverse,
+    );
+}
+
+#[test]
+fn matrix_delegate_requires_capability() {
+    let policy = AccessPolicy;
+    deny(
+        &policy,
+        Role::Citizen,
+        SubjectRelation::Delegate,
+        AccessDomain::WalletGraph,
+        AccessOperation::Read,
+    );
+    let with_cap = p(Role::Citizen).with_capability(Capability::ReadBalance);
+    assert!(policy
+        .check_access(
+            &with_cap,
+            SubjectRelation::Delegate,
+            AccessDomain::WalletGraph,
+            AccessOperation::Read,
+        )
+        .is_allowed());
+}
+
+#[test]
+fn matrix_default_deny_unknown_role_path() {
+    // System is the only god-mode path today; Public without matching domain is deny.
+    let policy = AccessPolicy;
+    deny(
+        &policy,
+        Role::Public,
+        SubjectRelation::Public,
+        AccessDomain::PrivateDataRef,
+        AccessOperation::Read,
+    );
+}
+
+/// Perf budget: single check_access should be well under 1ms (#328 / #2935 Phase 2).
+#[test]
+fn check_access_perf_budget_under_1ms_average() {
+    let policy = AccessPolicy;
+    let principal = p(Role::Citizen);
+    let iters = 50_000u32;
+    let start = std::time::Instant::now();
+    for _ in 0..iters {
+        let _ = policy.check_access(
+            &principal,
+            SubjectRelation::External,
+            AccessDomain::WalletGraph,
+            AccessOperation::Read,
+        );
+        let _ = policy.check_access(
+            &principal,
+            SubjectRelation::Self_,
+            AccessDomain::CoreIdentity,
+            AccessOperation::Read,
+        );
+        let _ = policy.check_access(
+            &SecurityPrincipal::public(),
+            SubjectRelation::Public,
+            AccessDomain::CoreIdentity,
+            AccessOperation::Resolve,
+        );
+    }
+    let elapsed = start.elapsed();
+    let avg_ns = elapsed.as_nanos() / (iters as u128 * 3);
+    // 1ms = 1_000_000 ns. Allow headroom on slow CI; still fail if pathological.
+    assert!(
+        avg_ns < 1_000_000,
+        "avg check_access {avg_ns}ns exceeds 1ms budget (total {:?})",
+        elapsed
+    );
+}

--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -2642,8 +2642,19 @@ impl BlockchainHandler {
     /// Export entire blockchain for sync
     async fn handle_export_chain(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
         let principal = self.extract_principal(&request);
-        if principal.role != lib_access_control::Role::Council && principal.role != lib_access_control::Role::System {
-            return Ok(ZhtpResponse::error(ZhtpStatus::Forbidden, "Chain export requires Council role".to_string()));
+        if !crate::api::principal::is_ops_elevated(&principal) {
+            crate::api::principal::log_access_decision(
+                &principal,
+                "blockchain",
+                "Ops",
+                "ExportChain",
+                false,
+                "requires Council or InfraAdmin",
+            );
+            return Ok(ZhtpResponse::error(
+                ZhtpStatus::Forbidden,
+                "Chain export requires Council or InfraAdmin role".to_string(),
+            ));
         }
         let blockchain_arc = self
             .get_blockchain()
@@ -2666,8 +2677,19 @@ impl BlockchainHandler {
     /// Import blockchain from another node
     async fn handle_import_chain(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
         let principal = self.extract_principal(&request);
-        if principal.role != lib_access_control::Role::Council && principal.role != lib_access_control::Role::System {
-            return Ok(ZhtpResponse::error(ZhtpStatus::Forbidden, "Chain import requires Council role".to_string()));
+        if !crate::api::principal::is_ops_elevated(&principal) {
+            crate::api::principal::log_access_decision(
+                &principal,
+                "blockchain",
+                "Ops",
+                "ImportChain",
+                false,
+                "requires Council or InfraAdmin",
+            );
+            return Ok(ZhtpResponse::error(
+                ZhtpStatus::Forbidden,
+                "Chain import requires Council or InfraAdmin role".to_string(),
+            ));
         }
         // Validate that body is not empty
         if request.body.is_empty() {

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1037,14 +1037,21 @@ impl NetworkHandler {
         Ok(ZhtpResponse::json(&response, None)?)
     }
 
-    /// POST /api/v1/node/halt-consensus — coordinated consensus halt (Council only)
+    /// POST /api/v1/node/halt-consensus — coordinated consensus halt (Council | InfraAdmin)
     async fn handle_halt_consensus(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
-        // Council-only gate
         let principal = crate::api::principal::extract_principal_from_request(&request);
-        if principal.role != lib_access_control::Role::Council {
+        if !crate::api::principal::is_ops_elevated(&principal) {
+            crate::api::principal::log_access_decision(
+                &principal,
+                "node",
+                "Ops",
+                "HaltConsensus",
+                false,
+                "requires Council or InfraAdmin",
+            );
             return Ok(ZhtpResponse::error(
                 ZhtpStatus::Forbidden,
-                "Consensus halt requires Council role".to_string(),
+                "Consensus halt requires Council or InfraAdmin role".to_string(),
             ));
         }
 

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -1732,12 +1732,18 @@ impl WalletHandler {
     /// - Provisioning wallets for observed-only identities
     async fn handle_provision_wallet(&self, request: ZhtpRequest) -> Result<ZhtpResponse> {
         let principal = self.extract_principal(&request);
-        if principal.role != lib_access_control::Role::Council
-            && principal.role != lib_access_control::Role::System
-        {
+        if !crate::api::principal::is_ops_elevated(&principal) {
+            crate::api::principal::log_access_decision(
+                &principal,
+                "wallet",
+                "Ops",
+                "ProvisionWallet",
+                false,
+                "requires Council or InfraAdmin",
+            );
             return Ok(create_error_response(
                 ZhtpStatus::Forbidden,
-                "Wallet provisioning requires council authorization".to_string(),
+                "Wallet provisioning requires Council or InfraAdmin authorization".to_string(),
             ));
         }
 

--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -191,6 +191,50 @@ pub fn may_read_wallet_subject(principal: &SecurityPrincipal, subject_identity_i
     }
 }
 
+/// Ops surfaces (halt, export/import, provision): Council or InfraAdmin.
+/// `System` remains accepted until Phase 3 removes god-mode.
+pub fn is_ops_elevated(principal: &SecurityPrincipal) -> bool {
+    use lib_access_control::Role;
+    matches!(
+        principal.role,
+        Role::Council | Role::InfraAdmin | Role::System
+    )
+}
+
+/// Structured access-decision audit log (#2935 Phase 2). Denies at INFO.
+pub fn log_access_decision(
+    principal: &SecurityPrincipal,
+    subject: &str,
+    domain: &str,
+    op: &str,
+    allowed: bool,
+    reason: &str,
+) {
+    if allowed {
+        tracing::debug!(
+            target: "access_control",
+            principal_did = %principal.did,
+            principal_role = ?principal.role,
+            subject = %subject,
+            domain = %domain,
+            op = %op,
+            reason = %reason,
+            "access allow"
+        );
+    } else {
+        tracing::info!(
+            target: "access_control",
+            principal_did = %principal.did,
+            principal_role = ?principal.role,
+            subject = %subject,
+            domain = %domain,
+            op = %op,
+            reason = %reason,
+            "access deny"
+        );
+    }
+}
+
 /// Determine the role for an authenticated DID by checking on-chain state
 /// and the optional ops allowlist.
 ///

--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -147,6 +147,12 @@ pub fn extract_principal_from_request(request: &ZhtpRequest) -> SecurityPrincipa
 }
 
 /// Env-configured ops allowlist for `Role::InfraAdmin` (comma-separated DIDs).
+///
+/// **Consensus-critical.** Holders get Phase 2 ops: halt consensus, full chain
+/// export/import, wallet provision, plus cross-user wallet read (Phase 1).
+/// Treat like a secret-grade allowlist: typos/leaks enable network DoS and
+/// full-chain exfiltration. See ADR `docs/arch/authorization-bootstrap-adr.md`.
+///
 /// Example: `ZHTP_INFRA_ADMIN_DIDS=did:zhtp:abc...,did:zhtp:def...`
 pub fn infra_admin_dids_from_env() -> Vec<String> {
     std::env::var("ZHTP_INFRA_ADMIN_DIDS")
@@ -159,6 +165,26 @@ pub fn infra_admin_dids_from_env() -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Log configured InfraAdmin DIDs once at process start so operators can see
+/// who holds halt/export/import/provision rights. Safe: DIDs are public ids.
+pub fn log_infra_admin_config_at_startup() {
+    let dids = infra_admin_dids_from_env();
+    if dids.is_empty() {
+        tracing::info!(
+            target: "access_control",
+            count = 0u32,
+            "ZHTP_INFRA_ADMIN_DIDS unset/empty — no env InfraAdmin; Council-only for ops elevation"
+        );
+    } else {
+        tracing::info!(
+            target: "access_control",
+            count = dids.len(),
+            infra_admin_dids = ?dids,
+            "ZHTP_INFRA_ADMIN_DIDS grants InfraAdmin (halt/export/import/provision + wallet read)"
+        );
+    }
 }
 
 /// True when wallet read privacy filters are enforced (default: on).
@@ -192,7 +218,10 @@ pub fn may_read_wallet_subject(principal: &SecurityPrincipal, subject_identity_i
 }
 
 /// Ops surfaces (halt, export/import, provision): Council or InfraAdmin.
-/// `System` remains accepted until Phase 3 removes god-mode.
+///
+/// `Role::System` is included for internal/policy compatibility until Phase 3
+/// removes god-mode, but it is **inert for HTTP**: `extract_principal_from_request`
+/// only yields Council / InfraAdmin / Citizen / Public — never System.
 pub fn is_ops_elevated(principal: &SecurityPrincipal) -> bool {
     use lib_access_control::Role;
     matches!(

--- a/zhtp/src/main.rs
+++ b/zhtp/src/main.rs
@@ -16,6 +16,9 @@ async fn main() -> anyhow::Result<()> {
 
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
+    // Operators must see who holds halt/export/import rights (Phase 2 #2935).
+    zhtp::api::principal::log_infra_admin_config_at_startup();
+
     // Parse command-line arguments
     let args = parse_cli_args();
 


### PR DESCRIPTION
## Summary

Implements **#2935 Phase 2** (stacked on Phase 1).

- **`is_ops_elevated`**: Council | InfraAdmin (System removed in Phase 3 stack tip).
- **Ops gates**: halt-consensus, chain export/import, wallet provision.
- **Audit**: `log_access_decision` denies at INFO (`target: access_control`).
- **CI matrix + perf**: `lib-access-control/src/matrix_tests.rs` — role/domain/op expectations + `check_access` &lt;1ms average budget.

## Stack

Phase 1 → **this** → Phase 3

## Test plan

- [x] `cargo test -p lib-access-control --lib` (18+ tests including matrix + perf)
- [ ] Reviewer: set `ZHTP_INFRA_ADMIN_DIDS` and confirm ops endpoints; Citizen still 403 on halt/export

Implements #2935 Phase 2.