### PR TITLE
fix(ipc): replace Unix domain sockets with platform-agnostic transport

### DIFF
--- a/lib-blockchain/src/ipc/client.rs
+++ b/lib-blockchain/src/ipc/client.rs
@@ -1,14 +1,18 @@
-//! IPC client — connects to the blockchain engine via Unix domain socket.
+//! IPC client — connects to the blockchain engine via platform-native transport.
+//!
+//! - **Unix**: Unix domain socket
+//! - **Windows**: TCP loopback (port discovered from path file)
 //!
 //! Provides owned-type query methods equivalent to `BlockchainQuery`.
 //! Can be used as a drop-in replacement for `Arc<RwLock<Blockchain>>` reads.
 
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixStream;
 use tokio::sync::Mutex;
 use tracing::warn;
 
+use super::TransportStream;
 use crate::block::Block;
 use crate::blockchain::ValidatorInfo;
 use crate::transaction::{
@@ -23,8 +27,10 @@ use super::protocol::*;
 /// Thread-safe: wraps the stream in a Mutex so multiple tasks can share it.
 /// For higher throughput, consider a connection pool.
 pub struct IpcClient {
-    stream: Mutex<Option<UnixStream>>,
+    stream: Mutex<Option<TransportStream>>,
     socket_path: PathBuf,
+    #[cfg(not(unix))]
+    tcp_addr: Mutex<Option<SocketAddr>>,
 }
 
 impl IpcClient {
@@ -33,12 +39,44 @@ impl IpcClient {
         Self {
             stream: Mutex::new(None),
             socket_path: socket_path.to_path_buf(),
+            #[cfg(not(unix))]
+            tcp_addr: Mutex::new(None),
         }
     }
 
     /// Connect to the blockchain engine. Reconnects if already connected.
     pub async fn connect(&self) -> anyhow::Result<()> {
-        let stream = UnixStream::connect(&self.socket_path).await?;
+        #[cfg(unix)]
+        {
+            let stream = TransportStream::connect(&self.socket_path).await?;
+            *self.stream.lock().await = Some(stream);
+            return Ok(());
+        }
+
+        #[cfg(not(unix))]
+        {
+            // On Windows, read the port from the path file
+            let port_file_content = tokio::fs::read_to_string(&self.socket_path).await?;
+            let port: u16 = port_file_content.trim().parse().map_err(|e| {
+                anyhow::anyhow!("Invalid port in path file '{}': {}", self.socket_path.display(), e)
+            })?;
+
+            // Also cache the address for reconnects
+            let addr = SocketAddr::from(([127, 0, 0, 1], port));
+            *self.tcp_addr.lock().await = Some(addr);
+
+            let stream = TransportStream::connect(addr).await?;
+            *self.stream.lock().await = Some(stream);
+            Ok(())
+        }
+    }
+
+    /// Reconnect using the cached TCP address (Windows only).
+    #[cfg(not(unix))]
+    async fn reconnect(&self) -> anyhow::Result<()> {
+        let addr = self.tcp_addr.lock().await;
+        let addr = addr.as_ref().ok_or_else(|| anyhow::anyhow!("No cached TCP address"))?;
+        let stream = TransportStream::connect(*addr).await?;
         *self.stream.lock().await = Some(stream);
         Ok(())
     }

--- a/lib-blockchain/src/ipc/mod.rs
+++ b/lib-blockchain/src/ipc/mod.rs
@@ -1,17 +1,55 @@
 //! IPC protocol for blockchain engine ↔ services communication.
 //!
 //! Enables running the blockchain engine as a separate process, with services
-//! connecting via Unix domain socket. All messages are length-prefixed bincode.
+//! connecting via platform-native transport:
+//! - **Unix**: Unix domain sockets
+//! - **Windows**: TCP loopback (127.0.0.1) with port discovery via path file
+//!
+//! All messages are length-prefixed bincode.
 //!
 //! ## Architecture
 //!
 //! ```text
-//! ┌─────────────────┐    Unix Socket    ┌──────────────────┐
-//! │  Services Layer  │ ◄──────────────► │ Blockchain Engine │
-//! │  (API, ZDNS,     │   IpcRequest /   │  (Consensus,      │
-//! │   rewards, ...)  │   IpcResponse    │   sled, mempool)  │
-//! └─────────────────┘                   └──────────────────┘
+//! ┌─────────────────┐    Transport        ┌──────────────────┐
+//! │  Services Layer  │ ◄────────────────► │ Blockchain Engine │
+//! │  (API, ZDNS,     │   IpcRequest /    │  (Consensus,      │
+//! │   rewards, ...)  │   IpcResponse     │   sled, mempool)  │
+//! └─────────────────┘                    └──────────────────┘
 //! ```
+
+#[cfg(unix)]
+use tokio::net::{UnixListener, UnixStream};
+
+#[cfg(not(unix))]
+use tokio::net::{TcpListener, TcpStream};
+
+/// Platform-specific transport stream type.
+///
+/// - On Unix: `UnixStream` (Unix domain socket)
+/// - On Windows: `TcpStream` (loopback TCP)
+#[cfg(unix)]
+pub type TransportStream = UnixStream;
+
+/// Platform-specific transport stream type.
+///
+/// - On Unix: `UnixStream` (Unix domain socket)
+/// - On Windows: `TcpStream` (loopback TCP)
+#[cfg(not(unix))]
+pub type TransportStream = TcpStream;
+
+/// Platform-specific transport listener type.
+///
+/// - On Unix: `UnixListener` (Unix domain socket)
+/// - On Windows: `TcpListener` (loopback TCP)
+#[cfg(unix)]
+pub type TransportListener = UnixListener;
+
+/// Platform-specific transport listener type.
+///
+/// - On Unix: `UnixListener` (Unix domain socket)
+/// - On Windows: `TcpListener` (loopback TCP)
+#[cfg(not(unix))]
+pub type TransportListener = TcpListener;
 
 pub mod protocol;
 pub mod server;

--- a/lib-blockchain/src/ipc/server.rs
+++ b/lib-blockchain/src/ipc/server.rs
@@ -1,29 +1,51 @@
-//! IPC server — listens on a Unix domain socket and dispatches queries
+//! IPC server — listens on a platform-native transport and dispatches queries
 //! to the blockchain engine.
+//!
+//! - **Unix**: Unix domain socket
+//! - **Windows**: TCP loopback (port written to path file for client discovery)
 
 use std::path::Path;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixListener;
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
+use super::{TransportListener, TransportStream};
 use crate::blockchain::Blockchain;
 use crate::query::BlockchainQuery;
 use super::protocol::*;
 
-/// Start the IPC server on the given Unix socket path.
+/// Start the IPC server on the given socket path.
 ///
 /// Spawns a background task that accepts connections and dispatches
 /// requests to the blockchain. Each connection is handled concurrently.
+///
+/// - **Unix**: binds a `UnixListener` at `socket_path`
+/// - **Windows**: binds a `TcpListener` on `127.0.0.1:0`, writes the assigned
+///   port to `socket_path` as a text file for client discovery
 pub async fn start_ipc_server(
     socket_path: &Path,
     blockchain: Arc<RwLock<Blockchain>>,
 ) -> std::io::Result<()> {
-    // Remove stale socket file if it exists
+    // Remove stale socket file if it exists (Unix only)
+    #[cfg(unix)]
     let _ = std::fs::remove_file(socket_path);
 
-    let listener = UnixListener::bind(socket_path)?;
+    #[cfg(unix)]
+    let listener = TransportListener::bind(socket_path)?;
+
+    #[cfg(not(unix))]
+    let listener = {
+        let l = TransportListener::bind("127.0.0.1:0".parse::<std::net::SocketAddr>().unwrap()).await?;
+        let local_addr = l.local_addr()?;
+        let port = local_addr.port();
+        // Write the assigned port to the path file so the client can discover it
+        tokio::fs::write(socket_path, port.to_string()).await?;
+        info!("IPC server listening on 127.0.0.1:{} (port file: {})", port, socket_path.display());
+        l
+    };
+
+    #[cfg(unix)]
     info!("IPC server listening on {}", socket_path.display());
 
     tokio::spawn(async move {
@@ -45,7 +67,7 @@ pub async fn start_ipc_server(
 }
 
 async fn handle_connection(
-    mut stream: tokio::net::UnixStream,
+    mut stream: TransportStream,
     blockchain: Arc<RwLock<Blockchain>>,
 ) {
     loop {


### PR DESCRIPTION
Summary
Replaced Unix domain sockets (UnixListener/UnixStream) with platform-conditional type aliases so the IPC layer compiles on Windows. On Windows, the server binds a TcpListener to 127.0.0.1:0 and writes the assigned port to the path file; the client reads the port from the file and connects via TcpStream. Unix behavior is unchanged.

Linked issues
Refs #2914 (split out Windows IPC changes from domain-update signature prefix PR).

Architecture compliance
n/a — standalone platform-compatibility fix, not part of an epic-tracked design doc.

Test plan
 cargo check -p lib-blockchain passes on Windows
 Manual verification: start blockchain engine on Windows, verify IPC client connects and queries succeed
Risk and reversibility
Low risk. Unix codepath is unchanged (same #[cfg(unix)] code as before). Windows codepath is new but isolated behind #[cfg(not(unix))]. No coordinated network restart needed