### PR TITLE
FIX: Make wallets_for_owner sled-first with in-memory overlay

### DIFF
--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -2023,3 +2023,130 @@ fn collect_spendable_outputs_reads_sled() {
     assert_eq!(owned.len(), 1);
     assert!(bc.spendable_outputs_for_owner(&[0xEE; 32]).is_empty());
 }
+
+#[test]
+fn wallets_for_owner_reads_sled_when_in_memory_empty() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("wfo_sled")).unwrap());
+
+    let owner = crate::types::hash::Hash::new([0xAB; 32]);
+    let other = crate::types::hash::Hash::new([0xCD; 32]);
+
+    let wallet_id = [0x11u8; 32];
+    let mut owned = test_wallet_data(wallet_id, "Sled Owned");
+    owned.owner_identity_id = Some(owner);
+
+    let other_id = [0x22u8; 32];
+    let mut unrelated = test_wallet_data(other_id, "Sled Other");
+    unrelated.owner_identity_id = Some(other);
+
+    store.begin_block(0).unwrap();
+    store
+        .put_wallet_projection(
+            &wallet_id,
+            &crate::storage::WalletProjectionRecord {
+                wallet_data: owned.clone(),
+                committed_at_height: 0,
+            },
+        )
+        .unwrap();
+    store
+        .put_wallet_projection(
+            &other_id,
+            &crate::storage::WalletProjectionRecord {
+                wallet_data: unrelated,
+                committed_at_height: 0,
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    // In-memory shadow is empty — simulates restart with durable sled state only.
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+
+    let found = bc.wallets_for_owner(&owner);
+    assert_eq!(found.len(), 1, "only the owned wallet matches this owner");
+    assert_eq!(found[0].0, hex::encode(wallet_id));
+    assert_eq!(found[0].1.wallet_name, "Sled Owned");
+
+    let found_other = bc.wallets_for_owner(&other);
+    assert_eq!(found_other.len(), 1, "other-owner wallet is found by its owner");
+    assert_eq!(found_other[0].1.wallet_name, "Sled Other");
+}
+
+#[test]
+fn wallets_for_owner_overlay_in_memory_wins() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("wfo_overlay")).unwrap());
+    let owner = crate::types::hash::Hash::new([0xEF; 32]);
+    let wallet_id = [0x33u8; 32];
+    let wallet_id_hex = hex::encode(wallet_id);
+
+    let mut sled_wallet = test_wallet_data(wallet_id, "From Sled");
+    sled_wallet.owner_identity_id = Some(owner);
+
+    store.begin_block(0).unwrap();
+    store
+        .put_wallet_projection(
+            &wallet_id,
+            &crate::storage::WalletProjectionRecord {
+                wallet_data: sled_wallet,
+                committed_at_height: 0,
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+
+    let mut mem_wallet = test_wallet_data(wallet_id, "From InMem");
+    mem_wallet.owner_identity_id = Some(owner);
+    bc.insert_wallet_shadow(wallet_id_hex.clone(), mem_wallet);
+
+    let found = bc.wallets_for_owner(&owner);
+    assert_eq!(found.len(), 1, "overlay dedupes by wallet_id");
+    assert_eq!(
+        found[0].1.wallet_name, "From InMem",
+        "in-memory overlay must win over sled"
+    );
+}
+
+#[test]
+fn wallets_for_owner_union_in_memory_and_sled() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(&temp.path().join("wfo_union")).unwrap());
+    let owner = crate::types::hash::Hash::new([0xBE; 32]);
+
+    let sled_id = [0x44u8; 32];
+    let mut sled_wallet = test_wallet_data(sled_id, "Sled Wallet");
+    sled_wallet.owner_identity_id = Some(owner);
+
+    store.begin_block(0).unwrap();
+    store
+        .put_wallet_projection(
+            &sled_id,
+            &crate::storage::WalletProjectionRecord {
+                wallet_data: sled_wallet,
+                committed_at_height: 0,
+            },
+        )
+        .unwrap();
+    store.commit_block().unwrap();
+
+    let mut bc = Blockchain::new().expect("blockchain construct");
+    bc.set_store(store);
+
+    let mem_id = [0x55u8; 32];
+    let mem_hex = hex::encode(mem_id);
+    let mut mem_wallet = test_wallet_data(mem_id, "InMem Wallet");
+    mem_wallet.owner_identity_id = Some(owner);
+    bc.insert_wallet_shadow(mem_hex, mem_wallet);
+
+    let found = bc.wallets_for_owner(&owner);
+    assert_eq!(found.len(), 2, "union of sled + in-memory wallets for same owner");
+    let names: Vec<&str> = found.iter().map(|(_, w)| w.wallet_name.as_str()).collect();
+    assert!(names.contains(&"Sled Wallet"), "sled wallet is in the result");
+    assert!(names.contains(&"InMem Wallet"), "in-memory wallet is in the result");
+}

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -735,18 +735,33 @@ impl Blockchain {
         }
     }
 
-    /// Wallets owned by an identity in the in-memory shadow only (O(N) over
-    /// `wallet_registry`, not sled). Do not call per-identity inside tight loops
-    /// on store-backed nodes with large wallet projections.
+    /// Wallets owned by an identity, sled-first with in-memory overlay (#2639).
+    ///
+    /// Reads durable wallet projections when the store is attached, then overlays
+    /// the in-memory shadow (pending / same-block registrations win on conflict).
+    /// Falls back to the in-memory shadow only when no store is attached.
     pub fn wallets_for_owner(
         &self,
         owner_identity_id: &crate::types::Hash,
     ) -> Vec<(String, crate::transaction::WalletTransactionData)> {
-        self.wallet_registry
-            .iter()
-            .filter(|(_, wallet)| wallet.owner_identity_id.as_ref() == Some(owner_identity_id))
-            .map(|(wallet_id, wallet)| (wallet_id.clone(), wallet.clone()))
-            .collect()
+        let mut out = HashMap::new();
+        // 1. sled first
+        if let Some(store) = self.get_store() {
+            if let Ok(iter) = store.iter_wallet_projections() {
+                for (wallet_id, record) in iter {
+                    if record.wallet_data.owner_identity_id.as_ref() == Some(owner_identity_id) {
+                        out.insert(hex::encode(wallet_id), record.wallet_data);
+                    }
+                }
+            }
+        }
+        // 2. in-memory overlay (wins on conflict)
+        for (wallet_id_hex, data) in &self.wallet_registry {
+            if data.owner_identity_id.as_ref() == Some(owner_identity_id) {
+                out.insert(wallet_id_hex.clone(), data.clone());
+            }
+        }
+        out.into_iter().collect()
     }
 
     /// Register a wallet via the trusted system-injection path (**enqueue only**).


### PR DESCRIPTION

## Summary

`wallets_for_owner()` read exclusively from the in-memory `wallet_registry` HashMap and was missed during the #2639 sled migration. Made it sled-first with an in-memory overlay so wallet lookups by owner survive restart, and added regression tests covering the sled-only, overlay, and union cases.

## Linked issues

Closes #2970
Refs #2639 (sled migration), #2769 (duplicate-wallet recovery bug caused by this gap), #2735 (GENESIS-7 bridge removal, unblocked by this reader)

## Architecture compliance

Implements `docs/arch/state-unification.md` § 2.1 (the intended sled-backed pipeline) and the #2639 sled-first facade pattern established by `wallet_registry_snapshot()` (lib-blockchain/src/blockchain/wallets.rs:930)) and `wallet_transaction_data()` ((lib-blockchain/src/blockchain/wallets.rs:912)). Same sled-first + in-memory-overlay contract, no deviation.

## Test plan

- [x] Unit tests added/updated — three new facade tests in [`facade_tests.rs`](lib-blockchain/src/blockchain/tests/facade_tests.rs): `wallets_for_owner_reads_sled_when_in_memory_empty`, `wallets_for_owner_overlay_in_memory_wins`, `wallets_for_owner_union_in_memory_and_sled`
- [ ] Integration tests added/updated
- [x] Manual verification: `cargo test -p lib-blockchain --lib facade_tests` → 47 passed, 0 failed (no regressions in sibling sled-first facades)

## Risk and reversibility

Read-path-only change with no consensus or wire-format impact; safe to deploy as a normal binary update with no coordinated network restart. Revert is a single-file rollback of `wallets_for_owner()` to the in-memory-only body.

---

Notes:
- The commit (`c6ad1197`) is already pushed to branch `2970-wallets_for_owner-...`.
- The "Integration tests" checkbox is left unchecked since no cli command for identity recover or restore.