### PR TITLE
dev-node consensus and config

### DIFF
--- a/lib-consensus/src/engines/consensus_engine/mod.rs
+++ b/lib-consensus/src/engines/consensus_engine/mod.rs
@@ -1031,6 +1031,14 @@ impl ConsensusEngine {
     /// ensures these two constants stay in sync.
     pub fn is_bft_mode_active(&self) -> bool {
         let validator_count = self.validator_manager.get_active_validators().len();
+
+        // In development mode, treat 1+ validators as BFT-active so that
+        // single-validator test/dev nodes can run the full consensus protocol
+        // (propose → prevote → precommit → commit) without requiring ≥3 peers.
+        if self.config.development_mode {
+            return validator_count >= 1;
+        }
+
         // Runtime assertion: BFT_MIN_VALIDATORS must match the types-module constant.
         debug_assert_eq!(
             BFT_MIN_VALIDATORS,

--- a/lib-consensus/src/engines/consensus_engine/network.rs
+++ b/lib-consensus/src/engines/consensus_engine/network.rs
@@ -202,8 +202,17 @@ impl ConsensusEngine {
                         && matches!(self.fsm_state, lib_consensus_core::fsm::ValidatorState::Bootstrapping)
                     {
                         let blockchain_height = self.current_round.height.saturating_sub(1);
-                        let caught_up = last_height_seen > 1
-                            && blockchain_height + 2 >= last_height_seen;
+
+                        // In development mode, skip the peer-height catch-up check
+                        // and immediately transition to active consensus. This allows
+                        // single-validator dev/test nodes to bypass the network-height
+                        // gate that expects peer observations before entering Idle.
+                        let caught_up = if self.config.development_mode {
+                            true
+                        } else {
+                            last_height_seen > 1
+                                && blockchain_height + 2 >= last_height_seen
+                        };
 
                         if !caught_up {
                             tracing::debug!(

--- a/lib-consensus/src/engines/consensus_engine/state_machine.rs
+++ b/lib-consensus/src/engines/consensus_engine/state_machine.rs
@@ -3004,6 +3004,17 @@ impl ConsensusEngine {
                 let validator_ids = self.get_active_validator_ids();
 
                 self.broadcast(msg, &validator_ids).await;
+
+                // After casting our precommit, immediately check for precommit
+                // quorum and transition to Commit step if reached. With a single
+                // validator (1/1 precommits = supermajority), this allows the
+                // engine to cast its commit vote and finalize without waiting
+                // for the precommit timeout to fire.
+                // NOTE: Gated on development_mode — multi-validator BFT relies on
+                // the precommit timeout for correct step timing.
+                if self.config.development_mode {
+                    self.enter_commit_step().await?;
+                }
             }
         }
 

--- a/zhtp/configs/dev-node.toml
+++ b/zhtp/configs/dev-node.toml
@@ -45,7 +45,7 @@ long_range_relays = false
 
 [blockchain_config]
 network_id = "zhtp-dev"
-block_time_seconds = 2  # Faster blocks for development
+block_time_seconds = 10  # Faster blocks for development
 max_block_size = 1048576
 zk_transactions = false  # Simplified for development
 smart_contracts = true
@@ -53,7 +53,7 @@ smart_contracts = true
 [consensus_config]
 consensus_type = "Hybrid"
 dao_enabled = true
-validator_enabled = false  # Can be enabled for testing
+validator_enabled = true  # Can be enabled for testing
 min_stake = 100  # Lower stake for development
 reward_multipliers = {}
 


### PR DESCRIPTION
 — single-validator BFT with development_mode gate, block_time=10s, validator_enabled=true 
