### PR TITLE
fix(auth): Phase A dual-auth prep — gate shutdown, ops-pure InfraAdmin

### DIFF
--- a/zhtp/src/api/handlers/blockchain/mod.rs
+++ b/zhtp/src/api/handlers/blockchain/mod.rs
@@ -3205,16 +3205,24 @@ impl BlockchainHandler {
             None
         };
 
-        // Access control: unfiltered enumeration is restricted to elevated roles.
+        // Access control: unfiltered enumeration is audit-class (not ops-only InfraAdmin).
+        // Dual-auth plan Phase A: InfraAdmin = ops purity, no blanket wallet enum.
         if owner_filter.is_none() {
             let allowed = matches!(
                 principal.role,
                 lib_access_control::Role::System
                     | lib_access_control::Role::Node
-                    | lib_access_control::Role::InfraAdmin
                     | lib_access_control::Role::Council
                     | lib_access_control::Role::Emergency
-            );
+            )
+                || principal.grant_allows(
+                    AccessDomain::WalletGraph,
+                    AccessOperation::Enumerate,
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                );
             if !allowed {
                 return Ok(ZhtpResponse::error(
                     ZhtpStatus::Forbidden,

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1020,9 +1020,27 @@ impl NetworkHandler {
     }
 
     /// POST /api/v1/node/shutdown — clean shutdown of the node process
-    async fn handle_node_shutdown(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
-        info!("API: Node shutdown requested");
-        // Signal the runtime to begin graceful shutdown
+    /// (ops-elevated only; was unauthenticated — dual-auth plan Phase A)
+    async fn handle_node_shutdown(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        let principal = crate::api::principal::extract_principal_from_request(&request);
+        if !crate::api::principal::is_ops_elevated(&principal) {
+            crate::api::principal::log_access_decision(
+                &principal,
+                "node",
+                "Ops",
+                "Shutdown",
+                false,
+                "requires Council or InfraAdmin",
+            );
+            return Ok(ZhtpResponse::error(
+                ZhtpStatus::Forbidden,
+                "Node shutdown requires Council or InfraAdmin role".to_string(),
+            ));
+        }
+        info!(
+            "API: Node shutdown requested by {} ({:?})",
+            principal.did, principal.role
+        );
         let response = serde_json::json!({
             "success": true,
             "message": "Shutdown initiated. Node will stop after current block is finalized.",

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1019,8 +1019,8 @@ impl NetworkHandler {
         Ok(ZhtpResponse::json(&response, None)?)
     }
 
-    /// POST /api/v1/node/shutdown — clean shutdown of the node process
-    /// (ops-elevated only; was unauthenticated — dual-auth plan Phase A)
+    /// POST /api/v1/node/shutdown — clean shutdown of the node process.
+    /// Requires ops elevation (`is_ops_elevated`: Council, InfraAdmin, or ops grant).
     async fn handle_node_shutdown(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
         let principal = crate::api::principal::extract_principal_from_request(&request);
         if !crate::api::principal::is_ops_elevated(&principal) {
@@ -1030,11 +1030,12 @@ impl NetworkHandler {
                 "Ops",
                 "Shutdown",
                 false,
-                "requires Council or InfraAdmin",
+                "requires ops elevation",
             );
             return Ok(ZhtpResponse::error(
                 ZhtpStatus::Forbidden,
-                "Node shutdown requires Council or InfraAdmin role".to_string(),
+                "Node shutdown requires ops elevation (Council, InfraAdmin, or ops grant)"
+                    .to_string(),
             ));
         }
         info!(

--- a/zhtp/src/api/principal.rs
+++ b/zhtp/src/api/principal.rs
@@ -56,13 +56,20 @@ mod tests {
             NodeType::FullNode,
         );
         let council = SecurityPrincipal::new("did:zhtp:council", Role::Council, NodeType::FullNode);
+        let infra = SecurityPrincipal::new(
+            "did:zhtp:infraadmin",
+            Role::InfraAdmin,
+            NodeType::FullNode,
+        );
         let public = SecurityPrincipal::public();
 
-        // When privacy is on (default), self OK, other denied, council OK, public denied.
+        // When privacy is on (default): self OK, other denied, council OK,
+        // InfraAdmin is ops-only (no cross-wallet via role), public denied.
         if wallet_read_privacy_enforced() {
             assert!(may_read_wallet_subject(&self_p, hex));
             assert!(!may_read_wallet_subject(&other, hex));
             assert!(may_read_wallet_subject(&council, hex));
+            assert!(!may_read_wallet_subject(&infra, hex));
             assert!(!may_read_wallet_subject(&public, hex));
         }
     }
@@ -148,10 +155,11 @@ pub fn extract_principal_from_request(request: &ZhtpRequest) -> SecurityPrincipa
 
 /// Env-configured ops allowlist for `Role::InfraAdmin` (comma-separated DIDs).
 ///
-/// **Consensus-critical.** Holders get Phase 2 ops: halt consensus, full chain
-/// export/import, wallet provision, plus cross-user wallet read (Phase 1).
+/// **Consensus-critical.** Holders get ops: halt consensus, full chain
+/// export/import, wallet provision. Cross-user wallet audit is **not** included
+/// (ops purity — dual-auth plan Phase A); that remains Council or audit grants.
 /// Treat like a secret-grade allowlist: typos/leaks enable network DoS and
-/// full-chain exfiltration. See ADR `docs/arch/authorization-bootstrap-adr.md`.
+/// full-chain exfiltration.
 ///
 /// Example: `ZHTP_INFRA_ADMIN_DIDS=did:zhtp:abc...,did:zhtp:def...`
 pub fn infra_admin_dids_from_env() -> Vec<String> {
@@ -182,7 +190,7 @@ pub fn log_infra_admin_config_at_startup() {
             target: "access_control",
             count = dids.len(),
             infra_admin_dids = ?dids,
-            "ZHTP_INFRA_ADMIN_DIDS grants InfraAdmin (halt/export/import/provision + wallet read)"
+            "ZHTP_INFRA_ADMIN_DIDS grants InfraAdmin (halt/export/import/provision; no cross-wallet audit)"
         );
     }
 }
@@ -203,19 +211,24 @@ pub fn wallet_read_privacy_enforced() -> bool {
 /// Whether `principal` may read wallet graph data for `subject_identity_id`
 /// (raw hex or `did:zhtp:`). Soft-privacy path: callers return empty/zero
 /// bodies on deny rather than 403.
+///
+/// **Role purity (dual-auth plan Phase A):** `InfraAdmin` is ops-only — no
+/// cross-identity wallet audit via role alone. Council retains bootstrap audit
+/// until audit grants land. Elevation for non-Council is self or ScopedGrant.
 pub fn may_read_wallet_subject(principal: &SecurityPrincipal, subject_identity_id: &str) -> bool {
     use lib_access_control::Role;
     if !wallet_read_privacy_enforced() {
         return true;
     }
     match principal.role {
-        Role::Council | Role::InfraAdmin => true,
+        Role::Council => true,
         Role::Citizen
         | Role::Device
         | Role::PolicyAdmin
         | Role::Emergency
         | Role::Node
-        | Role::System => {
+        | Role::System
+        | Role::InfraAdmin => {
             if identity_id_matches_caller(subject_identity_id, &principal.did) {
                 return true;
             }


### PR DESCRIPTION
## Summary
Phase A of dual-auth plan: seal holes before grant plumbing.

- Gate `POST .../node/shutdown` with `is_ops_elevated`
- InfraAdmin no longer cross-wallet role audit; self or ScopedGrant only
- Unfiltered wallet enum no longer treats InfraAdmin as fat audit role

## Stack
Depends on docs PR (`docs/dual-auth-model` → `development`). Base is docs branch.

## Test plan
- [ ] Unit/handler tests for shutdown + wallet subject read
- [ ] Confirm Council still has cross-wallet soft audit path (eligibility not yet cut)
- [ ] InfraAdmin cannot read other wallets without grant