### PR TITLE
fix(lib-network): add missing BLE_MESH_SERVICE_UUID and Mutex imports for windows

### DIFF
--- a/lib-network/src/protocols/bluetooth/discovery.rs
+++ b/lib-network/src/protocols/bluetooth/discovery.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
+use crate::constants::BLE_MESH_SERVICE_UUID;
+
 use super::device;
 use super::device::{BleDevice, MeshPeer};
 use super::BluetoothMeshProtocol;

--- a/lib-network/src/protocols/wifi_direct.rs
+++ b/lib-network/src/protocols/wifi_direct.rs
@@ -8,7 +8,7 @@ use lib_crypto::symmetric::chacha20::encrypt_data;
 use mdns_sd::{ServiceDaemon, ServiceInfo};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 


### PR DESCRIPTION
Add missing `BLE_MESH_SERVICE_UUID` and `std::sync::Mutex` imports in `lib-network` that caused compile failures on Windows. These code paths are `#[cfg(target_os = "windows")]`-gated, so the errors were masked on Linux/macOS.

## Linked issues

Refs #2918. Split from #2914.

## Architecture compliance

n/a — import-only fix, no logic change.

## Test plan

- [x] `cargo check -p lib-network` on Windows now passes for the two affected modules (Bluetooth discovery and WiFi Direct device-watcher blocks). The remaining `libc::kill` error in `zhtp/src/api/handlers/network/mod.rs` is unrelated and will be handled separately.

## Risk and reversibility

Zero. Two `use` statements added; no runtime behaviour change. Can be reverted by dropping the commit.