### PR TITLE
fix(#2979): client-aligned PQC wallet IDs for remote registration

### DIFF
--- a/lib-blockchain/src/blockchain.rs
+++ b/lib-blockchain/src/blockchain.rs
@@ -26,24 +26,24 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use tracing::{debug, error, info, warn};
 
-mod test_utils;
-#[cfg(test)]
-mod tests;
-mod credentials;
-pub mod rewards;
-mod dao;
-pub mod replay;
 mod contracts;
+mod credentials;
+mod dao;
+mod gateways;
 mod identity;
 mod init;
 mod oracle;
 mod persistence;
 mod projections;
-mod validators;
-mod gateways;
-mod wallets;
-mod utxo;
+pub mod replay;
+pub mod rewards;
 mod system_originator;
+mod test_utils;
+#[cfg(test)]
+mod tests;
+mod utxo;
+mod validators;
+mod wallets;
 pub use system_originator::SystemOriginator;
 
 pub use persistence::PersistenceStats;
@@ -1032,9 +1032,7 @@ impl Blockchain {
             // Use BlockExecutor for state mutations
             // Note: executor.apply_block() handles begin_block/commit_block internally
             let fee_floor = self.tx_fee_config.domain_registration_fee_atoms;
-            let treasury_wallet = self
-                .get_dao_treasury_wallet_id()
-                .map(|id| id.as_str());
+            let treasury_wallet = self.get_dao_treasury_wallet_id().map(|id| id.as_str());
             match executor.apply_block_committing_domain_fees(
                 &block,
                 Some(fee_floor),
@@ -1428,8 +1426,8 @@ impl Blockchain {
                     // are durable. If we crash between the two commits,
                     // the meta marker is absent → next startup falls
                     // back to historical replay (which re-runs backfill).
-                    if let Err(e) = self
-                        .commit_hot_state_projection_meta_only(store.as_ref(), &block)
+                    if let Err(e) =
+                        self.commit_hot_state_projection_meta_only(store.as_ref(), &block)
                     {
                         warn!(
                             "Failed to commit projection meta for block {}: {}",
@@ -1834,11 +1832,8 @@ impl Blockchain {
         // Legacy-path fee debits write in-mem first; mirror to sled when attached so
         // sled-first reads (token_balance) observe the debit (#2712 review).
         let mirror_fee_to_sled = self.get_store().is_some();
-        let mut sled_fee_sync: Vec<(
-            crate::storage::TokenId,
-            crate::storage::Address,
-            u128,
-        )> = Vec::new();
+        let mut sled_fee_sync: Vec<(crate::storage::TokenId, crate::storage::Address, u128)> =
+            Vec::new();
 
         // Get mutable reference to SOV token contract
         let sov_token = match self.token_contracts.get_mut(&sov_token_id) {
@@ -2113,9 +2108,7 @@ impl Blockchain {
             return None;
         }
         // The window holds the last `blocks.len()` blocks: [window_start ..= tip].
-        let window_start = self
-            .block_count()
-            .saturating_sub(self.blocks.len() as u64);
+        let window_start = self.block_count().saturating_sub(self.blocks.len() as u64);
         if height >= window_start {
             return self.blocks.get((height - window_start) as usize).cloned();
         }
@@ -2319,7 +2312,10 @@ impl Blockchain {
     }
 
     /// Reject duplicate or conflicting `RewardClaim` txs already in the mempool.
-    fn pending_reward_claim_conflicts(&self, incoming: &crate::transaction::reward_claim::RewardClaimData) -> bool {
+    fn pending_reward_claim_conflicts(
+        &self,
+        incoming: &crate::transaction::reward_claim::RewardClaimData,
+    ) -> bool {
         use crate::transaction::reward_claim::RewardEventKind;
         for tx in &self.pending_transactions {
             if tx.transaction_type != TransactionType::RewardClaim {
@@ -2364,7 +2360,9 @@ impl Blockchain {
         let tx_type = transaction.transaction_type;
         self.verify_and_enqueue_transaction(transaction.clone())?;
         match tx_type {
-            TransactionType::TokenTransfer | TransactionType::TokenMint | TransactionType::TokenCreation => {
+            TransactionType::TokenTransfer
+            | TransactionType::TokenMint
+            | TransactionType::TokenCreation => {
                 info!(
                     "[token/mempool] accepted: type={:?} tx={} size={} fee={}",
                     tx_type,
@@ -2441,7 +2439,11 @@ impl Blockchain {
         }
 
         let tx_hash = transaction.hash();
-        if self.pending_transactions.iter().any(|pending| pending.hash() == tx_hash) {
+        if self
+            .pending_transactions
+            .iter()
+            .any(|pending| pending.hash() == tx_hash)
+        {
             let tx_hash_hex = hex::encode(tx_hash.as_bytes());
             return Err(anyhow::anyhow!(
                 "Transaction {} rejected: duplicate already pending",
@@ -2453,8 +2455,7 @@ impl Blockchain {
         // `verify_transaction` collapses errors to bool and hid UnregisteredSender
         // as a generic "Transaction verification failed" to clients.
         {
-            let validator =
-                crate::transaction::validation::StatefulTransactionValidator::new(self);
+            let validator = crate::transaction::validation::StatefulTransactionValidator::new(self);
             if let Err(error) = validator.validate_transaction_with_state(&transaction) {
                 tracing::warn!("Transaction validation failed: {:?}", error);
                 tracing::warn!(
@@ -2638,13 +2639,9 @@ impl Blockchain {
                         label
                     ));
                 }
-                let identity_data = tx
-                    .identity_data()
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "ClientIdentityRegistration missing identity payload"
-                        )
-                    })?;
+                let identity_data = tx.identity_data().ok_or_else(|| {
+                    anyhow::anyhow!("ClientIdentityRegistration missing identity payload")
+                })?;
                 if identity_data.ownership_proof.is_empty() {
                     return Err(anyhow::anyhow!(
                         "ClientIdentityRegistration requires non-empty ownership_proof"
@@ -2729,17 +2726,17 @@ impl Blockchain {
     fn validate_welcome_bonus_mint_memo(tx: &Transaction) -> anyhow::Result<()> {
         const WELCOME_BONUS_ATOMS: u128 = lib_types::sov::atoms(5_000);
 
-        let mint_data = tx
-            .token_mint_data()
-            .ok_or_else(|| anyhow::anyhow!("TreasuryWalletBootstrap TokenMint missing mint data"))?;
+        let mint_data = tx.token_mint_data().ok_or_else(|| {
+            anyhow::anyhow!("TreasuryWalletBootstrap TokenMint missing mint data")
+        })?;
         let memo_str = std::str::from_utf8(&tx.memo).map_err(|_| {
             anyhow::anyhow!("TreasuryWalletBootstrap TokenMint memo is not valid UTF-8")
         })?;
-        let wallet_hex = memo_str
-            .strip_prefix("WELCOME_BONUS_V1:")
-            .ok_or_else(|| {
-                anyhow::anyhow!("TreasuryWalletBootstrap TokenMint memo missing WELCOME_BONUS_V1: prefix")
-            })?;
+        let wallet_hex = memo_str.strip_prefix("WELCOME_BONUS_V1:").ok_or_else(|| {
+            anyhow::anyhow!(
+                "TreasuryWalletBootstrap TokenMint memo missing WELCOME_BONUS_V1: prefix"
+            )
+        })?;
         if wallet_hex.is_empty() {
             return Err(anyhow::anyhow!(
                 "TreasuryWalletBootstrap TokenMint memo missing wallet recipient"
@@ -2790,7 +2787,11 @@ impl Blockchain {
         Self::validate_system_injection(originator, &transaction)?;
 
         let tx_hash = transaction.hash();
-        if self.pending_transactions.iter().any(|pending| pending.hash() == tx_hash) {
+        if self
+            .pending_transactions
+            .iter()
+            .any(|pending| pending.hash() == tx_hash)
+        {
             let tx_hash_hex = hex::encode(tx_hash.as_bytes());
             return Err(anyhow::anyhow!(
                 "Transaction {} rejected: duplicate already pending",
@@ -2804,10 +2805,7 @@ impl Blockchain {
             tx_hash = %hex::encode(&transaction.hash().as_bytes()[..8]),
             "system tx (bypass admission + verify)",
         );
-        *self
-            .system_tx_originators
-            .entry(label)
-            .or_insert(0) += 1;
+        *self.system_tx_originators.entry(label).or_insert(0) += 1;
 
         // Keep `mempool_state` paired with the pending pool. We bypass
         // `lib_mempool::admit()` here (no sig verify, no DoS caps for system
@@ -2830,11 +2828,7 @@ impl Blockchain {
         // verify_and_enqueue_transaction; best-effort).
         if let Some(store) = &self.store {
             if let Err(e) = store.put_pending_transaction(&transaction) {
-                tracing::warn!(
-                    originator = label,
-                    "system tx persistence failed: {}",
-                    e
-                );
+                tracing::warn!(originator = label, "system tx persistence failed: {}", e);
             }
         }
 
@@ -2856,16 +2850,20 @@ impl Blockchain {
         // Drain matching txes so we can update mempool_state from the actual
         // accepted-then-committed entries (sender + tx_bytes) rather than the
         // generic `transactions` slice that may also include never-admitted ones.
-        let (committed, remaining): (Vec<_>, Vec<_>) = std::mem::take(&mut self.pending_transactions)
-            .into_iter()
-            .partition(|tx| tx_hashes.contains(&tx.hash()));
+        let (committed, remaining): (Vec<_>, Vec<_>) =
+            std::mem::take(&mut self.pending_transactions)
+                .into_iter()
+                .partition(|tx| tx_hashes.contains(&tx.hash()));
         self.pending_transactions = remaining;
         for tx in &committed {
             let admit_tx = tx.to_admit_tx();
             self.mempool_state
                 .remove_tx(&admit_tx.sender, admit_tx.tx_bytes as u64);
             if let Some(store) = &self.store {
-                if let Err(e) = { let h = tx.hash().as_array(); store.delete_pending_transaction(&h) } {
+                if let Err(e) = {
+                    let h = tx.hash().as_array();
+                    store.delete_pending_transaction(&h)
+                } {
                     tracing::warn!("pending tx unpersist (commit) failed: {}", e);
                 }
             }
@@ -2883,7 +2881,10 @@ impl Blockchain {
             self.mempool_state
                 .remove_tx(&admit_tx.sender, admit_tx.tx_bytes as u64);
             if let Some(store) = &self.store {
-                if let Err(e) = { let h = tx.hash().as_array(); store.delete_pending_transaction(&h) } {
+                if let Err(e) = {
+                    let h = tx.hash().as_array();
+                    store.delete_pending_transaction(&h)
+                } {
                     tracing::warn!("pending tx unpersist (stale-nonce evict) failed: {}", e);
                 }
             }
@@ -2921,12 +2922,10 @@ impl Blockchain {
             ));
         }
         let sender_bal_post = token.balance_of(sender);
-        token
-            .set_balance(sender, sender_bal_post.saturating_sub(fee_amount as u128));
+        token.set_balance(sender, sender_bal_post.saturating_sub(fee_amount as u128));
         if let Some(ref tpk) = treasury_key {
             let tbal = token.balance_of(tpk);
-            token
-                .set_balance(tpk, tbal.saturating_add(fee_amount as u128));
+            token.set_balance(tpk, tbal.saturating_add(fee_amount as u128));
             debug!(
                 "TokenTransfer: {} SOV fee → DAO treasury (height {})",
                 fee_amount, height
@@ -2955,7 +2954,10 @@ impl Blockchain {
             self.mempool_state
                 .remove_tx(&admit_tx.sender, admit_tx.tx_bytes as u64);
             if let Some(store) = &self.store {
-                if let Err(e) = { let h = tx.hash().as_array(); store.delete_pending_transaction(&h) } {
+                if let Err(e) = {
+                    let h = tx.hash().as_array();
+                    store.delete_pending_transaction(&h)
+                } {
                     tracing::warn!("pending tx unpersist (phase2 evict) failed: {}", e);
                 }
             }
@@ -4320,9 +4322,9 @@ impl Blockchain {
 
         // Sum SOV balances across all wallets owned by this identity (#2637).
         let sov_balance: u128 = self
-            .get_wallets_for_owner(&user_local_id)
+            .wallets_for_owner(&user_local_id)
             .iter()
-            .map(|w| self.sov_wallet_balance_for_voting(&sov_id, &w.wallet_id.as_array()))
+            .map(|(_, w)| self.sov_wallet_balance_for_voting(&sov_id, &w.wallet_id.as_array()))
             .sum();
 
         // 1 SOV (1e18 atomic units) = 1 base vote unit
@@ -4339,10 +4341,12 @@ impl Blockchain {
                 let bytes = hex::decode(delegator_hex).ok()?;
                 let delegator_bytes: [u8; 32] = bytes.try_into().ok()?;
                 let delegator_local_id = crate::types::hash::Hash::new(delegator_bytes);
-                let delegator_wallets = self.get_wallets_for_owner(&delegator_local_id);
+                let delegator_wallets = self.wallets_for_owner(&delegator_local_id);
                 let bal: u128 = delegator_wallets
                     .iter()
-                    .map(|w| self.sov_wallet_balance_for_voting(&sov_id, &w.wallet_id.as_array()))
+                    .map(|(_, w)| {
+                        self.sov_wallet_balance_for_voting(&sov_id, &w.wallet_id.as_array())
+                    })
                     .sum();
                 Some((bal / lib_types::sov::SCALE) as u64)
             })
@@ -4498,6 +4502,7 @@ impl Blockchain {
                     ), // Default name
                     alias: None, // Will need DHT retrieval for real alias
                     public_key: wallet_ref.public_key.clone(),
+                    kyber_public_key: vec![],
                     owner_identity_id: wallet_ref.owner_identity_id,
                     seed_commitment: crate::types::Hash::from([0u8; 32]), // Default - will need DHT for real commitment
                     created_at: wallet_ref.created_at,
@@ -4533,9 +4538,11 @@ impl Blockchain {
 
         // Verify block chain continuity
         for i in 1..self.block_count() {
-            let (Some(current), Some(previous)) = (self.get_block(i), self.get_block(i - 1))
-            else {
-                error!("Block chain continuity broken: missing block near height {}", i);
+            let (Some(current), Some(previous)) = (self.get_block(i), self.get_block(i - 1)) else {
+                error!(
+                    "Block chain continuity broken: missing block near height {}",
+                    i
+                );
                 return Ok(false);
             };
 
@@ -4909,13 +4916,15 @@ impl Blockchain {
                         block.header.height,
                     ));
                 }
-                self.apply_block_trusted_for_sync(block).await.map_err(|e| {
-                    anyhow::anyhow!(
+                self.apply_block_trusted_for_sync(block)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!(
                         "Imported chain rejected: block {} failed verification during adoption: {}",
                         height,
                         e
                     )
-                })?;
+                    })?;
             }
 
             info!(
@@ -4971,8 +4980,7 @@ impl Blockchain {
         );
 
         // Use consensus rules to decide which chain to adopt
-        let decision =
-            crate::ChainEvaluator::evaluate_chains(&local_summary, &imported_summary);
+        let decision = crate::ChainEvaluator::evaluate_chains(&local_summary, &imported_summary);
 
         match decision {
             crate::ChainDecision::KeepLocal => {
@@ -5370,6 +5378,7 @@ impl Blockchain {
                     ),
                     alias: None,
                     public_key: wallet_ref.public_key.clone(),
+                    kyber_public_key: vec![],
                     owner_identity_id: wallet_ref.owner_identity_id,
                     seed_commitment: crate::types::Hash::from([0u8; 32]),
                     created_at: wallet_ref.created_at,
@@ -5768,6 +5777,7 @@ impl Blockchain {
                     ),
                     alias: None,
                     public_key: wallet_ref.public_key.clone(),
+                    kyber_public_key: vec![],
                     owner_identity_id: wallet_ref.owner_identity_id,
                     seed_commitment: crate::types::Hash::from([0u8; 32]),
                     created_at: wallet_ref.created_at,
@@ -5891,6 +5901,7 @@ impl Blockchain {
                     ),
                     alias: None,
                     public_key: wallet_ref.public_key.clone(),
+                    kyber_public_key: vec![],
                     owner_identity_id: wallet_ref.owner_identity_id,
                     seed_commitment: crate::types::Hash::from([0u8; 32]),
                     created_at: wallet_ref.created_at,
@@ -6937,12 +6948,7 @@ impl Blockchain {
                 .as_secs(),
         };
 
-        let memo = format!(
-            "pouw:mint:{}:{}",
-            hex::encode(recipient_key_id),
-            amount
-        )
-        .into_bytes();
+        let memo = format!("pouw:mint:{}:{}", hex::encode(recipient_key_id), amount).into_bytes();
 
         let mint_tx = Transaction::new_token_mint(mint_data, signature, memo);
         let tx_hash = mint_tx.hash();

--- a/lib-blockchain/src/blockchain/contracts.rs
+++ b/lib-blockchain/src/blockchain/contracts.rs
@@ -12,7 +12,10 @@ impl Blockchain {
                     {
                         let contract_id = lib_crypto::hash_blake3(web4_contract.domain.as_bytes());
                         self.register_web4_contract(contract_id, web4_contract, block.height());
-                        info!(" Processed Web4Contract deployment in block {}", block.height());
+                        info!(
+                            " Processed Web4Contract deployment in block {}",
+                            block.height()
+                        );
                     } else if let Ok(token_contract) =
                         bincode::deserialize::<crate::contracts::TokenContract>(
                             output.commitment.as_bytes(),
@@ -20,7 +23,10 @@ impl Blockchain {
                     {
                         let contract_id = token_contract.token_id;
                         self.register_token_contract(contract_id, token_contract, block.height());
-                        info!(" Processed TokenContract deployment in block {}", block.height());
+                        info!(
+                            " Processed TokenContract deployment in block {}",
+                            block.height()
+                        );
                     } else {
                         debug!(
                             " Could not deserialize contract in transaction {}",
@@ -209,289 +215,293 @@ impl Blockchain {
         'tx_loop: for transaction in &block.transactions {
             let tx_type = transaction.transaction_type;
             let arm_result: anyhow::Result<()> = (|| -> anyhow::Result<()> {
-            match tx_type {
-                TransactionType::TokenTransfer => {
-                    let transfer = transaction
-                        .token_transfer_data()
-                        .ok_or_else(|| anyhow::anyhow!("TokenTransfer missing data"))?;
+                match tx_type {
+                    TransactionType::TokenTransfer => {
+                        let transfer = transaction
+                            .token_transfer_data()
+                            .ok_or_else(|| anyhow::anyhow!("TokenTransfer missing data"))?;
 
-                    if transfer.amount == 0 {
-                        return Err(anyhow::anyhow!("TokenTransfer amount must be > 0"));
-                    }
+                        if transfer.amount == 0 {
+                            return Err(anyhow::anyhow!("TokenTransfer amount must be > 0"));
+                        }
 
-                    let is_sov = Self::is_sov_token_id(&transfer.token_id);
-                    let token_id = if is_sov {
-                        sov_token_id
-                    } else {
-                        transfer.token_id
-                    };
+                        let is_sov = Self::is_sov_token_id(&transfer.token_id);
+                        let token_id = if is_sov {
+                            sov_token_id
+                        } else {
+                            transfer.token_id
+                        };
 
-                    // Read the canonical nonce from sled via the getter that
-                    // falls through when the in-memory cache is empty. Direct
-                    // `self.token_nonces.get(...)` reads bypass the canonical
-                    // store and were the source of the g3/g5 halt at h=114445.
-                    let nonce_key = (token_id, transfer.from);
-                    let expected_nonce = self.get_token_nonce(&token_id, &transfer.from);
-                    if transfer.nonce != expected_nonce {
-                        return Err(anyhow::anyhow!(
-                            "TokenTransfer nonce mismatch: expected {}, got {}",
-                            expected_nonce,
-                            transfer.nonce
-                        ));
-                    }
+                        // Read the canonical nonce from sled via the getter that
+                        // falls through when the in-memory cache is empty. Direct
+                        // `self.token_nonces.get(...)` reads bypass the canonical
+                        // store and were the source of the g3/g5 halt at h=114445.
+                        let nonce_key = (token_id, transfer.from);
+                        let expected_nonce = self.get_token_nonce(&token_id, &transfer.from);
+                        if transfer.nonce != expected_nonce {
+                            return Err(anyhow::anyhow!(
+                                "TokenTransfer nonce mismatch: expected {}, got {}",
+                                expected_nonce,
+                                transfer.nonce
+                            ));
+                        }
 
-                    let sender_pk = transaction.signature.public_key.clone();
+                        let sender_pk = transaction.signature.public_key.clone();
 
-                    if token_id == sov_token_id {
-                        self.ensure_sov_token_contract();
-                    }
+                        if token_id == sov_token_id {
+                            self.ensure_sov_token_contract();
+                        }
 
-                    let amount_u64: u64 = transfer
-                        .amount
-                        .try_into()
-                        .map_err(|_| anyhow::anyhow!("TokenTransfer amount exceeds u64"))?;
+                        let amount_u64: u64 = transfer
+                            .amount
+                            .try_into()
+                            .map_err(|_| anyhow::anyhow!("TokenTransfer amount exceeds u64"))?;
 
-                    let fee_rate_bps = crate::contracts::tokens::constants::SOV_FEE_RATE_BPS;
-                    let fee_amount: u64 =
-                        (amount_u64 as u128 * fee_rate_bps as u128 / 10_000) as u64;
-                    let net_amount: u64 = amount_u64.saturating_sub(fee_amount);
+                        let fee_rate_bps = crate::contracts::tokens::constants::SOV_FEE_RATE_BPS;
+                        let fee_amount: u64 =
+                            (amount_u64 as u128 * fee_rate_bps as u128 / 10_000) as u64;
+                        let net_amount: u64 = amount_u64.saturating_sub(fee_amount);
 
-                    let treasury_pk_opt: Option<PublicKey> = self
-                        .dao_treasury_wallet_id
-                        .as_ref()
-                        .and_then(|hex_id| hex::decode(hex_id).ok())
-                        .and_then(|bytes| {
-                            if bytes.len() == 32 {
-                                let mut arr = [0u8; 32];
-                                arr.copy_from_slice(&bytes);
-                                Some(Self::wallet_key_for_sov(&arr))
-                            } else {
-                                None
-                            }
-                        });
+                        let treasury_pk_opt: Option<PublicKey> = self
+                            .dao_treasury_wallet_id
+                            .as_ref()
+                            .and_then(|hex_id| hex::decode(hex_id).ok())
+                            .and_then(|bytes| {
+                                if bytes.len() == 32 {
+                                    let mut arr = [0u8; 32];
+                                    arr.copy_from_slice(&bytes);
+                                    Some(Self::wallet_key_for_sov(&arr))
+                                } else {
+                                    None
+                                }
+                            });
 
-                    let tx_hash_obj = transaction.hash();
-                    let tx_hash_bytes = tx_hash_obj.as_bytes();
-                    let mut tx_hash = [0u8; 32];
-                    tx_hash.copy_from_slice(tx_hash_bytes);
+                        let tx_hash_obj = transaction.hash();
+                        let tx_hash_bytes = tx_hash_obj.as_bytes();
+                        let mut tx_hash = [0u8; 32];
+                        tx_hash.copy_from_slice(tx_hash_bytes);
 
-                    if is_sov {
-                        let from_wallet_id = hex::encode(transfer.from);
-                        let to_wallet_id = hex::encode(transfer.to);
+                        if is_sov {
+                            let from_wallet_id = hex::encode(transfer.from);
+                            let to_wallet_id = hex::encode(transfer.to);
 
-                        // Wallet lookup with transparent legacy migration.
-                        // Pre-fix wallets were registered under an HD-derived wallet_id; the new
-                        // wallet_id = blake3(dilithium_pk || kyber_pk) == signer's key_id.
-                        // When the sender's key_id is not in the registry, scan for a wallet whose
-                        // dilithium_pk matches the sender and migrate it in place — no user action
-                        // required.
-                        if !self.wallet_registry.contains_key(&from_wallet_id) {
-                            let sender_dilithium = sender_pk.dilithium_pk.to_vec();
-                            let legacy_key = self
-                                .wallet_registry
-                                .iter()
-                                .find(|(_, w)| {
-                                    w.public_key.len() == 2592
-                                        && w.public_key == sender_dilithium
-                                })
-                                .map(|(k, _)| k.clone());
+                            // Wallet lookup with transparent legacy migration.
+                            // Pre-fix wallets were registered under an HD-derived wallet_id; the new
+                            // wallet_id = blake3(dilithium_pk || kyber_pk) == signer's key_id.
+                            // When the sender's key_id is not in the registry, scan for a wallet whose
+                            // dilithium_pk matches the sender and migrate it in place — no user action
+                            // required.
+                            if !self.wallet_registry.contains_key(&from_wallet_id) {
+                                let sender_dilithium = sender_pk.dilithium_pk.to_vec();
+                                let legacy_key = self
+                                    .wallet_registry
+                                    .iter()
+                                    .find(|(_, w)| {
+                                        w.public_key.len() == 2592
+                                            && w.public_key == sender_dilithium
+                                    })
+                                    .map(|(k, _)| k.clone());
 
-                            if let Some(old_key) = legacy_key {
-                                if let Some(mut old_wallet) =
-                                    self.wallet_registry.remove(&old_key)
-                                {
-                                    let old_wallet_id_bytes: [u8; 32] = old_wallet
-                                        .wallet_id
-                                        .as_bytes()
-                                        .try_into()
-                                        .unwrap_or([0u8; 32]);
-                                    old_wallet.wallet_id = Hash::new(transfer.from);
-                                    self.wallet_registry
-                                        .insert(from_wallet_id.clone(), old_wallet);
-
-                                    // Migrate SOV balance: move from old wallet address to new
-                                    // without changing total_supply (purely a re-keying).
-                                    let old_sov_addr =
-                                        Self::wallet_key_for_sov(&old_wallet_id_bytes);
-                                    let new_sov_addr = Self::wallet_key_for_sov(&transfer.from);
-                                    if let Some(token) =
-                                        self.token_contracts.get_mut(&token_id)
+                                if let Some(old_key) = legacy_key {
+                                    if let Some(mut old_wallet) =
+                                        self.wallet_registry.remove(&old_key)
                                     {
-                                        let old_bal = token.balance_of(&old_sov_addr);
-                                        if old_bal > 0 {
-                                            token.set_balance(&old_sov_addr, 0);
-                                            let cur_new = token.balance_of(&new_sov_addr);
-                                            token.set_balance(
-                                                &new_sov_addr,
-                                                cur_new.saturating_add(old_bal),
-                                            );
+                                        let old_wallet_id_bytes: [u8; 32] = old_wallet
+                                            .wallet_id
+                                            .as_bytes()
+                                            .try_into()
+                                            .unwrap_or([0u8; 32]);
+                                        old_wallet.wallet_id = Hash::new(transfer.from);
+                                        self.wallet_registry
+                                            .insert(from_wallet_id.clone(), old_wallet);
+
+                                        // Migrate SOV balance: move from old wallet address to new
+                                        // without changing total_supply (purely a re-keying).
+                                        let old_sov_addr =
+                                            Self::wallet_key_for_sov(&old_wallet_id_bytes);
+                                        let new_sov_addr = Self::wallet_key_for_sov(&transfer.from);
+                                        if let Some(token) = self.token_contracts.get_mut(&token_id)
+                                        {
+                                            let old_bal = token.balance_of(&old_sov_addr);
+                                            if old_bal > 0 {
+                                                token.set_balance(&old_sov_addr, 0);
+                                                let cur_new = token.balance_of(&new_sov_addr);
+                                                token.set_balance(
+                                                    &new_sov_addr,
+                                                    cur_new.saturating_add(old_bal),
+                                                );
+                                            }
                                         }
-                                    }
-                                    info!(
+                                        info!(
                                         "🔄 Migrated SOV wallet {} → {} (transparent key_id migration)",
                                         old_key, from_wallet_id
                                     );
-                                }
-                            } else {
-                                // Same-block deterministic wallet materialization for legacy
-                                // senders (signature proves ownership). No welcome SOV mint —
-                                // inventing supply here was a #1983 / #1993 divergence source.
-                                // initial_balance stays 0; funding must be TokenMint history.
-                                let wallet_data = crate::transaction::WalletTransactionData {
-                                    wallet_id: Hash::new(transfer.from),
-                                    owner_identity_id: None,
-                                    alias: Some(format!("migrated_{}", &from_wallet_id[..8])),
-                                    wallet_name: "Migrated Wallet".to_string(),
-                                    wallet_type: "Primary".to_string(),
-                                    public_key: sender_pk.dilithium_pk.to_vec(),
-                                    capabilities: 0xFFFFFFFF,
-                                    created_at: 0,
-                                    registration_fee: 0,
-                                    initial_balance: 0,
-                                    seed_commitment: crate::types::hash::blake3_hash(
-                                        format!("migrated:{}", from_wallet_id).as_bytes(),
-                                    ),
-                                };
-                                self.insert_wallet_shadow(from_wallet_id.clone(), wallet_data);
-                                info!(
+                                    }
+                                } else {
+                                    // Same-block deterministic wallet materialization for legacy
+                                    // senders (signature proves ownership). No welcome SOV mint —
+                                    // inventing supply here was a #1983 / #1993 divergence source.
+                                    // initial_balance stays 0; funding must be TokenMint history.
+                                    let wallet_data = crate::transaction::WalletTransactionData {
+                                        wallet_id: Hash::new(transfer.from),
+                                        owner_identity_id: None,
+                                        alias: Some(format!("migrated_{}", &from_wallet_id[..8])),
+                                        wallet_name: "Migrated Wallet".to_string(),
+                                        wallet_type: "Primary".to_string(),
+                                        public_key: sender_pk.dilithium_pk.to_vec(),
+                                        kyber_public_key: vec![],
+                                        capabilities: 0xFFFFFFFF,
+                                        created_at: 0,
+                                        registration_fee: 0,
+                                        initial_balance: 0,
+                                        seed_commitment: crate::types::hash::blake3_hash(
+                                            format!("migrated:{}", from_wallet_id).as_bytes(),
+                                        ),
+                                    };
+                                    self.insert_wallet_shadow(from_wallet_id.clone(), wallet_data);
+                                    info!(
                                     "🔄 Transparent migration: materialised wallet {} at block execution (0 SOV; no mint)",
                                     &from_wallet_id[..16.min(from_wallet_id.len())],
                                 );
+                                }
                             }
-                        }
 
-                        if !self.wallet_registry.contains_key(&to_wallet_id) {
-                            return Err(anyhow::anyhow!(
-                                "TokenTransfer SOV recipient wallet not found"
-                            ));
-                        }
+                            if !self.wallet_registry.contains_key(&to_wallet_id) {
+                                return Err(anyhow::anyhow!(
+                                    "TokenTransfer SOV recipient wallet not found"
+                                ));
+                            }
 
-                        // Ownership check: compare dilithium_pk bytes directly.
-                        // PublicKey::new() computed key_id = blake3(dilithium_pk) only, ignoring
-                        // kyber — broken for kyber-enabled keys. Compare raw bytes instead.
-                        let from_wallet = self
-                            .wallet_registry
-                            .get(&from_wallet_id)
-                            .ok_or_else(|| {
-                                anyhow::anyhow!("TokenTransfer SOV sender wallet not found")
-                            })?;
-                        let sender_dilithium = sender_pk.dilithium_pk.as_slice();
-                        if from_wallet.public_key.len() != 2592
-                            || from_wallet.public_key.as_slice() != sender_dilithium
-                        {
-                            return Err(anyhow::anyhow!(
-                                "TokenTransfer SOV sender does not own wallet"
-                            ));
-                        }
+                            // Ownership check: compare dilithium_pk bytes directly.
+                            // PublicKey::new() computed key_id = blake3(dilithium_pk) only, ignoring
+                            // kyber — broken for kyber-enabled keys. Compare raw bytes instead.
+                            let from_wallet =
+                                self.wallet_registry.get(&from_wallet_id).ok_or_else(|| {
+                                    anyhow::anyhow!("TokenTransfer SOV sender wallet not found")
+                                })?;
+                            let sender_dilithium = sender_pk.dilithium_pk.as_slice();
+                            if from_wallet.public_key.len() != 2592
+                                || from_wallet.public_key.as_slice() != sender_dilithium
+                            {
+                                return Err(anyhow::anyhow!(
+                                    "TokenTransfer SOV sender does not own wallet"
+                                ));
+                            }
 
-                        let from_wallet_addr = Self::wallet_key_for_sov(&transfer.from);
-                        let to_wallet_addr = Self::wallet_key_for_sov(&transfer.to);
+                            let from_wallet_addr = Self::wallet_key_for_sov(&transfer.from);
+                            let to_wallet_addr = Self::wallet_key_for_sov(&transfer.to);
 
-                        let ctx = crate::contracts::executor::ExecutionContext::new(
-                            from_wallet_addr.clone(),
-                            block.height(),
-                            block.header.timestamp,
-                            0,
-                            tx_hash,
-                        );
+                            let ctx = crate::contracts::executor::ExecutionContext::new(
+                                from_wallet_addr.clone(),
+                                block.height(),
+                                block.header.timestamp,
+                                0,
+                                tx_hash,
+                            );
 
-                        let token = self
-                            .token_contracts
-                            .get_mut(&token_id)
-                            .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
-                        // Writes path: in-memory transfer below; balance_of is correct here (#2637).
-                        let from_bal = token.balance_of(&from_wallet_addr);
-                        if from_bal < amount_u64 as u128 {
-                            return Err(anyhow::anyhow!(
-                                "TokenTransfer insufficient balance: have {}, need {}",
-                                from_bal,
-                                amount_u64
-                            ));
-                        }
-                        token
-                            .transfer(&ctx, &to_wallet_addr, net_amount as u128)
-                            .map_err(|e| anyhow::anyhow!("TokenTransfer failed: {}", e))?;
-                        Self::apply_token_transfer_with_fee(
-                            token,
-                            &from_wallet_addr,
-                            amount_u64,
-                            fee_amount,
-                            &treasury_pk_opt,
-                            block.height(),
-                        )?;
-                    } else {
-                        if sender_pk.key_id != transfer.from {
-                            return Err(anyhow::anyhow!("TokenTransfer sender key_id mismatch"));
-                        }
-
-                        let recipient_pk_bytes = self
-                            .resolve_public_key_by_key_id(&transfer.to)
-                            .ok_or_else(|| anyhow::anyhow!("TokenTransfer recipient not found"))?;
-                        let recipient_pk = PublicKey::new(
-                            recipient_pk_bytes.as_slice().try_into().unwrap_or([0u8; 2592])
-                        );
-
-                        let ctx = crate::contracts::executor::ExecutionContext::new(
-                            sender_pk.clone(),
-                            block.height(),
-                            block.header.timestamp,
-                            0,
-                            tx_hash,
-                        );
-
-                        let token = self
-                            .token_contracts
-                            .get_mut(&token_id)
-                            .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
-                        // Writes path: in-memory transfer below; balance_of is correct here (#2637).
-                        let sender_bal = token.balance_of(&sender_pk);
-                        if sender_bal < amount_u64 as u128 {
-                            return Err(anyhow::anyhow!(
-                                "TokenTransfer insufficient balance: have {}, need {}",
-                                sender_bal,
-                                amount_u64
-                            ));
-                        }
-                        token
-                            .transfer(&ctx, &recipient_pk, net_amount as u128)
-                            .map_err(|e| anyhow::anyhow!("TokenTransfer failed: {}", e))?;
-                        Self::apply_token_transfer_with_fee(
-                            token,
-                            &sender_pk,
-                            amount_u64,
-                            fee_amount,
-                            &treasury_pk_opt,
-                            block.height(),
-                        )?;
-                    };
-
-                    // Nonce advance: sled is canonical in production (BlockExecutor
-                    // mode), so this in-memory write must be a no-op when the
-                    // executor is attached — `BlockExecutor::increment_token_nonce`
-                    // owns the canonical advance and a second write source here is
-                    // exactly what caused the g3/g5 halt at h=114445 (executor
-                    // wrote sled, this path wrote in-memory, the two drifted, and
-                    // validation/apply disagreed at commit time).
-                    //
-                    // When NO executor is attached (legacy store-less mode used by
-                    // tests and the deprecated processing path), there is no sled
-                    // for `get_token_nonce` to fall through to, so the in-memory
-                    // map IS the only nonce store and must continue to be written
-                    // here (CR PR #2675).
-                    if !self.has_executor() {
-                        *self.token_nonces.entry(nonce_key).or_insert(0) += 1;
-                    }
-
-                    if tracing::enabled!(tracing::Level::INFO) {
-                        let cbe_token_id = Self::derive_cbe_token_id_pub();
-                        let token_label: std::borrow::Cow<'_, str> = if is_sov {
-                            "SOV".into()
-                        } else if token_id == cbe_token_id {
-                            "CBE".into()
+                            let token = self
+                                .token_contracts
+                                .get_mut(&token_id)
+                                .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
+                            // Writes path: in-memory transfer below; balance_of is correct here (#2637).
+                            let from_bal = token.balance_of(&from_wallet_addr);
+                            if from_bal < amount_u64 as u128 {
+                                return Err(anyhow::anyhow!(
+                                    "TokenTransfer insufficient balance: have {}, need {}",
+                                    from_bal,
+                                    amount_u64
+                                ));
+                            }
+                            token
+                                .transfer(&ctx, &to_wallet_addr, net_amount as u128)
+                                .map_err(|e| anyhow::anyhow!("TokenTransfer failed: {}", e))?;
+                            Self::apply_token_transfer_with_fee(
+                                token,
+                                &from_wallet_addr,
+                                amount_u64,
+                                fee_amount,
+                                &treasury_pk_opt,
+                                block.height(),
+                            )?;
                         } else {
-                            hex::encode(&token_id[..4]).into()
+                            if sender_pk.key_id != transfer.from {
+                                return Err(anyhow::anyhow!(
+                                    "TokenTransfer sender key_id mismatch"
+                                ));
+                            }
+
+                            let recipient_pk_bytes =
+                                self.resolve_public_key_by_key_id(&transfer.to).ok_or_else(
+                                    || anyhow::anyhow!("TokenTransfer recipient not found"),
+                                )?;
+                            let recipient_pk = PublicKey::new(
+                                recipient_pk_bytes
+                                    .as_slice()
+                                    .try_into()
+                                    .unwrap_or([0u8; 2592]),
+                            );
+
+                            let ctx = crate::contracts::executor::ExecutionContext::new(
+                                sender_pk.clone(),
+                                block.height(),
+                                block.header.timestamp,
+                                0,
+                                tx_hash,
+                            );
+
+                            let token = self
+                                .token_contracts
+                                .get_mut(&token_id)
+                                .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
+                            // Writes path: in-memory transfer below; balance_of is correct here (#2637).
+                            let sender_bal = token.balance_of(&sender_pk);
+                            if sender_bal < amount_u64 as u128 {
+                                return Err(anyhow::anyhow!(
+                                    "TokenTransfer insufficient balance: have {}, need {}",
+                                    sender_bal,
+                                    amount_u64
+                                ));
+                            }
+                            token
+                                .transfer(&ctx, &recipient_pk, net_amount as u128)
+                                .map_err(|e| anyhow::anyhow!("TokenTransfer failed: {}", e))?;
+                            Self::apply_token_transfer_with_fee(
+                                token,
+                                &sender_pk,
+                                amount_u64,
+                                fee_amount,
+                                &treasury_pk_opt,
+                                block.height(),
+                            )?;
                         };
-                        info!(
+
+                        // Nonce advance: sled is canonical in production (BlockExecutor
+                        // mode), so this in-memory write must be a no-op when the
+                        // executor is attached — `BlockExecutor::increment_token_nonce`
+                        // owns the canonical advance and a second write source here is
+                        // exactly what caused the g3/g5 halt at h=114445 (executor
+                        // wrote sled, this path wrote in-memory, the two drifted, and
+                        // validation/apply disagreed at commit time).
+                        //
+                        // When NO executor is attached (legacy store-less mode used by
+                        // tests and the deprecated processing path), there is no sled
+                        // for `get_token_nonce` to fall through to, so the in-memory
+                        // map IS the only nonce store and must continue to be written
+                        // here (CR PR #2675).
+                        if !self.has_executor() {
+                            *self.token_nonces.entry(nonce_key).or_insert(0) += 1;
+                        }
+
+                        if tracing::enabled!(tracing::Level::INFO) {
+                            let cbe_token_id = Self::derive_cbe_token_id_pub();
+                            let token_label: std::borrow::Cow<'_, str> = if is_sov {
+                                "SOV".into()
+                            } else if token_id == cbe_token_id {
+                                "CBE".into()
+                            } else {
+                                hex::encode(&token_id[..4]).into()
+                            };
+                            info!(
                             "[token/transfer] committed: token={} from={} to={} amount={} fee={} net={} nonce={} height={} tx={}",
                             token_label,
                             hex::encode(&transfer.from[..4]),
@@ -503,366 +513,372 @@ impl Blockchain {
                             block.height(),
                             hex::encode(&tx_hash[..4]),
                         );
-                    }
+                        }
 
-                    if let Some(store) = &self.store {
-                        if let Some(token) = self.token_contracts.get(&token_id) {
-                            let store_ref: &dyn crate::storage::BlockchainStore = store.as_ref();
-                            if let Err(e) = store_ref.put_token_contract(token) {
-                                warn!("[token/transfer] failed to persist token contract: height={} token={} err={}", block.height(), hex::encode(&token_id[..4]), e);
+                        if let Some(store) = &self.store {
+                            if let Some(token) = self.token_contracts.get(&token_id) {
+                                let store_ref: &dyn crate::storage::BlockchainStore =
+                                    store.as_ref();
+                                if let Err(e) = store_ref.put_token_contract(token) {
+                                    warn!("[token/transfer] failed to persist token contract: height={} token={} err={}", block.height(), hex::encode(&token_id[..4]), e);
+                                }
                             }
                         }
                     }
-                }
-                TransactionType::TokenMint => {
-                    if transaction.version < 2 {
-                        return Err(anyhow::anyhow!(
-                            "TokenMint not supported in this serialization version"
-                        ));
-                    }
-
-                    let mint = transaction
-                        .token_mint_data()
-                        .ok_or_else(|| anyhow::anyhow!("TokenMint missing data"))?;
-
-                    if mint.amount == 0 {
-                        return Err(anyhow::anyhow!("TokenMint amount must be > 0"));
-                    }
-
-                    let is_sov = Self::is_sov_token_id(&mint.token_id);
-                    let recipient_pk = if is_sov {
-                        Self::wallet_key_for_sov(&mint.to)
-                    } else {
-                        let recipient_pk_bytes = self
-                            .resolve_public_key_by_key_id(&mint.to)
-                            .ok_or_else(|| anyhow::anyhow!("TokenMint recipient not found"))?;
-                        PublicKey::new(
-                            recipient_pk_bytes.as_slice().try_into().unwrap_or([0u8; 2592])
-                        )
-                    };
-
-                    let mut migration_from: Option<PublicKey> = None;
-                    if let Ok(memo_str) = std::str::from_utf8(&transaction.memo) {
-                        if let Some(rest) = memo_str.strip_prefix("UBI_DISTRIBUTION_V1:") {
-                            let mut parts = rest.split(':');
-                            let identity_id = parts.next().unwrap_or("").to_string();
-                            let wallet_id = parts.next().unwrap_or("").to_string();
-
-                            let entry = self
-                                .ubi_registry
-                                .get_mut(&identity_id)
-                                .ok_or_else(|| anyhow::anyhow!("UBI mint for unknown identity"))?;
-                            if entry.ubi_wallet_id != wallet_id {
-                                return Err(anyhow::anyhow!("UBI mint wallet mismatch"));
-                            }
-                            if Self::is_sov_token_id(&mint.token_id) {
-                                let mint_wallet_id = hex::encode(mint.to);
-                                if mint_wallet_id != wallet_id {
-                                    return Err(anyhow::anyhow!(
-                                        "UBI mint recipient wallet mismatch"
-                                    ));
-                                }
-                            }
-
-                            let is_due = match entry.last_payout_block {
-                                Some(last_block) => {
-                                    block.height().saturating_sub(last_block)
-                                        >= Self::BLOCKS_PER_DAY
-                                }
-                                None => true,
-                            };
-                            if !is_due {
-                                return Err(anyhow::anyhow!("UBI mint not due for identity"));
-                            }
-
-                            let mut expected_payout = entry.daily_amount;
-                            let mut new_remainder =
-                                entry.remainder_balance + (entry.monthly_amount % 30);
-                            if new_remainder >= 30 {
-                                expected_payout += new_remainder / 30;
-                                new_remainder %= 30;
-                            }
-
-                            if mint.amount != expected_payout {
-                                return Err(anyhow::anyhow!("UBI mint amount mismatch"));
-                            }
-
-                            entry.last_payout_block = Some(block.height());
-                            entry.total_received =
-                                entry.total_received.saturating_add(expected_payout);
-                            entry.remainder_balance = new_remainder;
-
-                            if let Some(wallet) = self.wallet_registry.get_mut(&wallet_id) {
-                                wallet.initial_balance =
-                                    wallet.initial_balance.saturating_add(expected_payout);
-                            }
-                        } else if let Some(rest) = memo_str.strip_prefix("TOKEN_MIGRATE_V1:") {
-                            let old_pk_bytes = hex::decode(rest)
-                                .map_err(|_| anyhow::anyhow!("Invalid TOKEN_MIGRATE_V1 memo"))?;
-                            migration_from = Some(PublicKey::new(
-                                old_pk_bytes.as_slice().try_into().unwrap_or([0u8; 2592])
+                    TransactionType::TokenMint => {
+                        if transaction.version < 2 {
+                            return Err(anyhow::anyhow!(
+                                "TokenMint not supported in this serialization version"
                             ));
                         }
-                    }
 
-                    let token_id = if is_sov { sov_token_id } else { mint.token_id };
+                        let mint = transaction
+                            .token_mint_data()
+                            .ok_or_else(|| anyhow::anyhow!("TokenMint missing data"))?;
 
-                    if token_id == sov_token_id {
-                        self.ensure_sov_token_contract();
-                    }
+                        if mint.amount == 0 {
+                            return Err(anyhow::anyhow!("TokenMint amount must be > 0"));
+                        }
 
-                    let is_ubi_mint = std::str::from_utf8(&transaction.memo)
-                        .ok()
-                        .is_some_and(|s| s.starts_with("UBI_DISTRIBUTION_V1:"));
-                    let is_migration = migration_from.is_some();
+                        let is_sov = Self::is_sov_token_id(&mint.token_id);
+                        let recipient_pk = if is_sov {
+                            Self::wallet_key_for_sov(&mint.to)
+                        } else {
+                            let recipient_pk_bytes = self
+                                .resolve_public_key_by_key_id(&mint.to)
+                                .ok_or_else(|| anyhow::anyhow!("TokenMint recipient not found"))?;
+                            PublicKey::new(
+                                recipient_pk_bytes
+                                    .as_slice()
+                                    .try_into()
+                                    .unwrap_or([0u8; 2592]),
+                            )
+                        };
 
-                    let amount_u64: u64 = mint
-                        .amount
-                        .try_into()
-                        .map_err(|_| anyhow::anyhow!("TokenMint amount exceeds u64"))?;
+                        let mut migration_from: Option<PublicKey> = None;
+                        if let Ok(memo_str) = std::str::from_utf8(&transaction.memo) {
+                            if let Some(rest) = memo_str.strip_prefix("UBI_DISTRIBUTION_V1:") {
+                                let mut parts = rest.split(':');
+                                let identity_id = parts.next().unwrap_or("").to_string();
+                                let wallet_id = parts.next().unwrap_or("").to_string();
 
-                    let is_kernel_controlled = self
-                        .token_contracts
-                        .get(&token_id)
-                        .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?
-                        .kernel_mint_authority
-                        .is_some();
+                                let entry =
+                                    self.ubi_registry.get_mut(&identity_id).ok_or_else(|| {
+                                        anyhow::anyhow!("UBI mint for unknown identity")
+                                    })?;
+                                if entry.ubi_wallet_id != wallet_id {
+                                    return Err(anyhow::anyhow!("UBI mint wallet mismatch"));
+                                }
+                                if Self::is_sov_token_id(&mint.token_id) {
+                                    let mint_wallet_id = hex::encode(mint.to);
+                                    if mint_wallet_id != wallet_id {
+                                        return Err(anyhow::anyhow!(
+                                            "UBI mint recipient wallet mismatch"
+                                        ));
+                                    }
+                                }
 
-                    if !is_sov && !is_ubi_mint && !is_migration && !is_kernel_controlled {
-                        let token = self
+                                let is_due = match entry.last_payout_block {
+                                    Some(last_block) => {
+                                        block.height().saturating_sub(last_block)
+                                            >= Self::BLOCKS_PER_DAY
+                                    }
+                                    None => true,
+                                };
+                                if !is_due {
+                                    return Err(anyhow::anyhow!("UBI mint not due for identity"));
+                                }
+
+                                let mut expected_payout = entry.daily_amount;
+                                let mut new_remainder =
+                                    entry.remainder_balance + (entry.monthly_amount % 30);
+                                if new_remainder >= 30 {
+                                    expected_payout += new_remainder / 30;
+                                    new_remainder %= 30;
+                                }
+
+                                if mint.amount != expected_payout {
+                                    return Err(anyhow::anyhow!("UBI mint amount mismatch"));
+                                }
+
+                                entry.last_payout_block = Some(block.height());
+                                entry.total_received =
+                                    entry.total_received.saturating_add(expected_payout);
+                                entry.remainder_balance = new_remainder;
+
+                                if let Some(wallet) = self.wallet_registry.get_mut(&wallet_id) {
+                                    wallet.initial_balance =
+                                        wallet.initial_balance.saturating_add(expected_payout);
+                                }
+                            } else if let Some(rest) = memo_str.strip_prefix("TOKEN_MIGRATE_V1:") {
+                                let old_pk_bytes = hex::decode(rest).map_err(|_| {
+                                    anyhow::anyhow!("Invalid TOKEN_MIGRATE_V1 memo")
+                                })?;
+                                migration_from = Some(PublicKey::new(
+                                    old_pk_bytes.as_slice().try_into().unwrap_or([0u8; 2592]),
+                                ));
+                            }
+                        }
+
+                        let token_id = if is_sov { sov_token_id } else { mint.token_id };
+
+                        if token_id == sov_token_id {
+                            self.ensure_sov_token_contract();
+                        }
+
+                        let is_ubi_mint = std::str::from_utf8(&transaction.memo)
+                            .ok()
+                            .is_some_and(|s| s.starts_with("UBI_DISTRIBUTION_V1:"));
+                        let is_migration = migration_from.is_some();
+
+                        let amount_u64: u64 = mint
+                            .amount
+                            .try_into()
+                            .map_err(|_| anyhow::anyhow!("TokenMint amount exceeds u64"))?;
+
+                        let is_kernel_controlled = self
                             .token_contracts
                             .get(&token_id)
-                            .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
-                        token
-                            .check_mint_authorization(&transaction.signature.public_key)
-                            .map_err(|e| anyhow::anyhow!("{}", e))?;
-                    }
+                            .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?
+                            .kernel_mint_authority
+                            .is_some();
 
-                    if let Some(from_pk) = migration_from {
-                        if is_kernel_controlled {
-                            let mut kernel = self.treasury_kernel.take().ok_or_else(|| {
+                        if !is_sov && !is_ubi_mint && !is_migration && !is_kernel_controlled {
+                            let token = self
+                                .token_contracts
+                                .get(&token_id)
+                                .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
+                            token
+                                .check_mint_authorization(&transaction.signature.public_key)
+                                .map_err(|e| anyhow::anyhow!("{}", e))?;
+                        }
+
+                        if let Some(from_pk) = migration_from {
+                            if is_kernel_controlled {
+                                let mut kernel = self.treasury_kernel.take().ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "Treasury Kernel not initialized - kernel-controlled token operations require kernel"
                                 )
                             })?;
-                            let burn_result = {
+                                let burn_result = {
+                                    let token =
+                                        self.token_contracts.get_mut(&token_id).ok_or_else(
+                                            || anyhow::anyhow!("Token contract not found"),
+                                        )?;
+                                    kernel.debit(
+                                        token,
+                                        &transaction.signature.public_key,
+                                        &from_pk,
+                                        amount_u64,
+                                        crate::contracts::treasury_kernel::DebitReason::Burn,
+                                    )
+                                };
+                                self.treasury_kernel = Some(kernel);
+                                burn_result.map_err(|e| {
+                                    anyhow::anyhow!("Token migration burn failed: {}", e)
+                                })?;
+                            } else {
                                 let token = self
                                     .token_contracts
                                     .get_mut(&token_id)
                                     .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
-                                kernel.debit(
-                                    token,
-                                    &transaction.signature.public_key,
-                                    &from_pk,
-                                    amount_u64,
-                                    crate::contracts::treasury_kernel::DebitReason::Burn,
-                                )
-                            };
-                            self.treasury_kernel = Some(kernel);
-                            burn_result.map_err(|e| {
-                                anyhow::anyhow!("Token migration burn failed: {}", e)
-                            })?;
-                        } else {
-                            let token = self
-                                .token_contracts
-                                .get_mut(&token_id)
-                                .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
-                            token.burn(&from_pk, amount_u64 as u128).map_err(|e| {
-                                anyhow::anyhow!("Token migration burn failed: {}", e)
-                            })?;
+                                token.burn(&from_pk, amount_u64 as u128).map_err(|e| {
+                                    anyhow::anyhow!("Token migration burn failed: {}", e)
+                                })?;
+                            }
                         }
-                    }
 
-                    if is_kernel_controlled {
-                        let mut kernel = self.treasury_kernel.take().ok_or_else(|| {
+                        if is_kernel_controlled {
+                            let mut kernel = self.treasury_kernel.take().ok_or_else(|| {
                             anyhow::anyhow!(
                                 "Treasury Kernel not initialized - kernel-controlled token operations require kernel"
                             )
                         })?;
-                        let mint_result = {
+                            let mint_result = {
+                                let token = self
+                                    .token_contracts
+                                    .get_mut(&token_id)
+                                    .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
+                                kernel.credit(
+                                    token,
+                                    &transaction.signature.public_key,
+                                    &recipient_pk,
+                                    amount_u64,
+                                    crate::contracts::treasury_kernel::CreditReason::Mint,
+                                )
+                            };
+                            self.treasury_kernel = Some(kernel);
+                            mint_result.map_err(|e| anyhow::anyhow!("TokenMint failed: {}", e))?;
+                        } else {
                             let token = self
                                 .token_contracts
                                 .get_mut(&token_id)
                                 .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
-                            kernel.credit(
-                                token,
-                                &transaction.signature.public_key,
-                                &recipient_pk,
-                                amount_u64,
-                                crate::contracts::treasury_kernel::CreditReason::Mint,
-                            )
-                        };
-                        self.treasury_kernel = Some(kernel);
-                        mint_result.map_err(|e| anyhow::anyhow!("TokenMint failed: {}", e))?;
-                    } else {
-                        let token = self
-                            .token_contracts
-                            .get_mut(&token_id)
-                            .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
-                        token
-                            .mint(&recipient_pk, amount_u64 as u128)
-                            .map_err(|e| anyhow::anyhow!("TokenMint failed: {}", e))?;
-                    }
+                            token
+                                .mint(&recipient_pk, amount_u64 as u128)
+                                .map_err(|e| anyhow::anyhow!("TokenMint failed: {}", e))?;
+                        }
 
-                    if let Some(store) = &self.store {
-                        let token = self
-                            .token_contracts
-                            .get(&token_id)
-                            .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
-                        let store_ref: &dyn crate::storage::BlockchainStore = store.as_ref();
-                        if let Err(e) = store_ref.put_token_contract(token) {
-                            warn!("Failed to persist token contract after mint: {}", e);
+                        if let Some(store) = &self.store {
+                            let token = self
+                                .token_contracts
+                                .get(&token_id)
+                                .ok_or_else(|| anyhow::anyhow!("Token contract not found"))?;
+                            let store_ref: &dyn crate::storage::BlockchainStore = store.as_ref();
+                            if let Err(e) = store_ref.put_token_contract(token) {
+                                warn!("Failed to persist token contract after mint: {}", e);
+                            }
+                        }
+
+                        // PoUW reward index (option A): a TokenMint carrying a
+                        // `pouw:mint:` memo is a proof-of-useful-work payout. Record
+                        // it keyed by recipient key_id so /api/v1/pouw/rewards can
+                        // report consensus-derived history. This runs in every
+                        // block-processing path (live commit + replay), so the
+                        // index is rebuilt deterministically and is identical on
+                        // every node. Dedup by tx_hash guards against a block being
+                        // processed twice.
+                        if transaction.memo.starts_with(b"pouw:mint:") {
+                            let tx_hash = transaction.hash().as_array();
+                            let entry = self.pouw_mint_index.entry(mint.to).or_default();
+                            if !entry.iter().any(|r| r.tx_hash == tx_hash) {
+                                entry.push(crate::PouwMintRecord {
+                                    amount: mint.amount,
+                                    block_height: block.height(),
+                                    tx_hash,
+                                });
+                            }
                         }
                     }
+                    TransactionType::TokenCreation => {
+                        let payload = crate::transaction::TokenCreationPayloadV1::decode_memo(
+                            &transaction.memo,
+                        )
+                        .map_err(|e| anyhow::anyhow!("Invalid TokenCreation memo: {}", e))?;
+                        let (creator_allocation, treasury_allocation) =
+                            payload.split_initial_supply();
 
-                    // PoUW reward index (option A): a TokenMint carrying a
-                    // `pouw:mint:` memo is a proof-of-useful-work payout. Record
-                    // it keyed by recipient key_id so /api/v1/pouw/rewards can
-                    // report consensus-derived history. This runs in every
-                    // block-processing path (live commit + replay), so the
-                    // index is rebuilt deterministically and is identical on
-                    // every node. Dedup by tx_hash guards against a block being
-                    // processed twice.
-                    if transaction.memo.starts_with(b"pouw:mint:") {
-                        let tx_hash = transaction.hash().as_array();
-                        let entry = self.pouw_mint_index.entry(mint.to).or_default();
-                        if !entry.iter().any(|r| r.tx_hash == tx_hash) {
-                            entry.push(crate::PouwMintRecord {
-                                amount: mint.amount,
-                                block_height: block.height(),
-                                tx_hash,
-                            });
-                        }
-                    }
-                }
-                TransactionType::TokenCreation => {
-                    let payload =
-                        crate::transaction::TokenCreationPayloadV1::decode_memo(&transaction.memo)
-                            .map_err(|e| anyhow::anyhow!("Invalid TokenCreation memo: {}", e))?;
-                    let (creator_allocation, treasury_allocation) = payload.split_initial_supply();
-
-                    let creator = transaction.signature.public_key.clone();
-                    if payload.treasury_recipient == creator.key_id {
-                        return Err(anyhow::anyhow!(
-                            "TokenCreation treasury_recipient must differ from creator"
-                        ));
-                    }
-
-                    let symbol_upper = payload.symbol.to_uppercase();
-                    for existing_token in self.token_contracts.values() {
-                        if existing_token.symbol.to_uppercase() == symbol_upper {
+                        let creator = transaction.signature.public_key.clone();
+                        if payload.treasury_recipient == creator.key_id {
                             return Err(anyhow::anyhow!(
-                                "Token symbol '{}' already exists",
-                                payload.symbol
+                                "TokenCreation treasury_recipient must differ from creator"
                             ));
                         }
-                    }
 
-                    let mut token = crate::contracts::TokenContract::new_custom(
-                        payload.name.clone(),
-                        payload.symbol.clone(),
-                        0,
-                        creator.clone(),
-                    );
-                    token.decimals = if payload.decimals == 0 {
-                        8
-                    } else {
-                        payload.decimals
-                    };
-                    token.max_supply = payload.initial_supply;
-                    token
-                        .mint(&creator, creator_allocation)
-                        .map_err(|e| anyhow::anyhow!("TokenCreation mint failed: {}", e))?;
-                    let treasury_pk = lib_crypto::types::keys::PublicKey {
-                        dilithium_pk: [0u8; 2592],
-                        kyber_pk: [0u8; 1568],
-                        key_id: payload.treasury_recipient,
-                    };
-                    token.mint(&treasury_pk, treasury_allocation).map_err(|e| {
-                        anyhow::anyhow!("TokenCreation treasury mint failed: {}", e)
-                    })?;
+                        let symbol_upper = payload.symbol.to_uppercase();
+                        for existing_token in self.token_contracts.values() {
+                            if existing_token.symbol.to_uppercase() == symbol_upper {
+                                return Err(anyhow::anyhow!(
+                                    "Token symbol '{}' already exists",
+                                    payload.symbol
+                                ));
+                            }
+                        }
 
-                    let token_id = token.token_id;
-                    if self.token_contracts.contains_key(&token_id) {
-                        return Err(anyhow::anyhow!(
-                            "Token with same name and symbol already exists"
-                        ));
-                    }
-
-                    self.contract_blocks.insert(token_id, block.height());
-                    self.token_contracts.insert(token_id, token.clone());
-
-                    if let Some(store) = &self.store {
-                        let store_ref: &dyn crate::storage::BlockchainStore = store.as_ref();
-                        if let Err(e) = store_ref.put_token_contract(&token) {
-                            warn!("Failed to persist token contract after creation: {}", e);
+                        let mut token = crate::contracts::TokenContract::new_custom(
+                            payload.name.clone(),
+                            payload.symbol.clone(),
+                            0,
+                            creator.clone(),
+                        );
+                        token.decimals = if payload.decimals == 0 {
+                            8
                         } else {
-                            let token_storage_id = crate::storage::TokenId(token_id);
-                            let creator_addr =
-                                crate::storage::Address::new(creator.key_id);
-                            let treasury_addr =
-                                crate::storage::Address::new(payload.treasury_recipient);
-                            // Idempotent: only seed sled rows that are still zero.
-                            if creator_allocation > 0
-                                && store_ref
-                                    .get_token_balance(&token_storage_id, &creator_addr)
-                                    .unwrap_or(0)
-                                    == 0
-                            {
-                                if let Err(e) = store_ref.set_token_balance(
-                                    &token_storage_id,
-                                    &creator_addr,
-                                    creator_allocation,
-                                ) {
-                                    warn!(
+                            payload.decimals
+                        };
+                        token.max_supply = payload.initial_supply;
+                        token
+                            .mint(&creator, creator_allocation)
+                            .map_err(|e| anyhow::anyhow!("TokenCreation mint failed: {}", e))?;
+                        let treasury_pk = lib_crypto::types::keys::PublicKey {
+                            dilithium_pk: [0u8; 2592],
+                            kyber_pk: [0u8; 1568],
+                            key_id: payload.treasury_recipient,
+                        };
+                        token.mint(&treasury_pk, treasury_allocation).map_err(|e| {
+                            anyhow::anyhow!("TokenCreation treasury mint failed: {}", e)
+                        })?;
+
+                        let token_id = token.token_id;
+                        if self.token_contracts.contains_key(&token_id) {
+                            return Err(anyhow::anyhow!(
+                                "Token with same name and symbol already exists"
+                            ));
+                        }
+
+                        self.contract_blocks.insert(token_id, block.height());
+                        self.token_contracts.insert(token_id, token.clone());
+
+                        if let Some(store) = &self.store {
+                            let store_ref: &dyn crate::storage::BlockchainStore = store.as_ref();
+                            if let Err(e) = store_ref.put_token_contract(&token) {
+                                warn!("Failed to persist token contract after creation: {}", e);
+                            } else {
+                                let token_storage_id = crate::storage::TokenId(token_id);
+                                let creator_addr = crate::storage::Address::new(creator.key_id);
+                                let treasury_addr =
+                                    crate::storage::Address::new(payload.treasury_recipient);
+                                // Idempotent: only seed sled rows that are still zero.
+                                if creator_allocation > 0
+                                    && store_ref
+                                        .get_token_balance(&token_storage_id, &creator_addr)
+                                        .unwrap_or(0)
+                                        == 0
+                                {
+                                    if let Err(e) = store_ref.set_token_balance(
+                                        &token_storage_id,
+                                        &creator_addr,
+                                        creator_allocation,
+                                    ) {
+                                        warn!(
                                         "Failed to persist creator balance after TokenCreation: {}",
                                         e
                                     );
+                                    }
                                 }
-                            }
-                            if treasury_allocation > 0
-                                && store_ref
-                                    .get_token_balance(&token_storage_id, &treasury_addr)
-                                    .unwrap_or(0)
-                                    == 0
-                            {
-                                if let Err(e) = store_ref.set_token_balance(
-                                    &token_storage_id,
-                                    &treasury_addr,
-                                    treasury_allocation,
-                                ) {
-                                    warn!(
+                                if treasury_allocation > 0
+                                    && store_ref
+                                        .get_token_balance(&token_storage_id, &treasury_addr)
+                                        .unwrap_or(0)
+                                        == 0
+                                {
+                                    if let Err(e) = store_ref.set_token_balance(
+                                        &token_storage_id,
+                                        &treasury_addr,
+                                        treasury_allocation,
+                                    ) {
+                                        warn!(
                                         "Failed to persist treasury balance after TokenCreation: {}",
                                         e
                                     );
+                                    }
                                 }
                             }
                         }
                     }
-                }
-                TransactionType::BondingCurveDeploy => {
-                    return Err(anyhow::anyhow!(
+                    TransactionType::BondingCurveDeploy => {
+                        return Err(anyhow::anyhow!(
                         "BondingCurveDeploy requires BlockExecutor; legacy bonding-curve mutation path is disabled"
                     ));
-                }
-                TransactionType::BondingCurveBuy => {
-                    return Err(anyhow::anyhow!(
+                    }
+                    TransactionType::BondingCurveBuy => {
+                        return Err(anyhow::anyhow!(
                         "BondingCurveBuy requires BlockExecutor; legacy bonding-curve mutation path is disabled"
                     ));
-                }
-                TransactionType::BondingCurveSell => {
-                    return Err(anyhow::anyhow!(
+                    }
+                    TransactionType::BondingCurveSell => {
+                        return Err(anyhow::anyhow!(
                         "BondingCurveSell requires BlockExecutor; legacy bonding-curve mutation path is disabled"
                     ));
-                }
-                TransactionType::BondingCurveGraduate => {
-                    return Err(anyhow::anyhow!(
+                    }
+                    TransactionType::BondingCurveGraduate => {
+                        return Err(anyhow::anyhow!(
                         "BondingCurveGraduate requires BlockExecutor; legacy bonding-curve mutation path is disabled"
                     ));
+                    }
+                    _ => {}
                 }
-                _ => {}
-            }
-            Ok(())
+                Ok(())
             })();
             if let Err(e) = arm_result {
                 return Err(e);
@@ -1453,7 +1469,9 @@ impl Blockchain {
         self.web4_contracts.get_mut(contract_id)
     }
 
-    pub(crate) fn get_all_token_contracts(&self) -> &HashMap<[u8; 32], crate::contracts::TokenContract> {
+    pub(crate) fn get_all_token_contracts(
+        &self,
+    ) -> &HashMap<[u8; 32], crate::contracts::TokenContract> {
         &self.token_contracts
     }
 
@@ -1502,12 +1520,7 @@ impl Blockchain {
     }
 
     /// Legacy in-memory shadow insert — genesis/bootstrap/tests (#2640).
-    pub fn insert_token_nonce_shadow(
-        &mut self,
-        token_id: [u8; 32],
-        sender: [u8; 32],
-        nonce: u64,
-    ) {
+    pub fn insert_token_nonce_shadow(&mut self, token_id: [u8; 32], sender: [u8; 32], nonce: u64) {
         self.token_nonces.insert((token_id, sender), nonce);
     }
 
@@ -1578,8 +1591,7 @@ impl Blockchain {
                                 continue;
                             }
                         }
-                        let expires_at =
-                            block_ts + payload.duration_days.saturating_mul(86_400);
+                        let expires_at = block_ts + payload.duration_days.saturating_mul(86_400);
                         let record = crate::transaction::OnChainDomainRecord {
                             domain: payload.domain.clone(),
                             owner_did: payload.owner_did,
@@ -1672,9 +1684,12 @@ impl Blockchain {
                             collection_id,
                             data.name.clone(),
                             data.symbol.clone(),
-                            format!("did:zhtp:{}", hex::encode(
-                                lib_crypto::hashing::hash_blake3(&tx.signature.public_key.dilithium_pk)
-                            )),
+                            format!(
+                                "did:zhtp:{}",
+                                hex::encode(lib_crypto::hashing::hash_blake3(
+                                    &tx.signature.public_key.dilithium_pk
+                                ))
+                            ),
                             tx.signature.public_key.key_id,
                             data.max_supply,
                             tx.signature.timestamp,
@@ -1697,7 +1712,8 @@ impl Blockchain {
                 }
                 TransactionType::NftMint => {
                     if let Some(data) = tx.nft_mint_data() {
-                        if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
+                        if let Some(collection) = self.nft_collections.get_mut(&data.collection_id)
+                        {
                             let metadata = NftMetadata {
                                 name: data.name.clone(),
                                 description: data.description.clone(),
@@ -1734,8 +1750,11 @@ impl Blockchain {
                                 hex::encode(&tx.signature.public_key.key_id[..8]),
                                 hex::encode(&data.from[..8]),
                             );
-                        } else if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
-                            if let Err(e) = collection.transfer(data.token_id, &data.from, data.to) {
+                        } else if let Some(collection) =
+                            self.nft_collections.get_mut(&data.collection_id)
+                        {
+                            if let Err(e) = collection.transfer(data.token_id, &data.from, data.to)
+                            {
                                 warn!("NFT transfer failed: {}", e);
                             } else {
                                 info!(
@@ -1756,7 +1775,9 @@ impl Blockchain {
                                 hex::encode(&tx.signature.public_key.key_id[..8]),
                                 hex::encode(&data.owner[..8]),
                             );
-                        } else if let Some(collection) = self.nft_collections.get_mut(&data.collection_id) {
+                        } else if let Some(collection) =
+                            self.nft_collections.get_mut(&data.collection_id)
+                        {
                             if let Err(e) = collection.burn(data.token_id, &data.owner) {
                                 warn!("NFT burn failed: {}", e);
                             } else {
@@ -1856,15 +1877,15 @@ impl Blockchain {
         treasury_wallet_id.copy_from_slice(&treasury_bytes);
 
         let sov_id = crate::contracts::utils::generate_lib_token_id();
-        let payer_key =
-            crate::contracts::utils::wallet_key_for_sov(payload.fee_payer_wallet_id);
-        let treasury_key =
-            crate::contracts::utils::wallet_key_for_sov(treasury_wallet_id);
+        let payer_key = crate::contracts::utils::wallet_key_for_sov(payload.fee_payer_wallet_id);
+        let treasury_key = crate::contracts::utils::wallet_key_for_sov(treasury_wallet_id);
 
-        let token = self
-            .token_contracts
-            .get_mut(&sov_id)
-            .ok_or_else(|| anyhow!("SOV token contract not initialised at height {}", block_height))?;
+        let token = self.token_contracts.get_mut(&sov_id).ok_or_else(|| {
+            anyhow!(
+                "SOV token contract not initialised at height {}",
+                block_height
+            )
+        })?;
 
         // (3) Lock-aware debit. debit_balance subtracts `locked_balances`
         // before checking sufficiency and returns an explicit Err with the
@@ -1903,8 +1924,8 @@ impl Blockchain {
             let tx_signer_key_id = tx.signature.public_key.key_id;
             match crate::transaction::DomainRegistrationPayload::decode_memo(&tx.memo) {
                 Ok(payload) => {
-                    let is_v2 = payload.fee_amount_atoms > 0
-                        || payload.fee_payer_wallet_id != [0u8; 32];
+                    let is_v2 =
+                        payload.fee_amount_atoms > 0 || payload.fee_payer_wallet_id != [0u8; 32];
                     if !is_v2 {
                         continue;
                     }
@@ -1984,8 +2005,8 @@ impl Blockchain {
         treasury_wallet_id: [u8; 32],
         fee_atoms: u128,
     ) -> Result<()> {
-        use anyhow::anyhow;
         use crate::storage::{Address, TokenId};
+        use anyhow::anyhow;
 
         let token = TokenId::new(sov_token_id);
         let payer_addr = Address::new(payer_wallet_id);

--- a/lib-blockchain/src/blockchain/persistence.rs
+++ b/lib-blockchain/src/blockchain/persistence.rs
@@ -112,6 +112,7 @@ impl WalletTransactionDataLegacy {
             wallet_name: self.wallet_name,
             alias: self.alias,
             public_key: self.public_key,
+            kyber_public_key: vec![],
             owner_identity_id: self.owner_identity_id,
             seed_commitment: self.seed_commitment,
             created_at: self.created_at,
@@ -125,7 +126,10 @@ impl WalletTransactionDataLegacy {
 fn migrate_legacy_wallet_registry(
     legacy: HashMap<String, WalletTransactionDataLegacy>,
 ) -> HashMap<String, crate::transaction::WalletTransactionData> {
-    legacy.into_iter().map(|(k, v)| (k, v.to_current())).collect()
+    legacy
+        .into_iter()
+        .map(|(k, v)| (k, v.to_current()))
+        .collect()
 }
 
 /// Blockchain V1 format (Dec 2025) - for backward compatibility migration
@@ -447,21 +451,28 @@ impl BlockchainStorageV3 {
             pending_transactions: bc.pending_transactions.clone(),
             identity_registry: bc.identity_registry.clone(),
             identity_blocks: bc.identity_blocks.clone(),
-            wallet_registry: bc.wallet_registry.iter().map(|(k, v)| {
-                (k.clone(), WalletTransactionDataLegacy {
-                    wallet_id: v.wallet_id,
-                    wallet_type: v.wallet_type.clone(),
-                    wallet_name: v.wallet_name.clone(),
-                    alias: v.alias.clone(),
-                    public_key: v.public_key.clone(),
-                    owner_identity_id: v.owner_identity_id,
-                    seed_commitment: v.seed_commitment,
-                    created_at: v.created_at,
-                    registration_fee: v.registration_fee,
-                    capabilities: v.capabilities,
-                    initial_balance: v.initial_balance as u64,
+            wallet_registry: bc
+                .wallet_registry
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        WalletTransactionDataLegacy {
+                            wallet_id: v.wallet_id,
+                            wallet_type: v.wallet_type.clone(),
+                            wallet_name: v.wallet_name.clone(),
+                            alias: v.alias.clone(),
+                            public_key: v.public_key.clone(),
+                            owner_identity_id: v.owner_identity_id,
+                            seed_commitment: v.seed_commitment,
+                            created_at: v.created_at,
+                            registration_fee: v.registration_fee,
+                            capabilities: v.capabilities,
+                            initial_balance: v.initial_balance as u64,
+                        },
+                    )
                 })
-            }).collect(),
+                .collect(),
             wallet_blocks: bc.wallet_blocks.clone(),
             // economics_transactions removed from Blockchain — V3 keeps the
             // field only to read pre-existing .dat files; new saves write empty.
@@ -869,8 +880,7 @@ impl BlockchainStorageV8 {
 pub(super) struct BlockchainStorageV9 {
     pub v8: BlockchainStorageV8,
     #[serde(default)]
-    pub domain_registry:
-        HashMap<String, crate::transaction::OnChainDomainRecord>,
+    pub domain_registry: HashMap<String, crate::transaction::OnChainDomainRecord>,
 }
 
 impl BlockchainStorageV9 {
@@ -1025,49 +1035,49 @@ impl Blockchain {
                     data,
                     "v11 blockchain",
                     |storage| {
-                    info!("📂 Loaded blockchain storage v11 (treasury kernel state)");
-                    storage.to_blockchain()
-                },
+                        info!("📂 Loaded blockchain storage v11 (treasury kernel state)");
+                        storage.to_blockchain()
+                    },
                 )?,
                 10 => deserialize_or_err::<BlockchainStorageV10, _, _>(
                     data,
                     "v10 blockchain",
                     |storage| {
-                    info!("📂 Loaded blockchain storage v10 (u128 wallet initial_balance)");
-                    storage.to_blockchain()
-                },
+                        info!("📂 Loaded blockchain storage v10 (u128 wallet initial_balance)");
+                        storage.to_blockchain()
+                    },
                 )?,
                 9 => deserialize_or_err::<BlockchainStorageV9, _, _>(
                     data,
                     "v9 blockchain",
                     |storage| {
-                    info!("📂 Loaded blockchain storage v9 (on-chain domain registry)");
-                    storage.to_blockchain()
-                },
+                        info!("📂 Loaded blockchain storage v9 (on-chain domain registry)");
+                        storage.to_blockchain()
+                    },
                 )?,
                 8 => deserialize_or_err::<BlockchainStorageV8, _, _>(
                     data,
                     "v8 blockchain",
                     |storage| {
-                    info!("📂 Loaded blockchain storage v8 (employment registry + CBE DAO format)");
-                    storage.to_blockchain()
-                },
+                        info!("📂 Loaded blockchain storage v8 (employment registry + CBE DAO format)");
+                        storage.to_blockchain()
+                    },
                 )?,
                 7 => deserialize_or_err::<BlockchainStorageV7, _, _>(
                     data,
                     "v7 blockchain",
                     |storage| {
-                    info!("📂 Loaded blockchain storage v7 (cbe-token persistence format)");
-                    storage.to_blockchain()
-                },
+                        info!("📂 Loaded blockchain storage v7 (cbe-token persistence format)");
+                        storage.to_blockchain()
+                    },
                 )?,
                 6 => deserialize_or_err::<BlockchainStorageV6, _, _>(
                     data,
                     "v6 blockchain",
                     |storage| {
-                    info!("📂 Loaded legacy blockchain storage v6 (migrating to v7)");
-                    storage.to_blockchain()
-                },
+                        info!("📂 Loaded legacy blockchain storage v6 (migrating to v7)");
+                        storage.to_blockchain()
+                    },
                 )?,
                 5 => deserialize_or_err::<LegacyBlockchainStorageV5, _, _>(
                     data,
@@ -1253,16 +1263,17 @@ impl Blockchain {
 
         // Initialize Treasury Kernel if not restored from V11 persistence.
         if blockchain.treasury_kernel.is_none() {
-            let kernel_init: Option<(lib_crypto::PublicKey, String)> = blockchain
-                .council_members
-                .first()
-                .and_then(|cm| {
+            let kernel_init: Option<(lib_crypto::PublicKey, String)> =
+                blockchain.council_members.first().and_then(|cm| {
                     let did = cm.identity_id.clone();
                     blockchain.identity_registry.get(&did).and_then(|id| {
                         match id.public_key.as_slice().try_into() {
                             Ok(pk_bytes) => Some((lib_crypto::PublicKey::new(pk_bytes), did)),
                             Err(_) => {
-                                warn!("Treasury Kernel skip: council pk length {}", id.public_key.len());
+                                warn!(
+                                    "Treasury Kernel skip: council pk length {}",
+                                    id.public_key.len()
+                                );
                                 None
                             }
                         }
@@ -1379,7 +1390,10 @@ where
             .stack_size(LARGE_STACK)
             .spawn_scoped(scope, f)
             .map_err(|e| {
-                anyhow::anyhow!("failed to spawn large-stack (de)serialization thread: {}", e)
+                anyhow::anyhow!(
+                    "failed to spawn large-stack (de)serialization thread: {}",
+                    e
+                )
             })?;
         handle
             .join()

--- a/lib-blockchain/src/blockchain/test_utils.rs
+++ b/lib-blockchain/src/blockchain/test_utils.rs
@@ -180,6 +180,7 @@ impl Blockchain {
         let wallet_data = crate::transaction::WalletTransactionData {
             wallet_id: wallet_id_hash,
             public_key: vec![],
+            kyber_public_key: vec![],
             wallet_type: "standard".to_string(),
             wallet_name: "test".to_string(),
             alias: None,
@@ -235,5 +236,4 @@ impl Blockchain {
         self.blocks.push(block);
         self.height = next_height;
     }
-
 }

--- a/lib-blockchain/src/blockchain/tests/facade_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/facade_tests.rs
@@ -306,7 +306,9 @@ fn repair_missing_token_creation_balances_restores_zeroed_tree() {
         .expect("contract metadata write");
     f.store.commit_block().unwrap();
     assert_eq!(
-        f.store.count_token_holders(&TokenId::new(f.token_id)).unwrap(),
+        f.store
+            .count_token_holders(&TokenId::new(f.token_id))
+            .unwrap(),
         0
     );
 
@@ -320,7 +322,10 @@ fn repair_missing_token_creation_balances_restores_zeroed_tree() {
     let repaired = bc
         .repair_missing_token_creation_balances(f.store.as_ref())
         .expect("repair should succeed");
-    assert_eq!(repaired, 2, "creator + treasury balances should be repaired");
+    assert_eq!(
+        repaired, 2,
+        "creator + treasury balances should be repaired"
+    );
 
     let (creator_alloc, treasury_alloc) = f.payload.split_initial_supply();
     assert_eq!(
@@ -368,7 +373,6 @@ fn repair_missing_token_creation_balances_fills_partial_tree() {
         treasury_alloc
     );
 }
-
 
 #[test]
 fn count_token_holders_reads_sled_when_store_attached() {
@@ -456,11 +460,7 @@ fn calculate_user_voting_power_reads_sled_not_in_memory() {
 
     store.begin_block(0).unwrap();
     store
-        .set_token_balance(
-            &TokenId::new(sov_id),
-            &Address::new(wallet_id),
-            amount,
-        )
+        .set_token_balance(&TokenId::new(sov_id), &Address::new(wallet_id), amount)
         .unwrap();
     store.commit_block().unwrap();
 
@@ -478,6 +478,7 @@ fn calculate_user_voting_power_reads_sled_not_in_memory() {
             wallet_name: "Test".to_string(),
             alias: None,
             public_key: vec![0u8; 2592],
+            kyber_public_key: vec![],
             owner_identity_id: Some(Hash::new(identity_id.0)),
             seed_commitment: Hash::default(),
             created_at: 0,
@@ -570,9 +571,18 @@ fn put_sled_identity(store: &SledStore, height: u64, did: &str, consensus: Ident
 fn identity_exists_union_inmem_or_sled() {
     // store-less: answers from the in-memory shadow.
     let mut bc = Blockchain::new().unwrap();
-    bc.insert_identity_shadow("did:zhtp:inmem".to_string(), mk_inmem_identity("did:zhtp:inmem"));
-    assert!(bc.identity_exists("did:zhtp:inmem"), "in-mem present -> true");
-    assert!(!bc.identity_exists("did:zhtp:ghost"), "absent everywhere -> false");
+    bc.insert_identity_shadow(
+        "did:zhtp:inmem".to_string(),
+        mk_inmem_identity("did:zhtp:inmem"),
+    );
+    assert!(
+        bc.identity_exists("did:zhtp:inmem"),
+        "in-mem present -> true"
+    );
+    assert!(
+        !bc.identity_exists("did:zhtp:ghost"),
+        "absent everywhere -> false"
+    );
 
     // sled-backed with an EMPTY in-mem registry (post-restart simulation):
     // the sled-only identity must still be found.
@@ -584,7 +594,10 @@ fn identity_exists_union_inmem_or_sled() {
         &store,
         0,
         did,
-        IdentityConsensus { did_hash, ..Default::default() },
+        IdentityConsensus {
+            did_hash,
+            ..Default::default()
+        },
     );
     let mut bc2 = Blockchain::new().unwrap();
     bc2.set_store(store);
@@ -592,7 +605,10 @@ fn identity_exists_union_inmem_or_sled() {
         !bc2.identity_shadow_contains_key(did),
         "test premise: this DID is sled-only (absent from the in-mem shadow)"
     );
-    assert!(bc2.identity_exists(did), "sled-only identity found via union");
+    assert!(
+        bc2.identity_exists(did),
+        "sled-only identity found via union"
+    );
     assert!(!bc2.identity_exists("did:zhtp:ghost"));
 }
 
@@ -607,14 +623,24 @@ fn identity_count_reads_sled() {
         let did = format!("did:zhtp:count{}", i);
         let did_hash = crate::storage::did_to_hash(&did);
         store
-            .put_identity(&did_hash, &IdentityConsensus { did_hash, ..Default::default() })
+            .put_identity(
+                &did_hash,
+                &IdentityConsensus {
+                    did_hash,
+                    ..Default::default()
+                },
+            )
             .unwrap();
     }
     store.commit_block().unwrap();
 
     let mut bc = Blockchain::new().unwrap();
     bc.set_store(store);
-    assert_eq!(bc.identity_count(), 3, "count comes from sled, not the in-mem shadow");
+    assert_eq!(
+        bc.identity_count(),
+        3,
+        "count comes from sled, not the in-mem shadow"
+    );
     assert_eq!(
         bc.iter_identities_consensus().len(),
         3,
@@ -639,7 +665,11 @@ fn identity_public_key_pins_to_consensus() {
     store
         .put_identity(
             &did_hash,
-            &IdentityConsensus { did_hash, public_key_hash: pk_hash, ..Default::default() },
+            &IdentityConsensus {
+                did_hash,
+                public_key_hash: pk_hash,
+                ..Default::default()
+            },
         )
         .unwrap();
     store
@@ -662,7 +692,11 @@ fn identity_public_key_pins_to_consensus() {
     store
         .put_identity(
             &bad_hash,
-            &IdentityConsensus { did_hash: bad_hash, public_key_hash: [0xAB; 32], ..Default::default() },
+            &IdentityConsensus {
+                did_hash: bad_hash,
+                public_key_hash: [0xAB; 32],
+                ..Default::default()
+            },
         )
         .unwrap();
     store
@@ -776,7 +810,10 @@ fn identity_registry_snapshot_includes_sled_without_in_memory() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     bc.set_store(store);
     let snap = bc.identity_registry_snapshot();
-    assert_eq!(snap.get(did).map(|d| d.display_name.as_str()), Some("Only Sled"));
+    assert_eq!(
+        snap.get(did).map(|d| d.display_name.as_str()),
+        Some("Only Sled")
+    );
 }
 
 #[test]
@@ -787,7 +824,13 @@ fn identity_display_name_taken_reads_sled() {
     let did_hash = crate::storage::did_to_hash(did);
     store.begin_block(0).unwrap();
     store
-        .put_identity(&did_hash, &IdentityConsensus { did_hash, ..Default::default() })
+        .put_identity(
+            &did_hash,
+            &IdentityConsensus {
+                did_hash,
+                ..Default::default()
+            },
+        )
         .unwrap();
     store
         .put_identity_metadata(
@@ -931,6 +974,7 @@ fn test_wallet_data(wallet_id: [u8; 32], name: &str) -> crate::transaction::Wall
         wallet_name: name.to_string(),
         alias: None,
         public_key: vec![],
+        kyber_public_key: vec![],
         owner_identity_id: None,
         seed_commitment: crate::types::hash::Hash::zero(),
         created_at: 0,
@@ -945,10 +989,7 @@ fn wallet_exists_union_inmem_or_sled() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     let wallet_id = [0x77u8; 32];
     let wallet_id_hex = hex::encode(wallet_id);
-    bc.insert_wallet_shadow(
-        wallet_id_hex.clone(),
-        test_wallet_data(wallet_id, "In-Mem"),
-    );
+    bc.insert_wallet_shadow(wallet_id_hex.clone(), test_wallet_data(wallet_id, "In-Mem"));
     assert!(bc.wallet_exists(&wallet_id_hex), "in-mem present -> true");
     assert!(!bc.wallet_exists("00000000000000000000000000000000000000000000000000000000000000ab"));
 
@@ -968,7 +1009,10 @@ fn wallet_exists_union_inmem_or_sled() {
 
     let mut bc2 = Blockchain::new().expect("blockchain construct");
     bc2.set_store(store);
-    assert!(bc2.wallet_exists(&wallet_id_hex), "sled-only wallet found via union");
+    assert!(
+        bc2.wallet_exists(&wallet_id_hex),
+        "sled-only wallet found via union"
+    );
 }
 
 #[test]
@@ -1019,7 +1063,10 @@ fn wallet_registry_snapshot_includes_sled_without_in_memory() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     bc.set_store(store);
     let snap = bc.wallet_registry_snapshot();
-    assert_eq!(snap.get(&did_hex).map(|w| w.wallet_name.as_str()), Some("Only Sled"));
+    assert_eq!(
+        snap.get(&did_hex).map(|w| w.wallet_name.as_str()),
+        Some("Only Sled")
+    );
 }
 
 #[test]
@@ -1043,7 +1090,11 @@ fn wallet_count_reads_sled() {
 
     let mut bc = Blockchain::new().unwrap();
     bc.set_store(store);
-    assert_eq!(bc.wallet_count(), 3, "count comes from sled, not the in-mem shadow");
+    assert_eq!(
+        bc.wallet_count(),
+        3,
+        "count comes from sled, not the in-mem shadow"
+    );
 }
 
 #[test]
@@ -1281,7 +1332,13 @@ fn identity_controlled_nodes_reads_sled_metadata() {
     let nodes = vec!["aa".repeat(32), "bb".repeat(32)];
     store.begin_block(0).unwrap();
     store
-        .put_identity(&did_hash, &IdentityConsensus { did_hash, ..Default::default() })
+        .put_identity(
+            &did_hash,
+            &IdentityConsensus {
+                did_hash,
+                ..Default::default()
+            },
+        )
         .unwrap();
     store
         .put_identity_metadata(
@@ -1339,7 +1396,10 @@ fn did_by_device_key_id_reads_sled_metadata() {
     store
         .put_identity(
             &did_hash,
-            &IdentityConsensus { did_hash, ..Default::default() },
+            &IdentityConsensus {
+                did_hash,
+                ..Default::default()
+            },
         )
         .unwrap();
     store
@@ -1400,7 +1460,10 @@ fn did_by_device_key_id_reads_sled_metadata() {
         &store,
         1,
         direct_did,
-        IdentityConsensus { did_hash: direct_hash, ..Default::default() },
+        IdentityConsensus {
+            did_hash: direct_hash,
+            ..Default::default()
+        },
     );
     assert_eq!(
         bc.did_by_device_key_id("abcd1234"),
@@ -1529,10 +1592,15 @@ fn validator_exists_union_inmem_or_sled() {
             governance_proposal_id: None,
         },
     };
-    store.put_validator_record_direct(&did_hash, &record).unwrap();
+    store
+        .put_validator_record_direct(&did_hash, &record)
+        .unwrap();
     let mut bc2 = Blockchain::new_runtime_state();
     bc2.store = Some(store);
-    assert!(bc2.validator_exists(did), "sled-only validator found via union");
+    assert!(
+        bc2.validator_exists(did),
+        "sled-only validator found via union"
+    );
     let got = bc2.validator_info_by_did(did).expect("sled read");
     assert_eq!(got.stake, 200_000);
 }
@@ -1560,11 +1628,7 @@ fn custom_token_balance_reads_sled_not_in_memory() {
     store.begin_block(0).unwrap();
     store.put_token_contract(&contract).unwrap();
     store
-        .set_token_balance(
-            &TokenId::new(token_id),
-            &Address::new(holder),
-            5_000,
-        )
+        .set_token_balance(&TokenId::new(token_id), &Address::new(holder), 5_000)
         .unwrap();
     store.commit_block().unwrap();
 
@@ -1583,9 +1647,11 @@ fn custom_token_balance_reads_sled_not_in_memory() {
     // In-mem-only read would wrongly return 0 — regression guard.
     assert_eq!(
         bc.token_contract_shadow(&token_id)
-            .map(|c| c.balance_of(&crate::integration::crypto_integration::PublicKey::new(
-                [0u8; 2592]
-            )))
+            .map(
+                |c| c.balance_of(&crate::integration::crypto_integration::PublicKey::new(
+                    [0u8; 2592]
+                ))
+            )
             .unwrap_or(0),
         0,
         "in-mem path absent/empty — the bug #2637 fixed"
@@ -1617,11 +1683,7 @@ fn legacy_fee_deduction_syncs_sled_balance() {
     let fee: u64 = 250;
 
     store
-        .force_set_token_balances(&[(
-            TokenId::new(sov_id),
-            Address::new(sender_id),
-            initial,
-        )])
+        .force_set_token_balances(&[(TokenId::new(sov_id), Address::new(sender_id), initial)])
         .unwrap();
 
     let mut bc = Blockchain::new().expect("blockchain construct");
@@ -1805,7 +1867,11 @@ fn validator_count_reads_sled() {
     }
     let mut bc = Blockchain::new_runtime_state();
     bc.store = Some(store);
-    assert_eq!(bc.validator_count(), 3, "count comes from sled, not the in-mem shadow");
+    assert_eq!(
+        bc.validator_count(),
+        3,
+        "count comes from sled, not the in-mem shadow"
+    );
 }
 
 /// iter_token_contract_entries returns sled ids + metadata (#2637).
@@ -2011,17 +2077,16 @@ fn utxo_count_reads_sled() {
     let op = OutPoint::new(TxHash::new([0x11; 32]), 0);
 
     store.begin_block(0).unwrap();
-    store
-        .put_utxo(
-            &op,
-            &Utxo::native(1_000, owner, 0),
-        )
-        .unwrap();
+    store.put_utxo(&op, &Utxo::native(1_000, owner, 0)).unwrap();
     store.commit_block().unwrap();
 
     let mut bc = Blockchain::new().expect("blockchain construct");
     bc.set_store(store);
-    assert_eq!(bc.utxo_count(), 1, "count comes from sled, not in-mem shadow");
+    assert_eq!(
+        bc.utxo_count(),
+        1,
+        "count comes from sled, not in-mem shadow"
+    );
     assert!(!bc.utxo_set_is_empty());
 }
 
@@ -2037,9 +2102,7 @@ fn collect_spendable_outputs_reads_sled() {
     let op = OutPoint::new(tx, 1);
 
     store.begin_block(0).unwrap();
-    store
-        .put_utxo(&op, &Utxo::native(500, owner, 0))
-        .unwrap();
+    store.put_utxo(&op, &Utxo::native(500, owner, 0)).unwrap();
     store.commit_block().unwrap();
 
     let mut bc = Blockchain::new().expect("blockchain construct");
@@ -2105,7 +2168,11 @@ fn wallets_for_owner_reads_sled_when_in_memory_empty() {
     assert_eq!(found[0].1.wallet_name, "Sled Owned");
 
     let found_other = bc.wallets_for_owner(&other);
-    assert_eq!(found_other.len(), 1, "other-owner wallet is found by its owner");
+    assert_eq!(
+        found_other.len(),
+        1,
+        "other-owner wallet is found by its owner"
+    );
     assert_eq!(found_other[0].1.wallet_name, "Sled Other");
 }
 
@@ -2179,8 +2246,18 @@ fn wallets_for_owner_union_in_memory_and_sled() {
     bc.insert_wallet_shadow(mem_hex, mem_wallet);
 
     let found = bc.wallets_for_owner(&owner);
-    assert_eq!(found.len(), 2, "union of sled + in-memory wallets for same owner");
+    assert_eq!(
+        found.len(),
+        2,
+        "union of sled + in-memory wallets for same owner"
+    );
     let names: Vec<&str> = found.iter().map(|(_, w)| w.wallet_name.as_str()).collect();
-    assert!(names.contains(&"Sled Wallet"), "sled wallet is in the result");
-    assert!(names.contains(&"InMem Wallet"), "in-memory wallet is in the result");
+    assert!(
+        names.contains(&"Sled Wallet"),
+        "sled wallet is in the result"
+    );
+    assert!(
+        names.contains(&"InMem Wallet"),
+        "in-memory wallet is in the result"
+    );
 }

--- a/lib-blockchain/src/blockchain/tests/genesis_allocation_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/genesis_allocation_tests.rs
@@ -16,7 +16,9 @@ fn test_sov_wallet_registration_deficit_minting() {
     let recipient_pk = Blockchain::wallet_key_for_sov(&wallet_id_bytes);
 
     if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
-        token.mint(&recipient_pk, 3000).expect("Pre-mint should succeed");
+        token
+            .mint(&recipient_pk, 3000)
+            .expect("Pre-mint should succeed");
     }
 
     let current_balance = blockchain
@@ -32,6 +34,7 @@ fn test_sov_wallet_registration_deficit_minting() {
         wallet_name: "Test Wallet".to_string(),
         alias: None,
         public_key: vec![0u8; 32],
+        kyber_public_key: vec![],
         owner_identity_id: None,
         seed_commitment: Hash::default(),
         created_at: 0,

--- a/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/mempool_admit_tests.rs
@@ -57,15 +57,21 @@ fn admit_gate_rejects_when_tx_count_cap_exceeded() {
 fn system_tx_originator_counter_increments_per_call() {
     let mut bc = Blockchain::new().expect("blockchain construct");
 
-    bc.add_system_transaction(make_tx(TransactionType::Coinbase), crate::blockchain::SystemOriginator::TestOriginator)
-        .expect("system tx accept");
-    bc.add_system_transaction(make_tx(TransactionType::Coinbase), crate::blockchain::SystemOriginator::TestOriginator)
-        .expect("system tx accept");
+    bc.add_system_transaction(
+        make_tx(TransactionType::Coinbase),
+        crate::blockchain::SystemOriginator::TestOriginator,
+    )
+    .expect("system tx accept");
+    bc.add_system_transaction(
+        make_tx(TransactionType::Coinbase),
+        crate::blockchain::SystemOriginator::TestOriginator,
+    )
+    .expect("system tx accept");
     bc.add_system_transaction(
         make_tx(TransactionType::Coinbase),
         crate::blockchain::SystemOriginator::Other("other_originator"),
     )
-        .expect("system tx accept");
+    .expect("system tx accept");
 
     assert_eq!(
         *bc.system_tx_originators.get("test_originator").unwrap(),
@@ -126,15 +132,22 @@ fn system_injection_rejects_unsigned_token_mint_from_unknown_originator() {
         to: [7u8; 32],
         amount: 100,
     };
-    let tx = Transaction::new_token_mint(mint_data, Signature {
-        signature: Vec::new(),
-        public_key: PublicKey::new([0u8; 2592]),
-        algorithm: SignatureAlgorithm::Dilithium5,
-        timestamp: 0,
-    }, b"not-a-pouw-mint".to_vec());
+    let tx = Transaction::new_token_mint(
+        mint_data,
+        Signature {
+            signature: Vec::new(),
+            public_key: PublicKey::new([0u8; 2592]),
+            algorithm: SignatureAlgorithm::Dilithium5,
+            timestamp: 0,
+        },
+        b"not-a-pouw-mint".to_vec(),
+    );
 
     let err = bc
-        .add_system_transaction(tx, crate::blockchain::SystemOriginator::Other("evil_originator"))
+        .add_system_transaction(
+            tx,
+            crate::blockchain::SystemOriginator::Other("evil_originator"),
+        )
         .expect_err("unsigned mint must be rejected");
     assert!(
         err.to_string().contains("untrusted originator"),
@@ -154,12 +167,16 @@ fn system_injection_allows_pouw_mint_with_matching_memo() {
         amount,
     };
     let memo = format!("pouw:mint:{}:{}", hex::encode(recipient), amount).into_bytes();
-    let tx = Transaction::new_token_mint(mint_data, Signature {
-        signature: Vec::new(),
-        public_key: PublicKey::new([0u8; 2592]),
-        algorithm: SignatureAlgorithm::Dilithium5,
-        timestamp: 0,
-    }, memo);
+    let tx = Transaction::new_token_mint(
+        mint_data,
+        Signature {
+            signature: Vec::new(),
+            public_key: PublicKey::new([0u8; 2592]),
+            algorithm: SignatureAlgorithm::Dilithium5,
+            timestamp: 0,
+        },
+        memo,
+    );
 
     bc.add_system_transaction(tx, crate::blockchain::SystemOriginator::PouwMint)
         .expect("pouw mint allowed");
@@ -177,12 +194,16 @@ fn system_injection_rejects_pouw_mint_with_mismatched_recipient() {
         amount,
     };
     let memo = format!("pouw:mint:{}:{}", hex::encode(recipient), amount).into_bytes();
-    let tx = Transaction::new_token_mint(mint_data, Signature {
-        signature: Vec::new(),
-        public_key: PublicKey::new([0u8; 2592]),
-        algorithm: SignatureAlgorithm::Dilithium5,
-        timestamp: 0,
-    }, memo);
+    let tx = Transaction::new_token_mint(
+        mint_data,
+        Signature {
+            signature: Vec::new(),
+            public_key: PublicKey::new([0u8; 2592]),
+            algorithm: SignatureAlgorithm::Dilithium5,
+            timestamp: 0,
+        },
+        memo,
+    );
 
     let err = bc
         .add_system_transaction(tx, crate::blockchain::SystemOriginator::PouwMint)
@@ -198,12 +219,16 @@ fn system_injection_rejects_token_mint_from_ipc_external() {
         to: [7u8; 32],
         amount: 100,
     };
-    let tx = Transaction::new_token_mint(mint_data, Signature {
-        signature: vec![1u8; 64],
-        public_key: PublicKey::new([0u8; 2592]),
-        algorithm: SignatureAlgorithm::Dilithium5,
-        timestamp: 0,
-    }, b"signed-but-untrusted".to_vec());
+    let tx = Transaction::new_token_mint(
+        mint_data,
+        Signature {
+            signature: vec![1u8; 64],
+            public_key: PublicKey::new([0u8; 2592]),
+            algorithm: SignatureAlgorithm::Dilithium5,
+            timestamp: 0,
+        },
+        b"signed-but-untrusted".to_vec(),
+    );
 
     let err = bc
         .add_system_transaction(tx, crate::blockchain::SystemOriginator::IpcExternal)
@@ -217,7 +242,10 @@ fn system_injection_rejects_wallet_registration_without_wallet_data() {
     let tx = make_tx(TransactionType::WalletRegistration);
 
     let err = bc
-        .add_system_transaction(tx, crate::blockchain::SystemOriginator::AutoWalletRegistration)
+        .add_system_transaction(
+            tx,
+            crate::blockchain::SystemOriginator::AutoWalletRegistration,
+        )
         .expect_err("wallet registration without payload must be rejected");
     assert!(err.to_string().contains("missing wallet_data"));
 }
@@ -231,6 +259,7 @@ fn system_injection_rejects_funded_wallet_registration_from_non_treasury() {
         wallet_name: "test".to_string(),
         alias: None,
         public_key: vec![0x22; 32],
+        kyber_public_key: vec![],
         owner_identity_id: None,
         seed_commitment: crate::types::Hash::new([0x33; 32]),
         created_at: 0,
@@ -251,7 +280,10 @@ fn system_injection_rejects_funded_wallet_registration_from_non_treasury() {
     );
 
     let err = bc
-        .add_system_transaction(tx, crate::blockchain::SystemOriginator::AutoWalletRegistration)
+        .add_system_transaction(
+            tx,
+            crate::blockchain::SystemOriginator::AutoWalletRegistration,
+        )
         .expect_err("funded wallet registration must be rejected");
     assert!(err.to_string().contains("initial_balance=1000"));
 }
@@ -314,6 +346,7 @@ fn register_wallet_is_enqueue_only_no_registry_or_mint() {
         wallet_name: "Primary".to_string(),
         alias: Some("primary".to_string()),
         public_key: pk.to_vec(),
+        kyber_public_key: vec![],
         owner_identity_id: None,
         seed_commitment: crate::types::Hash::default(),
         created_at: 1,
@@ -364,6 +397,7 @@ fn abort_pending_client_registration_clears_mempool_and_shadows() {
         wallet_name: "Primary".to_string(),
         alias: Some("primary".to_string()),
         public_key: pk.to_vec(),
+        kyber_public_key: vec![],
         owner_identity_id: None,
         seed_commitment: crate::types::Hash::default(),
         created_at: 1,
@@ -384,11 +418,7 @@ fn abort_pending_client_registration_clears_mempool_and_shadows() {
     assert!(bc.identity_exists(&did));
     assert!(bc.wallet_exists(&wallet_hex));
 
-    bc.abort_pending_client_registration(
-        &[identity_tx, wallet_tx],
-        &did,
-        &[wallet_hex.as_str()],
-    );
+    bc.abort_pending_client_registration(&[identity_tx, wallet_tx], &did, &[wallet_hex.as_str()]);
 
     assert!(
         bc.pending_transactions.is_empty(),
@@ -455,7 +485,10 @@ fn system_injection_rejects_treasury_welcome_bonus_with_bad_memo() {
     );
 
     let err = bc
-        .add_system_transaction(tx, crate::blockchain::SystemOriginator::TreasuryWalletBootstrap)
+        .add_system_transaction(
+            tx,
+            crate::blockchain::SystemOriginator::TreasuryWalletBootstrap,
+        )
         .expect_err("invalid welcome bonus memo must be rejected");
     assert!(err.to_string().contains("WELCOME_BONUS_V1"));
 }
@@ -464,8 +497,11 @@ fn duplicate_tx_hash_rejected_from_mempool() {
     let mut bc = Blockchain::new().expect("blockchain construct");
     let tx = make_tx(TransactionType::Coinbase);
 
-    bc.add_system_transaction(tx.clone(), crate::blockchain::SystemOriginator::TestOriginator)
-        .expect("first enqueue");
+    bc.add_system_transaction(
+        tx.clone(),
+        crate::blockchain::SystemOriginator::TestOriginator,
+    )
+    .expect("first enqueue");
     let err = bc
         .add_system_transaction(tx, crate::blockchain::SystemOriginator::TestOriginator)
         .expect_err("duplicate hash must be rejected");

--- a/lib-blockchain/src/blockchain/tests/oracle_storage_migration_tests.rs
+++ b/lib-blockchain/src/blockchain/tests/oracle_storage_migration_tests.rs
@@ -43,9 +43,12 @@ fn test_blockchain_storage_v4_oracle_pending_update() {
         .committee
         .set_members_for_test(vec![[1u8; 32], [2u8; 32], [3u8; 32], [4u8; 32]]);
 
-    let result =
-        bc.oracle_state
-            .schedule_committee_update(vec![[5u8; 32], [6u8; 32], [7u8; 32]], 10, 0, None);
+    let result = bc.oracle_state.schedule_committee_update(
+        vec![[5u8; 32], [6u8; 32], [7u8; 32]],
+        10,
+        0,
+        None,
+    );
     assert!(result.is_ok());
 
     println!(
@@ -148,9 +151,12 @@ fn test_blockchain_save_load_oracle_pending_update() {
         .committee
         .set_members_for_test(vec![[1u8; 32], [2u8; 32], [3u8; 32], [4u8; 32]]);
 
-    let result =
-        bc.oracle_state
-            .schedule_committee_update(vec![[5u8; 32], [6u8; 32], [7u8; 32]], 10, 0, None);
+    let result = bc.oracle_state.schedule_committee_update(
+        vec![[5u8; 32], [6u8; 32], [7u8; 32]],
+        10,
+        0,
+        None,
+    );
     assert!(result.is_ok());
 
     bc.last_oracle_epoch_processed = bc.last_committed_timestamp();
@@ -194,6 +200,7 @@ fn load_from_file_does_not_mint_or_repair_sov_balances() {
                 wallet_name: format!("Wallet-{}", hex::encode(&wallet_id[..4])),
                 alias: None,
                 public_key: vec![wallet_id[0]; 32],
+                kyber_public_key: vec![],
                 owner_identity_id: None,
                 seed_commitment: Hash::zero(),
                 created_at: 1_700_000_000,

--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -20,24 +20,21 @@ impl Blockchain {
             return;
         }
 
-        let kernel_init_data: Option<(lib_crypto::PublicKey, String)> = self
-            .council_members
-            .first()
-            .and_then(|cm| {
+        let kernel_init_data: Option<(lib_crypto::PublicKey, String)> =
+            self.council_members.first().and_then(|cm| {
                 let did = cm.identity_id.clone();
                 // #2639: sled-first, consensus-pinned key (in-mem fallback). On a
                 // restarted store-backed node the in-memory shadow is empty, so the
                 // council authority key would not be found and the treasury kernel
                 // would silently fail to initialize.
-                self.identity_public_key(&did).and_then(|pk| {
-                    match pk.as_slice().try_into() {
+                self.identity_public_key(&did)
+                    .and_then(|pk| match pk.as_slice().try_into() {
                         Ok(pk_bytes) => Some((lib_crypto::PublicKey::new(pk_bytes), did)),
                         Err(_) => {
                             warn!("Treasury Kernel skip: council pk length {}", pk.len());
                             None
                         }
-                    }
-                })
+                    })
             });
 
         if let Some((authority_pk, authority_did)) = kernel_init_data {
@@ -60,8 +57,8 @@ impl Blockchain {
     /// stake/unstake operations, not by the token itself.
     pub fn ensure_welfare_dao_tokens(&mut self) {
         use crate::contracts::economics::fee_router::{
-            DAO_HEALTHCARE_KEY_ID, DAO_EDUCATION_KEY_ID, DAO_ENERGY_KEY_ID,
-            DAO_HOUSING_KEY_ID, DAO_FOOD_KEY_ID,
+            DAO_EDUCATION_KEY_ID, DAO_ENERGY_KEY_ID, DAO_FOOD_KEY_ID, DAO_HEALTHCARE_KEY_ID,
+            DAO_HOUSING_KEY_ID,
         };
 
         let kernel_authority = match &self.treasury_kernel {
@@ -82,8 +79,7 @@ impl Blockchain {
 
         let mut created = 0;
         for (name, symbol, _dao_key_id) in tokens {
-            let token_id =
-                crate::contracts::utils::generate_custom_token_id(name, symbol);
+            let token_id = crate::contracts::utils::generate_custom_token_id(name, symbol);
             if self.token_contracts.contains_key(&token_id) {
                 continue;
             }
@@ -117,6 +113,7 @@ impl Blockchain {
                 wallet_name: "DAO Treasury".to_string(),
                 alias: None,
                 public_key: vec![],
+                kyber_public_key: vec![],
                 owner_identity_id: None,
                 seed_commitment: crate::types::Hash::zero(),
                 created_at: 0,
@@ -292,7 +289,11 @@ impl Blockchain {
                 continue;
             }
             let pk = PublicKey::new(
-                wallet.public_key.as_slice().try_into().unwrap_or([0u8; 2592])
+                wallet
+                    .public_key
+                    .as_slice()
+                    .try_into()
+                    .unwrap_or([0u8; 2592]),
             );
             if &pk.key_id == signer_key_id {
                 return Self::wallet_id_bytes(wallet_id);
@@ -324,8 +325,12 @@ impl Blockchain {
             }
             if let Some(wallet_id_bytes) = Self::wallet_id_bytes(wallet_id) {
                 let pk = PublicKey::new(
-                wallet.public_key.as_slice().try_into().unwrap_or([0u8; 2592])
-            );
+                    wallet
+                        .public_key
+                        .as_slice()
+                        .try_into()
+                        .unwrap_or([0u8; 2592]),
+                );
                 key_to_wallet.insert(pk.key_id, wallet_id_bytes);
             }
         }
@@ -347,8 +352,7 @@ impl Blockchain {
                 token.remove_balance(&pk);
                 let wallet_key = Self::wallet_key_for_sov(wallet_id_bytes);
                 let existing = token.balance_of(&wallet_key);
-                token
-                    .set_balance(&wallet_key, existing.saturating_add(bal));
+                token.set_balance(&wallet_key, existing.saturating_add(bal));
                 migrated_total = migrated_total.saturating_add(bal);
             }
         }
@@ -370,7 +374,11 @@ impl Blockchain {
                 continue;
             }
             let pk = PublicKey::new(
-                wallet.public_key.as_slice().try_into().unwrap_or([0u8; 2592])
+                wallet
+                    .public_key
+                    .as_slice()
+                    .try_into()
+                    .unwrap_or([0u8; 2592]),
             );
             if &pk.key_id == key_id {
                 return Some(wallet.public_key.clone());
@@ -495,10 +503,7 @@ impl Blockchain {
                 n
             ),
             Ok(_) => {}
-            Err(e) => warn!(
-                "⚠️ Failed to persist genesis SOV balances to sled: {}",
-                e
-            ),
+            Err(e) => warn!("⚠️ Failed to persist genesis SOV balances to sled: {}", e),
         }
         Ok(())
     }
@@ -541,10 +546,17 @@ impl Blockchain {
 
         // Build sled correction entries (balance = 0 → removes the key).
         // TokenId is Copy so we can use it directly in the closure.
-        let sled_entries: Vec<(crate::storage::TokenId, crate::storage::Address, u128)> = to_correct
-            .iter()
-            .map(|(bytes, _)| (sov_storage_token_id, crate::storage::Address::new(*bytes), 0u128))
-            .collect();
+        let sled_entries: Vec<(crate::storage::TokenId, crate::storage::Address, u128)> =
+            to_correct
+                .iter()
+                .map(|(bytes, _)| {
+                    (
+                        sov_storage_token_id,
+                        crate::storage::Address::new(*bytes),
+                        0u128,
+                    )
+                })
+                .collect();
 
         // Apply sled correction outside of block transaction.
         if let Some(store) = self.get_store() {
@@ -816,7 +828,11 @@ impl Blockchain {
             Signature {
                 signature: Vec::new(),
                 public_key: PublicKey::new(
-                    wallet_data.public_key.as_slice().try_into().unwrap_or([0u8; 2592])
+                    wallet_data
+                        .public_key
+                        .as_slice()
+                        .try_into()
+                        .unwrap_or([0u8; 2592]),
                 ),
                 algorithm: SignatureAlgorithm::DEFAULT,
                 timestamp: wallet_data.created_at,
@@ -844,11 +860,9 @@ impl Blockchain {
                 format!("funding_commitment_{}_{}", wallet_id, amount).as_bytes(),
             ),
             note: crate::types::hash::blake3_hash(format!("funding_note_{}", wallet_id).as_bytes()),
-            recipient: PublicKey::new(
-                recipient_identity.try_into().unwrap_or([0u8; 2592])
-            ),
-                        merkle_leaf: Hash::default(),
-};
+            recipient: PublicKey::new(recipient_identity.try_into().unwrap_or([0u8; 2592])),
+            merkle_leaf: Hash::default(),
+        };
         let utxo_hash = crate::types::hash::blake3_hash(
             format!("funding_utxo:{}:{}", wallet_id, amount).as_bytes(),
         );
@@ -1012,6 +1026,13 @@ impl Blockchain {
         })
     }
 
+    /// Deprecated: reads exclusively from the in-memory wallet_registry, which is
+    /// empty after restart. Use [`wallets_for_owner`](Self::wallets_for_owner) instead,
+    /// which reads sled-first with an in-memory overlay (#2639, #2971).
+    #[deprecated(
+        since = "0.0.0",
+        note = "Use wallets_for_owner() instead — this only reads the in-memory shadow which is empty after restart"
+    )]
     pub fn get_wallets_for_owner(
         &self,
         owner_identity_id: &Hash,

--- a/lib-blockchain/src/execution/executor.rs
+++ b/lib-blockchain/src/execution/executor.rs
@@ -1,4 +1,4 @@
-﻿//! Block Executor (Single Authority)
+//! Block Executor (Single Authority)
 //!
 //! The BlockExecutor is the **single entry point** for applying blocks to state.
 //! No consensus logic reads or writes state outside this module.
@@ -44,13 +44,14 @@ use crate::storage::{
 use crate::transaction::{
     asset_tx::{
         AssetAuthorityTransferCancelPayloadV1, AssetAuthorityTransferPayloadV1,
-        AssetLaunchPayloadV1, AssetManifestUpdatePayloadV1,
+        AssetBurnBpsUpdatePayloadV1, AssetLaunchPayloadV1, AssetManifestUpdatePayloadV1,
         AssetModuleUpgradePayloadV1, AssetRewardsDelegateRotatePayloadV1,
-        AssetBurnBpsUpdatePayloadV1, AssetRewardsPolicyUpdatePayloadV1,
+        AssetRewardsPolicyUpdatePayloadV1,
     },
     contract_deployment::ContractDeploymentPayloadV1,
-    contract_execution::DecodedContractExecutionMemo, decode_canonical_bonding_curve_tx,
-    envelope_signer_matches_sender, hash_transaction, token_creation::TokenCreationPayloadV1,
+    contract_execution::DecodedContractExecutionMemo,
+    decode_canonical_bonding_curve_tx, envelope_signer_matches_sender, hash_transaction,
+    token_creation::TokenCreationPayloadV1,
     CanonicalBondingCurveEnvelope, CanonicalBondingCurveTx, BONDING_CURVE_BUY_ACTION,
     BONDING_CURVE_SELL_ACTION, BONDING_CURVE_TX_PAYLOAD_LEN, DEFAULT_TOKEN_CREATION_FEE,
 };
@@ -67,8 +68,8 @@ use super::sovereign_asset::{
     require_cbe_curve_module_if_asset_present, require_governance_mint_signer,
     require_treasury_spend_signer, sync_curve_module_from_cbe_econ, AssetLaunchOutcome,
 };
-use crate::contracts::sovereign_asset::SupplyMode;
 use super::tx_apply::{self, CoinbaseOutcome, StateMutator, TransferOutcome};
+use crate::contracts::sovereign_asset::SupplyMode;
 
 use crate::protocol::ProtocolParams;
 use crate::resources::{BlockAccumulator, BlockLimits};
@@ -387,10 +388,12 @@ impl BlockExecutor {
         let mut contract = mutator
             .get_token_contract(&token_id)?
             .unwrap_or_else(crate::contracts::TokenContract::new_sov_native);
-        let current_supply = mutator.get_token_supply(&token_id)?.unwrap_or(contract.total_supply);
-        let new_supply = current_supply.checked_add(amount).ok_or_else(|| {
-            TxApplyError::InvalidType("SOV total supply overflow".to_string())
-        })?;
+        let current_supply = mutator
+            .get_token_supply(&token_id)?
+            .unwrap_or(contract.total_supply);
+        let new_supply = current_supply
+            .checked_add(amount)
+            .ok_or_else(|| TxApplyError::InvalidType("SOV total supply overflow".to_string()))?;
         let balance = mutator.get_token_balance_u128(&token_id, recipient)?;
         let recipient_pk = lib_crypto::PublicKey {
             dilithium_pk: [0u8; 2592],
@@ -614,8 +617,7 @@ impl BlockExecutor {
         self.store.begin_block(block_height)?;
 
         let guard = RollbackGuard::new(self.store.as_ref());
-        let outcome =
-            self.apply_block_inner(block, fee_floor_atoms, treasury_wallet_id_hex)?;
+        let outcome = self.apply_block_inner(block, fee_floor_atoms, treasury_wallet_id_hex)?;
 
         guard.disarm();
         Ok(outcome)
@@ -706,7 +708,9 @@ impl BlockExecutor {
         let mut total_fees: u128 = 0;
         let mut add_total_fees = |fee: u128| -> BlockApplyResult<()> {
             total_fees = total_fees.checked_add(fee).ok_or_else(|| {
-                BlockApplyError::ValidationFailed("total_fees overflow while applying block".to_string())
+                BlockApplyError::ValidationFailed(
+                    "total_fees overflow while applying block".to_string(),
+                )
             })?;
             Ok(())
         };
@@ -812,7 +816,8 @@ impl BlockExecutor {
                 // Credit 20B CBE to the SOV treasury address in the token ledger.
                 let cbe_token_id = TokenId::new(crate::Blockchain::derive_cbe_token_id_pub());
                 let treasury_addr = *self.fee_model.protocol_params.fee_sink_address();
-                let current = self.store
+                let current = self
+                    .store
                     .get_token_balance(&cbe_token_id, &treasury_addr)
                     .unwrap_or(0);
                 self.store
@@ -823,9 +828,7 @@ impl BlockExecutor {
                     )
                     .map_err(|e| BlockApplyError::PersistFailed(e.to_string()))?;
 
-                tracing::info!(
-                    "Genesis: 20B CBE treasury allocation credited (off-curve, S_c=0)"
-                );
+                tracing::info!("Genesis: 20B CBE treasury allocation credited (off-curve, S_c=0)");
             }
 
             // SOV-native bootstrap (GENESIS-1 / #2729): contract shell + migrated
@@ -954,10 +957,7 @@ impl BlockExecutor {
             // fully prevent (stateful eligibility at different heights).
             let tx_result = match self.apply_tx(&mutator, tx, block_height, block_timestamp) {
                 Ok(outcome) => outcome,
-                Err(TxApplyError::ReplayDropped {
-                    expected,
-                    actual,
-                }) => {
+                Err(TxApplyError::ReplayDropped { expected, actual }) => {
                     tracing::warn!(
                         index = index,
                         height = block_height,
@@ -1438,7 +1438,8 @@ impl BlockExecutor {
             TransactionType::AssetRewardsDelegateRotate => {
                 if !tx.inputs.is_empty() || !tx.outputs.is_empty() {
                     return Err(TxApplyError::InvalidType(
-                        "AssetRewardsDelegateRotate must not have UTXO inputs or outputs".to_string(),
+                        "AssetRewardsDelegateRotate must not have UTXO inputs or outputs"
+                            .to_string(),
                     ));
                 }
                 AssetRewardsDelegateRotatePayloadV1::decode_memo(&tx.memo).map_err(|e| {
@@ -1568,13 +1569,12 @@ impl BlockExecutor {
         for input in &tx.inputs {
             if !input.zk_proof.has_empty_proofs() {
                 // Step 1: Verify the proof's cryptographic validity.
-                match lib_proofs::transaction::ZkTransactionProof::verify_transaction(&input.zk_proof)
-                {
+                match lib_proofs::transaction::ZkTransactionProof::verify_transaction(
+                    &input.zk_proof,
+                ) {
                     Ok(true) => {}
                     Ok(false) => {
-                        return Err(TxApplyError::InvalidType(
-                            "Invalid ZK proof".to_string(),
-                        ))
+                        return Err(TxApplyError::InvalidType("Invalid ZK proof".to_string()))
                     }
                     Err(e) => {
                         return Err(TxApplyError::InvalidType(format!(
@@ -1933,7 +1933,9 @@ impl BlockExecutor {
         let contract_id = Self::dao_state_contract_id();
         let mut proposal_key = b"proposal:".to_vec();
         proposal_key.extend_from_slice(data.proposal_id.as_bytes());
-        let proposal_raw_opt = self.store.get_contract_storage(&contract_id, &proposal_key)?;
+        let proposal_raw_opt = self
+            .store
+            .get_contract_storage(&contract_id, &proposal_key)?;
 
         // CONS-514 (legacy-DAO tolerance): proposals submitted via the raw
         // broadcast path land in `blockchain.dao_proposals` (legacy tally
@@ -1965,8 +1967,8 @@ impl BlockExecutor {
         //         re-reads the proposal from canonical block iteration and
         //         enforces the deadline there.
         let proposal_in_storage = if let Some(proposal_raw) = proposal_raw_opt {
-            let proposal: crate::transaction::DaoProposalData =
-                bincode::deserialize(&proposal_raw).map_err(|e| {
+            let proposal: crate::transaction::DaoProposalData = bincode::deserialize(&proposal_raw)
+                .map_err(|e| {
                     TxApplyError::Internal(format!(
                         "Failed to deserialize proposal for vote check: {e}"
                     ))
@@ -2239,10 +2241,8 @@ impl BlockExecutor {
 
         // â”€â”€ 8. Balance check (reads from token_balances tree) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         if is_buy {
-            let sov_bal = mutator.get_token_balance_u128(
-                &Self::canonical_sov_token_id(),
-                &Address::new(sender),
-            )?;
+            let sov_bal = mutator
+                .get_token_balance_u128(&Self::canonical_sov_token_id(), &Address::new(sender))?;
             if sov_bal < amount_in_or_cbe {
                 return Err(TxApplyError::InvalidType(format!(
                     "BUY_CBE: insufficient SOV balance (have {}, need {})",
@@ -2251,10 +2251,7 @@ impl BlockExecutor {
             }
         } else {
             let cbe_token_id = TokenId::new(crate::Blockchain::derive_cbe_token_id_pub());
-            let cbe_bal = mutator.get_token_balance_u128(
-                &cbe_token_id,
-                &Address::new(sender),
-            )?;
+            let cbe_bal = mutator.get_token_balance_u128(&cbe_token_id, &Address::new(sender))?;
             if cbe_bal < amount_in_or_cbe {
                 return Err(TxApplyError::InvalidType(format!(
                     "SELL_CBE: insufficient CBE balance (have {}, need {})",
@@ -2344,16 +2341,16 @@ impl BlockExecutor {
         econ.sov_treasury_cbe_balance = econ
             .sov_treasury_cbe_balance
             .checked_add(sov_treasury_credit)
-            .ok_or_else(|| TxApplyError::InvalidType("BUY_CBE: sov_treasury overflow".to_string()))?;
+            .ok_or_else(|| {
+                TxApplyError::InvalidType("BUY_CBE: sov_treasury overflow".to_string())
+            })?;
         econ.liquidity_pool
             .mint(liquidity_credit)
             .map_err(|e| TxApplyError::InvalidType(format!("BUY_CBE: liquidity pool: {e}")))?;
         econ.liquidity_pool_balance = econ.liquidity_pool.balance;
 
         // SOVRN audit: liquidity_credit is already in SOV atoms (1:1).
-        econ.sovrn_total_supply = econ
-            .sovrn_total_supply
-            .saturating_add(liquidity_credit);
+        econ.sovrn_total_supply = econ.sovrn_total_supply.saturating_add(liquidity_credit);
 
         econ.satisfy_pre_backed(liquidity_credit);
 
@@ -2374,11 +2371,7 @@ impl BlockExecutor {
         )?;
 
         let cbe_token_id = TokenId::new(crate::Blockchain::derive_cbe_token_id_pub());
-        mutator.credit_token(
-            &cbe_token_id,
-            &Address::new(sender),
-            delta_s,
-        )?;
+        mutator.credit_token(&cbe_token_id, &Address::new(sender), delta_s)?;
 
         // â”€â”€ Event-driven SOV minting â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         // The 20% SOV treasury portion represents real SOV value entering
@@ -2387,11 +2380,7 @@ impl BlockExecutor {
         let sov_to_mint = sov_treasury_credit;
         if sov_to_mint > 0 {
             let treasury_addr = *self.fee_model.protocol_params.fee_sink_address();
-            mutator.credit_token(
-                &Self::canonical_sov_token_id(),
-                &treasury_addr,
-                sov_to_mint,
-            )?;
+            mutator.credit_token(&Self::canonical_sov_token_id(), &treasury_addr, sov_to_mint)?;
             econ.total_sov_minted = econ
                 .total_sov_minted
                 .checked_add(sov_to_mint)
@@ -2460,11 +2449,7 @@ impl BlockExecutor {
 
         // Wire CBE ledger: debit seller's CBE token balance.
         let cbe_token_id = TokenId::new(crate::Blockchain::derive_cbe_token_id_pub());
-        mutator.debit_token(
-            &cbe_token_id,
-            &Address::new(sender),
-            amount_cbe,
-        )?;
+        mutator.debit_token(&cbe_token_id, &Address::new(sender), amount_cbe)?;
 
         // Wire SOV ledger: credit seller's actual SOV token balance.
         mutator.credit_token(
@@ -2504,11 +2489,9 @@ impl BlockExecutor {
         };
         use crate::transaction::core::ProcessPayrollData;
 
-        let data: &ProcessPayrollData = tx
-            .process_payroll_data()
-            .ok_or_else(|| {
-                TxApplyError::InvalidType("ProcessPayroll missing payload".to_string())
-            })?;
+        let data: &ProcessPayrollData = tx.process_payroll_data().ok_or_else(|| {
+            TxApplyError::InvalidType("ProcessPayroll missing payload".to_string())
+        })?;
 
         let amount_cbe = data.amount_cbe; // X â€” what the collaborator earns
         let collaborator = data.collaborator_address;
@@ -2531,15 +2514,13 @@ impl BlockExecutor {
         let gross = amount_cbe
             .checked_mul(PAYROLL_GROSS_NUM)
             .and_then(|v| v.checked_div(PAYROLL_GROSS_DEN))
-            .ok_or_else(|| {
-                TxApplyError::InvalidType("PAYROLL_MINT: gross overflow".to_string())
-            })?;
+            .ok_or_else(|| TxApplyError::InvalidType("PAYROLL_MINT: gross overflow".to_string()))?;
 
-        let treasury_credit = gross * PAYROLL_TREASURY_PCT / 100;     // 20%
-        let base_reserve = gross * PAYROLL_RESERVE_PCT / 100;         // 32%
-        let collaborator_credit = amount_cbe;                         // exactly X
+        let treasury_credit = gross * PAYROLL_TREASURY_PCT / 100; // 20%
+        let base_reserve = gross * PAYROLL_RESERVE_PCT / 100; // 32%
+        let collaborator_credit = amount_cbe; // exactly X
         let rounding_dust = gross - treasury_credit - base_reserve - collaborator_credit;
-        let reserve_credit = base_reserve + rounding_dust;            // 32% + dust
+        let reserve_credit = base_reserve + rounding_dust; // 32% + dust
 
         // â”€â”€ 2. Debt ceiling check (against gross) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         let mut econ = mutator.get_cbe_economic_state()?;
@@ -2562,7 +2543,9 @@ impl BlockExecutor {
         // Compensation pool tracks what collaborators received.
         econ.compensation_pool
             .mint(collaborator_credit)
-            .map_err(|e| TxApplyError::InvalidType(format!("PAYROLL_MINT: compensation pool: {e}")))?;
+            .map_err(|e| {
+                TxApplyError::InvalidType(format!("PAYROLL_MINT: compensation pool: {e}"))
+            })?;
 
         // SOV treasury CBE balance (20% of gross).
         econ.sov_treasury_cbe_balance = econ
@@ -2627,11 +2610,7 @@ impl BlockExecutor {
 
         // 20% gross â†’ SOV treasury address (held as CBE)
         let treasury_addr = *self.fee_model.protocol_params.fee_sink_address();
-        mutator.credit_token(
-            &cbe_token_id,
-            &treasury_addr,
-            treasury_credit,
-        )?;
+        mutator.credit_token(&cbe_token_id, &treasury_addr, treasury_credit)?;
 
         // 32% gross â†’ locked reserve (no token credit â€” reserve is an accounting
         // entry in BondingCurveEconomicState, not a wallet balance; it backs the
@@ -2985,8 +2964,8 @@ impl BlockExecutor {
         block_timestamp: u64,
     ) -> Result<(), TxApplyError> {
         use lib_types::{
-            ObserverAdmissionRecord, ObserverAdmissionStatus, ObserverNodeInfo,
-            ObserverSponsorBinding, ObserverNetworkBinding, ObserverAdmissionActionMeta,
+            ObserverAdmissionActionMeta, ObserverAdmissionRecord, ObserverAdmissionStatus,
+            ObserverNetworkBinding, ObserverNodeInfo, ObserverSponsorBinding,
         };
 
         let data = tx.register_observer_data().ok_or_else(|| {
@@ -3217,11 +3196,9 @@ impl BlockExecutor {
         use lib_types::ObserverAdmissionActionMeta;
 
         // Replay protection: enforce monotonic SOV nonce on the signer.
-        let (signer_addr, sov_token) =
-            Self::check_observer_nonce(mutator, tx, nonce, op_name)?;
+        let (signer_addr, sov_token) = Self::check_observer_nonce(mutator, tx, nonce, op_name)?;
 
-        let (did_hash, mut record) =
-            Self::load_observer_record(mutator, observer_did, op_name)?;
+        let (did_hash, mut record) = Self::load_observer_record(mutator, observer_did, op_name)?;
 
         // Only the registered sponsor may drive sponsor-scoped lifecycle changes.
         if actor_did != record.sponsor.sponsoring_user_did {
@@ -3414,11 +3391,7 @@ impl BlockExecutor {
             ));
         }
 
-        self.apply_canonical_bonding_curve_tx_at_height(
-            mutator,
-            &envelope.payload,
-            block_height,
-        )
+        self.apply_canonical_bonding_curve_tx_at_height(mutator, &envelope.payload, block_height)
     }
 
     /// Apply a single transaction
@@ -4246,9 +4219,7 @@ fn validate_buy_limits(
     let effective = U256::from(amount_in)
         .checked_mul(U256::from(SCALE))
         .ok_or_else(|| {
-            TxApplyError::InvalidType(
-                "BUY_CBE: slippage overflow in amount_in * SCALE".to_string(),
-            )
+            TxApplyError::InvalidType("BUY_CBE: slippage overflow in amount_in * SCALE".to_string())
         })?
         / U256::from(delta_s);
     if effective > U256::from(max_price) {
@@ -4313,9 +4284,7 @@ mod tests {
     /// loop), gap must still produce TxApplyError::InvalidNonce (hard fail).
     #[test]
     fn test_validate_tx_stateful_distinguishes_replay_from_gap() {
-        use crate::integration::crypto_integration::{
-            PublicKey, Signature, SignatureAlgorithm,
-        };
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
         use crate::transaction::TokenTransferData;
         let store = create_test_store();
         let executor = create_test_executor(store.clone());
@@ -4485,7 +4454,10 @@ mod tests {
         expected.genesis_treasury_allocation = GENESIS_TREASURY_ALLOCATION;
         assert_eq!(state, expected);
         assert_eq!(state.s_c, 0); // off-curve: S_c stays 0
-        assert_eq!(state.genesis_treasury_allocation, GENESIS_TREASURY_ALLOCATION);
+        assert_eq!(
+            state.genesis_treasury_allocation,
+            GENESIS_TREASURY_ALLOCATION
+        );
         assert!(!state.graduated);
         assert!(!state.sell_enabled);
     }
@@ -4503,7 +4475,9 @@ mod tests {
 
         let cfg = crate::genesis::GenesisConfig::from_embedded().expect("embedded genesis");
         assert!(
-            cfg.sov_allocation_entries().expect("sov entries").is_empty(),
+            cfg.sov_allocation_entries()
+                .expect("sov entries")
+                .is_empty(),
             "GENESIS-3 genesis must not include bulk sov_balances"
         );
 
@@ -4566,7 +4540,10 @@ mod tests {
         store.commit_block().unwrap();
 
         assert!(first.sov_contract_installed);
-        assert_eq!(first.sov_balances_credited, 0, "GENESIS-3: no genesis SOV rows");
+        assert_eq!(
+            first.sov_balances_credited, 0,
+            "GENESIS-3: no genesis SOV rows"
+        );
         assert!(!second.sov_contract_installed);
         assert_eq!(second.sov_balances_credited, 0);
     }
@@ -4604,7 +4581,11 @@ mod tests {
         let initial_balance = fee.saturating_mul(2);
         let sov_token = TokenId::new(generate_lib_token_id());
         store
-            .force_set_token_balances(&[(sov_token, Address::new(payer_wallet_id), initial_balance)])
+            .force_set_token_balances(&[(
+                sov_token,
+                Address::new(payer_wallet_id),
+                initial_balance,
+            )])
             .unwrap();
 
         let treasury_id = crate::Blockchain::deterministic_treasury_wallet_id().as_array();
@@ -4649,11 +4630,7 @@ mod tests {
         );
 
         executor
-            .apply_block_committing_domain_fees(
-                &block1,
-                Some(fee),
-                Some(treasury_hex.as_str()),
-            )
+            .apply_block_committing_domain_fees(&block1, Some(fee), Some(treasury_hex.as_str()))
             .expect("domain fee must commit inside block transaction");
 
         let payer_after = store
@@ -4770,7 +4747,7 @@ mod tests {
                 commitment: Hash::default(),
                 note: Hash::default(),
                 recipient: create_dummy_public_key(),
-            merkle_leaf: Hash::default(),
+                merkle_leaf: Hash::default(),
             }],
             fee: 10_000, // High enough for testing fee params
             signature: create_dummy_signature(),
@@ -4789,7 +4766,7 @@ mod tests {
                 commitment: Hash::default(),
                 note: Hash::default(),
                 recipient: recipient_pk,
-            merkle_leaf: Hash::default(),
+                merkle_leaf: Hash::default(),
             }],
             fee: 0,
             signature: create_dummy_signature(),
@@ -5068,6 +5045,7 @@ mod tests {
                 wallet_name: "test-wallet".to_string(),
                 alias: None,
                 public_key: vec![0u8; 32],
+                kyber_public_key: vec![],
                 owner_identity_id: None,
                 seed_commitment: Hash::default(),
                 created_at: 0,
@@ -5306,7 +5284,8 @@ mod tests {
     fn test_token_creation_rejected_at_sunset_height() {
         const SUNSET: u64 = 1;
         let store = create_test_store();
-        let executor = create_test_executor(store.clone()).with_token_creation_sunset_height(SUNSET);
+        let executor =
+            create_test_executor(store.clone()).with_token_creation_sunset_height(SUNSET);
 
         let genesis = create_genesis_block();
         executor.apply_block(&genesis).unwrap();
@@ -5314,14 +5293,21 @@ mod tests {
         let block = create_block_with_txs(
             SUNSET,
             genesis.header.block_hash,
-            vec![create_token_creation_tx("At Sunset", "SUN", 1_000_000, [0xBB; 32])],
+            vec![create_token_creation_tx(
+                "At Sunset",
+                "SUN",
+                1_000_000,
+                [0xBB; 32],
+            )],
         );
         let err = executor
             .apply_block(&block)
             .expect_err("TokenCreation at sunset must reject block");
         let msg = format!("{err:?}");
         assert!(
-            msg.contains("TokenCreation") || msg.contains("deprecated") || msg.contains("Forbidden"),
+            msg.contains("TokenCreation")
+                || msg.contains("deprecated")
+                || msg.contains("Forbidden"),
             "expected sunset rejection, got: {msg}"
         );
     }
@@ -5330,7 +5316,8 @@ mod tests {
     fn test_token_creation_allowed_below_sunset_height() {
         const SUNSET: u64 = 2;
         let store = create_test_store();
-        let executor = create_test_executor(store.clone()).with_token_creation_sunset_height(SUNSET);
+        let executor =
+            create_test_executor(store.clone()).with_token_creation_sunset_height(SUNSET);
 
         let genesis = create_genesis_block();
         executor.apply_block(&genesis).unwrap();
@@ -5338,7 +5325,12 @@ mod tests {
         let block = create_block_with_txs(
             SUNSET - 1,
             genesis.header.block_hash,
-            vec![create_token_creation_tx("Below Sunset", "PRE", 1_000_000, [0xAA; 32])],
+            vec![create_token_creation_tx(
+                "Below Sunset",
+                "PRE",
+                1_000_000,
+                [0xAA; 32],
+            )],
         );
         executor
             .apply_block(&block)
@@ -5357,7 +5349,9 @@ mod tests {
         let block = create_block_with_txs(
             SUNSET,
             genesis.header.block_hash,
-            vec![create_token_creation_tx("Sunset", "SUN", 1_000_000, [0xCC; 32])],
+            vec![create_token_creation_tx(
+                "Sunset", "SUN", 1_000_000, [0xCC; 32],
+            )],
         );
         let err = executor
             .apply_block(&block)
@@ -5436,7 +5430,9 @@ mod tests {
         let expected_asset_id = hash_transaction(&tx).as_array();
 
         let block1 = create_block_with_txs(1, genesis.header.block_hash, vec![tx]);
-        executor.apply_block(&block1).expect("AssetLaunch should apply");
+        executor
+            .apply_block(&block1)
+            .expect("AssetLaunch should apply");
 
         let asset = store
             .get_sovereign_asset(&expected_asset_id)
@@ -5445,7 +5441,10 @@ mod tests {
         assert_eq!(asset.asset_id, expected_asset_id);
         assert_eq!(asset.id_source, AssetIdSource::LaunchTx);
         assert_eq!(asset.symbol, "BUBL");
-        assert_eq!(asset.dao_class, crate::contracts::sovereign_asset::DaoClass::Fp);
+        assert_eq!(
+            asset.dao_class,
+            crate::contracts::sovereign_asset::DaoClass::Fp
+        );
 
         let creator = Address::new(create_dummy_signature().public_key.key_id);
         let treasury = Address::new([0xAA; 32]);
@@ -5464,7 +5463,9 @@ mod tests {
         let genesis = create_genesis_block();
         executor.apply_block(&genesis).unwrap();
 
-        use crate::rewards_policy::{legacy_bubl_policy, policy_hash, validate_rewards_policy_value};
+        use crate::rewards_policy::{
+            legacy_bubl_policy, policy_hash, validate_rewards_policy_value,
+        };
 
         let delegate_key = [0xDD; 32];
         let policy = legacy_bubl_policy();
@@ -5511,14 +5512,19 @@ mod tests {
         let expected_asset_id = hash_transaction(&tx).as_array();
 
         let block1 = create_block_with_txs(1, genesis.header.block_hash, vec![tx]);
-        executor.apply_block(&block1).expect("AssetLaunch should apply");
+        executor
+            .apply_block(&block1)
+            .expect("AssetLaunch should apply");
 
         let asset = store
             .get_sovereign_asset(&expected_asset_id)
             .expect("read asset")
             .expect("asset exists");
         assert!(asset.module_flags.has_rewards());
-        assert_eq!(asset.module_bitmask() & AssetModuleFlags::REWARDS, AssetModuleFlags::REWARDS);
+        assert_eq!(
+            asset.module_bitmask() & AssetModuleFlags::REWARDS,
+            AssetModuleFlags::REWARDS
+        );
 
         let rewards_state = store
             .get_rewards_module_state(&expected_asset_id)
@@ -5619,7 +5625,9 @@ mod tests {
     #[test]
     fn test_asset_launch_curve_module_discoverable_without_bonding_curve_token() {
         use crate::contracts::bonding_curve::canonical::GRAD_THRESHOLD;
-        use crate::contracts::sovereign_asset::{AssetModuleFlags, CurveModuleState, CurvePhase, SupplyMode};
+        use crate::contracts::sovereign_asset::{
+            AssetModuleFlags, CurveModuleState, CurvePhase, SupplyMode,
+        };
         use crate::transaction::asset_tx::{
             build_dao_launch_manifest_bytes, manifest_cid_hash_from_bytes, AssetLaunchPayloadV1,
             CurveLaunchConfig,
@@ -5768,7 +5776,9 @@ mod tests {
 
     fn launch_rewards_asset(executor: &BlockExecutor, genesis: &Block) -> ([u8; 32], Block) {
         use crate::contracts::sovereign_asset::SupplyMode;
-        use crate::rewards_policy::{legacy_bubl_policy, policy_hash, validate_rewards_policy_value};
+        use crate::rewards_policy::{
+            legacy_bubl_policy, policy_hash, validate_rewards_policy_value,
+        };
         use crate::transaction::asset_tx::{AssetLaunchPayloadV1, RewardsLaunchConfig};
 
         let delegate_key = create_dummy_signature().public_key.key_id;
@@ -5825,16 +5835,14 @@ mod tests {
             create_dummy_signature(),
         );
         let block2 = create_block_with_txs(2, block1.header.block_hash, vec![bind_tx]);
-        executor.apply_block(&block2).expect("bind asset_id in policy");
+        executor
+            .apply_block(&block2)
+            .expect("bind asset_id in policy");
 
         (asset_id, block2)
     }
 
-    fn policy_update_tx(
-        asset_id: [u8; 32],
-        welcome_atoms: u128,
-        signer: Signature,
-    ) -> Transaction {
+    fn policy_update_tx(asset_id: [u8; 32], welcome_atoms: u128, signer: Signature) -> Transaction {
         use crate::rewards_policy::{policy_hash, validate_rewards_policy_value};
         use crate::transaction::asset_tx::{
             AssetAuthorityProof, AssetRewardsPolicyUpdatePayloadV1, RewardsPolicyUpdateConfig,
@@ -5882,11 +5890,7 @@ mod tests {
 
         let (asset_id, launch_block) = launch_rewards_asset(&executor, &genesis);
         let increased_welcome = WELCOME * 2;
-        let update_tx = policy_update_tx(
-            asset_id,
-            increased_welcome,
-            create_dummy_signature(),
-        );
+        let update_tx = policy_update_tx(asset_id, increased_welcome, create_dummy_signature());
         let block3 = create_block_with_txs(3, launch_block.header.block_hash, vec![update_tx]);
         executor.apply_block(&block3).expect("policy increase");
 
@@ -5931,7 +5935,9 @@ mod tests {
 
         let update_tx = policy_update_tx(asset_id, WELCOME / 2, create_dummy_signature());
         let block3 = create_block_with_txs(3, launch_block.header.block_hash, vec![update_tx]);
-        executor.apply_block(&block3).expect("policy decrease queue");
+        executor
+            .apply_block(&block3)
+            .expect("policy decrease queue");
 
         let state = store
             .get_rewards_module_state(&asset_id)
@@ -6386,11 +6392,7 @@ mod tests {
         // proposal lives in block history but not in contract_storage.
         let proposal_id = proposal_id_for("legacy-only-proposal");
         let proposal_tx = create_dao_proposal_tx(proposal_id);
-        let proposal_block = create_block_with_txs(
-            1,
-            genesis.header.block_hash,
-            vec![proposal_tx],
-        );
+        let proposal_block = create_block_with_txs(1, genesis.header.block_hash, vec![proposal_tx]);
         store.begin_block(1).unwrap();
         store.append_block(&proposal_block).unwrap();
         store.commit_block().unwrap();
@@ -6412,11 +6414,8 @@ mod tests {
         // Pre-fix this would error with "DaoVote references unknown
         // proposal" and halt the block; post-fix it applies cleanly.
         let vote_tx = create_dao_vote_tx(proposal_id, "alice", "Yes");
-        let vote_block = create_block_with_txs(
-            2,
-            proposal_block.header.block_hash,
-            vec![vote_tx.clone()],
-        );
+        let vote_block =
+            create_block_with_txs(2, proposal_block.header.block_hash, vec![vote_tx.clone()]);
         executor
             .apply_block(&vote_block)
             .expect("vote on legacy-only proposal must apply, not halt the block");
@@ -6673,8 +6672,14 @@ mod tests {
         let econ = store.get_cbe_economic_state().unwrap();
         assert_eq!(econ.s_c, delta_s, "supply must equal minted tokens");
         assert!(econ.reserve_balance > 0, "reserve (32%) must be credited");
-        assert!(econ.sov_treasury_cbe_balance > 0, "sov treasury (20%) must be credited");
-        assert!(econ.liquidity_pool_balance > 0, "liquidity pool (48%) must be credited");
+        assert!(
+            econ.sov_treasury_cbe_balance > 0,
+            "sov treasury (20%) must be credited"
+        );
+        assert!(
+            econ.liquidity_pool_balance > 0,
+            "liquidity pool (48%) must be credited"
+        );
         assert_eq!(
             econ.reserve_balance + econ.sov_treasury_cbe_balance + econ.liquidity_pool_balance,
             amount_in,
@@ -7428,12 +7433,20 @@ mod tests {
     // =========================================================================
 
     /// Helper: seed SOV balance inside a block-scoped write at the given height.
-    fn seed_sov_balance(store: &Arc<dyn BlockchainStore>, key_id: [u8; 32], amount: u64, block_height: u64, prev_hash: Hash) {
+    fn seed_sov_balance(
+        store: &Arc<dyn BlockchainStore>,
+        key_id: [u8; 32],
+        amount: u64,
+        block_height: u64,
+        prev_hash: Hash,
+    ) {
         let token_id = TokenId::new(crate::contracts::utils::generate_lib_token_id());
         let addr = Address::new(key_id);
         let block = create_block_at_height(block_height, prev_hash);
         store.begin_block(block_height).unwrap();
-        store.set_token_balance(&token_id, &addr, amount as u128).unwrap();
+        store
+            .set_token_balance(&token_id, &addr, amount as u128)
+            .unwrap();
         store.append_block(&block).unwrap();
         store.commit_block().unwrap();
     }
@@ -7527,7 +7540,10 @@ mod tests {
 
         let block2 = create_block_with_txs(2, Hash::new(block1_hash.0), vec![tx]);
         let result = executor.apply_block(&block2);
-        assert!(result.is_err(), "Should reject treasury allocation with insufficient balance");
+        assert!(
+            result.is_err(),
+            "Should reject treasury allocation with insufficient balance"
+        );
     }
 
     #[test]
@@ -7549,7 +7565,9 @@ mod tests {
         {
             let sov_token_id = TokenId::new(crate::contracts::utils::generate_lib_token_id());
             let addr = Address::new(buyer_key);
-            store.set_token_balance(&sov_token_id, &addr, amount_in).unwrap();
+            store
+                .set_token_balance(&sov_token_id, &addr, amount_in)
+                .unwrap();
 
             let seed = StateMutator::new(store.as_ref());
             seed.put_cbe_account_state(
@@ -7619,11 +7637,11 @@ mod tests {
     #[test]
     #[cfg(feature = "real-proofs")]
     fn test_real_zk_transaction_proof_end_to_end() {
+        use crate::storage::{OutPoint, TxHash};
         use crate::transaction::hashing::hash_transaction;
         use lib_fees::compute_fee_v2;
         use lib_proofs::transaction::ZkTransactionProof;
         use lib_types::fees::FeeParams;
-        use crate::storage::{OutPoint, TxHash};
 
         let store = create_test_store();
         let executor = BlockExecutor::with_store(store.clone());
@@ -7672,11 +7690,7 @@ mod tests {
             payload: crate::transaction::TransactionPayload::None,
         };
 
-        let funded_block = create_block_with_txs(
-            1,
-            genesis.header.block_hash,
-            vec![coinbase_tx],
-        );
+        let funded_block = create_block_with_txs(1, genesis.header.block_hash, vec![coinbase_tx]);
         executor.apply_block(&funded_block).unwrap();
 
         let coinbase_tx_hash = hash_transaction(&funded_block.transactions[0]);
@@ -7753,13 +7767,16 @@ mod tests {
 
         let fee_params = FeeParams::default();
         let total_fee = compute_fee_v2(&fee_input, &fee_params);
-        assert!(total_fee > 0, "Total fee should include ZK verification cost");
+        assert!(
+            total_fee > 0,
+            "Total fee should include ZK verification cost"
+        );
 
         // 5. Full block application should succeed with a real ZK proof
         let spend_block = create_block_with_txs(2, funded_block.header.block_hash, vec![tx]);
-        executor.apply_block(&spend_block).expect(
-            "Transaction with real ZK proof should be accepted into the chain"
-        );
+        executor
+            .apply_block(&spend_block)
+            .expect("Transaction with real ZK proof should be accepted into the chain");
         assert_eq!(store.latest_height().unwrap(), 2);
 
         // 6. The spent UTXO should no longer have a Merkle proof in the store.
@@ -7774,7 +7791,7 @@ mod tests {
     // =========================================================================
 
     use crate::transaction::{
-        RegisterObserverData, SuspendObserverData, RevokeObserverData, ReauthorizeObserverData,
+        ReauthorizeObserverData, RegisterObserverData, RevokeObserverData, SuspendObserverData,
     };
 
     /// Compute the signer key_id used by the dummy observer test signature.
@@ -7924,7 +7941,10 @@ mod tests {
 
         let did_hash = crate::storage::did_to_hash(&"did:zhtp:node1".to_string());
         let record = store.get_observer_record(&did_hash).unwrap();
-        assert!(record.is_some(), "observer record should exist after registration");
+        assert!(
+            record.is_some(),
+            "observer record should exist after registration"
+        );
         let record = record.unwrap();
         assert_eq!(record.status, lib_types::ObserverAdmissionStatus::Pending);
         assert_eq!(record.node_info.observer_node_did, "did:zhtp:node1");
@@ -7943,7 +7963,10 @@ mod tests {
         // duplicate-DID, not nonce mismatch).
         let tx2 = make_register_observer_tx_with_nonce("did:zhtp:node2", "did:zhtp:sponsor1", 1);
         let result = apply_block_with_tx(&executor, 3, block1.header.block_hash, tx2);
-        assert!(result.is_err(), "duplicate observer registration should be rejected");
+        assert!(
+            result.is_err(),
+            "duplicate observer registration should be rejected"
+        );
     }
 
     #[test]
@@ -7951,11 +7974,7 @@ mod tests {
         let (store, executor, prev_hash) = setup_observer_test();
 
         // Register observer at height 2 (nonce 0).
-        let tx_reg = make_register_observer_tx_with_nonce(
-            "did:zhtp:node3",
-            "did:zhtp:sponsor1",
-            0,
-        );
+        let tx_reg = make_register_observer_tx_with_nonce("did:zhtp:node3", "did:zhtp:sponsor1", 0);
         let block2 = create_block_with_txs(2, prev_hash, vec![tx_reg]);
         executor.apply_block(&block2).unwrap();
 
@@ -7969,59 +7988,45 @@ mod tests {
         let did_hash = crate::storage::did_to_hash(&"did:zhtp:node3".to_string());
 
         // Now suspend at height 4 (signer nonce is 1 because register consumed 0).
-        let tx_sus = make_suspend_observer_tx_with_nonce(
-            "did:zhtp:node3",
-            "did:zhtp:sponsor1",
-            1,
-        );
+        let tx_sus = make_suspend_observer_tx_with_nonce("did:zhtp:node3", "did:zhtp:sponsor1", 1);
         let block4 = create_block_with_txs(4, block2.header.block_hash, vec![tx_sus]);
         executor.apply_block(&block4).unwrap();
 
         let record = store.get_observer_record(&did_hash).unwrap().unwrap();
         assert_eq!(record.status, lib_types::ObserverAdmissionStatus::Suspended);
         assert!(record.action_meta.is_some());
-        assert_eq!(record.action_meta.as_ref().unwrap().actor_did, "did:zhtp:sponsor1");
+        assert_eq!(
+            record.action_meta.as_ref().unwrap().actor_did,
+            "did:zhtp:sponsor1"
+        );
     }
 
     #[test]
     fn test_suspend_pending_observer_rejected() {
         let (_store, executor, prev_hash) = setup_observer_test();
 
-        let tx_reg = make_register_observer_tx_with_nonce(
-            "did:zhtp:node4",
-            "did:zhtp:sponsor1",
-            0,
-        );
+        let tx_reg = make_register_observer_tx_with_nonce("did:zhtp:node4", "did:zhtp:sponsor1", 0);
         let block2 = create_block_with_txs(2, prev_hash, vec![tx_reg]);
         executor.apply_block(&block2).unwrap();
 
         // Try to suspend a Pending observer (must fail â€” only Active can be suspended).
-        let tx_sus = make_suspend_observer_tx_with_nonce(
-            "did:zhtp:node4",
-            "did:zhtp:sponsor1",
-            1,
-        );
+        let tx_sus = make_suspend_observer_tx_with_nonce("did:zhtp:node4", "did:zhtp:sponsor1", 1);
         let result = apply_block_with_tx(&executor, 3, block2.header.block_hash, tx_sus);
-        assert!(result.is_err(), "suspending a Pending observer should be rejected");
+        assert!(
+            result.is_err(),
+            "suspending a Pending observer should be rejected"
+        );
     }
 
     #[test]
     fn test_revoke_observer() {
         let (store, executor, prev_hash) = setup_observer_test();
 
-        let tx_reg = make_register_observer_tx_with_nonce(
-            "did:zhtp:node5",
-            "did:zhtp:sponsor1",
-            0,
-        );
+        let tx_reg = make_register_observer_tx_with_nonce("did:zhtp:node5", "did:zhtp:sponsor1", 0);
         let block2 = create_block_with_txs(2, prev_hash, vec![tx_reg]);
         executor.apply_block(&block2).unwrap();
 
-        let tx_rev = make_revoke_observer_tx_with_nonce(
-            "did:zhtp:node5",
-            "did:zhtp:sponsor1",
-            1,
-        );
+        let tx_rev = make_revoke_observer_tx_with_nonce("did:zhtp:node5", "did:zhtp:sponsor1", 1);
         let block3 = create_block_with_txs(3, block2.header.block_hash, vec![tx_rev]);
         executor.apply_block(&block3).unwrap();
 
@@ -8035,41 +8040,28 @@ mod tests {
     fn test_double_revoke_rejected() {
         let (_store, executor, prev_hash) = setup_observer_test();
 
-        let tx_reg = make_register_observer_tx_with_nonce(
-            "did:zhtp:node6",
-            "did:zhtp:sponsor1",
-            0,
-        );
+        let tx_reg = make_register_observer_tx_with_nonce("did:zhtp:node6", "did:zhtp:sponsor1", 0);
         let block2 = create_block_with_txs(2, prev_hash, vec![tx_reg]);
         executor.apply_block(&block2).unwrap();
 
-        let tx_rev1 = make_revoke_observer_tx_with_nonce(
-            "did:zhtp:node6",
-            "did:zhtp:sponsor1",
-            1,
-        );
+        let tx_rev1 = make_revoke_observer_tx_with_nonce("did:zhtp:node6", "did:zhtp:sponsor1", 1);
         let block3 = create_block_with_txs(3, block2.header.block_hash, vec![tx_rev1]);
         executor.apply_block(&block3).unwrap();
 
         // Second revoke must fail (status no longer Active/Pending/Suspended).
-        let tx_rev2 = make_revoke_observer_tx_with_nonce(
-            "did:zhtp:node6",
-            "did:zhtp:sponsor1",
-            2,
-        );
+        let tx_rev2 = make_revoke_observer_tx_with_nonce("did:zhtp:node6", "did:zhtp:sponsor1", 2);
         let result = apply_block_with_tx(&executor, 4, block3.header.block_hash, tx_rev2);
-        assert!(result.is_err(), "double-revoking an observer should be rejected");
+        assert!(
+            result.is_err(),
+            "double-revoking an observer should be rejected"
+        );
     }
 
     #[test]
     fn test_reauthorize_suspended_observer() {
         let (store, executor, prev_hash) = setup_observer_test();
 
-        let tx_reg = make_register_observer_tx_with_nonce(
-            "did:zhtp:node7",
-            "did:zhtp:sponsor1",
-            0,
-        );
+        let tx_reg = make_register_observer_tx_with_nonce("did:zhtp:node7", "did:zhtp:sponsor1", 0);
         let block2 = create_block_with_txs(2, prev_hash, vec![tx_reg]);
         executor.apply_block(&block2).unwrap();
 
@@ -8083,28 +8075,24 @@ mod tests {
         let did_hash = crate::storage::did_to_hash(&"did:zhtp:node7".to_string());
 
         // Reauthorize as original sponsor at height 4 (nonce 1).
-        let tx_rauth = make_reauthorize_observer_tx_with_nonce(
-            "did:zhtp:node7",
-            "did:zhtp:sponsor1",
-            1,
-        );
+        let tx_rauth =
+            make_reauthorize_observer_tx_with_nonce("did:zhtp:node7", "did:zhtp:sponsor1", 1);
         let block4 = create_block_with_txs(4, block2.header.block_hash, vec![tx_rauth]);
         executor.apply_block(&block4).unwrap();
 
         let record = store.get_observer_record(&did_hash).unwrap().unwrap();
         assert_eq!(record.status, lib_types::ObserverAdmissionStatus::Active);
-        assert!(record.action_meta.is_none(), "action_meta should be cleared on reauthorization");
+        assert!(
+            record.action_meta.is_none(),
+            "action_meta should be cleared on reauthorization"
+        );
     }
 
     #[test]
     fn test_reauthorize_wrong_sponsor_rejected() {
         let (store, executor, prev_hash) = setup_observer_test();
 
-        let tx_reg = make_register_observer_tx_with_nonce(
-            "did:zhtp:node8",
-            "did:zhtp:sponsor1",
-            0,
-        );
+        let tx_reg = make_register_observer_tx_with_nonce("did:zhtp:node8", "did:zhtp:sponsor1", 0);
         let block2 = create_block_with_txs(2, prev_hash, vec![tx_reg]);
         executor.apply_block(&block2).unwrap();
 
@@ -8117,13 +8105,13 @@ mod tests {
         );
 
         // Wrong sponsor at height 4 (nonce 1).
-        let tx_rauth = make_reauthorize_observer_tx_with_nonce(
-            "did:zhtp:node8",
-            "did:zhtp:impostor",
-            1,
-        );
+        let tx_rauth =
+            make_reauthorize_observer_tx_with_nonce("did:zhtp:node8", "did:zhtp:impostor", 1);
         let result = apply_block_with_tx(&executor, 4, block2.header.block_hash, tx_rauth);
-        assert!(result.is_err(), "reauthorize by wrong sponsor must be rejected");
+        assert!(
+            result.is_err(),
+            "reauthorize by wrong sponsor must be rejected"
+        );
     }
 
     #[test]
@@ -8136,26 +8124,21 @@ mod tests {
         let did_hash = crate::storage::did_to_hash(&"did:zhtp:node9".to_string());
         let record = store.get_observer_record(&did_hash).unwrap().unwrap();
         assert_eq!(record.sponsor.sponsoring_user_did, "did:zhtp:sponsor_abc");
-        assert_eq!(record.sponsor.proof_level, lib_types::ObserverProofLevel::Basic);
+        assert_eq!(
+            record.sponsor.proof_level,
+            lib_types::ObserverProofLevel::Basic
+        );
     }
 
     #[test]
     fn test_iter_observer_records_returns_all_admitted() {
         let (store, executor, prev_hash) = setup_observer_test();
 
-        let tx_a = make_register_observer_tx_with_nonce(
-            "did:zhtp:nodeA",
-            "did:zhtp:sponsorX",
-            0,
-        );
+        let tx_a = make_register_observer_tx_with_nonce("did:zhtp:nodeA", "did:zhtp:sponsorX", 0);
         let block2 = create_block_with_txs(2, prev_hash, vec![tx_a]);
         executor.apply_block(&block2).unwrap();
 
-        let tx_b = make_register_observer_tx_with_nonce(
-            "did:zhtp:nodeB",
-            "did:zhtp:sponsorY",
-            1,
-        );
+        let tx_b = make_register_observer_tx_with_nonce("did:zhtp:nodeB", "did:zhtp:sponsorY", 1);
         let block3 = create_block_with_txs(3, block2.header.block_hash, vec![tx_b]);
         executor.apply_block(&block3).unwrap();
 
@@ -8185,24 +8168,22 @@ mod tests {
         let run = || -> Vec<lib_types::ObserverAdmissionRecord> {
             let (store, executor, prev_hash) = setup_observer_test();
 
-            let tx_a = make_register_observer_tx_with_nonce(
-                "did:zhtp:repA",
-                "did:zhtp:repSponsorA",
-                0,
-            );
+            let tx_a =
+                make_register_observer_tx_with_nonce("did:zhtp:repA", "did:zhtp:repSponsorA", 0);
             let block2 = create_block_with_txs(2, prev_hash, vec![tx_a]);
             executor.apply_block(&block2).unwrap();
 
-            let tx_b = make_register_observer_tx_with_nonce(
-                "did:zhtp:repB",
-                "did:zhtp:repSponsorB",
-                1,
-            );
+            let tx_b =
+                make_register_observer_tx_with_nonce("did:zhtp:repB", "did:zhtp:repSponsorB", 1);
             let block3 = create_block_with_txs(3, block2.header.block_hash, vec![tx_b]);
             executor.apply_block(&block3).unwrap();
 
             let mut all = store.iter_observer_records().unwrap();
-            all.sort_by(|a, b| a.node_info.observer_node_did.cmp(&b.node_info.observer_node_did));
+            all.sort_by(|a, b| {
+                a.node_info
+                    .observer_node_did
+                    .cmp(&b.node_info.observer_node_did)
+            });
             all
         };
 
@@ -8222,11 +8203,8 @@ mod tests {
         // application with a nonce-mismatch error (signer nonce is now 1).
         let (_store, executor, prev_hash) = setup_observer_test();
 
-        let tx1 = make_register_observer_tx_with_nonce(
-            "did:zhtp:replay_a",
-            "did:zhtp:sponsor_replay",
-            0,
-        );
+        let tx1 =
+            make_register_observer_tx_with_nonce("did:zhtp:replay_a", "did:zhtp:sponsor_replay", 0);
         let block2 = create_block_with_txs(2, prev_hash, vec![tx1.clone()]);
         executor.apply_block(&block2).unwrap();
 
@@ -8303,11 +8281,8 @@ mod tests {
         let prev_hash = apply_genesis_and_get_hash(&executor);
         // Note: NO seed_observer_test_signer_sov() call.
 
-        let tx = make_register_observer_tx_with_nonce(
-            "did:zhtp:no_funds",
-            "did:zhtp:sponsor_nofund",
-            0,
-        );
+        let tx =
+            make_register_observer_tx_with_nonce("did:zhtp:no_funds", "did:zhtp:sponsor_nofund", 0);
         let result = apply_block_with_tx(&executor, 1, prev_hash, tx);
         assert!(
             result.is_err(),
@@ -8422,11 +8397,7 @@ mod tests {
         let block2 = create_block_with_txs(2, prev_hash, vec![tx1]);
         executor.apply_block(&block2).unwrap();
 
-        let tx_rev = make_revoke_observer_tx_with_nonce(
-            "did:zhtp:rq1",
-            "did:zhtp:sponsorRQ",
-            1,
-        );
+        let tx_rev = make_revoke_observer_tx_with_nonce("did:zhtp:rq1", "did:zhtp:sponsorRQ", 1);
         let block3 = create_block_with_txs(3, block2.header.block_hash, vec![tx_rev]);
         executor.apply_block(&block3).unwrap();
 

--- a/lib-blockchain/src/genesis/mod.rs
+++ b/lib-blockchain/src/genesis/mod.rs
@@ -222,7 +222,9 @@ where
             Ok(v as u128)
         }
         fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<u128, E> {
-            if v < 0 { return Err(E::custom("negative balance")); }
+            if v < 0 {
+                return Err(E::custom("negative balance"));
+            }
             Ok(v as u128)
         }
         fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<u128, E> {
@@ -587,6 +589,7 @@ impl GenesisConfig {
                     wallet_name: format!("migrated-{}", &w.wallet_id[..8]),
                     alias: None,
                     public_key: pk_bytes,
+                    kyber_public_key: vec![],
                     owner_identity_id: owner_id,
                     seed_commitment: crate::types::Hash::default(),
                     created_at: w.created_at,
@@ -852,9 +855,7 @@ impl GenesisConfig {
     /// `[opaque]` section is present. Pulled out into its own helper so
     /// every Blockchain construction path (apply_genesis_state, load_from_store)
     /// can load it consistently (reviewer #2569 — restart path was skipping it).
-    pub fn load_opaque_setup(
-        &self,
-    ) -> Result<Option<crate::opaque::OpaqueServerSetupBytes>> {
+    pub fn load_opaque_setup(&self) -> Result<Option<crate::opaque::OpaqueServerSetupBytes>> {
         match self.opaque {
             Some(ref op) => {
                 let bytes = crate::opaque::parse_server_setup_b64(&op.server_setup_b64)
@@ -868,9 +869,7 @@ impl GenesisConfig {
                 Ok(Some(bytes))
             }
             None => {
-                info!(
-                    "No [opaque] section in genesis — lobby auth disabled for this network"
-                );
+                info!("No [opaque] section in genesis — lobby auth disabled for this network");
                 Ok(None)
             }
         }
@@ -944,6 +943,7 @@ impl GenesisConfig {
                             wallet_name: String::new(),
                             alias: None,
                             public_key: pk_bytes,
+                            kyber_public_key: vec![],
                             owner_identity_id: owner_id,
                             seed_commitment: crate::types::Hash::default(),
                             created_at: w.created_at,
@@ -960,10 +960,10 @@ impl GenesisConfig {
         // Register usernames for identities with display_names.
         // Populates did_to_username so @username messaging lookups work.
         for id in &self.allocations.identities {
-            if !id.display_name.is_empty()
-                && !bc.did_to_username.contains_key(&id.did)
-            {
-                let username = id.display_name.to_lowercase()
+            if !id.display_name.is_empty() && !bc.did_to_username.contains_key(&id.did) {
+                let username = id
+                    .display_name
+                    .to_lowercase()
                     .chars()
                     .filter(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '_')
                     .collect::<String>();
@@ -1070,8 +1070,12 @@ fn key_from_hex(hex_str: &str) -> Result<crate::integration::crypto_integration:
     let trimmed = hex_str.strip_prefix("0x").unwrap_or(hex_str);
     let bytes = hex::decode(trimmed).context("Invalid hex in genesis.toml key")?;
     let key_id = lib_crypto::hash_blake3(&bytes);
-    let dilithium_pk: [u8; 2592] = bytes.as_slice().try_into()
-        .map_err(|_| anyhow::anyhow!("Invalid Dilithium key length in genesis.toml key: expected 2592 bytes, got {}", bytes.len()))?;
+    let dilithium_pk: [u8; 2592] = bytes.as_slice().try_into().map_err(|_| {
+        anyhow::anyhow!(
+            "Invalid Dilithium key length in genesis.toml key: expected 2592 bytes, got {}",
+            bytes.len()
+        )
+    })?;
     Ok(crate::integration::crypto_integration::PublicKey {
         dilithium_pk,
         kyber_pk: [0u8; 1568],
@@ -1111,7 +1115,10 @@ mod tests {
         // v2 chain (CONS-305 cutover): chain_id 2, distinct from v1's 1.
         assert_eq!(config.chain.chain_id, 2);
         assert_eq!(config.bootstrap_council.threshold, 1);
-        assert!(!config.bootstrap_council.members.is_empty(), "council must have at least one member");
+        assert!(
+            !config.bootstrap_council.members.is_empty(),
+            "council must have at least one member"
+        );
         assert_eq!(config.bonding_curve.graduation_threshold, 2_745_966);
     }
 
@@ -1132,7 +1139,10 @@ mod tests {
         let bc1 = config.build_block0().expect("build 1");
         let bc2 = config.build_block0().expect("build 2");
         // Both produce the same block hash
-        assert_eq!(bc1.blocks[0].header.block_hash, bc2.blocks[0].header.block_hash);
+        assert_eq!(
+            bc1.blocks[0].header.block_hash,
+            bc2.blocks[0].header.block_hash
+        );
     }
 
     #[test]

--- a/lib-blockchain/src/storage/sled_store.rs
+++ b/lib-blockchain/src/storage/sled_store.rs
@@ -125,14 +125,14 @@ pub struct SledStore {
     bubl_reward_partner: Tree,
     bubl_reward_partner_count: Tree,
     bubl_reward_streak: Tree,
-    utxo_merkle_leaves: Tree,    // leaf_index (u64 BE) → [u8; 32] leaf hash
-    utxo_merkle_index: Tree,     // outpoint (36 bytes) → leaf_index (u64 BE)
-    utxo_merkle_meta: Tree,      // metadata: next_leaf_index, current_root
-    utxo_merkle_nodes: Tree,     // level (u32 BE) || node_index (u64 BE) → [u8; 32]
+    utxo_merkle_leaves: Tree, // leaf_index (u64 BE) → [u8; 32] leaf hash
+    utxo_merkle_index: Tree,  // outpoint (36 bytes) → leaf_index (u64 BE)
+    utxo_merkle_meta: Tree,   // metadata: next_leaf_index, current_root
+    utxo_merkle_nodes: Tree,  // level (u32 BE) || node_index (u64 BE) → [u8; 32]
     meta: Tree,
-    wal: Tree,                   // Write-ahead log: durable block-commit post-image
-    fork_points: Tree,           // Fork audit log: direct durable writes (non-batched)
-    receipts: Tree,              // Transaction receipts: tx_hash → TransactionReceipt
+    wal: Tree,         // Write-ahead log: durable block-commit post-image
+    fork_points: Tree, // Fork audit log: direct durable writes (non-batched)
+    receipts: Tree,    // Transaction receipts: tx_hash → TransactionReceipt
     projection_hot_state_meta: Tree,
     projection_validators: Tree,
     projection_gateways: Tree,
@@ -672,7 +672,9 @@ impl SledStore {
     }
 
     /// Iterate all wallet projection entries.
-    pub fn iter_wallet_projections(&self) -> StorageResult<Vec<([u8; 32], WalletProjectionRecord)>> {
+    pub fn iter_wallet_projections(
+        &self,
+    ) -> StorageResult<Vec<([u8; 32], WalletProjectionRecord)>> {
         let mut entries = Vec::new();
         for item in self.wallets.iter() {
             let (key, value) = item.map_err(|e| StorageError::Database(e.to_string()))?;
@@ -697,7 +699,9 @@ impl SledStore {
         records: &[([u8; 32], WalletProjectionRecord)],
     ) -> StorageResult<()> {
         let mut batch = Batch::default();
-        self.wallets.clear().map_err(|e| StorageError::Database(e.to_string()))?;
+        self.wallets
+            .clear()
+            .map_err(|e| StorageError::Database(e.to_string()))?;
         for (wallet_id, record) in records {
             let value = Self::serialize(record)?;
             batch.insert(wallet_id.as_ref(), value);
@@ -758,7 +762,9 @@ impl SledStore {
             let mut zh = vec![[0u8; 32]];
             for _ in 1..=lib_proofs::transaction::circuit::MERKLE_DEPTH {
                 let last = *zh.last().unwrap();
-                zh.push(lib_proofs::transaction::circuit::real::hash_pair_u8(last, last));
+                zh.push(lib_proofs::transaction::circuit::real::hash_pair_u8(
+                    last, last,
+                ));
             }
             zh
         })
@@ -787,13 +793,11 @@ impl SledStore {
     }
 
     /// Update the Merkle path from `leaf_index` up to the root using `leaf_hash`.
-    fn update_merkle_path(
-        &self,
-        leaf_index: u64,
-        leaf_hash: [u8; 32],
-    ) -> StorageResult<()> {
+    fn update_merkle_path(&self, leaf_index: u64, leaf_hash: [u8; 32]) -> StorageResult<()> {
         let mut batch_guard = self.tx_batch.lock().unwrap();
-        let batch = batch_guard.as_mut().ok_or(StorageError::NoActiveTransaction)?;
+        let batch = batch_guard
+            .as_mut()
+            .ok_or(StorageError::NoActiveTransaction)?;
 
         let mut current_hash = leaf_hash;
         let mut current_index = leaf_index;
@@ -801,7 +805,9 @@ impl SledStore {
         for level in 0..lib_proofs::transaction::circuit::MERKLE_DEPTH as u32 {
             let key = Self::merkle_node_key(level, current_index);
             batch.utxo_merkle_nodes_cache.insert(key, current_hash);
-            batch.tree(TREE_UTXO_MERKLE_NODES).insert(key.as_ref(), current_hash.as_ref());
+            batch
+                .tree(TREE_UTXO_MERKLE_NODES)
+                .insert(key.as_ref(), current_hash.as_ref());
 
             let sibling_index = current_index ^ 1;
             let sibling_hash = self.get_merkle_node(batch, level, sibling_index)?;
@@ -817,11 +823,12 @@ impl SledStore {
         let depth = lib_proofs::transaction::circuit::MERKLE_DEPTH as u32;
         let root_key = Self::merkle_node_key(depth, 0);
         batch.utxo_merkle_nodes_cache.insert(root_key, current_hash);
-        batch.tree(TREE_UTXO_MERKLE_NODES).insert(root_key.as_ref(), current_hash.as_ref());
-        batch.tree(TREE_UTXO_MERKLE_META).insert(
-            keys::meta::UTXO_MERKLE_ROOT,
-            current_hash.as_ref(),
-        );
+        batch
+            .tree(TREE_UTXO_MERKLE_NODES)
+            .insert(root_key.as_ref(), current_hash.as_ref());
+        batch
+            .tree(TREE_UTXO_MERKLE_META)
+            .insert(keys::meta::UTXO_MERKLE_ROOT, current_hash.as_ref());
 
         Ok(())
     }
@@ -862,8 +869,8 @@ impl SledStore {
         match bincode::deserialize::<RewardsModuleState>(bytes) {
             Ok(state) => Ok(state),
             Err(_) => {
-                let legacy: LegacyRewardsModuleState =
-                    bincode::deserialize(bytes).map_err(|e| StorageError::Serialization(e.to_string()))?;
+                let legacy: LegacyRewardsModuleState = bincode::deserialize(bytes)
+                    .map_err(|e| StorageError::Serialization(e.to_string()))?;
                 Ok(RewardsModuleState {
                     spend_delegate_key_id: legacy.spend_delegate_key_id,
                     policy_cid: legacy.policy_cid,
@@ -1174,7 +1181,12 @@ impl SledStore {
         })
     }
 
-    fn put_in_block_batch(&self, tree: &'static str, key: &[u8], value: Vec<u8>) -> StorageResult<()> {
+    fn put_in_block_batch(
+        &self,
+        tree: &'static str,
+        key: &[u8],
+        value: Vec<u8>,
+    ) -> StorageResult<()> {
         let mut guard = self.tx_batch.lock().map_err(|e| {
             StorageError::Database(format!("lock poisoned in put_in_block_batch: {e}"))
         })?;
@@ -1272,7 +1284,9 @@ impl BlockchainStore for SledStore {
             batch
                 .tree(TREE_BLOCKS_BY_HEIGHT)
                 .insert(height_key.as_ref(), block_hash.as_bytes().as_ref());
-            batch.tree(TREE_BLOCKS_BY_HASH).insert(hash_key.as_ref(), block_bytes);
+            batch
+                .tree(TREE_BLOCKS_BY_HASH)
+                .insert(hash_key.as_ref(), block_bytes);
             for tx in &block.transactions {
                 for input in &tx.inputs {
                     batch
@@ -1392,10 +1406,7 @@ impl BlockchainStore for SledStore {
         let iter = self.utxos.iter().map(|result| {
             let (key, value) = result.map_err(|e| StorageError::Database(e.to_string()))?;
             let outpoint = keys::parse_utxo_key(key.as_ref()).ok_or_else(|| {
-                StorageError::CorruptedData(format!(
-                    "Invalid UTXO key length: {}",
-                    key.len()
-                ))
+                StorageError::CorruptedData(format!("Invalid UTXO key length: {}", key.len()))
             })?;
             let utxo: Utxo = Self::deserialize(&value)?;
             Ok((outpoint, utxo))
@@ -1506,7 +1517,9 @@ impl BlockchainStore for SledStore {
 
         let op_key = keys::utxo_key(op);
         let mut batch_guard = self.tx_batch.lock().unwrap();
-        let batch = batch_guard.as_mut().ok_or(StorageError::NoActiveTransaction)?;
+        let batch = batch_guard
+            .as_mut()
+            .ok_or(StorageError::NoActiveTransaction)?;
 
         // Ensure outpoint is not already indexed in this block or committed state.
         if batch.utxo_merkle_indexed.contains_key(&op_key) {
@@ -1514,17 +1527,28 @@ impl BlockchainStore for SledStore {
                 "UTXO already has a Merkle leaf in the current block".to_string(),
             ));
         }
-        if self.utxo_merkle_index.get(op_key.as_ref()).map(|v| v.is_some()).unwrap_or(false) {
+        if self
+            .utxo_merkle_index
+            .get(op_key.as_ref())
+            .map(|v| v.is_some())
+            .unwrap_or(false)
+        {
             return Err(StorageError::CorruptedData(
                 "UTXO already has a committed Merkle leaf".to_string(),
             ));
         }
 
-        let next_index = self.tx_utxo_merkle_next_index.fetch_add(1, Ordering::SeqCst);
+        let next_index = self
+            .tx_utxo_merkle_next_index
+            .fetch_add(1, Ordering::SeqCst);
         let index_bytes = next_index.to_be_bytes();
 
-        batch.tree(TREE_UTXO_MERKLE_LEAVES).insert(index_bytes.as_ref(), &leaf[..]);
-        batch.tree(TREE_UTXO_MERKLE_INDEX).insert(op_key.as_ref(), index_bytes.as_ref());
+        batch
+            .tree(TREE_UTXO_MERKLE_LEAVES)
+            .insert(index_bytes.as_ref(), &leaf[..]);
+        batch
+            .tree(TREE_UTXO_MERKLE_INDEX)
+            .insert(op_key.as_ref(), index_bytes.as_ref());
         batch.tree(TREE_UTXO_MERKLE_META).insert(
             keys::meta::UTXO_MERKLE_NEXT_INDEX,
             (next_index + 1).to_be_bytes().as_ref(),
@@ -1541,7 +1565,9 @@ impl BlockchainStore for SledStore {
 
         let op_key = keys::utxo_key(op);
         let mut batch_guard = self.tx_batch.lock().unwrap();
-        let batch = batch_guard.as_mut().ok_or(StorageError::NoActiveTransaction)?;
+        let batch = batch_guard
+            .as_mut()
+            .ok_or(StorageError::NoActiveTransaction)?;
 
         // If the outpoint was inserted in the current block, use the cached index.
         let index_bytes = if let Some(&idx) = batch.utxo_merkle_indexed.get(&op_key) {
@@ -1556,11 +1582,12 @@ impl BlockchainStore for SledStore {
         };
 
         if let Some(bytes) = index_bytes {
-            batch.tree(TREE_UTXO_MERKLE_LEAVES).insert(bytes.as_slice(), &[0u8; 32][..]);
+            batch
+                .tree(TREE_UTXO_MERKLE_LEAVES)
+                .insert(bytes.as_slice(), &[0u8; 32][..]);
             batch.tree(TREE_UTXO_MERKLE_INDEX).remove(op_key.as_ref());
             let idx = u64::from_be_bytes([
-                bytes[0], bytes[1], bytes[2], bytes[3],
-                bytes[4], bytes[5], bytes[6], bytes[7],
+                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
             ]);
             drop(batch_guard);
             self.update_merkle_path(idx, [0u8; 32])?;
@@ -1613,7 +1640,9 @@ impl BlockchainStore for SledStore {
             for level in 0..lib_proofs::transaction::circuit::MERKLE_DEPTH as u32 {
                 let sibling_index = current_index ^ 1;
                 let sibling_key = Self::merkle_node_key(level, sibling_index);
-                let sibling_hash = if let Some(hash) = batch_ref.and_then(|b| b.utxo_merkle_nodes_cache.get(&sibling_key)) {
+                let sibling_hash = if let Some(hash) =
+                    batch_ref.and_then(|b| b.utxo_merkle_nodes_cache.get(&sibling_key))
+                {
                     *hash
                 } else {
                     match self.utxo_merkle_nodes.get(sibling_key) {
@@ -1632,7 +1661,9 @@ impl BlockchainStore for SledStore {
 
             let depth = lib_proofs::transaction::circuit::MERKLE_DEPTH as u32;
             let root_key = Self::merkle_node_key(depth, 0);
-            let root = if let Some(hash) = batch_ref.and_then(|b| b.utxo_merkle_nodes_cache.get(&root_key)) {
+            let root = if let Some(hash) =
+                batch_ref.and_then(|b| b.utxo_merkle_nodes_cache.get(&root_key))
+            {
                 *hash
             } else {
                 match self.utxo_merkle_nodes.get(root_key) {
@@ -1781,7 +1812,9 @@ impl BlockchainStore for SledStore {
     fn iter_sovereign_asset_records(
         &self,
     ) -> StorageResult<
-        Box<dyn Iterator<Item = ([u8; 32], crate::contracts::sovereign_asset::SovereignAsset)> + '_>,
+        Box<
+            dyn Iterator<Item = ([u8; 32], crate::contracts::sovereign_asset::SovereignAsset)> + '_,
+        >,
     > {
         let mut results = Vec::new();
         for result in self.assets.iter() {
@@ -1839,7 +1872,9 @@ impl BlockchainStore for SledStore {
         let key = keys::asset_symbol_key(symbol);
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.tree(TREE_ASSET_SYMBOLS).insert(key, asset_id.as_ref());
+            batch
+                .tree(TREE_ASSET_SYMBOLS)
+                .insert(key, asset_id.as_ref());
         }
         Ok(())
     }
@@ -2031,7 +2066,9 @@ impl BlockchainStore for SledStore {
         let value = Self::serialize(state)?;
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.tree(TREE_ASSET_GOVERNANCE).insert(key.as_ref(), value);
+            batch
+                .tree(TREE_ASSET_GOVERNANCE)
+                .insert(key.as_ref(), value);
         }
         Ok(())
     }
@@ -2066,7 +2103,9 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.tree(TREE_TOKEN_SUPPLY).insert(key.as_ref(), value.as_ref());
+            batch
+                .tree(TREE_TOKEN_SUPPLY)
+                .insert(key.as_ref(), value.as_ref());
         }
 
         Ok(())
@@ -2142,7 +2181,9 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.tree(TREE_CONTRACT_STORAGE).remove(IVec::from(composite_key));
+            batch
+                .tree(TREE_CONTRACT_STORAGE)
+                .remove(IVec::from(composite_key));
         }
 
         Ok(())
@@ -2165,7 +2206,9 @@ impl BlockchainStore for SledStore {
         let value = Self::serialize(snapshot)?;
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.tree(TREE_META).insert(keys::meta::TOKEN_STATE_SNAPSHOT, value);
+            batch
+                .tree(TREE_META)
+                .insert(keys::meta::TOKEN_STATE_SNAPSHOT, value);
         }
 
         Ok(())
@@ -2590,11 +2633,7 @@ impl BlockchainStore for SledStore {
     ) -> StorageResult<
         Box<
             dyn Iterator<
-                    Item = StorageResult<(
-                        [u8; 32],
-                        IdentityConsensus,
-                        Option<IdentityMetadata>,
-                    )>,
+                    Item = StorageResult<([u8; 32], IdentityConsensus, Option<IdentityMetadata>)>,
                 > + '_,
         >,
     > {
@@ -2711,9 +2750,7 @@ impl BlockchainStore for SledStore {
         {
             let batch_guard = self.tx_batch.lock().unwrap();
             if let Some(ref batch) = *batch_guard {
-                if let Some(staged) =
-                    batch.tree_lookup(TREE_IDENTITY_METADATA, did_hash.as_ref())
-                {
+                if let Some(staged) = batch.tree_lookup(TREE_IDENTITY_METADATA, did_hash.as_ref()) {
                     return match staged {
                         Some(bytes) => {
                             let metadata: IdentityMetadata = Self::deserialize(&bytes)?;
@@ -2746,7 +2783,9 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.tree(TREE_IDENTITY_METADATA).insert(did_hash.as_ref(), value);
+            batch
+                .tree(TREE_IDENTITY_METADATA)
+                .insert(did_hash.as_ref(), value);
         }
 
         Ok(())
@@ -2892,8 +2931,7 @@ impl BlockchainStore for SledStore {
         for entry in self.validators.iter() {
             match entry {
                 Ok((key, value)) => {
-                    let record: crate::storage::StoredValidatorRecord =
-                        Self::deserialize(&value)?;
+                    let record: crate::storage::StoredValidatorRecord = Self::deserialize(&value)?;
                     if crate::storage::did_to_hash(&record.consensus.identity_id).as_ref()
                         != key.as_ref()
                     {
@@ -3060,7 +3098,10 @@ impl BlockchainStore for SledStore {
 
         // Initialize batch
         self.tx_height.store(height, Ordering::SeqCst);
-        let next_index = match self.utxo_merkle_meta.get(keys::meta::UTXO_MERKLE_NEXT_INDEX) {
+        let next_index = match self
+            .utxo_merkle_meta
+            .get(keys::meta::UTXO_MERKLE_NEXT_INDEX)
+        {
             Ok(Some(bytes)) if bytes.len() >= 8 => {
                 let mut arr = [0u8; 8];
                 arr.copy_from_slice(&bytes[..8]);
@@ -3068,7 +3109,8 @@ impl BlockchainStore for SledStore {
             }
             _ => 0,
         };
-        self.tx_utxo_merkle_next_index.store(next_index, Ordering::SeqCst);
+        self.tx_utxo_merkle_next_index
+            .store(next_index, Ordering::SeqCst);
         let mut batch_guard = self.tx_batch.lock().unwrap();
         *batch_guard = Some(PendingBatch::new());
 
@@ -3207,9 +3249,9 @@ impl BlockchainStore for SledStore {
     // =========================================================================
 
     fn get_raw(&self, tree: &'static str, key: &[u8]) -> StorageResult<Option<Vec<u8>>> {
-        let t = self.tree_by_name(tree).ok_or_else(|| {
-            StorageError::Database(format!("unknown table keyspace '{}'", tree))
-        })?;
+        let t = self
+            .tree_by_name(tree)
+            .ok_or_else(|| StorageError::Database(format!("unknown table keyspace '{}'", tree)))?;
         match t.get(key) {
             Ok(Some(v)) => Ok(Some(v.to_vec())),
             Ok(None) => Ok(None),
@@ -3217,12 +3259,7 @@ impl BlockchainStore for SledStore {
         }
     }
 
-    fn stage_raw(
-        &self,
-        tree: &'static str,
-        key: &[u8],
-        value: Option<&[u8]>,
-    ) -> StorageResult<()> {
+    fn stage_raw(&self, tree: &'static str, key: &[u8], value: Option<&[u8]>) -> StorageResult<()> {
         self.require_transaction()?;
         if self.tree_by_name(tree).is_none() {
             return Err(StorageError::Database(format!(
@@ -3244,9 +3281,9 @@ impl BlockchainStore for SledStore {
         &self,
         tree: &'static str,
     ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(Vec<u8>, Vec<u8>)>> + '_>> {
-        let t = self.tree_by_name(tree).ok_or_else(|| {
-            StorageError::Database(format!("unknown table keyspace '{}'", tree))
-        })?;
+        let t = self
+            .tree_by_name(tree)
+            .ok_or_else(|| StorageError::Database(format!("unknown table keyspace '{}'", tree)))?;
         Ok(Box::new(t.iter().map(|r| {
             r.map(|(k, v)| (k.to_vec(), v.to_vec()))
                 .map_err(|e| StorageError::Database(e.to_string()))
@@ -3426,7 +3463,9 @@ impl BlockchainStore for SledStore {
 
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.tree(TREE_BONDING_CURVE_SYMBOLS).remove(symbol.as_bytes());
+            batch
+                .tree(TREE_BONDING_CURVE_SYMBOLS)
+                .remove(symbol.as_bytes());
         }
 
         Ok(())
@@ -3456,7 +3495,9 @@ impl BlockchainStore for SledStore {
         let value = Self::serialize(state)?;
         let mut batch_guard = self.tx_batch.lock().unwrap();
         if let Some(ref mut batch) = *batch_guard {
-            batch.tree(TREE_META).insert(keys::meta::CBE_ECONOMIC_STATE, value);
+            batch
+                .tree(TREE_META)
+                .insert(keys::meta::CBE_ECONOMIC_STATE, value);
         }
 
         Ok(())
@@ -3494,7 +3535,6 @@ impl BlockchainStore for SledStore {
 
         Ok(())
     }
-
 
     fn put_quorum_proof(
         &self,
@@ -3549,7 +3589,9 @@ impl BlockchainStore for SledStore {
         let key = keys::dao_stake_key(&record.sector_dao_key_id, &record.staker);
         let value = Self::serialize(record)?;
         let mut batch_guard = self.tx_batch.lock().unwrap();
-        let batch = batch_guard.as_mut().ok_or(StorageError::NoActiveTransaction)?;
+        let batch = batch_guard
+            .as_mut()
+            .ok_or(StorageError::NoActiveTransaction)?;
         batch.tree(TREE_DAO_STAKES).insert(key.as_ref(), value);
         Ok(())
     }
@@ -3562,7 +3604,9 @@ impl BlockchainStore for SledStore {
         self.require_transaction()?;
         let key = keys::dao_stake_key(sector_dao_key_id, staker);
         let mut batch_guard = self.tx_batch.lock().unwrap();
-        let batch = batch_guard.as_mut().ok_or(StorageError::NoActiveTransaction)?;
+        let batch = batch_guard
+            .as_mut()
+            .ok_or(StorageError::NoActiveTransaction)?;
         batch.tree(TREE_DAO_STAKES).remove(key.as_ref());
         Ok(())
     }
@@ -3613,7 +3657,9 @@ impl BlockchainStore for SledStore {
             StorageError::Database(format!("lock poisoned in put_observer_record: {e}"))
         })?;
         if let Some(batch) = guard.as_mut() {
-            batch.tree(TREE_OBSERVER_REGISTRY).insert(did_hash.as_slice(), bytes);
+            batch
+                .tree(TREE_OBSERVER_REGISTRY)
+                .insert(did_hash.as_slice(), bytes);
             Ok(())
         } else {
             Err(StorageError::Database(
@@ -3627,7 +3673,9 @@ impl BlockchainStore for SledStore {
             StorageError::Database(format!("lock poisoned in delete_observer_record: {e}"))
         })?;
         if let Some(batch) = guard.as_mut() {
-            batch.tree(TREE_OBSERVER_REGISTRY).remove(did_hash.as_slice());
+            batch
+                .tree(TREE_OBSERVER_REGISTRY)
+                .remove(did_hash.as_slice());
             Ok(())
         } else {
             Err(StorageError::Database(
@@ -3660,9 +3708,9 @@ impl BlockchainStore for SledStore {
             return Ok(staged);
         }
         match self.bubl_reward_welcome.get(key) {
-            Ok(Some(bytes)) if bytes.len() == 8 => Ok(Some(u64::from_le_bytes(
-                bytes.as_ref().try_into().unwrap(),
-            ))),
+            Ok(Some(bytes)) if bytes.len() == 8 => {
+                Ok(Some(u64::from_le_bytes(bytes.as_ref().try_into().unwrap())))
+            }
             Ok(_) => Ok(None),
             Err(e) => Err(StorageError::Database(e.to_string())),
         }
@@ -3682,9 +3730,9 @@ impl BlockchainStore for SledStore {
             return Ok(staged);
         }
         match self.bubl_reward_daily.get(key) {
-            Ok(Some(bytes)) if bytes.len() == 8 => Ok(Some(u64::from_le_bytes(
-                bytes.as_ref().try_into().unwrap(),
-            ))),
+            Ok(Some(bytes)) if bytes.len() == 8 => {
+                Ok(Some(u64::from_le_bytes(bytes.as_ref().try_into().unwrap())))
+            }
             Ok(_) => Ok(None),
             Err(e) => Err(StorageError::Database(e.to_string())),
         }
@@ -3704,9 +3752,9 @@ impl BlockchainStore for SledStore {
             return Ok(staged);
         }
         match self.bubl_reward_partner.get(key) {
-            Ok(Some(bytes)) if bytes.len() == 8 => Ok(Some(u64::from_le_bytes(
-                bytes.as_ref().try_into().unwrap(),
-            ))),
+            Ok(Some(bytes)) if bytes.len() == 8 => {
+                Ok(Some(u64::from_le_bytes(bytes.as_ref().try_into().unwrap())))
+            }
             Ok(_) => Ok(None),
             Err(e) => Err(StorageError::Database(e.to_string())),
         }
@@ -3726,9 +3774,9 @@ impl BlockchainStore for SledStore {
             return Ok(staged);
         }
         match self.bubl_reward_partner_count.get(key) {
-            Ok(Some(bytes)) if bytes.len() == 4 => Ok(Some(u32::from_le_bytes(
-                bytes.as_ref().try_into().unwrap(),
-            ))),
+            Ok(Some(bytes)) if bytes.len() == 4 => {
+                Ok(Some(u32::from_le_bytes(bytes.as_ref().try_into().unwrap())))
+            }
             Ok(_) => Ok(None),
             Err(e) => Err(StorageError::Database(e.to_string())),
         }
@@ -3836,9 +3884,7 @@ impl BlockchainStore for SledStore {
         Ok(out)
     }
 
-    fn get_observer_policy(
-        &self,
-    ) -> StorageResult<Option<lib_types::ObserverAdmissionPolicy>> {
+    fn get_observer_policy(&self) -> StorageResult<Option<lib_types::ObserverAdmissionPolicy>> {
         match self.meta.get(keys::meta::OBSERVER_POLICY) {
             Ok(Some(bytes)) => {
                 let policy: lib_types::ObserverAdmissionPolicy = Self::deserialize(&bytes)?;
@@ -4131,6 +4177,7 @@ mod tests {
                 wallet_name: "Projection Wallet".to_string(),
                 alias: Some("wallet-proj".to_string()),
                 public_key: vec![0x11; 32],
+                kyber_public_key: vec![],
                 owner_identity_id: Some(Hash::new([0x22; 32])),
                 seed_commitment: Hash::new([0x33; 32]),
                 created_at: 1234,
@@ -4164,7 +4211,10 @@ mod tests {
         store
             .replace_wallet_projections(&[(wallet_id, record.clone())])
             .unwrap();
-        assert_eq!(store.get_wallet_projection(&wallet_id).unwrap(), Some(record));
+        assert_eq!(
+            store.get_wallet_projection(&wallet_id).unwrap(),
+            Some(record)
+        );
     }
 
     #[test]
@@ -4263,6 +4313,7 @@ mod tests {
                 wallet_name: "Recovery Wallet".to_string(),
                 alias: None,
                 public_key: vec![0x22; 32],
+                kyber_public_key: vec![],
                 owner_identity_id: Some(Hash::new([0x33; 32])),
                 seed_commitment: Hash::new([0x44; 32]),
                 created_at: 1_700_000_000,
@@ -4598,7 +4649,9 @@ mod tests {
 
         let mut updated_metadata = read_metadata.clone();
         updated_metadata.kyber_public_key = vec![0x26; 1568];
-        store.put_identity_metadata(&did_hash, &updated_metadata).unwrap();
+        store
+            .put_identity_metadata(&did_hash, &updated_metadata)
+            .unwrap();
 
         let after_update = store.get_identity_metadata(&did_hash).unwrap().unwrap();
         assert_eq!(after_update.kyber_public_key, vec![0x26; 1568]);
@@ -4761,11 +4814,17 @@ mod tests {
         assert!(root1.is_some(), "Merkle root should be set after commit");
 
         // 3. Proofs should be queryable
-        let proof1 = store.get_utxo_merkle_proof(&outpoint1).unwrap().expect("proof1");
+        let proof1 = store
+            .get_utxo_merkle_proof(&outpoint1)
+            .unwrap()
+            .expect("proof1");
         assert_eq!(proof1.leaf_index, 0);
         assert_eq!(proof1.root, root1.unwrap());
 
-        let proof2 = store.get_utxo_merkle_proof(&outpoint2).unwrap().expect("proof2");
+        let proof2 = store
+            .get_utxo_merkle_proof(&outpoint2)
+            .unwrap()
+            .expect("proof2");
         assert_eq!(proof2.leaf_index, 1);
         assert_eq!(proof2.root, root1.unwrap());
 
@@ -4778,7 +4837,10 @@ mod tests {
         assert!(store.get_utxo_merkle_proof(&outpoint1).unwrap().is_none());
 
         // 6. outpoint2 should still have a proof, but the root changed because leaf1 is now zero
-        let proof2_after = store.get_utxo_merkle_proof(&outpoint2).unwrap().expect("proof2_after");
+        let proof2_after = store
+            .get_utxo_merkle_proof(&outpoint2)
+            .unwrap()
+            .expect("proof2_after");
         assert_eq!(proof2_after.leaf_index, 1);
         let root2 = store.get_utxo_merkle_root().unwrap().expect("root2");
         assert_ne!(root2, root1.unwrap(), "Root should change after deletion");
@@ -4849,7 +4911,10 @@ mod tests {
                 let total = store
                     .debug_interrupt_commit(stop_after, write_latest_height)
                     .unwrap();
-                assert!(total >= 4, "block 1 should touch several trees ({scenario})");
+                assert!(
+                    total >= 4,
+                    "block 1 should touch several trees ({scenario})"
+                );
 
                 assert!(
                     store.wal.get(WAL_PENDING_KEY).unwrap().is_some(),
@@ -4868,7 +4933,10 @@ mod tests {
                     "recovery must finish block 1 ({scenario})"
                 );
                 let block = store.get_block_by_height(1).unwrap();
-                assert!(block.is_some(), "block 1 must be present after recovery ({scenario})");
+                assert!(
+                    block.is_some(),
+                    "block 1 must be present after recovery ({scenario})"
+                );
                 assert_eq!(block.unwrap().header.height, 1);
 
                 let recovered_account = store
@@ -4975,14 +5043,24 @@ mod tests {
 
         store.begin_block(0).unwrap();
         store.append_block(&block0).unwrap();
-        store.stage::<TableProbe>(&1u64.to_be_bytes(), &111u64).unwrap();
-        store.stage::<TableProbe>(&2u64.to_be_bytes(), &222u64).unwrap();
+        store
+            .stage::<TableProbe>(&1u64.to_be_bytes(), &111u64)
+            .unwrap();
+        store
+            .stage::<TableProbe>(&2u64.to_be_bytes(), &222u64)
+            .unwrap();
         // Staged writes are not visible until the block commits.
         assert_eq!(store.get::<TableProbe>(&1u64.to_be_bytes()).unwrap(), None);
         store.commit_block().unwrap();
 
-        assert_eq!(store.get::<TableProbe>(&1u64.to_be_bytes()).unwrap(), Some(111));
-        assert_eq!(store.get::<TableProbe>(&2u64.to_be_bytes()).unwrap(), Some(222));
+        assert_eq!(
+            store.get::<TableProbe>(&1u64.to_be_bytes()).unwrap(),
+            Some(111)
+        );
+        assert_eq!(
+            store.get::<TableProbe>(&2u64.to_be_bytes()).unwrap(),
+            Some(222)
+        );
         assert_eq!(store.get::<TableProbe>(&9u64.to_be_bytes()).unwrap(), None);
 
         let mut all = store.iter::<TableProbe>().unwrap();
@@ -4995,10 +5073,15 @@ mod tests {
         let block1 = create_test_block(1, block0.header.block_hash);
         store.begin_block(1).unwrap();
         store.append_block(&block1).unwrap();
-        store.stage_delete::<TableProbe>(&1u64.to_be_bytes()).unwrap();
+        store
+            .stage_delete::<TableProbe>(&1u64.to_be_bytes())
+            .unwrap();
         store.commit_block().unwrap();
         assert_eq!(store.get::<TableProbe>(&1u64.to_be_bytes()).unwrap(), None);
-        assert_eq!(store.get::<TableProbe>(&2u64.to_be_bytes()).unwrap(), Some(222));
+        assert_eq!(
+            store.get::<TableProbe>(&2u64.to_be_bytes()).unwrap(),
+            Some(222)
+        );
     }
 
     /// Generic table writes outside `begin_block` are rejected, like every

--- a/lib-blockchain/src/transaction/core.rs
+++ b/lib-blockchain/src/transaction/core.rs
@@ -550,6 +550,12 @@ pub struct WalletTransactionData {
     pub alias: Option<String>,
     /// Public key for wallet operations
     pub public_key: Vec<u8>,
+    /// Kyber1024 public key of the wallet owner (1568 bytes when present). Empty
+    /// for legacy/validator wallets registered before the field was added. For
+    /// client-aligned wallets the binding check computes wallet_id as
+    /// `blake3(public_key || kyber_public_key)`.
+    #[serde(default)]
+    pub kyber_public_key: Vec<u8>,
     /// Owner identity ID (if associated with DID)
     pub owner_identity_id: Option<Hash>,
     /// Seed phrase commitment hash (for recovery verification)
@@ -778,7 +784,7 @@ impl Transaction {
             dao_fee: 0,
             controlled_nodes: Vec::new(),
             owned_wallets: Vec::new(),
-                    kyber_public_key: Vec::new(),
+            kyber_public_key: Vec::new(),
         };
 
         Transaction {

--- a/lib-blockchain/src/transaction/system_tx_signature.rs
+++ b/lib-blockchain/src/transaction/system_tx_signature.rs
@@ -163,8 +163,19 @@ pub fn allows_empty_system_signature(transaction: &Transaction) -> bool {
             if transaction.signature.public_key.dilithium_pk != wallet_pk {
                 return false;
             }
+            // Legacy/validator wallets (zero kyber): wallet_id == blake3(pk).
             let key_id = crate::types::hash::blake3_hash(wallet_pk.as_slice());
-            w.wallet_id.as_bytes() == key_id.as_bytes()
+            if w.wallet_id.as_bytes() == key_id.as_bytes() {
+                return true;
+            }
+            // Client wallets: wallet_id == blake3(pk || kyber_pk).
+            if w.kyber_public_key.is_empty() {
+                return false;
+            }
+            let mut client_input = wallet_pk.to_vec();
+            client_input.extend_from_slice(&w.kyber_public_key);
+            let client_key_id = crate::types::hash::blake3_hash(&client_input);
+            w.wallet_id.as_bytes() == client_key_id.as_bytes()
         }
         _ => false,
     }
@@ -320,6 +331,7 @@ mod tests {
             wallet_name: "p".to_string(),
             alias: None,
             public_key: dilithium_pk.to_vec(),
+            kyber_public_key: vec![],
             owner_identity_id: None,
             seed_commitment: Hash::default(),
             created_at: 1,
@@ -360,5 +372,45 @@ mod tests {
             !allows_empty_system_signature(&forged),
             "empty sig must not allow wallet_id unbound from public_key"
         );
+    }
+
+    #[test]
+    fn wallet_registration_empty_sig_accepts_client_pk_kyber_binding() {
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+        use crate::transaction::core::WalletTransactionData;
+        use crate::types::Hash;
+
+        let dilithium_pk = [0xABu8; 2592];
+        let kyber_pk = vec![0x42u8; 1568];
+        let mut input = dilithium_pk.to_vec();
+        input.extend_from_slice(&kyber_pk);
+        let client_key_id = crate::types::hash::blake3_hash(&input);
+
+        let good = WalletTransactionData {
+            wallet_id: client_key_id,
+            wallet_type: "Primary".to_string(),
+            wallet_name: "p".to_string(),
+            alias: None,
+            public_key: dilithium_pk.to_vec(),
+            kyber_public_key: kyber_pk.clone(),
+            owner_identity_id: None,
+            seed_commitment: Hash::default(),
+            created_at: 1,
+            registration_fee: 0,
+            capabilities: 0,
+            initial_balance: 0,
+        };
+        let good_tx = Transaction::new_wallet_registration(
+            good,
+            vec![],
+            Signature {
+                signature: Vec::new(),
+                public_key: PublicKey::new(dilithium_pk),
+                algorithm: SignatureAlgorithm::DEFAULT,
+                timestamp: 1,
+            },
+            b"wallet-reg".to_vec(),
+        );
+        assert!(allows_empty_system_signature(&good_tx));
     }
 }

--- a/lib-blockchain/tests/g4_replay_acceptance_tests.rs
+++ b/lib-blockchain/tests/g4_replay_acceptance_tests.rs
@@ -42,12 +42,12 @@ use lib_blockchain::contracts::utils::generate_lib_token_id;
 use lib_blockchain::genesis::GenesisConfig;
 use lib_blockchain::storage::{Address, TokenId};
 
+use lib_blockchain::transaction::DEFAULT_TOKEN_CREATION_FEE;
 use lib_blockchain::transaction::{
     token_creation::TokenCreationPayloadV1, TokenMintData, TokenTransferData, Transaction,
     TransactionPayload, WalletTransactionData,
 };
 use lib_blockchain::types::Hash;
-use lib_blockchain::transaction::DEFAULT_TOKEN_CREATION_FEE;
 use lib_blockchain::types::TransactionType;
 use lib_blockchain::Blockchain;
 use tempfile::TempDir;
@@ -81,6 +81,7 @@ fn create_wallet_registration_tx(wallet_id: [u8; 32]) -> Transaction {
             wallet_name: "g4-repro".to_string(),
             wallet_type: "Primary".to_string(),
             public_key: owner.dilithium_pk.to_vec(),
+            kyber_public_key: vec![],
             capabilities: 0,
             created_at: 0,
             registration_fee: 0,
@@ -146,10 +147,7 @@ fn create_sov_transfer_tx_version(
     }
 }
 
-fn create_token_creation_tx(
-    creator_key_id: [u8; 32],
-    treasury_recipient: [u8; 32],
-) -> Transaction {
+fn create_token_creation_tx(creator_key_id: [u8; 32], treasury_recipient: [u8; 32]) -> Transaction {
     let payload = TokenCreationPayloadV1 {
         name: "Bubble".to_string(),
         symbol: "BUBL".to_string(),
@@ -275,7 +273,9 @@ fn build_dao_token_activity_chain() -> (Vec<lib_blockchain::block::Block>, DaoTo
     let block3 = block_at_height_with_txs(
         3,
         block2.header.block_hash,
-        vec![create_dao_token_transfer_tx(token_id, creator, recipient, 10_000, 0)],
+        vec![create_dao_token_transfer_tx(
+            token_id, creator, recipient, 10_000, 0,
+        )],
     );
 
     let expect = DaoTokenExpectation {
@@ -305,13 +305,12 @@ fn run_wipe_replay_parity(
         checkpoint_height
     );
 
-    let reference =
-        ReplayCheckpointSnapshot::from_store_at_height(
-            &*live_store,
-            checkpoint_height,
-            sample_wallets,
-            dao_expectations,
-        );
+    let reference = ReplayCheckpointSnapshot::from_store_at_height(
+        &*live_store,
+        checkpoint_height,
+        sample_wallets,
+        dao_expectations,
+    );
 
     let exported = live_sync.export_all_blocks().expect("export");
 
@@ -392,13 +391,17 @@ fn test_g4_wallet74010_sequence_isolated_replay() {
         .get_token_balance(&sov, &Address::new(wallet))
         .expect("read balance");
     assert_eq!(
-        bal, 4100 * ATOMS,
+        bal,
+        4100 * ATOMS,
         "after 5000 mint, zero-net 50 self-transfer, 900 outbound: have {bal}"
     );
     let nonce = store
         .get_token_nonce(&sov, &Address::new(wallet))
         .expect("read nonce");
-    assert_eq!(nonce, 2, "outbound transfer must advance nonce to 2 before final leg");
+    assert_eq!(
+        nonce, 2,
+        "outbound transfer must advance nonce to 2 before final leg"
+    );
 
     let err = sync
         .import_blocks(vec![h4])
@@ -432,19 +435,37 @@ fn test_g4_wallet74010_sequence_tx_version_eight() {
     let h2 = block_at_height_with_txs(
         2,
         prev,
-        vec![create_sov_transfer_tx_version(wallet, wallet, 50 * ATOMS, 0, 8u32)],
+        vec![create_sov_transfer_tx_version(
+            wallet,
+            wallet,
+            50 * ATOMS,
+            0,
+            8u32,
+        )],
     );
     prev = h2.header.block_hash;
     let h3 = block_at_height_with_txs(
         3,
         prev,
-        vec![create_sov_transfer_tx_version(wallet, recipient, 900 * ATOMS, 1, 8u32)],
+        vec![create_sov_transfer_tx_version(
+            wallet,
+            recipient,
+            900 * ATOMS,
+            1,
+            8u32,
+        )],
     );
     prev = h3.header.block_hash;
     let h4 = block_at_height_with_txs(
         4,
         prev,
-        vec![create_sov_transfer_tx_version(wallet, wallet, 4150 * ATOMS, 2, 8u32)],
+        vec![create_sov_transfer_tx_version(
+            wallet,
+            wallet,
+            4150 * ATOMS,
+            2,
+            8u32,
+        )],
     );
 
     let dir = TempDir::new().expect("tempdir");
@@ -511,12 +532,8 @@ fn test_paginated_fresh_sync_replay_parity() {
         .import_blocks(blocks.clone())
         .expect("live single-shot import");
 
-    let reference = ReplayCheckpointSnapshot::from_store_at_height(
-        &*live_store,
-        CHECKPOINT,
-        &sample,
-        &[],
-    );
+    let reference =
+        ReplayCheckpointSnapshot::from_store_at_height(&*live_store, CHECKPOINT, &sample, &[]);
 
     let replay_dir = TempDir::new().expect("replay tempdir");
     let replay_store = open_fresh_store(&replay_dir);
@@ -524,19 +541,16 @@ fn test_paginated_fresh_sync_replay_parity() {
     import_blocks_paginated(&replay_sync, blocks);
 
     assert_eq!(
-        replay_store.latest_height().expect("paginated replay height"),
+        replay_store
+            .latest_height()
+            .expect("paginated replay height"),
         CHECKPOINT
     );
 
-    let replayed = ReplayCheckpointSnapshot::from_store_at_height(
-        &*replay_store,
-        CHECKPOINT,
-        &sample,
-        &[],
-    );
-    compare_snapshots("paginated-fresh-sync", &reference, &replayed).expect(
-        "paginated import must match single-shot live reference",
-    );
+    let replayed =
+        ReplayCheckpointSnapshot::from_store_at_height(&*replay_store, CHECKPOINT, &sample, &[]);
+    compare_snapshots("paginated-fresh-sync", &reference, &replayed)
+        .expect("paginated import must match single-shot live reference");
 }
 
 /// DAO `TokenCreation` + custom-token transfer replay parity (BUBL class — g4-adjacent).
@@ -554,12 +568,12 @@ fn test_dao_token_creation_wipe_replay_parity() {
     sync.import_blocks(blocks).unwrap();
     let token = TokenId::new(dao_expect.token_id);
     let bal = store
-        .get_token_balance(
-            &token,
-            &Address::new(dao_expect.holder_wallet_id),
-        )
+        .get_token_balance(&token, &Address::new(dao_expect.holder_wallet_id))
         .unwrap();
-    assert_eq!(bal, 10_000, "BUBL recipient balance after TokenCreation + transfer");
+    assert_eq!(
+        bal, 10_000,
+        "BUBL recipient balance after TokenCreation + transfer"
+    );
 }
 
 /// Genesis block-0 only: SOV shell (no bulk allocations), legacy CBE treasury seed.
@@ -591,7 +605,10 @@ fn test_genesis_bootstrap_checkpoint_balances() {
     let have = store
         .get_token_balance(&sov_token, &Address::new(sample[0]))
         .expect("read SOV balance");
-    assert_eq!(have, 0, "no genesis SOV rows — balances enter via block txs");
+    assert_eq!(
+        have, 0,
+        "no genesis SOV rows — balances enter via block txs"
+    );
 
     // TODO(GENESIS-6, #2734): rewrite when CBE founding tx replaces block-0 seed.
     let cbe_token = TokenId::new(Blockchain::derive_cbe_token_id_pub());

--- a/lib-blockchain/tests/issue_1018_treasury_balance_tests.rs
+++ b/lib-blockchain/tests/issue_1018_treasury_balance_tests.rs
@@ -12,7 +12,9 @@ use lib_crypto::types::keys::PublicKey;
 
 mod common;
 
-fn create_test_pubkey(_id: u8) -> PublicKey { common::crypto_fixtures::dummy_public_key() }
+fn create_test_pubkey(_id: u8) -> PublicKey {
+    common::crypto_fixtures::dummy_public_key()
+}
 
 /// Setup a blockchain with treasury wallet and SOV token
 fn setup_blockchain_with_treasury() -> (Blockchain, PublicKey) {
@@ -28,6 +30,7 @@ fn setup_blockchain_with_treasury() -> (Blockchain, PublicKey) {
         wallet_name: "dao_treasury".to_string(),
         alias: Some("DAO Treasury".to_string()),
         public_key: treasury_pubkey.dilithium_pk.to_vec(),
+        kyber_public_key: vec![],
         owner_identity_id: None,
         seed_commitment: Hash::new([0u8; 32]),
         created_at: 0,
@@ -64,8 +67,7 @@ fn test_treasury_balance_uses_token_contract() {
     let treasury_amount: u128 = 1_000_000;
 
     if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
-        token
-            .set_balance(&treasury_pubkey, treasury_amount);
+        token.set_balance(&treasury_pubkey, treasury_amount);
     }
 
     // Query treasury balance - should reflect the credited amount
@@ -87,8 +89,7 @@ fn test_treasury_balance_not_placeholder() {
     let expected_amount: u128 = 5_555_555;
 
     if let Some(token) = blockchain.get_token_contract_mut(&sov_token_id) {
-        token
-            .set_balance(&treasury_pubkey, expected_amount);
+        token.set_balance(&treasury_pubkey, expected_amount);
     }
 
     // Query balance multiple times - should always return the exact amount
@@ -116,6 +117,7 @@ fn test_treasury_balance_returns_zero_without_token_contract() {
         wallet_name: "dao_treasury".to_string(),
         alias: Some("DAO Treasury".to_string()),
         public_key: treasury_pubkey.dilithium_pk.to_vec(),
+        kyber_public_key: vec![],
         owner_identity_id: None,
         seed_commitment: Hash::new([0u8; 32]),
         created_at: 0,

--- a/lib-blockchain/tests/token_regression_tests.rs
+++ b/lib-blockchain/tests/token_regression_tests.rs
@@ -25,8 +25,12 @@ mod common;
 // Test helpers
 // ============================================================================
 
-fn test_pubkey(id: u8) -> PublicKey { common::crypto_fixtures::seeded_public_key(id) }
-fn test_signature(pubkey: &PublicKey) -> Signature { common::crypto_fixtures::signature_for(pubkey) }
+fn test_pubkey(id: u8) -> PublicKey {
+    common::crypto_fixtures::seeded_public_key(id)
+}
+fn test_signature(pubkey: &PublicKey) -> Signature {
+    common::crypto_fixtures::signature_for(pubkey)
+}
 
 /// Create a test block at the given height with transactions.
 fn test_block(height: u64, transactions: Vec<Transaction>) -> Block {
@@ -65,6 +69,7 @@ fn wallet_registration_tx(
             wallet_name: format!("Wallet-{}", hex::encode(&wallet_id[..4])),
             alias: None,
             public_key: owner_pubkey.dilithium_pk.to_vec(),
+            kyber_public_key: vec![],
             owner_identity_id: None,
             seed_commitment: Hash::zero(),
             created_at: 1_700_000_000,
@@ -111,8 +116,8 @@ fn token_transfer_tx_with_nonce(
             commitment: Hash::new([3u8; 32]),
             note: Hash::new([4u8; 32]),
             recipient: test_pubkey(0),
-                    merkle_leaf: Hash::default(),
-}],
+            merkle_leaf: Hash::default(),
+        }],
         fee: 0,
         signature: test_signature(sender),
         memo: Vec::new(),
@@ -182,6 +187,7 @@ fn register_wallet(
             wallet_name: format!("Wallet-{}", hex::encode(&wallet_id[..4])),
             alias: None,
             public_key: owner.dilithium_pk.to_vec(),
+            kyber_public_key: vec![],
             owner_identity_id: None,
             seed_commitment: Hash::zero(),
             created_at: 1_700_000_000,

--- a/lib-blockchain/tests/token_snapshot_restart_tests.rs
+++ b/lib-blockchain/tests/token_snapshot_restart_tests.rs
@@ -14,9 +14,16 @@ use lib_crypto::types::signatures::{Signature, SignatureAlgorithm};
 
 mod common;
 
-fn test_pubkey(_id: u8) -> PublicKey { common::crypto_fixtures::dummy_public_key() }
+fn test_pubkey(_id: u8) -> PublicKey {
+    common::crypto_fixtures::dummy_public_key()
+}
 fn test_signature(pubkey: &PublicKey) -> Signature {
-    Signature { signature: vec![0u8; 64], public_key: pubkey.clone(), algorithm: SignatureAlgorithm::DEFAULT, timestamp: 0 }
+    Signature {
+        signature: vec![0u8; 64],
+        public_key: pubkey.clone(),
+        algorithm: SignatureAlgorithm::DEFAULT,
+        timestamp: 0,
+    }
 }
 
 fn wallet_registration_tx(wallet_id: [u8; 32], owner_pubkey: &PublicKey) -> Transaction {
@@ -27,6 +34,7 @@ fn wallet_registration_tx(wallet_id: [u8; 32], owner_pubkey: &PublicKey) -> Tran
             wallet_name: format!("Wallet-{}", hex::encode(&wallet_id[..4])),
             alias: None,
             public_key: owner_pubkey.dilithium_pk.to_vec(),
+            kyber_public_key: vec![],
             owner_identity_id: None,
             seed_commitment: Hash::zero(),
             created_at: 1_700_000_000,
@@ -73,8 +81,12 @@ fn token_mint_tx(signer: &PublicKey, token_id: [u8; 32], to: [u8; 32], amount: u
     )
 }
 
-fn create_genesis_block() -> Block { common::block_builders::genesis_block() }
-fn create_block_at_height(height: u64, prev_hash: Hash, txs: Vec<Transaction>) -> Block { common::block_builders::block_at_height_with_txs(height, prev_hash, txs) }
+fn create_genesis_block() -> Block {
+    common::block_builders::genesis_block()
+}
+fn create_block_at_height(height: u64, prev_hash: Hash, txs: Vec<Transaction>) -> Block {
+    common::block_builders::block_at_height_with_txs(height, prev_hash, txs)
+}
 
 fn wallet_key(wallet_id: &[u8; 32]) -> PublicKey {
     // Match the executor's wallet_key_for_sov format:
@@ -105,7 +117,7 @@ fn test_restart_replays_committed_token_state_and_nonces() -> Result<()> {
     let genesis = create_genesis_block();
     let executor = BlockExecutor::from_config(Arc::clone(&store), ExecutorConfig::default());
     executor.apply_block(&genesis)?;
-    
+
     // Create and apply block 1 with wallet registrations and mint
     let block1 = create_block_at_height(
         1,
@@ -117,7 +129,7 @@ fn test_restart_replays_committed_token_state_and_nonces() -> Result<()> {
         ],
     );
     executor.apply_block(&block1)?;
-    
+
     // Create and apply block 2 with transfer (separate block due to read-your-writes limitation)
     let block2 = create_block_at_height(
         2,
@@ -164,7 +176,7 @@ fn test_cross_node_loads_converge_to_identical_token_state() -> Result<()> {
     let genesis = create_genesis_block();
     let executor = BlockExecutor::from_config(Arc::clone(&store), ExecutorConfig::default());
     executor.apply_block(&genesis)?;
-    
+
     // Create and apply block 1 with wallet registrations and mint
     let block1 = create_block_at_height(
         1,
@@ -176,7 +188,7 @@ fn test_cross_node_loads_converge_to_identical_token_state() -> Result<()> {
         ],
     );
     executor.apply_block(&block1)?;
-    
+
     // Create and apply block 2 with transfer (separate block due to read-your-writes limitation)
     let block2 = create_block_at_height(
         2,
@@ -209,7 +221,10 @@ fn test_cross_node_loads_converge_to_identical_token_state() -> Result<()> {
     assert_eq!(token_b.balance_of(&wallet_key(&recipient_wallet)), 2_500);
     assert_eq!(node_a.get_token_nonce(&sov_token_id, &sender_wallet), 1);
     assert_eq!(node_b.get_token_nonce(&sov_token_id, &sender_wallet), 1);
-    assert_eq!(node_a.token_nonces_snapshot(), node_b.token_nonces_snapshot());
+    assert_eq!(
+        node_a.token_nonces_snapshot(),
+        node_b.token_nonces_snapshot()
+    );
     assert_eq!(node_a.token_contract_count(), node_b.token_contract_count());
 
     Ok(())
@@ -230,7 +245,7 @@ fn test_restart_preserves_sov_supply_and_recipient_count() -> Result<()> {
     let genesis = create_genesis_block();
     let executor = BlockExecutor::from_config(Arc::clone(&store), ExecutorConfig::default());
     executor.apply_block(&genesis)?;
-    
+
     // Create and apply block 1 with wallet registrations and mint
     let block1 = create_block_at_height(
         1,
@@ -243,20 +258,34 @@ fn test_restart_preserves_sov_supply_and_recipient_count() -> Result<()> {
         ],
     );
     executor.apply_block(&block1)?;
-    
+
     // Create and apply block 2 with first transfer
     let block2 = create_block_at_height(
         2,
         block1.header.block_hash,
-        vec![token_transfer_tx(&signer, sov_token_id, alice_wallet, bob_wallet, 5_000, 0)],
+        vec![token_transfer_tx(
+            &signer,
+            sov_token_id,
+            alice_wallet,
+            bob_wallet,
+            5_000,
+            0,
+        )],
     );
     executor.apply_block(&block2)?;
-    
+
     // Create and apply block 3 with second transfer (separate block due to nonce increment)
     let block3 = create_block_at_height(
         3,
         block2.header.block_hash,
-        vec![token_transfer_tx(&signer, sov_token_id, alice_wallet, carol_wallet, 2_000, 1)],
+        vec![token_transfer_tx(
+            &signer,
+            sov_token_id,
+            alice_wallet,
+            carol_wallet,
+            2_000,
+            1,
+        )],
     );
     executor.apply_block(&block3)?;
 
@@ -313,12 +342,13 @@ fn test_uncommitted_block_does_not_leak_token_state_after_restart() -> Result<()
     let sov_token_id = generate_lib_token_id();
 
     let committed_store: Arc<dyn BlockchainStore> = Arc::new(SledStore::open(&db_path)?);
-    
+
     // Create and apply genesis first
     let genesis = create_genesis_block();
-    let executor = BlockExecutor::from_config(Arc::clone(&committed_store), ExecutorConfig::default());
+    let executor =
+        BlockExecutor::from_config(Arc::clone(&committed_store), ExecutorConfig::default());
     executor.apply_block(&genesis)?;
-    
+
     // Create and apply block 1 with token transactions
     let test_block = create_block_at_height(
         1,

--- a/lib-blockchain/tests/wallet_projection_restart_tests.rs
+++ b/lib-blockchain/tests/wallet_projection_restart_tests.rs
@@ -10,8 +10,12 @@ use lib_crypto::types::signatures::{Signature, SignatureAlgorithm};
 
 mod common;
 
-fn test_pubkey(_id: u8) -> PublicKey { common::crypto_fixtures::dummy_public_key() }
-fn test_signature(pubkey: &PublicKey) -> Signature { common::crypto_fixtures::signature_for(pubkey) }
+fn test_pubkey(_id: u8) -> PublicKey {
+    common::crypto_fixtures::dummy_public_key()
+}
+fn test_signature(pubkey: &PublicKey) -> Signature {
+    common::crypto_fixtures::signature_for(pubkey)
+}
 
 fn wallet_data(wallet_id: [u8; 32], owner_pubkey: &PublicKey, name: &str) -> WalletTransactionData {
     WalletTransactionData {
@@ -20,6 +24,7 @@ fn wallet_data(wallet_id: [u8; 32], owner_pubkey: &PublicKey, name: &str) -> Wal
         wallet_name: name.to_string(),
         alias: None,
         public_key: owner_pubkey.dilithium_pk.to_vec(),
+        kyber_public_key: vec![],
         owner_identity_id: None,
         seed_commitment: Hash::zero(),
         created_at: 1_700_000_000,
@@ -105,7 +110,10 @@ fn test_wallet_projection_loaded_state_matches_replay_rebuilt_state() -> Result<
         replay_rebuilt.wallet_blocks.get(&wallet_id_hex)
     );
     assert_eq!(replay_rebuilt.wallet_blocks.get(&wallet_id_hex), Some(&0));
-    assert_eq!(store.get_wallet_projection(&wallet_id)?, Some(canonical_record));
+    assert_eq!(
+        store.get_wallet_projection(&wallet_id)?,
+        Some(canonical_record)
+    );
 
     Ok(())
 }
@@ -166,7 +174,10 @@ fn test_uncommitted_wallet_projection_update_does_not_leak_after_restart() -> Re
 
     let wallet_id_hex = hex::encode(wallet_id);
     assert_eq!(recovered.height, 0);
-    assert_eq!(recovered.wallet_transaction_data(&wallet_id_hex), Some(wallet));
+    assert_eq!(
+        recovered.wallet_transaction_data(&wallet_id_hex),
+        Some(wallet)
+    );
     assert_eq!(recovered.wallet_blocks.get(&wallet_id_hex), Some(&0));
     assert_eq!(
         recovered_store.get_wallet_projection(&wallet_id)?,

--- a/lib-identity/src/identity/manager.rs
+++ b/lib-identity/src/identity/manager.rs
@@ -63,7 +63,7 @@ impl IdentityManager {
     /// Create a new citizen identity with quantum-resistant keys and full citizenship benefits.
     ///
     /// # Migration Note
-    /// 
+    ///
     /// This method now uses real Dilithium5 key generation via `lib_crypto::KeyPair::generate()`.
     /// The old fake hash-based key generation has been removed.
     ///
@@ -435,7 +435,9 @@ impl IdentityManager {
         };
         let relation = self.determine_relation(principal, &identity);
         let policy = lib_access_control::AccessPolicy::default();
-        policy.check_access(principal, relation, domain, operation).is_allowed()
+        policy
+            .check_access(principal, relation, domain, operation)
+            .is_allowed()
     }
 
     /// Add an existing identity to the manager
@@ -581,47 +583,49 @@ impl IdentityManager {
             "external_citizen".to_string(),
         );
 
-        // Generate master seed for HD wallet derivation (64 bytes)
-        let mut master_seed = [0u8; 64];
-        {
-            use rand::RngCore;
-            rand::rngs::OsRng.fill_bytes(&mut master_seed);
-        }
+        // Client-aligned wallet IDs (#2979): derive deterministically from the
+        // client's PQC keys — NOT from a server-side HD master seed. The client
+        // derives key_id = blake3(dilithium_pk || kyber_pk) locally and never
+        // transmits its private key, so the server must reproduce the same IDs.
+        let primary_wallet_id = {
+            let mut input = public_key.dilithium_pk.to_vec();
+            input.extend_from_slice(&kyber_public_key);
+            Hash(lib_crypto::hash_blake3(&input))
+        };
+        let ubi_wallet_id = {
+            let mut input = primary_wallet_id.0.to_vec();
+            input.extend_from_slice(b"ubi");
+            Hash(lib_crypto::hash_blake3(&input))
+        };
+        let savings_wallet_id = {
+            let mut input = primary_wallet_id.0.to_vec();
+            input.extend_from_slice(b"savings");
+            Hash(lib_crypto::hash_blake3(&input))
+        };
 
-        // Initialize wallet manager with master seed for HD derivation
-        identity.wallet_manager =
-            crate::wallets::WalletManager::from_master_seed(id.clone(), master_seed);
-
-        // Create HD wallets at fixed indices: 0=Primary, 1=UBI, 2=Savings
-        let (primary_wallet_id, _) = identity
-            .wallet_manager
-            .create_hd_wallet(
-                WalletType::Primary,
-                "Primary Wallet".to_string(),
-                Some("primary".to_string()),
-            )
-            .await?;
-
-        let (ubi_wallet_id, _) = identity
-            .wallet_manager
-            .create_hd_wallet(
-                WalletType::UBI,
-                "UBI Wallet".to_string(),
-                Some("ubi".to_string()),
-            )
-            .await?;
-
-        let (savings_wallet_id, _) = identity
-            .wallet_manager
-            .create_hd_wallet(
-                WalletType::Savings,
-                "Savings Wallet".to_string(),
-                Some("savings".to_string()),
-            )
-            .await?;
-
-        // Generate 24-word master seed phrase from first 32 bytes of master seed
-        let master_seed_phrase = crate::recovery::RecoveryPhrase::from_entropy(&master_seed[..32])?;
+        // Register the three wallets carrying the client's real Dilithium public key.
+        identity.wallet_manager = crate::wallets::WalletManager::new(id.clone());
+        identity.wallet_manager.add_client_wallet(
+            primary_wallet_id.clone(),
+            WalletType::Primary,
+            "Primary Wallet".to_string(),
+            Some("primary".to_string()),
+            public_key.dilithium_pk.to_vec(),
+        )?;
+        identity.wallet_manager.add_client_wallet(
+            ubi_wallet_id.clone(),
+            WalletType::UBI,
+            "UBI Wallet".to_string(),
+            Some("ubi".to_string()),
+            public_key.dilithium_pk.to_vec(),
+        )?;
+        identity.wallet_manager.add_client_wallet(
+            savings_wallet_id.clone(),
+            WalletType::Savings,
+            "Savings Wallet".to_string(),
+            Some("savings".to_string()),
+            public_key.dilithium_pk.to_vec(),
+        )?;
 
         // Register for DAO governance
         let dao_registration =
@@ -687,9 +691,17 @@ impl IdentityManager {
             hex::encode(&id.0[..8])
         );
 
-        // Compile master seed phrase for secure storage (single phrase derives all wallets)
-        let wallet_seed_phrases =
-            crate::citizenship::onboarding::WalletSeedPhrases { master_seed_phrase };
+        // No server-side seed phrase for remote registrations — the client holds the
+        // private key and derives wallets from its own keys (#2979).
+        let wallet_seed_phrases = crate::citizenship::onboarding::WalletSeedPhrases {
+            master_seed_phrase: crate::recovery::RecoveryPhrase {
+                words: Vec::new(),
+                entropy: Vec::new(),
+                checksum: String::new(),
+                language: "english".to_string(),
+                word_count: 0,
+            },
+        };
 
         Ok(CitizenshipResult::new(
             id,
@@ -1001,7 +1013,7 @@ impl IdentityManager {
             proof_data: final_proof.to_vec(),
             public_inputs: public_inputs,
             verification_key: verification_key.to_vec(),
-            proof: vec![],       // Legacy compatibility field
+            proof: vec![], // Legacy compatibility field
             ..lib_proofs::ZkProof::empty()
         })
     }
@@ -1125,27 +1137,31 @@ impl IdentityManager {
                 arr[..4864].copy_from_slice(&private_key_bytes);
                 arr
             }
-            _ => return Err(anyhow!(
-                "Invalid private key size: expected 4864 or 4896 bytes for Dilithium5, got {}",
-                private_key_bytes.len()
-            )),
+            _ => {
+                return Err(anyhow!(
+                    "Invalid private key size: expected 4864 or 4896 bytes for Dilithium5, got {}",
+                    private_key_bytes.len()
+                ))
+            }
         };
-        let dilithium_pk: [u8; 2592] = public_key.as_slice().try_into()
+        let dilithium_pk: [u8; 2592] = public_key
+            .as_slice()
+            .try_into()
             .map_err(|_| anyhow!("Invalid public key size: expected 2592 bytes for Dilithium5"))?;
 
         // Wrap in PrivateKey struct
         let private_key = lib_crypto::PrivateKey {
             dilithium_sk,
             dilithium_pk,
-            kyber_sk: [0u8; 3168],    // Not used in current implementation
-            master_seed: [0u8; 64],   // Derived separately
+            kyber_sk: [0u8; 3168],  // Not used in current implementation
+            master_seed: [0u8; 64], // Derived separately
         };
 
         // Create identity structure
         let mut identity = ZhtpIdentity::from_legacy_fields(
             identity_id.clone(),
             IdentityType::Device, // Device avoids age/jurisdiction requirement
-            public_key, // Pass the Vec<u8> for API compatibility
+            public_key,           // Pass the Vec<u8> for API compatibility
             private_key.clone(),
             "restored".to_string(), // Device name for restored identity
             self.generate_ownership_proof(&dilithium_sk, &dilithium_pk)
@@ -1631,9 +1647,10 @@ mod access_control_tests {
     fn test_unknown_identity_returns_none() {
         let manager = IdentityManager::new();
         let principal = SecurityPrincipal::public();
-        let fake_id =
-            IdentityId::from_hex("0000000000000000000000000000000000000000000000000000000000000000")
-                .unwrap();
+        let fake_id = IdentityId::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap();
         let view = manager.get_identity_view(&principal, &fake_id);
         assert!(view.is_none(), "Unknown identity should return None");
     }
@@ -1694,7 +1711,10 @@ mod access_control_tests {
         device.owner_identity_id = Some(user_id.clone());
         let device_did = device.did.clone();
         manager.add_identity(device);
-        assert_ne!(user_did, device_did, "test setup: user/device DIDs must differ");
+        assert_ne!(
+            user_did, device_did,
+            "test setup: user/device DIDs must differ"
+        );
 
         // Role::Device is the production role for mobile QUIC principals;
         // get_identity_view's DeviceOwner branch is gated on it.
@@ -1733,8 +1753,7 @@ mod access_control_tests {
         let device_principal =
             SecurityPrincipal::new(&device_did, Role::Device, NodeType::FullNode);
 
-        let unrelated_view =
-            manager.get_identity_view_by_did(&device_principal, &other_did);
+        let unrelated_view = manager.get_identity_view_by_did(&device_principal, &other_did);
         assert!(
             matches!(unrelated_view, Some(IdentityView::Public(_))),
             "Device principal with no owner link must only see Public \
@@ -1743,8 +1762,7 @@ mod access_control_tests {
 
         // And the user (subject from previous test) without the owner
         // link wired up must also be Public.
-        let user_view =
-            manager.get_identity_view_by_did(&device_principal, &user_did);
+        let user_view = manager.get_identity_view_by_did(&device_principal, &user_did);
         assert!(
             matches!(user_view, Some(IdentityView::Public(_))),
             "Device principal without owner_identity_id wired to user \

--- a/lib-identity/src/wallets/manager_integration.rs
+++ b/lib-identity/src/wallets/manager_integration.rs
@@ -160,6 +160,65 @@ impl WalletManager {
         Ok(wallet_id)
     }
 
+    /// Add a client-key wallet with a deterministic (client-derived) wallet ID.
+    ///
+    /// For remote registrations the client derives `key_id = blake3(dilithium_pk || kyber_pk)`,
+    /// so the wallet ID and public key are fixed by the client's keys — not an HD seed.
+    /// `public_key` is the client's real Dilithium5 public key (2592 bytes).
+    pub fn add_client_wallet(
+        &mut self,
+        wallet_id: WalletId,
+        wallet_type: WalletType,
+        name: String,
+        alias: Option<String>,
+        public_key: Vec<u8>,
+    ) -> Result<WalletId> {
+        if let Some(ref alias) = alias {
+            if self.alias_map.contains_key(alias) {
+                return Err(anyhow!("Wallet alias '{}' already exists", alias));
+            }
+        }
+        if self.wallets.contains_key(&wallet_id) {
+            return Ok(wallet_id);
+        }
+
+        let current_time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let wallet = QuantumWallet {
+            id: wallet_id.clone(),
+            wallet_type,
+            name,
+            alias: alias.clone(),
+            balance: 0, // Will be synced from blockchain registry
+            staked_balance: 0,
+            pending_rewards: 0,
+            owner_id: self.owner_id.clone(),
+            public_key,
+            seed_phrase: None,
+            encrypted_seed: None,
+            seed_commitment: None,
+            created_at: current_time,
+            last_transaction: None,
+            recent_transactions: Vec::new(),
+            is_active: true,
+            dao_properties: None,
+            derivation_index: None,
+            password_hash: None,
+            owned_content: Vec::new(),
+            total_storage_used: 0,
+            total_content_value: 0,
+        };
+
+        self.wallets.insert(wallet_id.clone(), wallet);
+        if let Some(alias) = alias {
+            self.alias_map.insert(alias, wallet_id.clone());
+        }
+        Ok(wallet_id)
+    }
+
     // Note: Basic wallet creation removed - use create_wallet_with_seed_phrase() for all wallets
     // This ensures consistent seed phrase support across all wallet types
 

--- a/zhtp-cli/src/commands/blockchain.rs
+++ b/zhtp-cli/src/commands/blockchain.rs
@@ -225,8 +225,7 @@ fn audit_wallet_migration(
         total_wallets_in_local_state: blockchain.wallet_registry_shadow_len(),
         noncanonical_wallet_count: blockchain.collect_noncanonical_wallets().len(),
         treasury_wallet_id: treasury_wallet_id_hex.clone(),
-        treasury_wallet_present_in_local_state: blockchain
-            .wallet_exists(&treasury_wallet_id_hex),
+        treasury_wallet_present_in_local_state: blockchain.wallet_exists(&treasury_wallet_id_hex),
         treasury_wallet_canonical_in_history: blockchain.dao_treasury_wallet_is_canonical(),
         treasury_wallet_requires_schema_change: blockchain
             .wallet_transaction_data(&treasury_wallet_id_hex)
@@ -630,6 +629,7 @@ mod tests {
             wallet_name: "Ghost Wallet".to_string(),
             alias: Some("primary".to_string()),
             public_key: vec![0x22; 2592],
+            kyber_public_key: vec![],
             owner_identity_id: Some(lib_blockchain::Hash::new([0x33; 32])),
             seed_commitment: lib_blockchain::Hash::new([0x44; 32]),
             created_at: 1_700_000_000,
@@ -651,6 +651,7 @@ mod tests {
             wallet_name: "DAO Treasury".to_string(),
             alias: None,
             public_key: vec![],
+            kyber_public_key: vec![],
             owner_identity_id: None,
             seed_commitment: lib_blockchain::Hash::zero(),
             created_at: 0,

--- a/zhtp/src/api/handlers/balance_key.rs
+++ b/zhtp/src/api/handlers/balance_key.rs
@@ -92,6 +92,7 @@ mod tests {
             wallet_name: "Primary".to_string(),
             alias: None,
             public_key: dilithium_pk.to_vec(),
+            kyber_public_key: vec![],
             owner_identity_id: Some(Hash::from_slice(&owner)),
             seed_commitment: Hash::default(),
             created_at: 0,
@@ -123,11 +124,9 @@ mod tests {
             .expect("register wallet");
 
         let via_wallet = resolve_custom_token_balance_key(&bc, &wallet_hex).expect("wallet");
-        let via_did = resolve_custom_token_balance_key(
-            &bc,
-            &format!("did:zhtp:{}", hex::encode(via_wallet)),
-        )
-        .expect("did");
+        let via_did =
+            resolve_custom_token_balance_key(&bc, &format!("did:zhtp:{}", hex::encode(via_wallet)))
+                .expect("did");
 
         assert_ne!(via_wallet, wallet_id, "must not use raw wallet_id bytes");
         assert_eq!(via_wallet, via_did, "wallet_id and DID must agree");

--- a/zhtp/src/api/handlers/identity/backup_recovery.rs
+++ b/zhtp/src/api/handlers/identity/backup_recovery.rs
@@ -398,12 +398,17 @@ pub async fn handle_recover_identity(
                 "Recovery: identity {} not found — auto-creating from seed",
                 hex::encode(&identity_id.0[..8])
             );
-            auto_create_identity_from_seed(&identity_manager, identity_id.clone(), dilithium_pk, opt_root_secret)
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::warn!("Recovery auto-create identity failed: {}", e);
-                    format!("did:zhtp:{}", hex::encode(&identity_id.0))
-                })
+            auto_create_identity_from_seed(
+                &identity_manager,
+                identity_id.clone(),
+                dilithium_pk,
+                opt_root_secret,
+            )
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("Recovery auto-create identity failed: {}", e);
+                format!("did:zhtp:{}", hex::encode(&identity_id.0))
+            })
         } else {
             tracing::debug!("Recovery: identity not found for derived id");
             return Ok(ZhtpResponse::error(
@@ -435,7 +440,9 @@ pub async fn handle_recover_identity(
 
     // Look up display_name and username from on-chain state
     let (display_name, username) = {
-        if let Ok(blockchain_arc) = crate::runtime::blockchain_provider::get_global_blockchain().await {
+        if let Ok(blockchain_arc) =
+            crate::runtime::blockchain_provider::get_global_blockchain().await
+        {
             let blockchain = blockchain_arc.read().await;
             let dn = blockchain.identity_display_name(&did); // #2639: sled-first (metadata)
             let un = blockchain.did_to_username.get(&did).cloned();
@@ -497,7 +504,9 @@ async fn auto_create_identity_from_seed(
                 "seed-recovery".to_string(),
                 {
                     // Preserve existing on-chain display_name if available
-                    let existing_name = if let Ok(bc_arc) = crate::runtime::blockchain_provider::get_global_blockchain().await {
+                    let existing_name = if let Ok(bc_arc) =
+                        crate::runtime::blockchain_provider::get_global_blockchain().await
+                    {
                         let bc = bc_arc.read().await;
                         bc.identity_display_name(&did) // #2639: sled-first (metadata)
                     } else {
@@ -540,11 +549,8 @@ async fn auto_create_identity_from_seed(
     // Queue a blockchain IdentityRegistration system tx so the identity is durable
     // in the ledger and other nodes recognise it after the next block.
     if let Ok(shared_bc) = crate::runtime::blockchain_provider::get_global_blockchain().await {
-        if let Ok(mut blockchain) = tokio::time::timeout(
-            tokio::time::Duration::from_secs(5),
-            shared_bc.write(),
-        )
-        .await
+        if let Ok(mut blockchain) =
+            tokio::time::timeout(tokio::time::Duration::from_secs(5), shared_bc.write()).await
         {
             // Only submit if not already in the on-chain identity_registry.
             if !blockchain.query_identity_exists(&did) {
@@ -573,7 +579,10 @@ async fn auto_create_identity_from_seed(
                     },
                     b"seed-recovery-auto-register".to_vec(),
                 );
-                if let Err(e) = blockchain.add_system_transaction(reg_tx, lib_blockchain::SystemOriginator::SeedRecoveryIdentity) {
+                if let Err(e) = blockchain.add_system_transaction(
+                    reg_tx,
+                    lib_blockchain::SystemOriginator::SeedRecoveryIdentity,
+                ) {
                     tracing::warn!("Recovery: failed to queue identity registration tx: {}", e);
                 } else {
                     // Identity will be added to registry when the block containing
@@ -607,11 +616,11 @@ async fn migrate_wallets_for_identity(
     identity_id: lib_crypto::Hash,
     dilithium_pk: Option<Vec<u8>>,
 ) {
-    let shared_blockchain =
-        match crate::runtime::blockchain_provider::get_global_blockchain().await {
-            Ok(b) => b,
-            Err(_) => return,
-        };
+    let shared_blockchain = match crate::runtime::blockchain_provider::get_global_blockchain().await
+    {
+        Ok(b) => b,
+        Err(_) => return,
+    };
 
     // Collect wallets needing migration under a short read lock.
     // We include wallets with initial_balance == 0 as well — those were typically
@@ -707,13 +716,18 @@ async fn migrate_wallets_for_identity(
         )
         .await
         else {
-            tracing::warn!("Migration: write lock timeout for wallet {}", &wallet_id_hex[..16.min(wallet_id_hex.len())]);
+            tracing::warn!(
+                "Migration: write lock timeout for wallet {}",
+                &wallet_id_hex[..16.min(wallet_id_hex.len())]
+            );
             continue;
         };
 
         // add_system_transaction bypasses signature validation (correct for a
         // server-originated system tx where we hold no user private key).
-        match blockchain.add_system_transaction(reg_tx, lib_blockchain::SystemOriginator::MigrationWallet) {
+        match blockchain
+            .add_system_transaction(reg_tx, lib_blockchain::SystemOriginator::MigrationWallet)
+        {
             Ok(_) => tracing::info!(
                 "Migration: queued WalletRegistration for {} ({} SOV)",
                 &wallet_id_hex[..16.min(wallet_id_hex.len())],
@@ -754,6 +768,7 @@ async fn create_fallback_wallet(
         wallet_name: "Recovered Wallet".to_string(),
         alias: None,
         public_key: dilithium_pk.to_vec(),
+        kyber_public_key: vec![],
         owner_identity_id: Some(lib_blockchain::Hash::from_slice(&identity_id.0)),
         seed_commitment: lib_blockchain::types::hash::blake3_hash(wallet_id_bytes.as_bytes()),
         created_at: now_ts,
@@ -784,7 +799,10 @@ async fn create_fallback_wallet(
         return;
     };
 
-    match blockchain.add_system_transaction(reg_tx, lib_blockchain::SystemOriginator::RecoveryFallbackWallet) {
+    match blockchain.add_system_transaction(
+        reg_tx,
+        lib_blockchain::SystemOriginator::RecoveryFallbackWallet,
+    ) {
         Ok(_) => {
             blockchain.insert_wallet_shadow(wallet_id_hex.clone(), wallet_data);
             tracing::info!(
@@ -1412,8 +1430,10 @@ pub async fn handle_migrate_identity(
         hex::decode(&req.signature).map_err(|_| anyhow::anyhow!("Invalid signature hex"))?;
 
     // Convert to lib_crypto::PublicKey (computes key_id = Blake3(dilithium_pk))
-    let new_public_key_bytes: [u8; 2592] = new_public_key_bytes.as_slice().try_into()
-        .map_err(|_| anyhow::anyhow!("Invalid public key size: expected 2592 bytes (Dilithium5)"))?;
+    let new_public_key_bytes: [u8; 2592] =
+        new_public_key_bytes.as_slice().try_into().map_err(|_| {
+            anyhow::anyhow!("Invalid public key size: expected 2592 bytes (Dilithium5)")
+        })?;
     let new_public_key = lib_crypto::PublicKey::new(new_public_key_bytes);
     let new_did = format!("did:zhtp:{}", hex::encode(new_public_key.key_id));
 
@@ -1535,9 +1555,14 @@ pub async fn handle_migrate_identity(
                             short_key_max_len =
                                 Some(short_key_max_len.map(|v| v.max(key_len)).unwrap_or(key_len));
                         } else if token_opt.is_some() {
-                            let old_pk_bytes: [u8; 2592] = wallet_data.public_key.as_slice().try_into()
+                            let old_pk_bytes: [u8; 2592] = wallet_data
+                                .public_key
+                                .as_slice()
+                                .try_into()
                                 .unwrap_or([0u8; 2592]);
-                            let new_pk_bytes: [u8; 2592] = new_public_key_bytes.as_slice().try_into()
+                            let new_pk_bytes: [u8; 2592] = new_public_key_bytes
+                                .as_slice()
+                                .try_into()
                                 .unwrap_or([0u8; 2592]);
                             let old_pk = lib_crypto::PublicKey::new(old_pk_bytes);
                             let new_pk = lib_crypto::PublicKey::new(new_pk_bytes);
@@ -1821,8 +1846,10 @@ pub async fn handle_migrate_identity(
                                 .token_balance(&sov_token_id, &wallet_id_bytes)
                                 .unwrap_or(0);
                             if current_balance < existing.initial_balance as u128 {
-                                let mint_amount = existing.initial_balance as u128 - current_balance;
-                                let mint_amount_u64 = u64::try_from(mint_amount).unwrap_or(u64::MAX);
+                                let mint_amount =
+                                    existing.initial_balance as u128 - current_balance;
+                                let mint_amount_u64 =
+                                    u64::try_from(mint_amount).unwrap_or(u64::MAX);
                                 let memo =
                                     format!("TOKEN_BACKFILL_V1:{}", wallet_id_str).into_bytes();
                                 if let Ok(tx) = build_signed_sov_mint_tx(
@@ -1852,8 +1879,8 @@ pub async fn handle_migrate_identity(
                         }
                     } else {
                         if blockchain.query_token_contract(&sov_token_id).is_some() {
-                            let old_pk_bytes: [u8; 2592] = old_public_key.as_slice().try_into()
-                                .unwrap_or([0u8; 2592]);
+                            let old_pk_bytes: [u8; 2592] =
+                                old_public_key.as_slice().try_into().unwrap_or([0u8; 2592]);
                             let old_pk = lib_crypto::PublicKey::new(old_pk_bytes);
                             if old_pk.key_id != wallet_addr.key_id {
                                 let old_balance = blockchain
@@ -1865,7 +1892,8 @@ pub async fn handle_migrate_identity(
                                         hex::encode(&old_public_key)
                                     )
                                     .into_bytes();
-                                    let old_balance_u64 = u64::try_from(old_balance).unwrap_or(u64::MAX);
+                                    let old_balance_u64 =
+                                        u64::try_from(old_balance).unwrap_or(u64::MAX);
                                     if let Ok(tx) = build_signed_sov_mint_tx(
                                         &migration_authority_kp,
                                         chain_id,
@@ -2159,15 +2187,27 @@ async fn load_migration_authority_keypair() -> anyhow::Result<lib_crypto::KeyPai
         ));
     }
 
-    let dilithium_pk: [u8; 2592] = ks.dilithium_pk.as_slice().try_into()
+    let dilithium_pk: [u8; 2592] = ks
+        .dilithium_pk
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid dilithium_pk size: expected 2592 bytes"))?;
-    let dilithium_sk: [u8; 4896] = ks.dilithium_sk.as_slice().try_into()
+    let dilithium_sk: [u8; 4896] = ks
+        .dilithium_sk
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid dilithium_sk size: expected 4896 bytes"))?;
-    let kyber_sk: [u8; 3168] = ks.kyber_sk.as_slice().try_into()
+    let kyber_sk: [u8; 3168] = ks
+        .kyber_sk
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid kyber_sk size: expected 3168 bytes"))?;
-    let master_seed: [u8; 64] = ks.master_seed.as_slice().try_into()
+    let master_seed: [u8; 64] = ks
+        .master_seed
+        .as_slice()
+        .try_into()
         .map_err(|_| anyhow::anyhow!("Invalid master_seed size: expected 64 bytes"))?;
-    
+
     let public_key = lib_crypto::PublicKey::new(dilithium_pk);
     let private_key = lib_crypto::PrivateKey {
         dilithium_sk,
@@ -2201,9 +2241,10 @@ fn build_signed_sov_mint_tx(
         token_mint_data,
         lib_blockchain::integration::crypto_integration::Signature {
             signature: Vec::new(),
-            public_key: lib_blockchain::integration::crypto_integration::PublicKey::new([0u8; 2592]),
-            algorithm:
-                lib_blockchain::integration::crypto_integration::SignatureAlgorithm::DEFAULT,
+            public_key: lib_blockchain::integration::crypto_integration::PublicKey::new(
+                [0u8; 2592],
+            ),
+            algorithm: lib_blockchain::integration::crypto_integration::SignatureAlgorithm::DEFAULT,
             timestamp: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs())
@@ -2371,7 +2412,10 @@ mod tests {
         let kp = crystals_dilithium::dilithium5::Keypair::generate(Some(&seed));
         let new_pk_bytes = kp.public.to_bytes().to_vec();
         let expected_new_did = {
-            let pk_arr: [u8; 2592] = new_pk_bytes.clone().try_into().expect("dilithium5 pk must be 2592 bytes");
+            let pk_arr: [u8; 2592] = new_pk_bytes
+                .clone()
+                .try_into()
+                .expect("dilithium5 pk must be 2592 bytes");
             let pk = lib_crypto::PublicKey::new(pk_arr);
             format!("did:zhtp:{}", hex::encode(pk.key_id))
         };
@@ -2599,30 +2643,32 @@ mod tests {
         networking_key_arr.iter_mut().for_each(|b| *b ^= 0xFF); // distinct from consensus_key
         let networking_key = networking_key_arr.to_vec();
         let mut rewards_key_arr = validator_kp.public_key.dilithium_pk;
-        rewards_key_arr.iter_mut().for_each(|b| *b = b.wrapping_add(1)); // distinct from others
+        rewards_key_arr
+            .iter_mut()
+            .for_each(|b| *b = b.wrapping_add(1)); // distinct from others
         let rewards_key = rewards_key_arr.to_vec();
         // Test scaffold: direct insert for test setup (not production code)
         bc.insert_validator_shadow(lib_blockchain::ValidatorInfo {
-                identity_id: validator_did,
-                stake: 1_000,
-                storage_provided: 0,
-                consensus_key,
-                networking_key,
-                rewards_key,
-                network_address: "127.0.0.1:0".to_string(),
-                commission_rate: 0,
-                status: "active".to_string(),
-                registered_at: 0,
-                last_activity: 0,
-                blocks_validated: 0,
-                slash_count: 0,
-                // Test helper: use genesis (off-chain) source since this is inserted
-                // directly into the registry at height 0 for testing purposes.
-                admission_source: lib_blockchain::blockchain::ADMISSION_SOURCE_OFFCHAIN_GENESIS
-                    .to_string(),
-                governance_proposal_id: None,
-                oracle_key_id: None,
-            });
+            identity_id: validator_did,
+            stake: 1_000,
+            storage_provided: 0,
+            consensus_key,
+            networking_key,
+            rewards_key,
+            network_address: "127.0.0.1:0".to_string(),
+            commission_rate: 0,
+            status: "active".to_string(),
+            registered_at: 0,
+            last_activity: 0,
+            blocks_validated: 0,
+            slash_count: 0,
+            // Test helper: use genesis (off-chain) source since this is inserted
+            // directly into the registry at height 0 for testing purposes.
+            admission_source: lib_blockchain::blockchain::ADMISSION_SOURCE_OFFCHAIN_GENESIS
+                .to_string(),
+            governance_proposal_id: None,
+            oracle_key_id: None,
+        });
 
         for (wid, wtype, name, alias, pk, created_at, balance) in &wallet_summaries {
             let wallet_id_hex = hex::encode(wid.0);
@@ -2640,6 +2686,7 @@ mod tests {
                     wallet_name: name.clone(),
                     alias: alias.clone(),
                     public_key: pk.clone(),
+                    kyber_public_key: vec![],
                     owner_identity_id: Some(lib_blockchain::Hash::from_slice(&old_identity_id.0)),
                     seed_commitment,
                     created_at: *created_at,
@@ -2683,7 +2730,11 @@ mod tests {
 
         // Verify wallet ownership moved to the new identity, and old identity is empty.
         let new_identity_id_1 = {
-            let pk_arr: [u8; 2592] = new_identity_1.public_key.clone().try_into().expect("pk must be 2592 bytes");
+            let pk_arr: [u8; 2592] = new_identity_1
+                .public_key
+                .clone()
+                .try_into()
+                .expect("pk must be 2592 bytes");
             let pk = lib_crypto::PublicKey::new(pk_arr);
             lib_crypto::Hash::from_bytes(&pk.key_id)
         };

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -23,8 +23,8 @@ use lib_access_control::{Role, SecurityPrincipal};
 use lib_types::NodeType;
 
 // Identity management imports
-use lib_identity::{CitizenshipResult, IdentityManager, IdentityType, RecoveryPhraseManager};
 use lib_identity::types::IdentityView;
+use lib_identity::{CitizenshipResult, IdentityManager, IdentityType, RecoveryPhraseManager};
 
 // Identity and economic model imports
 use lib_identity::economics::EconomicModel as IdentityEconomicModel;
@@ -99,10 +99,7 @@ fn register_wallet_or_abort(
                 blockchain.abort_pending_client_registration(queued_txs, did, wallet_id_hexes);
                 Err((
                     ZhtpStatus::InternalServerError,
-                    format!(
-                        "Failed to track {} wallet for registration rollback",
-                        label
-                    ),
+                    format!("Failed to track {} wallet for registration rollback", label),
                 ))
             }
         },
@@ -420,10 +417,14 @@ impl IdentityHandler {
                     format!("welcome_bonus_note_{}", identity_id_hex).as_bytes(),
                 ),
                 recipient: PublicKey::new(
-                    citizenship_result.identity_id.as_bytes().try_into().unwrap_or([0u8; 2592])
+                    citizenship_result
+                        .identity_id
+                        .as_bytes()
+                        .try_into()
+                        .unwrap_or([0u8; 2592]),
                 ),
-                            merkle_leaf: Hash::default(),
-};
+                merkle_leaf: Hash::default(),
+            };
 
             let outputs = vec![welcome_bonus_output];
 
@@ -483,6 +484,7 @@ impl IdentityHandler {
                 wallet_name: "Primary Wallet".to_string(),
                 alias: None,
                 public_key: keypair.public_key.dilithium_pk.to_vec(),
+                kyber_public_key: vec![],
                 owner_identity_id: Some(lib_blockchain::Hash::from(
                     citizenship_result.identity_id.0,
                 )),
@@ -507,6 +509,7 @@ impl IdentityHandler {
                 wallet_name: "UBI Wallet".to_string(),
                 alias: None,
                 public_key: keypair.public_key.dilithium_pk.to_vec(),
+                kyber_public_key: vec![],
                 owner_identity_id: Some(lib_blockchain::Hash::from(
                     citizenship_result.identity_id.0,
                 )),
@@ -531,6 +534,7 @@ impl IdentityHandler {
                 wallet_name: "Savings Wallet".to_string(),
                 alias: None,
                 public_key: keypair.public_key.dilithium_pk.to_vec(),
+                kyber_public_key: vec![],
                 owner_identity_id: Some(lib_blockchain::Hash::from(
                     citizenship_result.identity_id.0,
                 )),
@@ -779,10 +783,13 @@ impl IdentityHandler {
                 format!("wallet_init_note_{}", wallet_id_hex).as_bytes(),
             ),
             recipient: PublicKey::new(
-                recipient_identity.as_slice().try_into().unwrap_or([0u8; 2592])
+                recipient_identity
+                    .as_slice()
+                    .try_into()
+                    .unwrap_or([0u8; 2592]),
             ),
-                    merkle_leaf: Hash::default(),
-};
+            merkle_leaf: Hash::default(),
+        };
 
         let outputs = vec![wallet_dust_output];
 
@@ -1626,7 +1633,10 @@ impl IdentityHandler {
         if kyber_pk.len() != 1568 {
             return Ok(ZhtpResponse::error(
                 ZhtpStatus::BadRequest,
-                format!("kyber_public_key must be 1568 bytes (got {})", kyber_pk.len()),
+                format!(
+                    "kyber_public_key must be 1568 bytes (got {})",
+                    kyber_pk.len()
+                ),
             ));
         }
 
@@ -1712,11 +1722,18 @@ impl IdentityHandler {
             // Submit IdentityUpdate system transaction for block persistence
             let mut identity_data = blockchain
                 .identity_transaction_data(&req.did)
-                .unwrap_or_else(|| lib_blockchain::transaction::IdentityTransactionData::new(
-                    req.did.clone(), String::new(), identity_pk.clone(),
-                    vec![], "human".to_string(),
-                    lib_blockchain::types::Hash::default(), 0, 0,
-                ));
+                .unwrap_or_else(|| {
+                    lib_blockchain::transaction::IdentityTransactionData::new(
+                        req.did.clone(),
+                        String::new(),
+                        identity_pk.clone(),
+                        vec![],
+                        "human".to_string(),
+                        lib_blockchain::types::Hash::default(),
+                        0,
+                        0,
+                    )
+                });
             identity_data.kyber_public_key = kyber_pk;
 
             let update_tx = lib_blockchain::Transaction::new_identity_update(
@@ -1736,7 +1753,9 @@ impl IdentityHandler {
                 },
                 format!("kyber-key-update:{}", &req.did[..20.min(req.did.len())]).into_bytes(),
             );
-            if let Err(e) = blockchain.add_system_transaction(update_tx, lib_blockchain::SystemOriginator::KyberKeyUpdate) {
+            if let Err(e) = blockchain
+                .add_system_transaction(update_tx, lib_blockchain::SystemOriginator::KyberKeyUpdate)
+            {
                 tracing::warn!("Failed to submit Kyber key update tx: {}", e);
             }
         }
@@ -1879,7 +1898,9 @@ impl IdentityHandler {
 
         {
             let mut blockchain = blockchain_arc.write().await;
-            if let Err(e) = blockchain.add_system_transaction(tx, lib_blockchain::SystemOriginator::CredentialClaim) {
+            if let Err(e) = blockchain
+                .add_system_transaction(tx, lib_blockchain::SystemOriginator::CredentialClaim)
+            {
                 return Ok(ZhtpResponse::error(
                     ZhtpStatus::InternalServerError,
                     format!("Failed to submit claim tx: {}", e),
@@ -2046,7 +2067,9 @@ impl IdentityHandler {
         }
 
         // Create PublicKey struct from raw bytes - this computes key_id = Blake3(dilithium_pk)
-        let public_key_bytes_array: [u8; 2592] = public_key_bytes.as_slice().try_into()
+        let public_key_bytes_array: [u8; 2592] = public_key_bytes
+            .as_slice()
+            .try_into()
             .map_err(|_| anyhow::anyhow!("Invalid public key length: expected 2592 bytes"))?;
         let public_key = lib_crypto::PublicKey::new(public_key_bytes_array);
 
@@ -2150,9 +2173,7 @@ impl IdentityHandler {
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| format!("user_{}", &hex::encode(&public_key.key_id)[..8]));
 
-        if let Err(e) =
-            lib_blockchain::transaction::credentials::validate_username(&display_name)
-        {
+        if let Err(e) = lib_blockchain::transaction::credentials::validate_username(&display_name) {
             return Ok(ZhtpResponse::error(ZhtpStatus::BadRequest, e));
         }
 
@@ -2197,10 +2218,7 @@ impl IdentityHandler {
         }
 
         let wait_for_inclusion = req_data.wait_for_inclusion;
-        let wait_timeout = req_data
-            .wait_timeout_secs
-            .unwrap_or(30)
-            .clamp(1, 120);
+        let wait_timeout = req_data.wait_timeout_secs.unwrap_or(30).clamp(1, 120);
 
         // Create identity record (without private key - client keeps it)
         let created_at = std::time::SystemTime::now()
@@ -2373,6 +2391,13 @@ impl IdentityHandler {
             let seed_commitment =
                 lib_blockchain::types::hash::blake3_hash(b"client_wallet_seed");
             let owner_identity_id = Some(lib_blockchain::Hash::from_slice(&identity_id.0));
+
+            // Client-aligned wallets (#2979): wallet public_key = the client's real
+            // Dilithium key, kyber_public_key = the client's Kyber key. The binding
+            // check validates wallet_id == blake3(pk) or blake3(pk || kyber_pk).
+            let client_dilithium_pk = public_key_bytes.clone();
+            let client_kyber_pk = kyber_public_key.clone().unwrap_or_default();
+
             let wallet_specs = [
                 (
                     "primary",
@@ -2381,7 +2406,8 @@ impl IdentityHandler {
                         wallet_type: "Primary".to_string(),
                         wallet_name: "Primary Wallet".to_string(),
                         alias: Some("primary".to_string()),
-                        public_key: public_key_bytes.clone(),
+                        public_key: client_dilithium_pk.clone(),
+                        kyber_public_key: client_kyber_pk.clone(),
                         owner_identity_id,
                         seed_commitment,
                         created_at,
@@ -2397,7 +2423,8 @@ impl IdentityHandler {
                         wallet_type: "UBI".to_string(),
                         wallet_name: "UBI Wallet".to_string(),
                         alias: Some("ubi".to_string()),
-                        public_key: public_key_bytes.clone(),
+                        public_key: client_dilithium_pk.clone(),
+                        kyber_public_key: client_kyber_pk.clone(),
                         owner_identity_id,
                         seed_commitment,
                         created_at,
@@ -2413,7 +2440,8 @@ impl IdentityHandler {
                         wallet_type: "Savings".to_string(),
                         wallet_name: "Savings Wallet".to_string(),
                         alias: Some("savings".to_string()),
-                        public_key: public_key_bytes.clone(),
+                        public_key: client_dilithium_pk.clone(),
+                        kyber_public_key: client_kyber_pk.clone(),
                         owner_identity_id,
                         seed_commitment,
                         created_at,
@@ -2506,8 +2534,7 @@ impl IdentityHandler {
         let mut status = "queued";
         let mut committed_height: Option<u64> = None;
         if wait_for_inclusion {
-            let deadline = std::time::Instant::now()
-                + std::time::Duration::from_secs(wait_timeout);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_timeout);
             loop {
                 if let Ok(blockchain_arc) =
                     crate::runtime::blockchain_provider::get_global_blockchain().await

--- a/zhtp/src/api/handlers/wallet/mod.rs
+++ b/zhtp/src/api/handlers/wallet/mod.rs
@@ -22,7 +22,6 @@ use lib_economy::wallets::{
 };
 use lib_identity::{identity::ZhtpIdentity as Identity, IdentityManager};
 
-
 // Access control imports
 use crate::api::principal::{
     extract_principal_from_request, identity_id_matches_caller, may_read_wallet_subject,
@@ -89,7 +88,8 @@ impl ZhtpRequestHandler for WalletHandler {
         if crate::session_manager::is_request_password_session(&request).await {
             return Ok(create_error_response(
                 ZhtpStatus::Forbidden,
-                "Wallet access requires key authentication (mobile app or seed phrase recovery)".to_string(),
+                "Wallet access requires key authentication (mobile app or seed phrase recovery)"
+                    .to_string(),
             ));
         }
 
@@ -399,7 +399,9 @@ impl WalletHandler {
                     .map(|bytes| {
                         let mut key_id = [0u8; 32];
                         key_id.copy_from_slice(&bytes);
-                        blockchain.token_balance(&sov_token_id, &key_id).unwrap_or(0)
+                        blockchain
+                            .token_balance(&sov_token_id, &key_id)
+                            .unwrap_or(0)
                     })
                     .unwrap_or(0);
                 let wallet_info = WalletInfo {
@@ -471,7 +473,9 @@ impl WalletHandler {
                     .map(|bytes| {
                         let mut key_id = [0u8; 32];
                         key_id.copy_from_slice(bytes);
-                        blockchain.token_balance(&sov_token_id, &key_id).unwrap_or(0)
+                        blockchain
+                            .token_balance(&sov_token_id, &key_id)
+                            .unwrap_or(0)
                     })
                     .unwrap_or(0)
             };
@@ -616,22 +620,27 @@ impl WalletHandler {
                     // fixes the synthetic-PublicKey balance_of bug that returned 0.
                     let native_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
                     if blockchain.get_token_contract(&native_token_id).is_some() {
-                        let addr: [u8; 32] = match hex::decode(&wallet_id_hex)
-                            .ok()
-                            .filter(|b| b.len() == 32)
-                        {
-                            Some(bytes) => {
-                                let mut key_id = [0u8; 32];
-                                key_id.copy_from_slice(&bytes);
-                                key_id
-                            }
-                            None => lib_blockchain::integration::crypto_integration::PublicKey::new(
-                                wallet_data.public_key.as_slice().try_into().unwrap_or([0u8; 2592]),
-                            )
-                            .key_id,
-                        };
-                        let token_balance =
-                            blockchain.token_balance(&native_token_id, &addr).unwrap_or(0);
+                        let addr: [u8; 32] =
+                            match hex::decode(&wallet_id_hex).ok().filter(|b| b.len() == 32) {
+                                Some(bytes) => {
+                                    let mut key_id = [0u8; 32];
+                                    key_id.copy_from_slice(&bytes);
+                                    key_id
+                                }
+                                None => {
+                                    lib_blockchain::integration::crypto_integration::PublicKey::new(
+                                        wallet_data
+                                            .public_key
+                                            .as_slice()
+                                            .try_into()
+                                            .unwrap_or([0u8; 2592]),
+                                    )
+                                    .key_id
+                                }
+                            };
+                        let token_balance = blockchain
+                            .token_balance(&native_token_id, &addr)
+                            .unwrap_or(0);
                         if token_balance != available_balance {
                             tracing::debug!(
                                 "Using SOV token balance for wallet {}: {} (was {})",
@@ -808,7 +817,8 @@ impl WalletHandler {
             }
         };
 
-        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&req_data.identity_id) {
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&req_data.identity_id)
+        {
             Ok(b) => b,
             Err(resp) => return Ok(resp),
         };
@@ -897,7 +907,8 @@ impl WalletHandler {
             ));
         }
 
-        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&req_data.identity_id) {
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&req_data.identity_id)
+        {
             Ok(b) => b,
             Err(resp) => return Ok(resp),
         };
@@ -994,7 +1005,8 @@ impl WalletHandler {
             ));
         }
 
-        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&req_data.identity_id) {
+        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&req_data.identity_id)
+        {
             Ok(b) => b,
             Err(resp) => return Ok(resp),
         };
@@ -1114,16 +1126,16 @@ impl WalletHandler {
         // Snapshot is keyed by DID (`did:zhtp:<64-hex>`). O(1) lookup first;
         // fall back to value scan only if a non-canonical key was stored.
         let did_key = format!("did:zhtp:{}", hex::encode(identity_id));
-        let identity_data = identity_registry
-            .get(&did_key)
-            .cloned()
-            .or_else(|| {
-                identity_registry.values().find(|data| {
+        let identity_data = identity_registry.get(&did_key).cloned().or_else(|| {
+            identity_registry
+                .values()
+                .find(|data| {
                     lib_identity::did::parse_did_to_identity_id(&data.did)
                         .map(|id| id.as_bytes() == identity_id.as_slice())
                         .unwrap_or(false)
-                }).cloned()
-            })?;
+                })
+                .cloned()
+        })?;
 
         let identity_type = match identity_data.identity_type.to_ascii_lowercase().as_str() {
             "human" => lib_identity::IdentityType::Human,
@@ -1273,8 +1285,9 @@ impl WalletHandler {
         }
         Some(
             lib_blockchain::integration::crypto_integration::PublicKey::new(
-                public_key.try_into().unwrap_or([0u8; 2592])
-            ).key_id,
+                public_key.try_into().unwrap_or([0u8; 2592]),
+            )
+            .key_id,
         )
     }
 
@@ -1613,10 +1626,11 @@ impl WalletHandler {
             ));
         }
 
-        let identity_id_bytes = match Self::parse_identity_id_or_bad_request(&send_req.from_identity) {
-            Ok(b) => b,
-            Err(resp) => return Ok(resp),
-        };
+        let identity_id_bytes =
+            match Self::parse_identity_id_or_bad_request(&send_req.from_identity) {
+                Ok(b) => b,
+                Err(resp) => return Ok(resp),
+            };
 
         // Parse recipient address (validate format)
         let _to_address_bytes = hex::decode(&send_req.to_address)
@@ -1764,8 +1778,8 @@ impl WalletHandler {
             .map_err(|e| anyhow::anyhow!("invalid provision request: {}", e))?;
 
         // Parse wallet_id
-        let wallet_id_bytes = hex::decode(&req.wallet_id)
-            .map_err(|_| anyhow::anyhow!("invalid wallet_id hex"))?;
+        let wallet_id_bytes =
+            hex::decode(&req.wallet_id).map_err(|_| anyhow::anyhow!("invalid wallet_id hex"))?;
         if wallet_id_bytes.len() != 32 {
             return Ok(create_error_response(
                 ZhtpStatus::BadRequest,
@@ -1776,11 +1790,12 @@ impl WalletHandler {
         wallet_id_arr.copy_from_slice(&wallet_id_bytes);
 
         // Parse owner identity ID
-        let owner_hex = req.owner_identity_id
+        let owner_hex = req
+            .owner_identity_id
             .strip_prefix("did:zhtp:")
             .unwrap_or(&req.owner_identity_id);
-        let owner_bytes = hex::decode(owner_hex)
-            .map_err(|_| anyhow::anyhow!("invalid owner_identity_id hex"))?;
+        let owner_bytes =
+            hex::decode(owner_hex).map_err(|_| anyhow::anyhow!("invalid owner_identity_id hex"))?;
         if owner_bytes.len() != 32 {
             return Ok(create_error_response(
                 ZhtpStatus::BadRequest,
@@ -1837,11 +1852,16 @@ impl WalletHandler {
             wallet_name: format!("{} Wallet (provisioned)", req.wallet_type),
             alias: Some(req.wallet_type.to_lowercase()),
             public_key: public_key_for_wallet,
+            kyber_public_key: vec![],
             owner_identity_id: Some(lib_blockchain::Hash::from_slice(&owner_arr)),
             seed_commitment: lib_blockchain::types::hash::blake3_hash(b"provisioned_wallet"),
             created_at: now,
             registration_fee: 0,
-            capabilities: if req.wallet_type == "Primary" { 0xFF } else { 0x01 },
+            capabilities: if req.wallet_type == "Primary" {
+                0xFF
+            } else {
+                0x01
+            },
             initial_balance: 0,
         };
 
@@ -1887,7 +1907,10 @@ impl WalletHandler {
                     },
                     format!("Provisioned identity {}", &did[..40.min(did.len())]).into_bytes(),
                 );
-                if let Err(e) = blockchain.add_system_transaction(identity_tx, lib_blockchain::SystemOriginator::IdentityProvisioning) {
+                if let Err(e) = blockchain.add_system_transaction(
+                    identity_tx,
+                    lib_blockchain::SystemOriginator::IdentityProvisioning,
+                ) {
                     tracing::warn!("Failed to submit identity tx: {}", e);
                 }
                 // Cache warmup: identity must be visible immediately for QUIC handshake
@@ -1898,7 +1921,9 @@ impl WalletHandler {
                 // lands), but this is acceptable for the handshake check.
                 blockchain.insert_identity_shadow(did.clone(), identity_data);
                 let current_height = blockchain.get_height();
-                blockchain.identity_blocks.insert(did.clone(), current_height);
+                blockchain
+                    .identity_blocks
+                    .insert(did.clone(), current_height);
                 tracing::info!(
                     "📝 Identity registered: {} (system tx + in-memory)",
                     &did[..40.min(did.len())],
@@ -1908,11 +1933,8 @@ impl WalletHandler {
             match blockchain.register_wallet(wallet_data) {
                 Ok(tx_hash) => {
                     if req.welcome_bonus && welcome_bonus_amount > 0 {
-                        let memo = format!(
-                            "WELCOME_BONUS_V1:{}",
-                            hex::encode(wallet_id_arr)
-                        )
-                        .into_bytes();
+                        let memo =
+                            format!("WELCOME_BONUS_V1:{}", hex::encode(wallet_id_arr)).into_bytes();
                         if let Ok(mint_tx) = crate::runtime::token_utils::build_sov_mint_tx(
                             &wallet_id_arr,
                             welcome_bonus_amount,
@@ -1924,10 +1946,7 @@ impl WalletHandler {
                                 mint_tx,
                                 lib_blockchain::SystemOriginator::TreasuryWalletBootstrap,
                             ) {
-                                tracing::warn!(
-                                    "Failed to queue welcome bonus TokenMint: {}",
-                                    e
-                                );
+                                tracing::warn!("Failed to queue welcome bonus TokenMint: {}", e);
                             }
                         } else {
                             tracing::warn!("Failed to build welcome bonus TokenMint");
@@ -1949,12 +1968,10 @@ impl WalletHandler {
                         "tx_hash": hex::encode(tx_hash.as_bytes()),
                     }))
                 }
-                Err(e) => {
-                    Ok(create_error_response(
-                        ZhtpStatus::BadRequest,
-                        format!("Wallet provision failed: {}", e),
-                    ))
-                }
+                Err(e) => Ok(create_error_response(
+                    ZhtpStatus::BadRequest,
+                    format!("Wallet provision failed: {}", e),
+                )),
             }
         }
     }

--- a/zhtp/src/api/handlers/web4/domains.rs
+++ b/zhtp/src/api/handlers/web4/domains.rs
@@ -5,18 +5,17 @@ use crate::web4_manifest::{
 };
 use anyhow::anyhow;
 use base64::{engine::general_purpose, Engine as _};
+use lib_access_control::{Role, SecurityPrincipal};
 use lib_blockchain::BlockchainQuery;
 use lib_identity::{types::IdentityView, wallets::wallet_types::WalletType, ZhtpIdentity};
-use lib_access_control::{SecurityPrincipal, Role};
-use lib_types::NodeType;
 use lib_network::web4::{
-    domain_signing::validate_domain_owner_signature_hex,
-    DomainEconomicSettings, DomainLookupResponse, DomainMetadata, DomainRegistrationRequest,
-    PublicOwnerInfo,
+    domain_signing::validate_domain_owner_signature_hex, DomainEconomicSettings,
+    DomainLookupResponse, DomainMetadata, DomainRegistrationRequest, PublicOwnerInfo,
 };
 use lib_proofs::ZeroKnowledgeProof;
 use lib_protocols::zhtp::ZhtpResult;
 use lib_protocols::{ZhtpRequest, ZhtpResponse, ZhtpStatus};
+use lib_types::NodeType;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
@@ -47,10 +46,7 @@ fn attach_client_domain_tx_signature(
     };
 
     if let Some(err) = validate_domain_owner_signature_hex(domain_tx_signature_hex) {
-        return Err(anyhow!(
-            "domain_tx_signature_hex invalid: {}",
-            err
-        ));
+        return Err(anyhow!("domain_tx_signature_hex invalid: {}", err));
     }
 
     let owner_pk: [u8; 2592] = owner_dilithium_pk
@@ -235,7 +231,9 @@ impl Web4Handler {
         if let Ok(manifest_request) =
             serde_json::from_slice::<ManifestDomainRegistrationRequest>(&request_body)
         {
-            return self.register_domain_from_manifest(manifest_request, principal).await;
+            return self
+                .register_domain_from_manifest(manifest_request, principal)
+                .await;
         }
 
         // Fall back to simple request with inline content
@@ -305,11 +303,10 @@ impl Web4Handler {
                 })?;
                 drop(bc);
 
-                let pubkey = lib_crypto::PublicKey::new(
-                    pk.as_slice().try_into().map_err(|_| {
+                let pubkey =
+                    lib_crypto::PublicKey::new(pk.as_slice().try_into().map_err(|_| {
                         anyhow!("Chain identity public_key is not Dilithium5 size (2592)")
-                    })?,
-                );
+                    })?);
                 // `IdentityTransactionData` doesn't carry device_id/node_id —
                 // those are local-only fields populated when we see a peer
                 // over QUIC. For a chain-loaded owner identity we hand in
@@ -370,8 +367,7 @@ impl Web4Handler {
         // amount as `u64` whole tokens, not atoms). Truncating division —
         // governance rates are expected to be whole-SOV multiples and the
         // signature gate just enforces that the client knew the price.
-        let registration_fee_whole: u64 =
-            (registration_fee_sov / lib_types::TOKEN_SCALE_18) as u64;
+        let registration_fee_whole: u64 = (registration_fee_sov / lib_types::TOKEN_SCALE_18) as u64;
 
         // Fee is fixed; if the client provides it explicitly, it must match.
         let user_provided_fee = simple_request.fee.unwrap_or(registration_fee_whole);
@@ -493,7 +489,9 @@ impl Web4Handler {
         // unrelated branches.
         let is_register = {
             let blockchain = self.blockchain.read().await;
-            !blockchain.domain_registry.contains_key(&simple_request.domain)
+            !blockchain
+                .domain_registry
+                .contains_key(&simple_request.domain)
         };
 
         let sov_token_id = lib_blockchain::contracts::utils::generate_lib_token_id();
@@ -532,9 +530,7 @@ impl Web4Handler {
                         "SOV token contract not initialized. Network may still be bootstrapping."
                     ));
                 }
-                let user_sov_balance = blockchain
-                    .token_balance(&sov_token_id, &bytes)
-                    .unwrap_or(0);
+                let user_sov_balance = blockchain.token_balance(&sov_token_id, &bytes).unwrap_or(0);
 
                 info!(
                     " User SOV balance: {} atoms (fee: {} atoms)",
@@ -556,7 +552,8 @@ impl Web4Handler {
                      signed TokenTransfer of {} atoms ({} SOV) from your Primary wallet to \
                      the DAO treasury. Use lib-client \
                      `build_domain_register_request_with_fee_payment` to construct it.",
-                    registration_fee_sov, registration_fee_whole
+                    registration_fee_sov,
+                    registration_fee_whole
                 )
             })?;
             let trimmed = fee_tx_hex.trim();
@@ -596,9 +593,9 @@ impl Web4Handler {
             // Validate the payload contents match what the registration
             // requires: SOV token, ≥ registration fee, from owner's
             // Primary wallet, to the deterministic DAO treasury wallet.
-            let transfer = fee_tx.token_transfer_data().ok_or_else(|| {
-                anyhow!("fee_payment_tx missing TokenTransfer payload")
-            })?;
+            let transfer = fee_tx
+                .token_transfer_data()
+                .ok_or_else(|| anyhow!("fee_payment_tx missing TokenTransfer payload"))?;
             if transfer.token_id != sov_token_id {
                 return Err(anyhow!(
                     "fee_payment_tx must use the SOV token (token_id={}), got {}",
@@ -621,8 +618,7 @@ impl Web4Handler {
                     hex::encode(transfer.from)
                 ));
             }
-            let expected_treasury =
-                lib_blockchain::Blockchain::deterministic_treasury_wallet_id();
+            let expected_treasury = lib_blockchain::Blockchain::deterministic_treasury_wallet_id();
             if transfer.to != expected_treasury.as_array() {
                 return Err(anyhow!(
                     "fee_payment_tx recipient must be the DAO treasury wallet (expected {}, got {})",
@@ -833,7 +829,9 @@ impl Web4Handler {
             // Check if domain already exists to choose registration vs update
             let is_update = {
                 let blockchain = self.blockchain.read().await;
-                blockchain.domain_registry.contains_key(&simple_request.domain)
+                blockchain
+                    .domain_registry
+                    .contains_key(&simple_request.domain)
             };
 
             let (tx_type, memo) = if is_update {
@@ -846,8 +844,12 @@ impl Web4Handler {
                     message: Some(format!("{}: {}", title, description)),
                     fee_tx_hash: fee_tx_hash_hex.clone(),
                 };
-                (lib_blockchain::TransactionType::DomainUpdate, payload.encode_memo()
-                    .map_err(|e| anyhow::anyhow!("Failed to encode domain update: {}", e))?)
+                (
+                    lib_blockchain::TransactionType::DomainUpdate,
+                    payload
+                        .encode_memo()
+                        .map_err(|e| anyhow::anyhow!("Failed to encode domain update: {}", e))?,
+                )
             } else {
                 // Optional DAO asset binding (M4 / Q10): shared parser so
                 // client/server domain_tx_signature skeletons stay byte-identical.
@@ -873,8 +875,12 @@ impl Web4Handler {
                     fee_payer_wallet_id: [0u8; 32],
                     asset_id: bound_asset_id,
                 };
-                (lib_blockchain::TransactionType::DomainRegistration, payload.encode_memo()
-                    .map_err(|e| anyhow::anyhow!("Failed to encode domain registration: {}", e))?)
+                (
+                    lib_blockchain::TransactionType::DomainRegistration,
+                    payload.encode_memo().map_err(|e| {
+                        anyhow::anyhow!("Failed to encode domain registration: {}", e)
+                    })?,
+                )
             };
 
             if simple_request.domain_tx_signature_hex.is_empty() {
@@ -893,15 +899,13 @@ impl Web4Handler {
             )?;
             let domain_tx_hash_hex = hex::encode(domain_tx.hash().as_bytes());
             let mut blockchain = self.blockchain.write().await;
-            blockchain
-                .add_pending_transaction(domain_tx)
-                .map_err(|e| {
-                    anyhow!(
-                        "domain {} tx rejected by mempool: {}",
-                        if is_update { "update" } else { "registration" },
-                        e
-                    )
-                })?;
+            blockchain.add_pending_transaction(domain_tx).map_err(|e| {
+                anyhow!(
+                    "domain {} tx rejected by mempool: {}",
+                    if is_update { "update" } else { "registration" },
+                    e
+                )
+            })?;
             info!(
                 " Domain {} tx submitted: {}",
                 if is_update { "update" } else { "registration" },
@@ -1169,15 +1173,18 @@ impl Web4Handler {
                     message: Some(format!("DeployManifest {}", request.deploy_manifest_cid)),
                     fee_tx_hash: fee_tx_hash_hex.clone(),
                 };
-                (lib_blockchain::TransactionType::DomainUpdate, payload.encode_memo()
-                    .map_err(|e| anyhow::anyhow!("Failed to encode domain update: {}", e))?)
+                (
+                    lib_blockchain::TransactionType::DomainUpdate,
+                    payload
+                        .encode_memo()
+                        .map_err(|e| anyhow::anyhow!("Failed to encode domain update: {}", e))?,
+                )
             } else {
                 // Resolve the signer's Primary wallet so the V2 payload can
                 // carry `fee_payer_wallet_id`. Validator + executor both
                 // require this for the canonical fee debit; without it
                 // mempool admit rejects the tx.
-                let owner_identity_hash =
-                    lib_blockchain::Hash::from_slice(&owner_identity.id.0);
+                let owner_identity_hash = lib_blockchain::Hash::from_slice(&owner_identity.id.0);
                 let owner_wallet_id_bytes: [u8; 32] = {
                     let bc = self.blockchain.read().await;
                     let wallet_id = bc
@@ -1210,8 +1217,12 @@ impl Web4Handler {
                     fee_payer_wallet_id: owner_wallet_id_bytes,
                     asset_id: None,
                 };
-                (lib_blockchain::TransactionType::DomainRegistration, payload.encode_memo()
-                    .map_err(|e| anyhow::anyhow!("Failed to encode domain registration: {}", e))?)
+                (
+                    lib_blockchain::TransactionType::DomainRegistration,
+                    payload.encode_memo().map_err(|e| {
+                        anyhow::anyhow!("Failed to encode domain registration: {}", e)
+                    })?,
+                )
             };
 
             if request.domain_tx_signature_hex.is_empty() {
@@ -1230,15 +1241,13 @@ impl Web4Handler {
             )?;
             let domain_tx_hash_hex = hex::encode(domain_tx.hash().as_bytes());
             let mut blockchain = self.blockchain.write().await;
-            blockchain
-                .add_pending_transaction(domain_tx)
-                .map_err(|e| {
-                    anyhow!(
-                        "domain {} tx rejected by mempool: {}",
-                        if is_update { "update" } else { "registration" },
-                        e
-                    )
-                })?;
+            blockchain.add_pending_transaction(domain_tx).map_err(|e| {
+                anyhow!(
+                    "domain {} tx rejected by mempool: {}",
+                    if is_update { "update" } else { "registration" },
+                    e
+                )
+            })?;
             domain_tx_hash_hex
         };
 
@@ -1262,7 +1271,6 @@ impl Web4Handler {
             None,
         ))
     }
-
 
     /// Register a new Web4 domain
     pub async fn register_domain(&self, request_body: Vec<u8>) -> ZhtpResult<ZhtpResponse> {
@@ -1309,8 +1317,8 @@ impl Web4Handler {
             public: api_request.public,
             economic_settings: DomainEconomicSettings {
                 // Display fee matches client/server default (TxFeeConfig / 10^18).
-                registration_fee:
-                    lib_blockchain::transaction::DEFAULT_DOMAIN_REGISTRATION_FEE_WHOLE as f64,
+                registration_fee: lib_blockchain::transaction::DEFAULT_DOMAIN_REGISTRATION_FEE_WHOLE
+                    as f64,
                 renewal_fee: 5.0,
                 transfer_fee: 2.0,
                 hosting_budget: 100.0,
@@ -1436,11 +1444,9 @@ impl Web4Handler {
             })
         });
         let owner = match owner_raw {
-            Some(value) if !value.is_empty() => {
-                urlencoding::decode(value)
-                    .map(|s| s.into_owned())
-                    .unwrap_or_else(|_| value.to_string())
-            }
+            Some(value) if !value.is_empty() => urlencoding::decode(value)
+                .map(|s| s.into_owned())
+                .unwrap_or_else(|_| value.to_string()),
             _ => {
                 return Ok(ZhtpResponse::error(
                     ZhtpStatus::BadRequest,
@@ -2349,7 +2355,11 @@ mod tests {
 
     // ── catalog merge unit tests ──────────────────────────────────────────────
 
-    fn make_on_chain(domain: &str, owner: &str, version: u64) -> lib_blockchain::transaction::OnChainDomainRecord {
+    fn make_on_chain(
+        domain: &str,
+        owner: &str,
+        version: u64,
+    ) -> lib_blockchain::transaction::OnChainDomainRecord {
         lib_blockchain::transaction::OnChainDomainRecord {
             domain: domain.to_string(),
             owner_did: owner.to_string(),
@@ -2368,7 +2378,11 @@ mod tests {
         }
     }
 
-    fn make_sled(domain: &str, owner_bytes: [u8; 32], version: u64) -> lib_network::web4::DomainRecord {
+    fn make_sled(
+        domain: &str,
+        owner_bytes: [u8; 32],
+        version: u64,
+    ) -> lib_network::web4::DomainRecord {
         lib_network::web4::DomainRecord {
             domain: domain.to_string(),
             owner: lib_crypto::Hash(owner_bytes),
@@ -2388,7 +2402,10 @@ mod tests {
     #[test]
     fn catalog_merge_on_chain_wins_over_sled() {
         let mut on_chain = std::collections::HashMap::new();
-        on_chain.insert("foo.sov".to_string(), make_on_chain("foo.sov", "did:zhtp:aaa", 3));
+        on_chain.insert(
+            "foo.sov".to_string(),
+            make_on_chain("foo.sov", "did:zhtp:aaa", 3),
+        );
 
         let sled = vec![make_sled("foo.sov", [0u8; 32], 1)];
         let entries = merge_catalog_entries(&on_chain, sled);
@@ -2425,8 +2442,14 @@ mod tests {
     #[test]
     fn catalog_merge_sorted_alphabetically() {
         let mut on_chain = std::collections::HashMap::new();
-        on_chain.insert("zoo.sov".to_string(), make_on_chain("zoo.sov", "did:zhtp:z", 1));
-        on_chain.insert("aaa.sov".to_string(), make_on_chain("aaa.sov", "did:zhtp:a", 1));
+        on_chain.insert(
+            "zoo.sov".to_string(),
+            make_on_chain("zoo.sov", "did:zhtp:z", 1),
+        );
+        on_chain.insert(
+            "aaa.sov".to_string(),
+            make_on_chain("aaa.sov", "did:zhtp:a", 1),
+        );
 
         let sled = vec![make_sled("mmm.sov", [0u8; 32], 1)];
         let entries = merge_catalog_entries(&on_chain, sled);
@@ -2515,6 +2538,7 @@ mod tests {
             wallet_name: format!("{}-wallet", wallet_type),
             alias: None,
             public_key,
+            kyber_public_key: vec![],
             owner_identity_id,
             seed_commitment: lib_blockchain::Hash::zero(),
             created_at: 1_700_000_000,
@@ -2523,7 +2547,6 @@ mod tests {
             initial_balance: 0,
         }
     }
-
 
     async fn setup_handler() -> anyhow::Result<(
         Web4Handler,
@@ -2581,7 +2604,8 @@ mod tests {
             key_id: owner_wallet_id,
         };
         // 101 SOV — enough to cover the 100 SOV domain registration fee (atoms).
-        sov.mint(&owner_wallet_key, lib_types::sov::atoms(101)).unwrap();
+        sov.mint(&owner_wallet_key, lib_types::sov::atoms(101))
+            .unwrap();
         blockchain.insert_token_contract(generate_lib_token_id(), sov);
 
         let blockchain = Arc::new(RwLock::new(blockchain));
@@ -2589,9 +2613,13 @@ mod tests {
             .private_key
             .clone()
             .expect("test identity should include private key");
-        let handler =
-            Web4Handler::new_with_registry(registry, publisher, identity_manager, blockchain.clone())
-                .await?;
+        let handler = Web4Handler::new_with_registry(
+            registry,
+            publisher,
+            identity_manager,
+            blockchain.clone(),
+        )
+        .await?;
 
         Ok((
             handler,
@@ -2723,8 +2751,8 @@ mod tests {
             memo: memo_v3.clone(),
             payload: lib_blockchain::transaction::TransactionPayload::None,
         };
-        let sig = lib_crypto::sign_message(&keypair, skeleton.signing_hash().as_bytes())
-            .expect("sign");
+        let sig =
+            lib_crypto::sign_message(&keypair, skeleton.signing_hash().as_bytes()).expect("sign");
         let sig_hex = hex::encode(&sig.signature);
 
         attach_client_domain_tx_signature(
@@ -2777,8 +2805,14 @@ mod tests {
     /// debit path — that path silently dropped every fee at block-apply.
     #[tokio::test]
     async fn register_domain_requires_fee_payment_tx() -> anyhow::Result<()> {
-        let (handler, owner_identity, _owner_wallet_id, _treasury_wallet_id, _owner_private, blockchain) =
-            setup_handler().await?;
+        let (
+            handler,
+            owner_identity,
+            _owner_wallet_id,
+            _treasury_wallet_id,
+            _owner_private,
+            blockchain,
+        ) = setup_handler().await?;
         let request =
             simple_registration_request(&owner_identity, "needs-fee.zhtp", "<html>ok</html>")?;
 
@@ -2844,7 +2878,8 @@ mod tests {
                     kyber_pk: [0u8; 1568],
                     key_id: [0u8; 32],
                 },
-                algorithm: lib_blockchain::integration::crypto_integration::SignatureAlgorithm::Dilithium5,
+                algorithm:
+                    lib_blockchain::integration::crypto_integration::SignatureAlgorithm::Dilithium5,
                 timestamp: 0,
             },
             memo: vec![],
@@ -2857,11 +2892,8 @@ mod tests {
             .expect("serialize wrong-type tx");
         let wrong_hex = hex::encode(&wrong_bytes);
 
-        let mut request = simple_registration_request(
-            &owner_identity,
-            "wrong-fee-type.zhtp",
-            "<html>x</html>",
-        )?;
+        let mut request =
+            simple_registration_request(&owner_identity, "wrong-fee-type.zhtp", "<html>x</html>")?;
         request["fee_payment_tx"] = serde_json::Value::String(wrong_hex);
 
         let principal = SecurityPrincipal::new(
@@ -2896,8 +2928,14 @@ mod tests {
     /// path succeeds with an empty fee_tx_hash.
     #[tokio::test]
     async fn update_domain_does_not_require_fee_payment_tx() -> anyhow::Result<()> {
-        let (handler, owner_identity, owner_wallet_id, _treasury_wallet_id, _owner_private, blockchain) =
-            setup_handler().await?;
+        let (
+            handler,
+            owner_identity,
+            owner_wallet_id,
+            _treasury_wallet_id,
+            _owner_private,
+            blockchain,
+        ) = setup_handler().await?;
         let domain = "already-registered.zhtp";
 
         // Pre-seed the on-chain domain registry so the handler sees
@@ -2928,8 +2966,7 @@ mod tests {
 
         // Build the request WITHOUT fee_payment_tx — the update path
         // must accept it (no fee charged).
-        let request =
-            simple_registration_request(&owner_identity, domain, "<html>updated</html>")?;
+        let request = simple_registration_request(&owner_identity, domain, "<html>updated</html>")?;
         assert!(
             request.get("fee_payment_tx").is_none(),
             "request must not include fee_payment_tx for this test"
@@ -2951,9 +2988,7 @@ mod tests {
         let fee_txs = bc
             .pending_transactions
             .iter()
-            .filter(|t| {
-                t.transaction_type == lib_blockchain::TransactionType::TokenTransfer
-            })
+            .filter(|t| t.transaction_type == lib_blockchain::TransactionType::TokenTransfer)
             .count();
         assert_eq!(
             fee_txs, 0,
@@ -2965,8 +3000,14 @@ mod tests {
 
     #[tokio::test]
     async fn register_domain_insufficient_balance_fails() -> anyhow::Result<()> {
-        let (handler, owner_identity, owner_wallet_id, _treasury_wallet_id, _owner_private, blockchain) =
-            setup_handler().await?;
+        let (
+            handler,
+            owner_identity,
+            owner_wallet_id,
+            _treasury_wallet_id,
+            _owner_private,
+            blockchain,
+        ) = setup_handler().await?;
 
         // Drain the owner balance so fee cannot be paid
         {

--- a/zhtp/src/runtime/blockchain_provider.rs
+++ b/zhtp/src/runtime/blockchain_provider.rs
@@ -478,9 +478,7 @@ fn spawn_projection_listener(mut rx: tokio::sync::broadcast::Receiver<Blockchain
                         identity_data,
                         ..
                     } => {
-                        if let Err(e) =
-                            handle_identity_registered(tx_hash, identity_data).await
-                        {
+                        if let Err(e) = handle_identity_registered(tx_hash, identity_data).await {
                             warn!(
                                 "Failed to rebuild identity projection from committed event: {}",
                                 e
@@ -493,10 +491,7 @@ fn spawn_projection_listener(mut rx: tokio::sync::broadcast::Receiver<Blockchain
                         ..
                     } => {
                         if let Err(e) = handle_wallet_registered(tx_hash, wallet_data).await {
-                            warn!(
-                                "Failed to rebuild wallet index from committed event: {}",
-                                e
-                            );
+                            warn!("Failed to rebuild wallet index from committed event: {}", e);
                         }
                     }
                     _ => {}
@@ -577,8 +572,13 @@ pub async fn set_global_blockchain(blockchain: Arc<RwLock<Blockchain>>) -> Resul
 
     // Start IPC server for out-of-process services (Phase 4)
     let socket_path = crate::node_data_dir().join("blockchain.sock");
-    if let Err(e) = lib_blockchain::ipc::server::start_ipc_server(&socket_path, blockchain.clone()).await {
-        warn!("Failed to start blockchain IPC server: {} (services will use in-process path)", e);
+    if let Err(e) =
+        lib_blockchain::ipc::server::start_ipc_server(&socket_path, blockchain.clone()).await
+    {
+        warn!(
+            "Failed to start blockchain IPC server: {} (services will use in-process path)",
+            e
+        );
     } else {
         info!("Blockchain IPC server started at {}", socket_path.display());
     }
@@ -798,9 +798,8 @@ mod tests {
 
         let provider_for_check = provider.clone();
         let did = council_did.to_string();
-        let membership_check = tokio::spawn(async move {
-            provider_for_check.is_council_member(&did).await
-        });
+        let membership_check =
+            tokio::spawn(async move { provider_for_check.is_council_member(&did).await });
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert!(
@@ -847,7 +846,8 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_council_cache_does_not_clobber_seeded_cache_when_chain_empty() {
-        let council_did = "did:zhtp:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        let council_did =
+            "did:zhtp:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
         let mut bc = Blockchain::new().expect("genesis");
         // load_from_store replaces bc; council_members is not sled-persisted.
         bc.council_members.clear();
@@ -867,7 +867,11 @@ mod tests {
         // Simulate load_from_store replacing bc with empty council_members.
         provider.refresh_council_member_cache().await;
         assert_eq!(
-            provider.council_member_cache.read().expect("cache lock").len(),
+            provider
+                .council_member_cache
+                .read()
+                .expect("cache lock")
+                .len(),
             1,
             "refresh must not clobber config-seeded cache"
         );
@@ -888,7 +892,8 @@ mod tests {
     async fn seed_council_cache_after_bootstrap_startup_order() {
         use lib_blockchain::dao::{CouncilBootstrapConfig, CouncilBootstrapEntry};
 
-        let council_did = "did:zhtp:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let council_did =
+            "did:zhtp:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let mut bc = Blockchain::new().expect("genesis");
         let bc_arc = Arc::new(RwLock::new(bc));
         let provider = BlockchainProvider::new();
@@ -973,9 +978,8 @@ mod tests {
         let read_guard = bc_arc.read().await;
         let provider_clone = provider.clone();
         let did = council_did.to_string();
-        let check = tokio::task::spawn_blocking(move || {
-            provider_clone.is_council_member_blocking(&did)
-        });
+        let check =
+            tokio::task::spawn_blocking(move || provider_clone.is_council_member_blocking(&did));
 
         let result = tokio::time::timeout(std::time::Duration::from_millis(500), check).await;
         drop(read_guard);
@@ -983,10 +987,7 @@ mod tests {
             result.is_ok(),
             "nested-read + cold cache must not deadlock when no writer is queued"
         );
-        assert_eq!(
-            result.unwrap().expect("join"),
-            Some(true)
-        );
+        assert_eq!(result.unwrap().expect("join"), Some(true));
     }
 
     #[tokio::test]
@@ -1094,6 +1095,7 @@ mod tests {
                 wallet_name: "Canonical Wallet".to_string(),
                 alias: None,
                 public_key: vec![0x66; 32],
+                kyber_public_key: vec![],
                 owner_identity_id: Some(lib_blockchain::Hash::from_slice(&[0x11; 32])),
                 seed_commitment: lib_blockchain::Hash::zero(),
                 created_at: 1234,
@@ -1139,6 +1141,7 @@ mod tests {
                 wallet_name: "Canonical Wallet".to_string(),
                 alias: None,
                 public_key: vec![0x66; 32],
+                kyber_public_key: vec![],
                 owner_identity_id: Some(lib_blockchain::Hash::from_slice(&[0x11; 32])),
                 seed_commitment: lib_blockchain::Hash::zero(),
                 created_at: 1234,

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -734,9 +734,9 @@ async fn migrate_identities_to_blockchain() -> Result<(u32, u32)> {
                                 info!("⚠️  Failed to add migration block: {}", e);
                                 // Fallback: save to file (deprecated, for legacy mode only)
                                 #[allow(deprecated)]
-                                if let Err(e2) = bc.save_to_file(
-                                    &crate::node_data_path("data/testnet/blockchain.dat"),
-                                ) {
+                                if let Err(e2) = bc.save_to_file(&crate::node_data_path(
+                                    "data/testnet/blockchain.dat",
+                                )) {
                                     info!("⚠️  Fallback save also failed: {}", e2);
                                 }
                             } else {
@@ -748,9 +748,9 @@ async fn migrate_identities_to_blockchain() -> Result<(u32, u32)> {
                             info!("⚠️  Failed to mine migration block: {}", e);
                             // Fallback: save to file (deprecated, for legacy mode only)
                             #[allow(deprecated)]
-                            if let Err(e2) = bc.save_to_file(
-                                &crate::node_data_path("data/testnet/blockchain.dat"),
-                            ) {
+                            if let Err(e2) = bc
+                                .save_to_file(&crate::node_data_path("data/testnet/blockchain.dat"))
+                            {
                                 info!("⚠️  Fallback save also failed: {}", e2);
                             }
                         }
@@ -1043,6 +1043,7 @@ async fn bootstrap_identities_from_dht(
                                                     wallet_name: "Primary Wallet".to_string(),
                                                     alias: Some("primary".to_string()),
                                                     public_key: pk_bytes_for_migration.clone(),
+                                                    kyber_public_key: vec![],
                                                     owner_identity_id: Some(
                                                         lib_blockchain::Hash::from_slice(
                                                             &identity_hash.0,
@@ -1080,6 +1081,7 @@ async fn bootstrap_identities_from_dht(
                                                     wallet_name: "UBI Wallet".to_string(),
                                                     alias: Some("ubi".to_string()),
                                                     public_key: pk_bytes_for_migration.clone(),
+                                                    kyber_public_key: vec![],
                                                     owner_identity_id: Some(
                                                         lib_blockchain::Hash::from_slice(
                                                             &identity_hash.0,
@@ -1112,6 +1114,7 @@ async fn bootstrap_identities_from_dht(
                                                     wallet_name: "Savings Wallet".to_string(),
                                                     alias: Some("savings".to_string()),
                                                     public_key: pk_bytes_for_migration.clone(),
+                                                    kyber_public_key: vec![],
                                                     owner_identity_id: Some(
                                                         lib_blockchain::Hash::from_slice(
                                                             &identity_hash.0,
@@ -1370,6 +1373,7 @@ mod tests {
                 wallet_name: "Primary Wallet".to_string(),
                 alias: Some("main".to_string()),
                 public_key: vec![0x41; 32],
+                kyber_public_key: vec![],
                 owner_identity_id: Some(Hash::from_slice(identity_id.as_bytes())),
                 seed_commitment: Hash::new([0x51; 32]),
                 created_at: 1_700_000_001,

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -65,11 +65,12 @@ impl std::fmt::Display for RemoteChainState {
 
 pub mod blockchain_provider;
 pub mod bootstrap_peers_provider; // FIX: Global access to bootstrap peers for UnifiedServer
+pub mod chain_identity_resolve;
 pub mod components;
 pub mod dht_indexing;
 pub mod did_startup;
+pub mod divergence_service;
 pub mod edge_state_provider; // Global access to edge node state for header-only sync
-pub mod chain_identity_resolve;
 pub mod grant_registry_provider;
 pub mod identity_manager_provider;
 pub mod manifest_pin_bridge;
@@ -88,21 +89,20 @@ pub mod services;
 pub mod shared_blockchain;
 pub mod shared_dht;
 pub mod storage_provider; // Global access to storage for component sharing
-pub mod validator_ip;
-pub mod divergence_service;
 pub mod storage_rewards;
 #[cfg(test)]
 pub mod test_api_integration;
 pub mod token_utils;
+pub mod validator_ip;
 
 pub use blockchain_provider::{
     initialize_global_blockchain_provider, is_global_blockchain_available, set_global_blockchain,
     set_global_catchup_trigger, trigger_global_catchup,
 };
-pub use components::*;
 pub use chain_identity_resolve::{
     resolve_pouw_client_identity, PouwClientIdentity, PouwIdentitySource,
 };
+pub use components::*;
 pub use identity_manager_provider::{
     get_global_identity_manager, initialize_global_identity_manager_provider,
     set_global_identity_manager,
@@ -452,7 +452,10 @@ async fn try_initial_sync_from_peer(
                     }
                     info!(
                         "✅ Per-block fallback succeeded for blocks {}-{} from {} ({} blocks)",
-                        start, end, peer_addr, singles.len()
+                        start,
+                        end,
+                        peer_addr,
+                        singles.len()
                     );
                     singles
                 }
@@ -1036,7 +1039,8 @@ impl RuntimeOrchestrator {
                     Err(e) => {
                         tracing::error!(
                             "Invalid zdns bind address '{}': {} — skipping ZDNS init",
-                            self.config.zdns_config.bind, e
+                            self.config.zdns_config.bind,
+                            e
                         );
                     }
                     Ok(bind) => {
@@ -1055,7 +1059,9 @@ impl RuntimeOrchestrator {
                                         }
                                     }
                                 }
-                                if found.is_some() { break; }
+                                if found.is_some() {
+                                    break;
+                                }
                             }
                             match found {
                                 Some(ip) => ip,
@@ -1080,18 +1086,25 @@ impl RuntimeOrchestrator {
                         protocols.zdns_gateway_ip = gateway_ip;
                         protocols.zdns_bind_addr = bind;
                         protocols.zdns_port = self.config.zdns_config.port;
-                        protocols.zdns_bootstrap_ips = self.config.network_config.bootstrap_peers
+                        protocols.zdns_bootstrap_ips = self
+                            .config
+                            .network_config
+                            .bootstrap_peers
                             .iter()
                             .filter_map(|p| p.split(':').next()?.parse::<std::net::Ipv4Addr>().ok())
                             .collect();
-                        info!("ZDNS enabled: bind={}:{} gateway_ip={} bootstrap_ips={}",
-                            bind, self.config.zdns_config.port, gateway_ip, protocols.zdns_bootstrap_ips.len());
+                        info!(
+                            "ZDNS enabled: bind={}:{} gateway_ip={} bootstrap_ips={}",
+                            bind,
+                            self.config.zdns_config.port,
+                            gateway_ip,
+                            protocols.zdns_bootstrap_ips.len()
+                        );
                     }
                 }
             }
 
-            self.register_component(Arc::new(protocols))
-            .await?;
+            self.register_component(Arc::new(protocols)).await?;
         }
 
         if !is_registered(ComponentId::Consensus).await {
@@ -1273,9 +1286,7 @@ impl RuntimeOrchestrator {
                             &mut bc,
                             &self.config.network_config.bootstrap_validators,
                         ) {
-                            warn!(
-                                "Failed to seed bootstrap validators after load_from_store: {e}"
-                            );
+                            warn!("Failed to seed bootstrap validators after load_from_store: {e}");
                         }
                         bc.ensure_council_bootstrap(&self.config.consensus_config.council);
                         info!(
@@ -1407,7 +1418,13 @@ impl RuntimeOrchestrator {
                     stake: 1_000,
                     storage_provided: 0,
                     commission_rate: 500,
-                    consensus_key: wallet.node_private_data.quantum_keypair.public_key.as_slice().try_into().unwrap_or([0u8; 2592]),
+                    consensus_key: wallet
+                        .node_private_data
+                        .quantum_keypair
+                        .public_key
+                        .as_slice()
+                        .try_into()
+                        .unwrap_or([0u8; 2592]),
                     network_address: std::env::var("ZHTP_VALIDATOR_ENDPOINT").unwrap_or_default(),
                 }]
             };
@@ -1463,10 +1480,7 @@ impl RuntimeOrchestrator {
                             n
                         ),
                         Ok(_) => {}
-                        Err(e) => warn!(
-                            "⚠️ Failed to persist genesis SOV balances to sled: {}",
-                            e
-                        ),
+                        Err(e) => warn!("⚠️ Failed to persist genesis SOV balances to sled: {}", e),
                     }
                 }
             }
@@ -1563,7 +1577,10 @@ impl RuntimeOrchestrator {
     }
 
     fn trusted_sync_sources(config: &NodeConfig) -> &[crate::config::TrustedSyncSource] {
-        &config.network_config.observer_admission.trusted_sync_sources
+        &config
+            .network_config
+            .observer_admission
+            .trusted_sync_sources
     }
 
     fn validate_observer_admission_policy_config(
@@ -1754,7 +1771,10 @@ impl RuntimeOrchestrator {
             }
         }
         if !all_peers.is_empty() {
-            info!(" Bootstrap peers for mesh (config+discovery): {} peer(s)", all_peers.len());
+            info!(
+                " Bootstrap peers for mesh (config+discovery): {} peer(s)",
+                all_peers.len()
+            );
             crate::runtime::bootstrap_peers_provider::set_bootstrap_peers(all_peers).await?;
         }
 
@@ -2090,14 +2110,16 @@ impl RuntimeOrchestrator {
 
         // Create signing context for TLS certificate pinning (Issue #739)
         // This requires the TLS certificate to exist (created by QUIC server)
-        let signing_ctx = lib_network::protocols::quic_mesh::tls_spki_hash_at_or_none(&crate::node_data_path("data/tls/server.crt"))
-            .map(|tls_spki_sha256| {
-                lib_network::discovery::local_network::DiscoverySigningContext {
-                    dilithium_sk: keypair.private_key.dilithium_sk.clone(),
-                    dilithium_pk: keypair.public_key.dilithium_pk.clone(),
-                    tls_spki_sha256,
-                }
-            });
+        let signing_ctx = lib_network::protocols::quic_mesh::tls_spki_hash_at_or_none(
+            &crate::node_data_path("data/tls/server.crt"),
+        )
+        .map(|tls_spki_sha256| {
+            lib_network::discovery::local_network::DiscoverySigningContext {
+                dilithium_sk: keypair.private_key.dilithium_sk.clone(),
+                dilithium_pk: keypair.public_key.dilithium_pk.clone(),
+                tls_spki_sha256,
+            }
+        });
 
         if signing_ctx.is_some() {
             info!("TLS certificate pinning enabled for discovery announcements");
@@ -2662,7 +2684,8 @@ impl RuntimeOrchestrator {
                     }
                 }
                 if !all_peers.is_empty() {
-                    crate::runtime::bootstrap_peers_provider::set_bootstrap_peers(all_peers).await?;
+                    crate::runtime::bootstrap_peers_provider::set_bootstrap_peers(all_peers)
+                        .await?;
                 }
             }
 
@@ -2788,10 +2811,17 @@ impl RuntimeOrchestrator {
         if self.config.zdns_config.enabled {
             match self.config.zdns_config.bind.parse::<std::net::IpAddr>() {
                 Err(e) => {
-                    tracing::error!("Invalid zdns bind '{}': {} — skipping", self.config.zdns_config.bind, e);
+                    tracing::error!(
+                        "Invalid zdns bind '{}': {} — skipping",
+                        self.config.zdns_config.bind,
+                        e
+                    );
                 }
                 Ok(bind) => {
-                    let gateway_ip = self.config.network_config.bootstrap_validators
+                    let gateway_ip = self
+                        .config
+                        .network_config
+                        .bootstrap_validators
                         .iter()
                         .flat_map(|bv| bv.endpoints.iter())
                         .filter_map(|ep| ep.split(':').next()?.parse::<std::net::Ipv4Addr>().ok())
@@ -2810,12 +2840,20 @@ impl RuntimeOrchestrator {
                     protocols.zdns_gateway_ip = gateway_ip;
                     protocols.zdns_bind_addr = bind;
                     protocols.zdns_port = self.config.zdns_config.port;
-                    protocols.zdns_bootstrap_ips = self.config.network_config.bootstrap_peers
+                    protocols.zdns_bootstrap_ips = self
+                        .config
+                        .network_config
+                        .bootstrap_peers
                         .iter()
                         .filter_map(|p| p.split(':').next()?.parse::<std::net::Ipv4Addr>().ok())
                         .collect();
-                    info!("🌐 ZDNS enabled: bind={}:{} gateway_ip={} bootstrap_ips={}",
-                        bind, self.config.zdns_config.port, gateway_ip, protocols.zdns_bootstrap_ips.len());
+                    info!(
+                        "🌐 ZDNS enabled: bind={}:{} gateway_ip={} bootstrap_ips={}",
+                        bind,
+                        self.config.zdns_config.port,
+                        gateway_ip,
+                        protocols.zdns_bootstrap_ips.len()
+                    );
                 }
             }
         }
@@ -2918,6 +2956,7 @@ impl RuntimeOrchestrator {
                             wallet_name: wallet.name.clone(),
                             wallet_type: format!("{:?}", wallet.wallet_type),
                             public_key: wallet.public_key.clone(),
+                            kyber_public_key: vec![],
                             capabilities: 0,
                             created_at: wallet.created_at,
                             registration_fee: 0,
@@ -2957,11 +2996,10 @@ impl RuntimeOrchestrator {
                                     let welcome_bonus = SOV_WELCOME_BONUS;
 
                                     // Update wallet registry balance
-                                    blockchain_ref
-                                        .update_wallet_shadow_initial_balance(
-                                            &wallet_id_hex,
-                                            welcome_bonus,
-                                        );
+                                    blockchain_ref.update_wallet_shadow_initial_balance(
+                                        &wallet_id_hex,
+                                        welcome_bonus,
+                                    );
 
                                     // Create spendable UTXO for the welcome bonus
                                     let utxo_output =
@@ -2978,8 +3016,8 @@ impl RuntimeOrchestrator {
                                                     .as_bytes(),
                                             ),
                                             recipient: lib_crypto::PublicKey::new([0u8; 2592]),
-                                                                                    merkle_leaf: lib_blockchain::Hash::default(),
-};
+                                            merkle_leaf: lib_blockchain::Hash::default(),
+                                        };
                                     let utxo_hash = lib_blockchain::types::hash::blake3_hash(
                                         format!("welcome_bonus_utxo:{}", wallet_id_hex).as_bytes(),
                                     );
@@ -3111,6 +3149,7 @@ impl RuntimeOrchestrator {
                                             wallet_name: wallet.name.clone(),
                                             wallet_type: format!("{:?}", wallet.wallet_type),
                                             public_key: wallet.public_key.clone(),
+                                            kyber_public_key: vec![],
                                             capabilities: 0,
                                             created_at: wallet.created_at,
                                             registration_fee: 0,
@@ -3231,8 +3270,8 @@ impl RuntimeOrchestrator {
                                                         .as_bytes(),
                                                 ),
                                                 recipient: lib_crypto::PublicKey::new([0u8; 2592]),
-                                                                                            merkle_leaf: lib_blockchain::Hash::default(),
-};
+                                                merkle_leaf: lib_blockchain::Hash::default(),
+                                            };
                                         let utxo_hash = lib_blockchain::types::hash::blake3_hash(
                                             format!("welcome_bonus_utxo:{}", wallet_id_hex)
                                                 .as_bytes(),
@@ -3274,6 +3313,7 @@ impl RuntimeOrchestrator {
                                             wallet_name: wallet.name.clone(),
                                             wallet_type: format!("{:?}", wallet.wallet_type),
                                             public_key: wallet.public_key.clone(),
+                                            kyber_public_key: vec![],
                                             capabilities: 0,
                                             created_at: wallet.created_at,
                                             registration_fee: 0,
@@ -3402,9 +3442,9 @@ impl RuntimeOrchestrator {
         {
             let own_did = {
                 let wallet_guard = self.user_wallet.read().await;
-                wallet_guard.as_ref().map(|w| {
-                    format!("did:zhtp:{}", hex::encode(&w.node_identity.id.0))
-                })
+                wallet_guard
+                    .as_ref()
+                    .map(|w| format!("did:zhtp:{}", hex::encode(&w.node_identity.id.0)))
             };
             // Initial discovery + periodic re-check, all in background
             crate::runtime::validator_ip::spawn_periodic_ip_update(own_did, 300);
@@ -3415,7 +3455,9 @@ impl RuntimeOrchestrator {
         // ZHTP_DIVERGENCE_DETECT is set. Samples in-memory vs sled state and
         // reports drift before the read-migration phases flip to sled-first.
         // ====================================================================
-        if let Ok(blockchain_arc) = crate::runtime::blockchain_provider::get_global_blockchain().await {
+        if let Ok(blockchain_arc) =
+            crate::runtime::blockchain_provider::get_global_blockchain().await
+        {
             crate::runtime::divergence_service::spawn_divergence_detector(blockchain_arc);
         }
 
@@ -3425,20 +3467,25 @@ impl RuntimeOrchestrator {
         // this gateway via block processing.
         // ====================================================================
         if self.config.zdns_config.enabled {
-            if let Ok(blockchain_arc) = crate::runtime::blockchain_provider::get_global_blockchain().await {
+            if let Ok(blockchain_arc) =
+                crate::runtime::blockchain_provider::get_global_blockchain().await
+            {
                 let wallet_guard = self.user_wallet.read().await;
                 if let Some(wallet) = wallet_guard.as_ref() {
                     let did = format!("did:zhtp:{}", hex::encode(&wallet.user_identity.id.0));
                     let gateway_key_bytes = wallet.user_identity.public_key.as_bytes();
-                    let gateway_key: [u8; 2592] = gateway_key_bytes
-                        .try_into()
-                        .unwrap_or([0u8; 2592]);
+                    let gateway_key: [u8; 2592] =
+                        gateway_key_bytes.try_into().unwrap_or([0u8; 2592]);
 
                     // Determine public endpoint
-                    let endpoint = crate::runtime::validator_ip::discover_public_ip().await
+                    let endpoint = crate::runtime::validator_ip::discover_public_ip()
+                        .await
                         .map(|ip| format!("{}:{}", ip, self.config.protocols_config.api_port))
                         .unwrap_or_else(|| {
-                            self.config.network_config.bootstrap_peers.first()
+                            self.config
+                                .network_config
+                                .bootstrap_peers
+                                .first()
                                 .cloned()
                                 .unwrap_or_default()
                         });
@@ -3486,19 +3533,21 @@ impl RuntimeOrchestrator {
                         };
 
                         // Create temp tx to compute signing_hash, then sign it
-                        let memo = format!("Gateway registration: {} @ {}", &did[..30], endpoint).into_bytes();
+                        let memo = format!("Gateway registration: {} @ {}", &did[..30], endpoint)
+                            .into_bytes();
                         let empty_sig = lib_crypto::Signature {
                             signature: vec![],
                             public_key: lib_crypto::PublicKey::new([0u8; 2592]),
                             algorithm: lib_crypto::SignatureAlgorithm::DEFAULT,
                             timestamp,
                         };
-                        let temp_tx = lib_blockchain::transaction::Transaction::new_gateway_registration(
-                            gateway_data.clone(),
-                            vec![],
-                            empty_sig,
-                            memo.clone(),
-                        );
+                        let temp_tx =
+                            lib_blockchain::transaction::Transaction::new_gateway_registration(
+                                gateway_data.clone(),
+                                vec![],
+                                empty_sig,
+                                memo.clone(),
+                            );
                         let signing_hash = temp_tx.signing_hash();
 
                         match lib_crypto::sign_message(&keypair, signing_hash.as_bytes()) {
@@ -3519,7 +3568,9 @@ impl RuntimeOrchestrator {
                                 // Submit to local mempool first
                                 {
                                     let mut blockchain = blockchain_arc.write().await;
-                                    if let Err(e) = blockchain.add_pending_transaction(transaction.clone()) {
+                                    if let Err(e) =
+                                        blockchain.add_pending_transaction(transaction.clone())
+                                    {
                                         warn!("⚠️ Gateway registration tx local mempool: {}", e);
                                     }
                                 }
@@ -3538,9 +3589,8 @@ impl RuntimeOrchestrator {
                                     "transaction_data": tx_hex,
                                 });
                                 let own_ip = endpoint.split(':').next().unwrap_or("");
-                                if let Some(validator_ep) = self.config.network_config.bootstrap_peers
-                                    .iter()
-                                    .find(|p| {
+                                if let Some(validator_ep) =
+                                    self.config.network_config.bootstrap_peers.iter().find(|p| {
                                         let peer_ip = p.split(':').next().unwrap_or("");
                                         peer_ip != own_ip && !peer_ip.is_empty()
                                     })
@@ -3548,14 +3598,19 @@ impl RuntimeOrchestrator {
                                     let validator_ep = validator_ep.clone();
                                     let wallet_guard2 = self.user_wallet.read().await;
                                     if let Some(w) = wallet_guard2.as_ref() {
-                                        let trust = lib_network::web4::trust::TrustConfig::bootstrap();
+                                        let trust =
+                                            lib_network::web4::trust::TrustConfig::bootstrap();
                                         let cfg = lib_network::client::ZhtpClientConfig {
                                             allow_bootstrap: true,
                                             ..Default::default()
                                         };
                                         match lib_network::client::ZhtpClient::new_with_config(
-                                            w.node_identity.clone(), trust, cfg
-                                        ).await {
+                                            w.node_identity.clone(),
+                                            trust,
+                                            cfg,
+                                        )
+                                        .await
+                                        {
                                             Ok(mut client) => {
                                                 match client.connect(&validator_ep).await {
                                                     Ok(()) => {
@@ -3574,7 +3629,11 @@ impl RuntimeOrchestrator {
                                         }
                                     }
                                 }
-                                info!("🌐 Gateway registration tx submitted: {} @ {}", &did[..30], endpoint);
+                                info!(
+                                    "🌐 Gateway registration tx submitted: {} @ {}",
+                                    &did[..30],
+                                    endpoint
+                                );
                             }
                             Err(e) => warn!("⚠️ Failed to sign gateway registration: {}", e),
                         }
@@ -5073,7 +5132,9 @@ impl RuntimeOrchestrator {
         tracing::info!("🔌 register_runtime_handlers: acquiring components read lock...");
         // Get ProtocolsComponent from the components HashMap
         let components = self.components.read().await;
-        tracing::info!("🔌 register_runtime_handlers: components lock acquired, looking up Protocols...");
+        tracing::info!(
+            "🔌 register_runtime_handlers: components lock acquired, looking up Protocols..."
+        );
         let component = components
             .get(&ComponentId::Protocols)
             .ok_or_else(|| anyhow::anyhow!("ProtocolsComponent not found"))?;
@@ -5200,12 +5261,14 @@ impl RuntimeOrchestrator {
         {
             let cfg_peers = orchestrator.config.network_config.bootstrap_peers.clone();
             if !cfg_peers.is_empty() {
-                if let Err(e) = crate::runtime::bootstrap_peers_provider::set_bootstrap_peers(
-                    cfg_peers.clone(),
-                )
-                .await
+                if let Err(e) =
+                    crate::runtime::bootstrap_peers_provider::set_bootstrap_peers(cfg_peers.clone())
+                        .await
                 {
-                    warn!("Failed to store bootstrap peers for QUIC connections: {}", e);
+                    warn!(
+                        "Failed to store bootstrap peers for QUIC connections: {}",
+                        e
+                    );
                 } else {
                     info!(
                         "Stored {} bootstrap peer(s) for persistent QUIC connections: {:?}",
@@ -5317,14 +5380,16 @@ impl RuntimeOrchestrator {
         };
 
         // Create signing context for TLS certificate pinning (Issue #739)
-        let signing_ctx = lib_network::protocols::quic_mesh::tls_spki_hash_at_or_none(&crate::node_data_path("data/tls/server.crt"))
-            .map(|tls_spki_sha256| {
-                lib_network::discovery::local_network::DiscoverySigningContext {
-                    dilithium_sk: keypair.private_key.dilithium_sk.clone(),
-                    dilithium_pk: keypair.public_key.dilithium_pk.clone(),
-                    tls_spki_sha256,
-                }
-            });
+        let signing_ctx = lib_network::protocols::quic_mesh::tls_spki_hash_at_or_none(
+            &crate::node_data_path("data/tls/server.crt"),
+        )
+        .map(|tls_spki_sha256| {
+            lib_network::discovery::local_network::DiscoverySigningContext {
+                dilithium_sk: keypair.private_key.dilithium_sk.clone(),
+                dilithium_pk: keypair.public_key.dilithium_pk.clone(),
+                tls_spki_sha256,
+            }
+        });
 
         // Start local discovery service (broadcasts immediately, then every 30s)
         if let Err(e) = lib_network::discovery::local_network::start_local_discovery(
@@ -5338,8 +5403,10 @@ impl RuntimeOrchestrator {
         {
             warn!("      Failed to start local discovery: {}", e);
         } else {
-            let signed =
-                lib_network::protocols::quic_mesh::tls_spki_hash_at_or_none(&crate::node_data_path("data/tls/server.crt")).is_some();
+            let signed = lib_network::protocols::quic_mesh::tls_spki_hash_at_or_none(
+                &crate::node_data_path("data/tls/server.crt"),
+            )
+            .is_some();
             info!(
                 "      ✓ Multicast broadcasting started (224.0.1.75:37775, TLS pinning: {})",
                 signed
@@ -5566,9 +5633,7 @@ fn validate_local_restore_compatibility(
         );
         if allow_genesis_mismatch {
             warn!("⚠️  {}", message);
-            warn!(
-                "⚠️  Proceeding because --allow-emergency-restore-genesis-mismatch was set"
-            );
+            warn!("⚠️  Proceeding because --allow-emergency-restore-genesis-mismatch was set");
             Ok(())
         } else {
             Err(anyhow::anyhow!(
@@ -5619,9 +5684,7 @@ pub(super) fn try_restore_oracle_from_dat(
             Ok(true)
         }
         Some(_) => {
-            warn!(
-                "⚠️  Emergency restore requested, but blockchain.dat has no oracle committee"
-            );
+            warn!("⚠️  Emergency restore requested, but blockchain.dat has no oracle committee");
             Ok(false)
         }
         None => Ok(false),
@@ -5640,13 +5703,9 @@ pub(super) async fn ensure_council_bootstrap_and_cache(
         let mut bc = blockchain_arc.write().await;
         bc.ensure_council_bootstrap(council_config);
     }
-    if let Some(provider) = crate::runtime::blockchain_provider::get_global_blockchain_provider()
-    {
+    if let Some(provider) = crate::runtime::blockchain_provider::get_global_blockchain_provider() {
         provider.seed_council_member_cache(
-            council_config
-                .members
-                .iter()
-                .map(|m| m.identity_id.clone()),
+            council_config.members.iter().map(|m| m.identity_id.clone()),
         );
         provider.refresh_council_member_cache().await;
     }
@@ -5686,9 +5745,9 @@ pub(super) fn seed_validators_from_bootstrap_config(
             let hash = blake3::hash(format!("{}::consensus", bv.identity_id).as_bytes());
             key[..32].copy_from_slice(hash.as_bytes());
             // Fill rest with derived data to avoid all-zeros
-            for i in 1..(2592/32) {
+            for i in 1..(2592 / 32) {
                 let chunk_hash = blake3::hash(&[hash.as_bytes(), &[i as u8][..]].concat());
-                key[i*32..(i+1)*32].copy_from_slice(chunk_hash.as_bytes());
+                key[i * 32..(i + 1) * 32].copy_from_slice(chunk_hash.as_bytes());
             }
             key
         });
@@ -5736,10 +5795,7 @@ pub(super) fn try_restore_validators_from_dat(
 ) -> Result<bool> {
     match load_validated_blockchain_dat(dat_path, allow_genesis_mismatch)? {
         Some(dat_bc) if !dat_bc.get_active_validators().is_empty() => {
-            let restored: Vec<_> = dat_bc
-                .validator_registry_snapshot()
-                .into_values()
-                .collect();
+            let restored: Vec<_> = dat_bc.validator_registry_snapshot().into_values().collect();
             let count = restored.len();
             bc.validator_blocks = dat_bc.validator_blocks;
             bc.install_bootstrap_validator_records(restored)?;
@@ -5871,7 +5927,10 @@ mod runtime_orchestrator_tests {
 
         let network_info = crate::runtime::ExistingNetworkInfo {
             peer_count: 3,
-            chain_state: crate::runtime::RemoteChainState::Committed { height: 42, hash: [0u8; 32] },
+            chain_state: crate::runtime::RemoteChainState::Committed {
+                height: 42,
+                hash: [0u8; 32],
+            },
             network_id: "testnet".to_string(),
             bootstrap_peers: vec!["127.0.0.1:9334".to_string()],
             environment: crate::config::Environment::Development,
@@ -5977,12 +6036,13 @@ mod runtime_orchestrator_tests {
         config.node_role = NodeRole::Observer;
         config.consensus_config.validator_enabled = false;
         config.network_config.observer_admission.required = true;
-        config.network_config.observer_admission.trusted_sync_sources = vec![
-            crate::config::TrustedSyncSource {
-                address: "127.0.0.1:9334".to_string(),
-                peer_did: None,
-            },
-        ];
+        config
+            .network_config
+            .observer_admission
+            .trusted_sync_sources = vec![crate::config::TrustedSyncSource {
+            address: "127.0.0.1:9334".to_string(),
+            peer_did: None,
+        }];
 
         let err = RuntimeOrchestrator::validate_observer_admission_policy_config(&config, false)
             .expect_err("observer admission should require an explicit local DID allowlist");
@@ -6076,7 +6136,10 @@ mod runtime_orchestrator_tests {
 
         let network_info = crate::runtime::ExistingNetworkInfo {
             peer_count: 4,
-            chain_state: crate::runtime::RemoteChainState::Committed { height: 128, hash: [0u8; 32] },
+            chain_state: crate::runtime::RemoteChainState::Committed {
+                height: 128,
+                hash: [0u8; 32],
+            },
             network_id: "observer-testnet".to_string(),
             bootstrap_peers: vec!["127.0.0.1:9334".to_string()],
             environment: Environment::Development,
@@ -6131,7 +6194,10 @@ mod runtime_orchestrator_tests {
 
         let discovered_network = crate::runtime::ExistingNetworkInfo {
             peer_count: 4,
-            chain_state: crate::runtime::RemoteChainState::Committed { height: 128, hash: [0u8; 32] },
+            chain_state: crate::runtime::RemoteChainState::Committed {
+                height: 128,
+                hash: [0u8; 32],
+            },
             network_id: "observer-sequence-testnet".to_string(),
             bootstrap_peers: vec!["127.0.0.1:9334".to_string(), "127.0.0.1:9335".to_string()],
             environment: Environment::Development,
@@ -6199,7 +6265,10 @@ mod runtime_orchestrator_tests {
             .expect("observer runtime should initialize");
         let network_info = crate::runtime::ExistingNetworkInfo {
             peer_count: 1,
-            chain_state: crate::runtime::RemoteChainState::Committed { height: 42, hash: [0u8; 32] },
+            chain_state: crate::runtime::RemoteChainState::Committed {
+                height: 42,
+                hash: [0u8; 32],
+            },
             network_id: "observer-runtime-join".to_string(),
             bootstrap_peers: vec!["127.0.0.1:1".to_string()],
             environment: Environment::Development,
@@ -6294,7 +6363,10 @@ mod runtime_orchestrator_tests {
 
         let discovered_network = crate::runtime::ExistingNetworkInfo {
             peer_count: 3,
-            chain_state: crate::runtime::RemoteChainState::Committed { height: 64, hash: [0u8; 32] },
+            chain_state: crate::runtime::RemoteChainState::Committed {
+                height: 64,
+                hash: [0u8; 32],
+            },
             network_id: "observer-shared-network".to_string(),
             bootstrap_peers: vec![
                 "127.0.0.1:9334".to_string(),
@@ -6532,23 +6604,23 @@ mod oracle_startup_tests {
         let consensus_key = [0xABu8; 2592];
         let key_id = lib_blockchain::blake3_hash(&consensus_key).as_array();
         bc.insert_validator_shadow(ValidatorInfo {
-                identity_id: "did:zhtp:validator-test".to_string(),
-                stake: 1_000_000,
-                storage_provided: 0,
-                consensus_key,
-                networking_key: vec![0xCDu8; 32],
-                rewards_key: vec![0xEFu8; 32],
-                network_address: "10.0.0.1:9334".to_string(),
-                commission_rate: 5,
-                status: "active".to_string(),
-                registered_at: 0,
-                last_activity: 0,
-                blocks_validated: 0,
-                slash_count: 0,
-                admission_source: "test".to_string(),
-                governance_proposal_id: None,
-                oracle_key_id: None,
-            });
+            identity_id: "did:zhtp:validator-test".to_string(),
+            stake: 1_000_000,
+            storage_provided: 0,
+            consensus_key,
+            networking_key: vec![0xCDu8; 32],
+            rewards_key: vec![0xEFu8; 32],
+            network_address: "10.0.0.1:9334".to_string(),
+            commission_rate: 5,
+            status: "active".to_string(),
+            registered_at: 0,
+            last_activity: 0,
+            blocks_validated: 0,
+            slash_count: 0,
+            admission_source: "test".to_string(),
+            governance_proposal_id: None,
+            oracle_key_id: None,
+        });
 
         // Replicate the bootstrap logic from seed_blockchain_validator_registry.
         // Type system now enforces 2592-byte keys, no length check needed.
@@ -6578,23 +6650,23 @@ mod oracle_startup_tests {
         // Insert a validator with an all-zeros consensus key (invalid).
         // Type system enforces 2592-byte size, but we can still test for invalid content.
         bc.insert_validator_shadow(ValidatorInfo {
-                identity_id: "did:zhtp:bad-validator".to_string(),
-                stake: 1_000_000,
-                storage_provided: 0,
-                consensus_key: [0u8; 2592], // all zeros — invalid key
-                networking_key: vec![0x01u8; 32],
-                rewards_key: vec![0x02u8; 32],
-                network_address: "10.0.0.2:9334".to_string(),
-                commission_rate: 0,
-                status: "active".to_string(),
-                registered_at: 0,
-                last_activity: 0,
-                blocks_validated: 0,
-                slash_count: 0,
-                admission_source: "test".to_string(),
-                governance_proposal_id: None,
-                oracle_key_id: None,
-            });
+            identity_id: "did:zhtp:bad-validator".to_string(),
+            stake: 1_000_000,
+            storage_provided: 0,
+            consensus_key: [0u8; 2592], // all zeros — invalid key
+            networking_key: vec![0x01u8; 32],
+            rewards_key: vec![0x02u8; 32],
+            network_address: "10.0.0.2:9334".to_string(),
+            commission_rate: 0,
+            status: "active".to_string(),
+            registered_at: 0,
+            last_activity: 0,
+            blocks_validated: 0,
+            slash_count: 0,
+            admission_source: "test".to_string(),
+            governance_proposal_id: None,
+            oracle_key_id: None,
+        });
 
         // Filter out validators with all-zeros keys (invalid)
         let committee_members: Vec<([u8; 32], [u8; 2592])> = bc

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -99,8 +99,8 @@ impl GenesisFundingService {
                     format!("validator_stake_note_{}_{}", validator_id_hex, index).as_bytes(),
                 ),
                 recipient: PublicKey::new([0u8; 2592]),
-                            merkle_leaf: lib_blockchain::Hash::default(),
-};
+                merkle_leaf: lib_blockchain::Hash::default(),
+            };
 
             genesis_outputs.push(validator_output);
             total_validator_stake += validator.stake;
@@ -131,8 +131,8 @@ impl GenesisFundingService {
                 commitment: lib_blockchain::types::hash::blake3_hash(b"ubi_pool_commitment_500000"),
                 note: lib_blockchain::types::hash::blake3_hash(b"ubi_pool_note"),
                 recipient: PublicKey::new([0u8; 2592]),
-                            merkle_leaf: lib_blockchain::Hash::default(),
-},
+                merkle_leaf: lib_blockchain::Hash::default(),
+            },
             // Mining rewards pool
             TransactionOutput {
                 commitment: lib_blockchain::types::hash::blake3_hash(
@@ -140,15 +140,15 @@ impl GenesisFundingService {
                 ),
                 note: lib_blockchain::types::hash::blake3_hash(b"mining_pool_note"),
                 recipient: PublicKey::new([0u8; 2592]),
-                            merkle_leaf: lib_blockchain::Hash::default(),
-},
+                merkle_leaf: lib_blockchain::Hash::default(),
+            },
             // Development fund
             TransactionOutput {
                 commitment: lib_blockchain::types::hash::blake3_hash(b"dev_pool_commitment_200000"),
                 note: lib_blockchain::types::hash::blake3_hash(b"dev_pool_note"),
                 recipient: PublicKey::new([0u8; 2592]),
-                            merkle_leaf: lib_blockchain::Hash::default(),
-},
+                merkle_leaf: lib_blockchain::Hash::default(),
+            },
         ]);
 
         // Add user primary wallet funding (welcome bonus: 5,000 SOV)
@@ -199,6 +199,7 @@ impl GenesisFundingService {
                 wallet_name: "Primary Wallet".to_string(),
                 alias: None,
                 public_key: identity_dilithium_pubkey.clone(), // Full 1312-byte Dilithium5 public key
+                kyber_public_key: vec![],
                 owner_identity_id: user_identity_id
                     .as_ref()
                     .map(|id| lib_blockchain::Hash::from_slice(&id.0)),
@@ -248,9 +249,7 @@ impl GenesisFundingService {
                                 SOV_WELCOME_BONUS as u128,
                             )])
                             .map_err(|e| {
-                                anyhow::anyhow!(
-                                    "failed to persist genesis wallet SOV to sled: {e}"
-                                )
+                                anyhow::anyhow!("failed to persist genesis wallet SOV to sled: {e}")
                             })?;
                     }
                 }
@@ -330,9 +329,7 @@ impl GenesisFundingService {
         // block 1 (parents the post-funding hash).
         if let Some(store) = blockchain.store.as_ref() {
             store.replace_block(genesis_block).map_err(|e| {
-                anyhow::anyhow!(
-                    "failed to re-persist funded genesis block to store: {e}"
-                )
+                anyhow::anyhow!("failed to re-persist funded genesis block to store: {e}")
             })?;
             info!(
                 "💾 Re-persisted funded genesis (height 0) to SledStore: {}",

--- a/zhtp/src/server/mesh/identity_api.rs
+++ b/zhtp/src/server/mesh/identity_api.rs
@@ -79,10 +79,13 @@ pub async fn handle_identity_mesh_request(
     // Helper to deny unauthenticated public principals from mutating mesh endpoints.
     async fn check_public_denied(principal: &SecurityPrincipal) -> Option<Result<Option<Vec<u8>>>> {
         if principal.role == Role::Public {
-            Some(create_error_mesh_response(
-                403,
-                "Public principals cannot perform this operation over mesh",
-            ).await)
+            Some(
+                create_error_mesh_response(
+                    403,
+                    "Public principals cannot perform this operation over mesh",
+                )
+                .await,
+            )
         } else {
             None
         }
@@ -625,8 +628,6 @@ async fn create_identity_direct(
     identity_manager: &Arc<RwLock<IdentityManager>>,
     request_data: &serde_json::Value,
 ) -> Result<serde_json::Value> {
-    let mut manager = identity_manager.write().await;
-
     // Extract display name from request data
     let display_name = request_data
         .get("display_name")
@@ -634,7 +635,143 @@ async fn create_identity_direct(
         .unwrap_or("Anonymous Citizen")
         .to_string();
 
+    let device_id = request_data
+        .get("device_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("mesh")
+        .to_string();
+
     info!("✨ Creating identity for: {}", display_name);
+
+    // Extract the client's dilithium_pk and kyber_pk from the registration request.
+    // The app sends a ZhtpIdentity JSON with public_key.dilithium_pk and public_key.kyber_pk
+    // as byte arrays. Use these to derive the client's key_id = blake3(dilithium_pk || kyber_pk),
+    // which becomes the primary wallet_id (see register_external_citizen_identity).
+    let extract_bytes_array = |json: &serde_json::Value, field: &str| -> Option<Vec<u8>> {
+        json.get("public_key")
+            .and_then(|pk| pk.get(field))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_u64().map(|b| b as u8))
+                    .collect::<Vec<u8>>()
+            })
+    };
+
+    let client_dilithium_pk =
+        extract_bytes_array(request_data, "dilithium_pk").filter(|v| v.len() == 2592);
+    let client_kyber_pk = extract_bytes_array(request_data, "kyber_pk").filter(|v| v.len() == 1568);
+
+    // Client-aligned registration (#2979): route through register_external_citizen_identity
+    // with the client's PQC keys so wallet IDs are deterministic and wallet txs carry the
+    // client's real Dilithium public key (not an HD synthetic key).
+    if let Some(dil_pk) = client_dilithium_pk {
+        let dil_arr: [u8; 2592] = dil_pk
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Client dilithium_pk must be 2592 bytes"))?;
+        let kyb_vec: Vec<u8> = client_kyber_pk.unwrap_or_default();
+        let kyber_arr: [u8; 1568] = if kyb_vec.len() == 1568 {
+            kyb_vec
+                .as_slice()
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("Client kyber_pk must be 1568 bytes"))?
+        } else {
+            [0u8; 1568]
+        };
+        let client_public_key = lib_crypto::PublicKey::new_with_kyber(dil_arr, kyber_arr);
+        // Identity DID binds to blake3(dilithium_pk) (matches the identity binding check).
+        let did = format!(
+            "did:zhtp:{}",
+            hex::encode(lib_crypto::hashing::hash_blake3(&dil_pk))
+        );
+
+        let created_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let mut manager = identity_manager.write().await;
+        let mut economic_model = lib_identity::economics::EconomicModel::new();
+        let identity_result = manager
+            .register_external_citizen_identity(
+                did.clone(),
+                client_public_key,
+                kyb_vec.clone(),
+                device_id,
+                Some(display_name.clone()),
+                created_at,
+                &mut economic_model,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to register external citizen identity: {}", e))?;
+        drop(manager);
+
+        let identity_id_hex = hex::encode(&identity_result.identity_id.0);
+        let primary_wallet_id = hex::encode(&identity_result.primary_wallet_id.0);
+        let ubi_wallet_id = hex::encode(&identity_result.ubi_wallet_id.0);
+        let savings_wallet_id = hex::encode(&identity_result.savings_wallet_id.0);
+        let client_pk_hex = hex::encode(&dil_pk);
+        let client_kyber_hex = hex::encode(&kyb_vec);
+
+        let identity_json = serde_json::json!({
+            "identity_id": identity_id_hex,
+            "citizenship_result": {
+                "identity_id": identity_id_hex,
+                "display_name": display_name,
+                "primary_wallet_id": primary_wallet_id,
+                "ubi_wallet_id": ubi_wallet_id,
+                "savings_wallet_id": savings_wallet_id,
+                "privacy_credentials": {
+                    "public_key": client_pk_hex,
+                    "ownership_proof": ""
+                },
+                "primary_wallet_pubkey": client_pk_hex,
+                "ubi_wallet_pubkey": client_pk_hex,
+                "savings_wallet_pubkey": client_pk_hex,
+                "kyber_public_key": client_kyber_hex,
+                "created_at": created_at
+            }
+        });
+
+        info!("⛓️ Attempting blockchain registration (client-aligned)...");
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            record_identity_on_blockchain(&identity_json),
+        )
+        .await
+        {
+            Ok(Ok(())) => {
+                info!("✅ Identity successfully registered on blockchain");
+            }
+            Ok(Err(e)) => {
+                error!("❌ BLOCKCHAIN REGISTRATION FAILED: {}", e);
+            }
+            Err(_) => {
+                error!("⏱️ BLOCKCHAIN REGISTRATION TIMEOUT - operation took >5 seconds");
+            }
+        }
+
+        return Ok(serde_json::json!({
+            "success": true,
+            "identity_id": identity_result.identity_id,
+            "citizenship_result": {
+                "identity_id": identity_result.identity_id,
+                "primary_wallet_id": primary_wallet_id,
+                "ubi_wallet_id": ubi_wallet_id,
+                "savings_wallet_id": savings_wallet_id,
+                "dao_registration": identity_result.dao_registration,
+                "ubi_registration": identity_result.ubi_registration,
+                "web4_access": identity_result.web4_access,
+                "privacy_credentials": identity_result.privacy_credentials,
+                "welcome_bonus": identity_result.welcome_bonus,
+                "created_at": identity_result.privacy_credentials.created_at
+            }
+        }));
+    }
+
+    // Legacy fallback: no client keys → server-side keygen.
+    let mut manager = identity_manager.write().await;
 
     // Create a new zkDID identity with full citizenship
     let mut economic_model = lib_identity::economics::EconomicModel::new();
@@ -692,59 +829,20 @@ async fn create_identity_direct(
 
     drop(manager_read);
 
-    // Extract the client's dilithium_pk and kyber_pk from the registration request.
-    // The app sends a ZhtpIdentity JSON with public_key.dilithium_pk and public_key.kyber_pk
-    // as byte arrays. Use these to compute the client's key_id = blake3(dilithium_pk || kyber_pk),
-    // which becomes the primary wallet_id. This ensures wallet_id == signer's key_id, allowing
-    // the transfer validation check (data.from == signature.public_key.key_id) to pass.
-    let extract_bytes_array = |json: &serde_json::Value, field: &str| -> Option<Vec<u8>> {
-        json.get("public_key")
-            .and_then(|pk| pk.get(field))
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_u64().map(|b| b as u8))
-                    .collect::<Vec<u8>>()
-            })
-    };
-
-    let client_dilithium_pk = extract_bytes_array(request_data, "dilithium_pk")
-        .filter(|v| v.len() == 2592);
-    let client_kyber_pk = extract_bytes_array(request_data, "kyber_pk")
-        .filter(|v| v.len() == 1568);
-
-    let (effective_wallet_id_hex, effective_wallet_pubkey_hex) =
-        if let (Some(ref dil_pk), Some(ref kyb_pk)) = (&client_dilithium_pk, &client_kyber_pk) {
-            let kyber_is_zeros = kyb_pk.iter().all(|&b| b == 0);
-            let key_id: [u8; 32] = if kyber_is_zeros {
-                lib_crypto::hashing::hash_blake3(dil_pk)
-            } else {
-                lib_crypto::hashing::hash_blake3_multiple(&[dil_pk.as_slice(), kyb_pk.as_slice()])
-            };
-            (hex::encode(key_id), hex::encode(dil_pk))
-        } else {
-            // Fallback to HD wallet_id if client public key is not provided/valid
-            info!("⚠️ Client public key not found in registration request — using HD wallet_id");
-            (
-                hex::encode(&identity_result.primary_wallet_id.0),
-                hex::encode(&primary_pubkey),
-            )
-        };
-
     // Build identity JSON
     let identity_id_hex = hex::encode(&identity_result.identity_id.0);
     let identity_json = serde_json::json!({
         "identity_id": identity_id_hex,
         "citizenship_result": {
             "identity_id": identity_id_hex,
-            "primary_wallet_id": effective_wallet_id_hex,
+            "primary_wallet_id": hex::encode(&identity_result.primary_wallet_id.0),
             "ubi_wallet_id": hex::encode(&identity_result.ubi_wallet_id.0),
             "savings_wallet_id": hex::encode(&identity_result.savings_wallet_id.0),
             "privacy_credentials": {
                 "public_key": hex::encode(&public_key.as_bytes()),
                 "ownership_proof": hex::encode(&ownership_proof_bytes)
             },
-            "primary_wallet_pubkey": effective_wallet_pubkey_hex,
+            "primary_wallet_pubkey": hex::encode(&primary_pubkey),
             "ubi_wallet_pubkey": hex::encode(&ubi_pubkey),
             "savings_wallet_pubkey": hex::encode(&savings_pubkey),
             "created_at": identity_result.privacy_credentials.created_at
@@ -771,14 +869,12 @@ async fn create_identity_direct(
     }
 
     // Return the full response structure expected by browser.
-    // primary_wallet_id is the client's key_id (blake3(dilithium_pk || kyber_pk)) if the
-    // client's public key was extracted from the request; otherwise the HD wallet_id fallback.
     Ok(serde_json::json!({
         "success": true,
         "identity_id": identity_result.identity_id,
         "citizenship_result": {
             "identity_id": identity_result.identity_id,
-            "primary_wallet_id": effective_wallet_id_hex,
+            "primary_wallet_id": identity_result.primary_wallet_id,
             "ubi_wallet_id": identity_result.ubi_wallet_id,
             "savings_wallet_id": identity_result.savings_wallet_id,
             "dao_registration": identity_result.dao_registration,
@@ -1132,6 +1228,7 @@ async fn record_standalone_wallet_on_blockchain(
         wallet_name: wallet_name.to_string(),
         alias: wallet_alias.clone(),
         public_key: vec![0u8; 32],
+        kyber_public_key: vec![],
         owner_identity_id: Some(lib_blockchain::Hash::from_slice(&identity_id.0)),
         seed_commitment: lib_blockchain::Hash::from_slice(&seed_commitment),
         created_at: std::time::SystemTime::now()
@@ -1163,8 +1260,9 @@ async fn record_standalone_wallet_on_blockchain(
                     .as_secs()
             })),
             wallet_private_record: Some(
-                bincode::serialize(&wallet_private_data)
-                    .map_err(|e| anyhow::anyhow!("Failed to serialize wallet private data: {}", e))?
+                bincode::serialize(&wallet_private_data).map_err(|e| {
+                    anyhow::anyhow!("Failed to serialize wallet private data: {}", e)
+                })?,
             ),
         },
     );
@@ -1647,6 +1745,12 @@ fn register_wallet_on_blockchain(
             .and_then(|hex_str| hex::decode(hex_str).ok())
             .unwrap_or_else(|| vec![0u8; 32]);
 
+        let wallet_kyber = citizenship_result
+            .get("kyber_public_key")
+            .and_then(|v| v.as_str())
+            .and_then(|hex_str| hex::decode(hex_str).ok())
+            .unwrap_or_default();
+
         let seed_commitment = lib_blockchain::Hash::from_slice(&[0u8; 32]);
 
         // Welcome bonus (5,000 SOV) goes to Primary wallet
@@ -1666,6 +1770,7 @@ fn register_wallet_on_blockchain(
             wallet_name: format!("{} Wallet", wallet_type),
             alias: Some(wallet_type.to_lowercase()),
             public_key: wallet_pubkey,
+            kyber_public_key: wallet_kyber,
             owner_identity_id: Some(lib_blockchain::Hash::new(identity_hash.0)),
             seed_commitment,
             created_at,


### PR DESCRIPTION
Derive remote-registration wallet IDs from the client's PQC keys instead of a server-side HD master seed:
- primary_wallet_id = blake3(dilithium_pk || kyber_pk)
- ubi_wallet_id = blake3(primary_wallet_id || \ubi\)
- savings_wallet_id = blake3(primary_wallet_id || \savings\)

Wallet txs now carry the client's real dilithium_pk plus a new WalletTransactionData.kyber_public_key field. Widen allows_empty_system_signature to accept both wallet_id == blake3(pk) (legacy) and wallet_id == blake3(pk || kyber_pk) (client). Revert the HD synthetic 2592-byte public-key workaround.