### PR TITLE
fix(auth): require ops elevation for POST /node/shutdown

### DIFF
--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1020,9 +1020,27 @@ impl NetworkHandler {
     }
 
     /// POST /api/v1/node/shutdown — clean shutdown of the node process
-    async fn handle_node_shutdown(&self, _request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
-        info!("API: Node shutdown requested");
-        // Signal the runtime to begin graceful shutdown
+    /// (ops-elevated only; was unauthenticated — dual-auth plan Phase A)
+    async fn handle_node_shutdown(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
+        let principal = crate::api::principal::extract_principal_from_request(&request);
+        if !crate::api::principal::is_ops_elevated(&principal) {
+            crate::api::principal::log_access_decision(
+                &principal,
+                "node",
+                "Ops",
+                "Shutdown",
+                false,
+                "requires Council or InfraAdmin",
+            );
+            return Ok(ZhtpResponse::error(
+                ZhtpStatus::Forbidden,
+                "Node shutdown requires Council or InfraAdmin role".to_string(),
+            ));
+        }
+        info!(
+            "API: Node shutdown requested by {} ({:?})",
+            principal.did, principal.role
+        );
         let response = serde_json::json!({
             "success": true,
             "message": "Shutdown initiated. Node will stop after current block is finalized.",

--- a/zhtp/src/api/handlers/network/mod.rs
+++ b/zhtp/src/api/handlers/network/mod.rs
@@ -1019,8 +1019,8 @@ impl NetworkHandler {
         Ok(ZhtpResponse::json(&response, None)?)
     }
 
-    /// POST /api/v1/node/shutdown — clean shutdown of the node process
-    /// (ops-elevated only; was unauthenticated — dual-auth plan Phase A)
+    /// POST /api/v1/node/shutdown — clean shutdown of the node process.
+    /// Requires ops elevation (`is_ops_elevated`: Council, InfraAdmin, or ops grant).
     async fn handle_node_shutdown(&self, request: ZhtpRequest) -> ZhtpResult<ZhtpResponse> {
         let principal = crate::api::principal::extract_principal_from_request(&request);
         if !crate::api::principal::is_ops_elevated(&principal) {
@@ -1030,11 +1030,12 @@ impl NetworkHandler {
                 "Ops",
                 "Shutdown",
                 false,
-                "requires Council or InfraAdmin",
+                "requires ops elevation",
             );
             return Ok(ZhtpResponse::error(
                 ZhtpStatus::Forbidden,
-                "Node shutdown requires Council or InfraAdmin role".to_string(),
+                "Node shutdown requires ops elevation (Council, InfraAdmin, or ops grant)"
+                    .to_string(),
             ));
         }
         info!(


### PR DESCRIPTION
## Summary
**Urgent security fix.** `POST /api/v1/node/shutdown` was unauthenticated on `development` and could SIGTERM the node process.

Gates on `is_ops_elevated` (Council | InfraAdmin), same pattern as halt-consensus.

This is a **surgical cherry-pick** of only the shutdown gate from dual-auth Phase A (#2947). It does **not** include InfraAdmin wallet purity or the rest of the dual-auth stack, so it can land immediately without waiting on the docs PR base.

## Test plan
- [ ] Unauthenticated `POST /api/v1/node/shutdown` → 403 (not SIGTERM)
- [ ] Council or `ZHTP_INFRA_ADMIN_DIDS` principal → 200 + shutdown path
- [ ] Diff is one function in `network/mod.rs` only

## Deploy
Recommend merge + deploy to g1–g3 as soon as CI is green.