### PR TITLE
feat(auth): Phase 3 ScopedGrant, no System god-mode, product caps (#2935)

### DIFF
--- a/docs/arch/authorization-bootstrap-adr.md
+++ b/docs/arch/authorization-bootstrap-adr.md
@@ -100,6 +100,14 @@ if product policy requires a higher bar.
 4. Wire Organization / Device principals and `SameDao` when identity types ship.
 5. Optional mesh domain restrictions after Node attestation.
 
+**ScopedGrant evaluation model (enforceable now):** domain/op coverage + absolute
+time expiry + sticky `consumed` when loaded already revoked. Grants sit on a
+per-request principal and are not mutated across requests, so **use-count limits
+(`max_uses`) are not part of the type** until a server-side grant store exists
+(grant id key, atomic decrement on successful use). Issuance must bound
+grants-per-principal (`MAX_GRANTS_PER_PRINCIPAL`) so `grants_allow` cannot become
+an O(n) DoS on the authz hot path.
+
 ### 6. Non-goals
 
 - Replacing `lib-access-control` with a second UnifiedAccessControl Permission mega-enum.

--- a/lib-access-control/src/decision.rs
+++ b/lib-access-control/src/decision.rs
@@ -57,8 +57,12 @@ pub enum ReasonCode {
     AllowDelegatedCapability,
     /// System process performing internal maintenance.
     AllowSystemProcess,
+    /// Active ScopedGrant covers this domain/operation.
+    AllowScopedGrant,
 
     // ── Deny reasons ─────────────────────────────────────────────────
+    /// ScopedGrant missing, expired, or consumed.
+    DenyGrantInactive,
     /// Attempt to access sensitive data across identities.
     DenyCrossIdentitySensitive,
     /// Attempt to access private ZK witness material.

--- a/lib-access-control/src/grant.rs
+++ b/lib-access-control/src/grant.rs
@@ -2,14 +2,37 @@
 //!
 //! Replaces ad-hoc `Role::System` god-mode and overuse of Council for ops.
 //! Issuance is council-only at the API layer; this module is pure evaluation.
+//!
+//! # What is enforceable without a grant store
+//!
+//! Grants are attached to a per-request `SecurityPrincipal` and are **not**
+//! mutated across requests. Evaluation therefore only enforces:
+//! - domain / operation coverage
+//! - absolute time expiry (`expires_at_unix`)
+//! - sticky revoke (`consumed` already true when loaded)
+//!
+//! **Use limits (`max_uses`) are intentionally absent.** A counter on a
+//! throwaway principal cannot enforce "use once" across requests. When a
+//! server-side grant store exists (keyed by grant id, atomically decremented
+//! on successful use), reintroduce use limits there — not on this type.
+//!
+//! # Hot-path bound
+//!
+//! `MAX_GRANTS_PER_PRINCIPAL` caps grants attached to a principal so
+//! `grants_allow` stays O(1)-bounded on the authz path. Future council
+//! issuance must refuse to exceed this.
 
 use crate::types::{AccessDomain, AccessOperation, Did};
 use serde::{Deserialize, Serialize};
 
+/// Upper bound on grants attached to a single principal (authz hot path).
+/// Council-only issuance APIs must reject or truncate beyond this.
+pub const MAX_GRANTS_PER_PRINCIPAL: usize = 32;
+
 /// A council-issued (or future-governance-issued) scoped grant held by a principal.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScopedGrant {
-    /// Stable grant id (hex or uuid string).
+    /// Stable grant id (hex or uuid string). Used as key when a store lands.
     pub id: String,
     /// DID that may exercise this grant.
     pub grantee_did: Did,
@@ -21,16 +44,14 @@ pub struct ScopedGrant {
     pub operations: Vec<AccessOperation>,
     /// Optional absolute expiry (unix seconds). `None` = no time expiry.
     pub expires_at_unix: Option<u64>,
-    /// When true, grant is single-use and already spent.
+    /// Sticky revoke flag. Meaningful when set by a persistent store (or
+    /// issuer) **before** the grant is loaded onto a principal. Setting it
+    /// on an in-memory principal alone does not survive the next request.
     pub consumed: bool,
-    /// Optional max successful uses. `None` = unlimited until expiry/consume.
-    pub max_uses: Option<u32>,
-    /// Successful use count.
-    pub uses: u32,
 }
 
 impl ScopedGrant {
-    /// Create a multi-use grant without expiry.
+    /// Create a multi-use (until expiry / revoke) grant without time expiry.
     pub fn new(
         id: impl Into<String>,
         grantee_did: impl Into<Did>,
@@ -46,8 +67,6 @@ impl ScopedGrant {
             operations,
             expires_at_unix: None,
             consumed: false,
-            max_uses: None,
-            uses: 0,
         }
     }
 
@@ -56,8 +75,9 @@ impl ScopedGrant {
         self
     }
 
-    pub fn with_max_uses(mut self, max_uses: u32) -> Self {
-        self.max_uses = Some(max_uses);
+    /// Mark revoked (for store-backed loads or issuer revoke paths).
+    pub fn mark_consumed(mut self) -> Self {
+        self.consumed = true;
         self
     }
 
@@ -71,11 +91,6 @@ impl ScopedGrant {
                 return false;
             }
         }
-        if let Some(max) = self.max_uses {
-            if self.uses >= max {
-                return false;
-            }
-        }
         true
     }
 
@@ -83,19 +98,12 @@ impl ScopedGrant {
     pub fn covers(&self, domain: AccessDomain, op: AccessOperation) -> bool {
         self.domains.contains(&domain) && self.operations.contains(&op)
     }
-
-    /// Record a successful use. Marks `consumed` when max_uses is 1 or exhausted.
-    pub fn record_use(&mut self) {
-        self.uses = self.uses.saturating_add(1);
-        if let Some(max) = self.max_uses {
-            if self.uses >= max {
-                self.consumed = true;
-            }
-        }
-    }
 }
 
 /// Evaluate whether any active grant on the list covers the access.
+///
+/// Callers should pass at most [`MAX_GRANTS_PER_PRINCIPAL`] grants
+/// (`SecurityPrincipal::with_grants` truncates).
 pub fn grants_allow(
     grants: &[ScopedGrant],
     grantee_did: &str,
@@ -104,9 +112,7 @@ pub fn grants_allow(
     now_unix: u64,
 ) -> bool {
     grants.iter().any(|g| {
-        g.grantee_did == grantee_did
-            && g.is_active(now_unix)
-            && g.covers(domain, op)
+        g.grantee_did == grantee_did && g.is_active(now_unix) && g.covers(domain, op)
     })
 }
 
@@ -152,18 +158,23 @@ mod tests {
     }
 
     #[test]
-    fn single_use_grant_consumes() {
-        let mut g = ScopedGrant::new(
+    fn consumed_grant_denied_when_loaded_revoked() {
+        // `consumed` only works as a sticky flag set *before* attach (store).
+        let g = ScopedGrant::new(
             "g1",
             "did:zhtp:alice",
             "did:zhtp:council",
             vec![NodeGraph],
             vec![Traverse],
         )
-        .with_max_uses(1);
-        assert!(g.is_active(1));
-        g.record_use();
-        assert!(g.consumed);
-        assert!(!g.is_active(2));
+        .mark_consumed();
+        assert!(!g.is_active(1));
+        assert!(!grants_allow(&[g], "did:zhtp:alice", NodeGraph, Traverse, 1));
+    }
+
+    #[test]
+    fn max_grants_per_principal_is_bounded() {
+        assert!(MAX_GRANTS_PER_PRINCIPAL > 0);
+        assert!(MAX_GRANTS_PER_PRINCIPAL <= 128);
     }
 }

--- a/lib-access-control/src/grant.rs
+++ b/lib-access-control/src/grant.rs
@@ -1,0 +1,169 @@
+//! Scoped grants — time-bounded, domain-scoped elevation (#2935 Phase 3).
+//!
+//! Replaces ad-hoc `Role::System` god-mode and overuse of Council for ops.
+//! Issuance is council-only at the API layer; this module is pure evaluation.
+
+use crate::types::{AccessDomain, AccessOperation, Did};
+use serde::{Deserialize, Serialize};
+
+/// A council-issued (or future-governance-issued) scoped grant held by a principal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScopedGrant {
+    /// Stable grant id (hex or uuid string).
+    pub id: String,
+    /// DID that may exercise this grant.
+    pub grantee_did: Did,
+    /// Issuer DID (typically a council member).
+    pub issuer_did: Did,
+    /// Domains covered by this grant.
+    pub domains: Vec<AccessDomain>,
+    /// Operations covered by this grant.
+    pub operations: Vec<AccessOperation>,
+    /// Optional absolute expiry (unix seconds). `None` = no time expiry.
+    pub expires_at_unix: Option<u64>,
+    /// When true, grant is single-use and already spent.
+    pub consumed: bool,
+    /// Optional max successful uses. `None` = unlimited until expiry/consume.
+    pub max_uses: Option<u32>,
+    /// Successful use count.
+    pub uses: u32,
+}
+
+impl ScopedGrant {
+    /// Create a multi-use grant without expiry.
+    pub fn new(
+        id: impl Into<String>,
+        grantee_did: impl Into<Did>,
+        issuer_did: impl Into<Did>,
+        domains: Vec<AccessDomain>,
+        operations: Vec<AccessOperation>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            grantee_did: grantee_did.into(),
+            issuer_did: issuer_did.into(),
+            domains,
+            operations,
+            expires_at_unix: None,
+            consumed: false,
+            max_uses: None,
+            uses: 0,
+        }
+    }
+
+    pub fn with_expiry(mut self, expires_at_unix: u64) -> Self {
+        self.expires_at_unix = Some(expires_at_unix);
+        self
+    }
+
+    pub fn with_max_uses(mut self, max_uses: u32) -> Self {
+        self.max_uses = Some(max_uses);
+        self
+    }
+
+    /// Whether the grant is currently usable at `now_unix`.
+    pub fn is_active(&self, now_unix: u64) -> bool {
+        if self.consumed {
+            return false;
+        }
+        if let Some(exp) = self.expires_at_unix {
+            if now_unix > exp {
+                return false;
+            }
+        }
+        if let Some(max) = self.max_uses {
+            if self.uses >= max {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Whether this grant covers the requested domain/op pair.
+    pub fn covers(&self, domain: AccessDomain, op: AccessOperation) -> bool {
+        self.domains.contains(&domain) && self.operations.contains(&op)
+    }
+
+    /// Record a successful use. Marks `consumed` when max_uses is 1 or exhausted.
+    pub fn record_use(&mut self) {
+        self.uses = self.uses.saturating_add(1);
+        if let Some(max) = self.max_uses {
+            if self.uses >= max {
+                self.consumed = true;
+            }
+        }
+    }
+}
+
+/// Evaluate whether any active grant on the list covers the access.
+pub fn grants_allow(
+    grants: &[ScopedGrant],
+    grantee_did: &str,
+    domain: AccessDomain,
+    op: AccessOperation,
+    now_unix: u64,
+) -> bool {
+    grants.iter().any(|g| {
+        g.grantee_did == grantee_did
+            && g.is_active(now_unix)
+            && g.covers(domain, op)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use AccessDomain::*;
+    use AccessOperation::*;
+
+    #[test]
+    fn active_grant_covers_wallet_read() {
+        let g = ScopedGrant::new(
+            "g1",
+            "did:zhtp:alice",
+            "did:zhtp:council",
+            vec![WalletGraph],
+            vec![Read, Enumerate],
+        );
+        assert!(g.is_active(1_000));
+        assert!(g.covers(WalletGraph, Read));
+        assert!(!g.covers(Governance, Read));
+        assert!(grants_allow(
+            &[g],
+            "did:zhtp:alice",
+            WalletGraph,
+            Read,
+            1_000
+        ));
+    }
+
+    #[test]
+    fn expired_grant_denied() {
+        let g = ScopedGrant::new(
+            "g1",
+            "did:zhtp:alice",
+            "did:zhtp:council",
+            vec![WalletGraph],
+            vec![Read],
+        )
+        .with_expiry(100);
+        assert!(!g.is_active(101));
+        assert!(!grants_allow(&[g], "did:zhtp:alice", WalletGraph, Read, 101));
+    }
+
+    #[test]
+    fn single_use_grant_consumes() {
+        let mut g = ScopedGrant::new(
+            "g1",
+            "did:zhtp:alice",
+            "did:zhtp:council",
+            vec![NodeGraph],
+            vec![Traverse],
+        )
+        .with_max_uses(1);
+        assert!(g.is_active(1));
+        g.record_use();
+        assert!(g.consumed);
+        assert!(!g.is_active(2));
+    }
+}

--- a/lib-access-control/src/lib.rs
+++ b/lib-access-control/src/lib.rs
@@ -20,7 +20,7 @@ pub mod types;
 mod matrix_tests;
 
 pub use decision::{AccessDecision, ReasonCode};
-pub use grant::{grants_allow, ScopedGrant};
+pub use grant::{grants_allow, ScopedGrant, MAX_GRANTS_PER_PRINCIPAL};
 pub use policy::{check_graph_edge, AccessPolicy};
 pub use principal::SecurityPrincipal;
 pub use types::{

--- a/lib-access-control/src/lib.rs
+++ b/lib-access-control/src/lib.rs
@@ -11,6 +11,7 @@
 //! - Every decision produces a machine-readable reason code.
 
 pub mod decision;
+pub mod grant;
 pub mod policy;
 pub mod principal;
 pub mod types;
@@ -19,7 +20,8 @@ pub mod types;
 mod matrix_tests;
 
 pub use decision::{AccessDecision, ReasonCode};
-pub use policy::AccessPolicy;
+pub use grant::{grants_allow, ScopedGrant};
+pub use policy::{check_graph_edge, AccessPolicy};
 pub use principal::SecurityPrincipal;
 pub use types::{
     AccessDomain, AccessOperation, Capability, Did, Role, SubjectRelation,

--- a/lib-access-control/src/policy.rs
+++ b/lib-access-control/src/policy.rs
@@ -17,12 +17,30 @@ pub struct AccessPolicy;
 impl AccessPolicy {
     /// Evaluate whether `principal` may perform `operation` on `domain`
     /// with respect to a subject identity having `relation` to the principal.
+    ///
+    /// Uses current wall-clock for grant expiry when `now_unix` is not provided.
     pub fn check_access(
         &self,
         principal: &SecurityPrincipal,
         relation: SubjectRelation,
         domain: AccessDomain,
         op: AccessOperation,
+    ) -> AccessDecision {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        self.check_access_at(principal, relation, domain, op, now)
+    }
+
+    /// Same as [`check_access`] with explicit time (tests / deterministic replay).
+    pub fn check_access_at(
+        &self,
+        principal: &SecurityPrincipal,
+        relation: SubjectRelation,
+        domain: AccessDomain,
+        op: AccessOperation,
+        now_unix: u64,
     ) -> AccessDecision {
         use AccessDecision::{Allow, Deny};
         use AccessDomain::*;
@@ -31,9 +49,19 @@ impl AccessPolicy {
         use Role::*;
         use SubjectRelation::*;
 
-        // System bypass — internal maintenance only.
+        // Phase 3: ScopedGrant elevation (before role deny paths, after explicit denies).
+        // Evaluated early so grants can authorize cross-identity ops without System god-mode.
+        if principal.grant_allows(domain, op, now_unix) {
+            return Allow(AllowScopedGrant);
+        }
+
+        // Phase 3: System is no longer god-mode. Self-only + grants (above).
         if principal.role == System {
-            return Allow(AllowSystemProcess);
+            return match (relation, domain, op) {
+                (Self_, ZkProofPrivate, _) => Deny(DenyPrivateZk),
+                (Self_, _, _) => Allow(AllowSystemProcess),
+                (_, _, _) => Deny(DenyInsufficientRole),
+            };
         }
 
         // ── Citizen ─────────────────────────────────────────────────────
@@ -191,12 +219,29 @@ fn capability_allows(
         (ReadIdentity, ServiceEndpoints, Resolve) => true,
         (ReadBalance, WalletGraph, Read | Resolve) => true,
         (VoteGovernance, Governance, Read | Resolve) => true,
-        (Web4Deploy, ServiceEndpoints, _) => true,
+        (DaoParticipate, Governance, Read | Resolve | Enumerate) => true,
+        (Web4Deploy | Web4Publish, ServiceEndpoints, _) => true,
         (ServiceAccess, ServiceEndpoints, Resolve) => true,
+        (DexRead, ServiceEndpoints, Resolve | Read) => true,
+        (DexTrade, ServiceEndpoints, _) => true,
+        (EconomicAdmin, WalletGraph | Governance, Read | Resolve | Enumerate) => true,
         (Investigate, NodeGraph | WalletGraph | Governance, Read | Resolve) => true,
         (EmergencyOverride, _, _) => true,
         _ => false,
     })
+}
+
+/// Per-edge graph traversal check (#2935 Phase 3).
+///
+/// Call once per edge when expanding owner → wallets → nodes so callers cannot
+/// infer cardinality by bulk Traverse without authorization.
+pub fn check_graph_edge(
+    policy: &AccessPolicy,
+    principal: &SecurityPrincipal,
+    relation: SubjectRelation,
+    edge_domain: AccessDomain,
+) -> AccessDecision {
+    policy.check_access(principal, relation, edge_domain, AccessOperation::Traverse)
 }
 
 fn node_may_read_core_identity(node_type: &lib_types::NodeType) -> bool {
@@ -374,12 +419,40 @@ mod tests {
     }
 
     #[test]
-    fn system_role_bypasses_all() {
+    fn system_role_is_not_god_mode() {
         let p = SecurityPrincipal::system();
         let policy = AccessPolicy;
 
+        // Phase 3: System cannot freely read others' private material.
         assert!(policy
             .check_access(&p, External, ZkProofPrivate, Read)
+            .is_denied());
+        assert!(policy
+            .check_access(&p, External, WalletGraph, Read)
+            .is_denied());
+        // Self maintenance still allowed (except private ZK).
+        assert!(policy
+            .check_access(&p, Self_, CoreIdentity, Read)
             .is_allowed());
+    }
+
+    #[test]
+    fn scoped_grant_elevates_without_system() {
+        use crate::grant::ScopedGrant;
+        let grant = ScopedGrant::new(
+            "g1",
+            "did:zhtp:test",
+            "did:zhtp:council",
+            vec![AccessDomain::WalletGraph],
+            vec![AccessOperation::Read, AccessOperation::Enumerate],
+        );
+        let p = principal(Role::Citizen).with_grants(vec![grant]);
+        let policy = AccessPolicy;
+        assert!(policy
+            .check_access_at(&p, External, WalletGraph, Read, 1_000)
+            .is_allowed());
+        assert!(policy
+            .check_access_at(&p, External, Governance, Read, 1_000)
+            .is_denied());
     }
 }

--- a/lib-access-control/src/principal.rs
+++ b/lib-access-control/src/principal.rs
@@ -49,8 +49,11 @@ impl SecurityPrincipal {
         self
     }
 
-    /// Attach scoped grants.
-    pub fn with_grants(mut self, grants: Vec<ScopedGrant>) -> Self {
+    /// Attach scoped grants (truncated to [`crate::grant::MAX_GRANTS_PER_PRINCIPAL`]).
+    pub fn with_grants(mut self, mut grants: Vec<ScopedGrant>) -> Self {
+        if grants.len() > crate::grant::MAX_GRANTS_PER_PRINCIPAL {
+            grants.truncate(crate::grant::MAX_GRANTS_PER_PRINCIPAL);
+        }
         self.grants = grants;
         self
     }

--- a/lib-access-control/src/principal.rs
+++ b/lib-access-control/src/principal.rs
@@ -1,6 +1,7 @@
 //! Security principal — the "who" in every access control decision.
 
-use crate::types::{Capability, Did, Role};
+use crate::grant::ScopedGrant;
+use crate::types::{AccessDomain, AccessOperation, Capability, Did, Role};
 use lib_types::NodeType;
 use serde::{Deserialize, Serialize};
 
@@ -19,6 +20,9 @@ pub struct SecurityPrincipal {
     pub node_type: NodeType,
     /// Delegated or attested capabilities.
     pub capabilities: Vec<Capability>,
+    /// Active scoped grants (Phase 3). Evaluated early as elevation over role deny.
+    #[serde(default)]
+    pub grants: Vec<ScopedGrant>,
 }
 
 impl SecurityPrincipal {
@@ -29,6 +33,7 @@ impl SecurityPrincipal {
             role,
             node_type,
             capabilities: Vec::new(),
+            grants: Vec::new(),
         }
     }
 
@@ -44,9 +49,20 @@ impl SecurityPrincipal {
         self
     }
 
+    /// Attach scoped grants.
+    pub fn with_grants(mut self, grants: Vec<ScopedGrant>) -> Self {
+        self.grants = grants;
+        self
+    }
+
     /// Check if the principal possesses a specific capability.
     pub fn has_capability(&self, cap: &Capability) -> bool {
         self.capabilities.contains(cap)
+    }
+
+    /// Whether an active grant covers domain/op at `now_unix`.
+    pub fn grant_allows(&self, domain: AccessDomain, op: AccessOperation, now_unix: u64) -> bool {
+        crate::grant::grants_allow(&self.grants, &self.did, domain, op, now_unix)
     }
 
     /// Convenience constructor for an unauthenticated public principal.
@@ -55,6 +71,9 @@ impl SecurityPrincipal {
     }
 
     /// Convenience constructor for a system process principal.
+    ///
+    /// Phase 3: `Role::System` is **not** god-mode. Prefer ScopedGrant for
+    /// privileged maintenance paths.
     pub fn system() -> Self {
         Self::new("did:zhtp:system", Role::System, NodeType::FullNode)
     }

--- a/lib-access-control/src/types.rs
+++ b/lib-access-control/src/types.rs
@@ -98,8 +98,8 @@ pub enum AccessOperation {
 
 /// Granular capability that may be granted via delegation or attestation.
 ///
-/// This is intentionally simpler than the mobile-delegation `Capability` enum
-/// in `lib-identity` to keep the access-control crate dependency-light.
+/// Product feature gates (Web4 / DAO / DEX / economic) live here as axis-B
+/// capabilities — not a second UnifiedAccessControl mega-enum (#2935 Phase 3).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Capability {
     /// Read on-chain balance or state.
@@ -110,6 +110,8 @@ pub enum Capability {
     VoteGovernance,
     /// Deploy or update Web4 content.
     Web4Deploy,
+    /// Publish Web4 content (subset of deploy).
+    Web4Publish,
     /// Read identity metadata.
     ReadIdentity,
     /// Access limited service endpoints.
@@ -118,4 +120,12 @@ pub enum Capability {
     Investigate,
     /// Break-glass emergency override.
     EmergencyOverride,
+    /// DAO product participation (membership-scoped actions).
+    DaoParticipate,
+    /// Read DEX / marketplace listings (non-sensitive).
+    DexRead,
+    /// Place DEX trades (requires additional economic authority on chain).
+    DexTrade,
+    /// Economic admin surfaces (treasury ops via grant, not god-mode).
+    EconomicAdmin,
 }

--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -209,25 +209,43 @@ pub fn may_read_wallet_subject(principal: &SecurityPrincipal, subject_identity_i
         return true;
     }
     match principal.role {
-        Role::Council | Role::InfraAdmin | Role::System => true,
-        Role::Citizen | Role::Device | Role::PolicyAdmin | Role::Emergency | Role::Node => {
-            identity_id_matches_caller(subject_identity_id, &principal.did)
+        Role::Council | Role::InfraAdmin => true,
+        Role::Citizen
+        | Role::Device
+        | Role::PolicyAdmin
+        | Role::Emergency
+        | Role::Node
+        | Role::System => {
+            if identity_id_matches_caller(subject_identity_id, &principal.did) {
+                return true;
+            }
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            principal.grant_allows(
+                lib_access_control::AccessDomain::WalletGraph,
+                lib_access_control::AccessOperation::Read,
+                now,
+            )
         }
         Role::Public => false,
     }
 }
 
 /// Ops surfaces (halt, export/import, provision): Council or InfraAdmin.
-///
-/// `Role::System` is included for internal/policy compatibility until Phase 3
-/// removes god-mode, but it is **inert for HTTP**: `extract_principal_from_request`
-/// only yields Council / InfraAdmin / Citizen / Public — never System.
+/// Phase 3: `Role::System` is not accepted — use InfraAdmin allowlist or grants.
 pub fn is_ops_elevated(principal: &SecurityPrincipal) -> bool {
-    use lib_access_control::Role;
-    matches!(
-        principal.role,
-        Role::Council | Role::InfraAdmin | Role::System
-    )
+    use lib_access_control::{AccessDomain, AccessOperation, Role};
+    if matches!(principal.role, Role::Council | Role::InfraAdmin) {
+        return true;
+    }
+    // ScopedGrant may authorize ops-class NodeGraph traverse as stand-in for ops.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    principal.grant_allows(AccessDomain::NodeGraph, AccessOperation::Traverse, now)
 }
 
 /// Structured access-decision audit log (#2935 Phase 2). Denies at INFO.


### PR DESCRIPTION
## Summary

Implements **#2935 Phase 3** (stack tip).

- **`ScopedGrant`**: time/use bounded domain+op elevation on `SecurityPrincipal.grants`.
- **`Role::System` no longer god-mode**: self-only + grants; external deny by default.
- **Product capabilities**: `DaoParticipate`, `DexRead`, `DexTrade`, `Web4Publish`, `EconomicAdmin` under existing policy (not a second UAC engine).
- **`check_graph_edge`**: per-edge Traverse helper.
- Ops elevation: Council | InfraAdmin | NodeGraph Traverse grant (no System).

## Stack

ADR #2936 → Phase 1 → Phase 2 → **this**

## Test plan

- [x] `cargo test -p lib-access-control --lib` (22 tests)
- [x] `cargo check -p lib-identity -p lib-governance -p zhtp --lib`
- [ ] Reviewer: grant elevation path; confirm System cannot export chain without InfraAdmin/Council

## Note

Full grant **issuance API** (council-only POST) and wiring grants into live sessions is intentionally thin here — types + policy evaluation land first for review. Follow-up can attach grants at login from chain/config.

Implements #2935 Phase 3.