### PR TITLE
Fix/dev node treasury bootstrap

### DIFF
--- a/lib-blockchain/src/transaction/system_tx_signature.rs
+++ b/lib-blockchain/src/transaction/system_tx_signature.rs
@@ -163,19 +163,40 @@ pub fn allows_empty_system_signature(transaction: &Transaction) -> bool {
             if transaction.signature.public_key.dilithium_pk != wallet_pk {
                 return false;
             }
-            // Legacy/validator wallets (zero kyber): wallet_id == blake3(pk).
-            let key_id = crate::types::hash::blake3_hash(wallet_pk.as_slice());
-            if w.wallet_id.as_bytes() == key_id.as_bytes() {
+            // Primary wallet ids: blake3(pk) [legacy/validator] or blake3(pk || kyber) [client].
+            let legacy_primary = crate::types::hash::blake3_hash(wallet_pk.as_slice());
+            let client_primary = if w.kyber_public_key.is_empty() {
+                None
+            } else {
+                let mut client_input = wallet_pk.to_vec();
+                client_input.extend_from_slice(&w.kyber_public_key);
+                Some(crate::types::hash::blake3_hash(&client_input))
+            };
+
+            // Derived UBI/savings wallet ids (#2979): blake3(primary || "ubi"/"savings").
+            // Accept the primary id or either derived id so system-injected zero-balance
+            // wallet registrations (register_wallet) remain bound to the payload key.
+            let matches_primary_or_derived = |primary: &crate::types::Hash| -> bool {
+                if w.wallet_id.as_bytes() == primary.as_bytes() {
+                    return true;
+                }
+                for suffix in [b"ubi".as_slice(), b"savings".as_slice()] {
+                    let mut input = primary.as_bytes().to_vec();
+                    input.extend_from_slice(suffix);
+                    if w.wallet_id.as_bytes() == crate::types::hash::blake3_hash(&input).as_bytes()
+                    {
+                        return true;
+                    }
+                }
+                false
+            };
+
+            if matches_primary_or_derived(&legacy_primary) {
                 return true;
             }
-            // Client wallets: wallet_id == blake3(pk || kyber_pk).
-            if w.kyber_public_key.is_empty() {
-                return false;
-            }
-            let mut client_input = wallet_pk.to_vec();
-            client_input.extend_from_slice(&w.kyber_public_key);
-            let client_key_id = crate::types::hash::blake3_hash(&client_input);
-            w.wallet_id.as_bytes() == client_key_id.as_bytes()
+            client_primary
+                .map(|p| matches_primary_or_derived(&p))
+                .unwrap_or(false)
         }
         _ => false,
     }
@@ -526,5 +547,61 @@ mod tests {
             allows_empty_system_signature(&legacy_tx),
             "legacy wallet (blake3(pk) binding) must pass empty-sig check"
         );
+    }
+
+    /// Regression (#2985 follow-up): UBI/savings wallet ids derive from the primary id
+    /// (#2979), so their zero-balance empty-signature system registrations must also
+    /// satisfy the pk-binding in `allows_empty_system_signature` — otherwise block
+    /// commit rejects them as `InvalidSignature`.
+    #[test]
+    fn derived_ubi_savings_wallets_pass_empty_sig_binding() {
+        use crate::integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm};
+        use crate::transaction::core::WalletTransactionData;
+        use crate::types::hash::blake3_hash;
+        use crate::types::Hash;
+
+        let keypair = lib_crypto::generate_keypair().expect("keypair");
+        let dilithium_pk = keypair.public_key.dilithium_pk;
+        let kyber_pk = keypair.public_key.kyber_pk.to_vec();
+
+        let mut primary_input = dilithium_pk.to_vec();
+        primary_input.extend_from_slice(&kyber_pk);
+        let primary_id = blake3_hash(&primary_input);
+
+        for (suffix, label) in [(&b"ubi"[..], "UBI"), (&b"savings"[..], "savings")] {
+            let mut derived_input = primary_id.as_bytes().to_vec();
+            derived_input.extend_from_slice(suffix);
+            let derived_id = blake3_hash(&derived_input);
+
+            let wallet = WalletTransactionData {
+                wallet_id: derived_id,
+                wallet_type: label.to_string(),
+                wallet_name: format!("{label} Wallet"),
+                alias: None,
+                public_key: dilithium_pk.to_vec(),
+                kyber_public_key: kyber_pk.clone(),
+                owner_identity_id: None,
+                seed_commitment: Hash::default(),
+                created_at: 1_700_000_000,
+                registration_fee: 0,
+                capabilities: 0,
+                initial_balance: 0,
+            };
+            let tx = Transaction::new_wallet_registration(
+                wallet,
+                vec![],
+                Signature {
+                    signature: Vec::new(),
+                    public_key: PublicKey::new(dilithium_pk),
+                    algorithm: SignatureAlgorithm::DEFAULT,
+                    timestamp: 1,
+                },
+                format!("wallet-reg:{label}").into_bytes(),
+            );
+            assert!(
+                allows_empty_system_signature(&tx),
+                "{label} wallet (blake3(primary || {label:?}) binding) must pass empty-sig check"
+            );
+        }
     }
 }

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -2584,8 +2584,11 @@ impl RuntimeOrchestrator {
                     } else {
                         info!("📂 SledStore is empty - creating genesis (validator, peers all at height 0)");
                     }
-                    let mut bc = lib_blockchain::Blockchain::new()?;
-                    bc.set_store(store.clone());
+                    // Attach the BlockExecutor on the fresh-bootstrap path (parity with
+                    // load_from_store). Without it, process_and_commit_block takes the
+                    // legacy branch whose TokenMint path casts amount to u64 and overflows
+                    // on the 5000 SOV (18-decimal) welcome mint.
+                    let mut bc = lib_blockchain::Blockchain::new_with_store(store.clone())?;
 
                     // Log the genesis block hash for verification/debugging.
                     // Note: Full hash verification against CANONICAL_GENESIS_HASH is done
@@ -2730,6 +2733,40 @@ impl RuntimeOrchestrator {
         // load_from_store on restart (mod.rs ~1249), which replaces *bc and
         // wipes council_members — bootstrap + cache seed must run AFTER that.
         ensure_council_bootstrap_and_cache(&self.config.consensus_config.council).await?;
+
+        // Dev-node treasury bootstrap (#2985 follow-up): treasury-kernel init runs
+        // inside load_from_store *before* the council is bootstrapped, so on a fresh
+        // dev chain (empty [bootstrap_council].members) the kernel is left unset and
+        // every SOV mint is rejected as Unauthorized. Re-run init now that the council
+        // is populated, then fall back to the node's own validator key when no council
+        // is configured (single-node dev chain). Production replaces the fallback with
+        // the key ceremony + [bootstrap_council].members (#1909).
+        {
+            let blockchain_arc =
+                crate::runtime::blockchain_provider::get_global_blockchain().await?;
+            let mut bc = blockchain_arc.write().await;
+            if bc.treasury_kernel.is_none() {
+                bc.init_treasury_kernel_if_missing();
+            }
+            let dev_env = matches!(
+                self.config.environment,
+                crate::config::Environment::Development
+            );
+            if bc.treasury_kernel.is_none() && dev_env {
+                match crate::runtime::token_utils::load_validator_keypair_from_keystore().await {
+                    Ok(kp) => {
+                        bc.initialize_treasury_kernel(kp.public_key);
+                        warn!(
+                            "Treasury Kernel initialized with node validator key \
+                             (dev bootstrap: no council configured)"
+                        );
+                    }
+                    Err(e) => {
+                        warn!("Treasury Kernel dev bootstrap skipped: {e}");
+                    }
+                }
+            }
+        }
 
         // Derive deterministic NodeId from DID + device name and cache for runtime access
         let device_name = resolve_device_name(Some(&wallet_result.node_identity.primary_device))


### PR DESCRIPTION
lib-blockchain/src/transaction/system_tx_signature.rs — derived-wallet empty-sig binding fix. allows_empty_system_signature WalletRegistration arm now accepts blake3(primary) or blake3(primary||"ubi"/"savings"). Test derived_ubi_savings_wallets_pass_empty_sig_binding added. Correct.

zhtp/src/runtime/mod.rs — two fixes:

:2587 — Blockchain::new_with_store(store) instead of new()+set_store() (fresh-node executor, u64 overflow fix).
:2737 — treasury kernel re-init after council bootstrap, then dev fallback to validator key gated on Environment::Development.