### PR TITLE
fix: gate libc::kill behind #[cfg(unix)] for Windows compatibility

### DIFF
--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1031,8 +1031,11 @@ impl NetworkHandler {
         // Spawn shutdown in background so the response gets sent first
         tokio::spawn(async {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            info!("Node shutdown: sending SIGTERM to self");
+            info!("Node shutdown: terminating process");
+            #[cfg(unix)]
             unsafe { libc::kill(libc::getpid(), libc::SIGTERM); }
+            #[cfg(not(unix))]
+            std::process::exit(0);
         });
         Ok(ZhtpResponse::json(&response, None)?)
     }


### PR DESCRIPTION
Summary
Gated the POSIX-only libc::kill call behind #[cfg(unix)] and added a std::process::exit(0) fallback for non-Unix (Windows) targets, fixing the Windows compilation error.

Linked issues
Closes #2943

Architecture compliance
n/a

Test plan
 Manual verification: cargo build --package zhtp succeeds on Windows
Risk and reversibility
Low risk. The change only affects the node shutdown API endpoint; no consensus or networking logic is touched. Revert is a simple git revert.