### PR TITLE
refactor(#2996): rename SOV_WELCOME_BONUS to DEV_BOOTSTRAP_BONUS

### DIFF
--- a/lib-identity/src/citizenship/welcome_bonus.rs
+++ b/lib-identity/src/citizenship/welcome_bonus.rs
@@ -1,6 +1,6 @@
 //! Welcome bonus for new citizens from the original identity.rs
 
-use crate::constants::SOV_WELCOME_BONUS_SOV;
+use crate::constants::DEV_BOOTSTRAP_BONUS_SOV;
 use crate::economics::{EconomicModel, Priority, Transaction, TransactionType};
 use crate::types::IdentityId;
 use crate::wallets::WalletId;
@@ -55,7 +55,7 @@ impl WelcomeBonus {
             .as_secs();
 
         // Welcome bonus: 5,000 SOV tokens to get started (atomic units)
-        let bonus_amount = lib_types::sov::atoms(SOV_WELCOME_BONUS_SOV as u128);
+        let bonus_amount = lib_types::sov::atoms(DEV_BOOTSTRAP_BONUS_SOV as u128);
 
         // Create welcome bonus transaction
         let bonus_tx = Transaction::new(
@@ -82,7 +82,7 @@ impl WelcomeBonus {
         tracing::info!(
             "WELCOME BONUS: Citizen {} received {} SOV tokens",
             hex::encode(&identity_id.0[..8]),
-            SOV_WELCOME_BONUS_SOV
+            DEV_BOOTSTRAP_BONUS_SOV
         );
 
         Ok(Self::new(

--- a/lib-identity/src/constants.rs
+++ b/lib-identity/src/constants.rs
@@ -30,10 +30,10 @@ pub const TESTNET_GENESIS_HASH: [u8; 32] = [
 pub const SOV_ATOMIC_UNITS: u128 = lib_types::sov::SCALE;
 
 /// Welcome bonus amount in SOV (human units)
-pub const SOV_WELCOME_BONUS_SOV: u128 = 5_000;
+pub const DEV_BOOTSTRAP_BONUS_SOV: u128 = 5_000;
 
 /// Welcome bonus in atomic units (18-decimal)
-pub const SOV_WELCOME_BONUS: u128 = lib_types::sov::atoms(5_000);
+pub const DEV_BOOTSTRAP_BONUS: u128 = lib_types::sov::atoms(5_000);
 
 /// Monthly UBI amount in SOV (human units)
 pub const SOV_UBI_MONTHLY_SOV: u128 = 1_000;

--- a/lib-identity/src/identity/manager_tests.rs
+++ b/lib-identity/src/identity/manager_tests.rs
@@ -11,7 +11,7 @@ mod tests {
     use crate::citizenship::*;
     use crate::economics::EconomicModel;
     use crate::wallets::WalletType;
-    use crate::constants::{SOV_ATOMIC_UNITS, SOV_UBI_MONTHLY_SOV, SOV_WELCOME_BONUS_SOV};
+    use crate::constants::{SOV_ATOMIC_UNITS, SOV_UBI_MONTHLY_SOV, DEV_BOOTSTRAP_BONUS_SOV};
     use lib_crypto::Hash;
     use std::collections::HashMap;
 
@@ -97,7 +97,7 @@ mod tests {
         assert_eq!(citizenship_result.privacy_credentials.credentials.len(), 2); // Age + Reputation
         
         // Verify welcome bonus
-        assert_eq!(citizenship_result.welcome_bonus.bonus_amount, SOV_WELCOME_BONUS_SOV * SOV_ATOMIC_UNITS);
+        assert_eq!(citizenship_result.welcome_bonus.bonus_amount, DEV_BOOTSTRAP_BONUS_SOV * SOV_ATOMIC_UNITS);
         assert_eq!(citizenship_result.welcome_bonus.wallet_id, citizenship_result.primary_wallet_id);
         
         // Verify the identity was stored in manager

--- a/lib-identity/tests/integration_tests.rs
+++ b/lib-identity/tests/integration_tests.rs
@@ -4,7 +4,7 @@
 //! including citizen onboarding, credential verification, and zero-knowledge proofs.
 
 use lib_crypto::Hash;
-use lib_identity::constants::{SOV_ATOMIC_UNITS, SOV_UBI_MONTHLY_SOV, SOV_WELCOME_BONUS_SOV};
+use lib_identity::constants::{SOV_ATOMIC_UNITS, SOV_UBI_MONTHLY_SOV, DEV_BOOTSTRAP_BONUS_SOV};
 use lib_identity::credentials::creation::CredentialFactory;
 use lib_identity::identity::activity_tracking::{ActivityTracker, ActivityType};
 use lib_identity::*;
@@ -74,7 +74,7 @@ async fn test_complete_citizen_onboarding_flow() {
     // Verify welcome bonus
     assert_eq!(
         citizenship_result.welcome_bonus.bonus_amount,
-        SOV_WELCOME_BONUS_SOV * SOV_ATOMIC_UNITS
+        DEV_BOOTSTRAP_BONUS_SOV * SOV_ATOMIC_UNITS
     );
 
     println!("Complete citizen onboarding test passed!");
@@ -438,7 +438,7 @@ async fn test_citizenship_system_integration() {
         );
         assert_eq!(
             result.welcome_bonus.bonus_amount,
-            SOV_WELCOME_BONUS_SOV * SOV_ATOMIC_UNITS
+            DEV_BOOTSTRAP_BONUS_SOV * SOV_ATOMIC_UNITS
         );
     }
 

--- a/zhtp/src/api/handlers/constants.rs
+++ b/zhtp/src/api/handlers/constants.rs
@@ -5,10 +5,10 @@
 pub const SOV_ATOMIC_UNITS: u128 = lib_types::sov::SCALE;
 
 /// SOV token welcome bonus amount (human units)
-pub const SOV_WELCOME_BONUS_SOV: u128 = 5_000;
+pub const DEV_BOOTSTRAP_BONUS_SOV: u128 = 5_000;
 
 /// SOV token welcome bonus amount for new users (atomic units)
-pub const SOV_WELCOME_BONUS: u128 = lib_types::sov::atoms(5_000);
+pub const DEV_BOOTSTRAP_BONUS: u128 = lib_types::sov::atoms(5_000);
 
 /// Custom ZHTP recovery phrase word count
 pub const ZHTP_RECOVERY_PHRASE_WORD_COUNT: usize = 20;

--- a/zhtp/src/api/handlers/identity/mod.rs
+++ b/zhtp/src/api/handlers/identity/mod.rs
@@ -30,7 +30,7 @@ use lib_identity::{CitizenshipResult, IdentityManager, IdentityType, RecoveryPhr
 use lib_identity::economics::EconomicModel as IdentityEconomicModel;
 
 // Blockchain imports for transaction creation
-use crate::api::handlers::constants::{SOV_ATOMIC_UNITS, SOV_WELCOME_BONUS, SOV_WELCOME_BONUS_SOV};
+use crate::api::handlers::constants::{SOV_ATOMIC_UNITS, DEV_BOOTSTRAP_BONUS, DEV_BOOTSTRAP_BONUS_SOV};
 use lib_blockchain::{
     integration::crypto_integration::{PublicKey, Signature, SignatureAlgorithm},
     transaction::core::IdentityTransactionData,
@@ -44,7 +44,7 @@ use lib_blockchain::{
 /// routing/storage and, on testnet, the faucet — no automatic mint).
 fn welcome_bonus_for(environment: &crate::config::environment::Environment) -> u128 {
     match environment {
-        crate::config::environment::Environment::Development => SOV_WELCOME_BONUS,
+        crate::config::environment::Environment::Development => DEV_BOOTSTRAP_BONUS,
         _ => 0,
     }
 }
@@ -2291,7 +2291,7 @@ impl IdentityHandler {
         // by a throwaway server keypair over transaction.hash().
         let did_string = did.clone();
         let welcome_bonus_amount = if welcome_bonus_is_development() {
-            SOV_WELCOME_BONUS
+            DEV_BOOTSTRAP_BONUS
         } else {
             0
         };
@@ -2516,7 +2516,7 @@ impl IdentityHandler {
                 queued_txs.push(mint_tx.clone());
                 tracing::info!(
                     "💰 Primary wallet queued; {} SOV welcome bonus mint pending block inclusion",
-                    SOV_WELCOME_BONUS_SOV
+                    DEV_BOOTSTRAP_BONUS_SOV
                 );
             }
 
@@ -2695,7 +2695,7 @@ mod welcome_bonus_gate_tests {
     fn development_mints_full_welcome_bonus() {
         assert_eq!(
             welcome_bonus_for(&Environment::Development),
-            SOV_WELCOME_BONUS
+            DEV_BOOTSTRAP_BONUS
         );
     }
 

--- a/zhtp/src/api/handlers/marketplace/mod.rs
+++ b/zhtp/src/api/handlers/marketplace/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Handles buying, selling, and transferring content ownership with blockchain integration.
 
-use crate::api::handlers::constants::SOV_WELCOME_BONUS;
+use crate::api::handlers::constants::DEV_BOOTSTRAP_BONUS;
 use anyhow::anyhow;
 use lib_blockchain::{TransactionOutput, TransactionType};
 use lib_crypto::hashing::hash_blake3;
@@ -460,7 +460,7 @@ impl MarketplaceHandler {
         );
 
         for view in owned_outputs {
-            let utxo_amount = SOV_WELCOME_BONUS;
+            let utxo_amount = DEV_BOOTSTRAP_BONUS;
             wallet_utxos.push((view.legacy_hash, view.output_index, utxo_amount));
             info!(
                 "    Found UTXO: {}",

--- a/zhtp/src/runtime/components/identity.rs
+++ b/zhtp/src/runtime/components/identity.rs
@@ -5,7 +5,7 @@ use tokio::sync::RwLock;
 use tokio::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
-use crate::api::handlers::constants::{SOV_WELCOME_BONUS, SOV_WELCOME_BONUS_SOV};
+use crate::api::handlers::constants::{DEV_BOOTSTRAP_BONUS, DEV_BOOTSTRAP_BONUS_SOV};
 use crate::runtime::node_runtime::NodeRole;
 use crate::runtime::{Component, ComponentHealth, ComponentId, ComponentMessage, ComponentStatus};
 use lib_identity::IdentityManager;
@@ -200,7 +200,7 @@ impl Component for IdentityComponent {
         if !genesis_ids.is_empty() {
             info!(
                 "Funding genesis primary wallets with {} SOV welcome bonus...",
-                SOV_WELCOME_BONUS_SOV
+                DEV_BOOTSTRAP_BONUS_SOV
             );
             for genesis_identity in &genesis_ids {
                 if genesis_identity.identity_type == lib_identity::IdentityType::Human {

--- a/zhtp/src/runtime/did_startup.rs
+++ b/zhtp/src/runtime/did_startup.rs
@@ -4,7 +4,7 @@
 //! Nodes run under wallet context rather than identity context. Identities are optional
 //! and can be linked to wallets later for citizen services like UBI and DAO participation.
 
-use crate::api::handlers::constants::SOV_WELCOME_BONUS;
+use crate::api::handlers::constants::DEV_BOOTSTRAP_BONUS;
 use crate::keyfile_names::{
     KeystorePrivateKey, NODE_IDENTITY_FILENAME, NODE_PRIVATE_KEY_FILENAME, USER_IDENTITY_FILENAME,
     USER_PRIVATE_KEY_FILENAME, WALLET_DATA_FILENAME,
@@ -69,7 +69,7 @@ struct PersistedWalletData {
 }
 
 fn default_genesis_balance() -> u128 {
-    SOV_WELCOME_BONUS // Default genesis wallet balance (atomic units)
+    DEV_BOOTSTRAP_BONUS // Default genesis wallet balance (atomic units)
 }
 
 /// Get the default keystore path (under node_data_dir/keystore)
@@ -406,7 +406,7 @@ fn save_to_keystore(
         .values()
         .find(|w| w.wallet_type == lib_identity::WalletType::Primary)
         .map(|w| w.balance)
-        .unwrap_or(SOV_WELCOME_BONUS); // Default to genesis balance if not found
+        .unwrap_or(DEV_BOOTSTRAP_BONUS); // Default to genesis balance if not found
 
     let wallet_data = PersistedWalletData {
         wallet_name: result.wallet_name.clone(),

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -10,12 +10,52 @@ use tokio::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
 use super::config::NodeConfig;
-use crate::api::handlers::constants::{DEV_BOOTSTRAP_BONUS, DEV_BOOTSTRAP_BONUS_SOV};
+use crate::api::handlers::constants::{
+    DEV_BOOTSTRAP_BONUS, DEV_BOOTSTRAP_BONUS_SOV, SOV_ATOMIC_UNITS,
+};
 use crate::runtime::node_identity::{
     derive_node_id, log_runtime_node_identity, resolve_device_name, set_runtime_node_identity,
     RuntimeNodeIdentity,
 };
 // Removed ZK coordinator - using unified lib-proofs system directly
+
+/// Credit the Development bootstrap bonus to a wallet as a spendable UTXO.
+///
+/// No-op when `amount_atoms` is 0 (non-Development environments). Consolidates
+/// the four previously-duplicated welcome-bonus UTXO blocks into one path.
+fn credit_dev_bootstrap_utxo(
+    blockchain: &mut lib_blockchain::Blockchain,
+    wallet_id_hex: &str,
+    amount_atoms: u128,
+) {
+    if amount_atoms == 0 {
+        return;
+    }
+    blockchain.update_wallet_shadow_initial_balance(wallet_id_hex, amount_atoms);
+    let utxo_output = lib_blockchain::transaction::TransactionOutput {
+        commitment: lib_blockchain::types::hash::blake3_hash(
+            format!(
+                "welcome_bonus_commitment_{}_{}",
+                wallet_id_hex, amount_atoms
+            )
+            .as_bytes(),
+        ),
+        note: lib_blockchain::types::hash::blake3_hash(
+            format!("welcome_bonus_note_{}", wallet_id_hex).as_bytes(),
+        ),
+        recipient: lib_crypto::PublicKey::new([0u8; 2592]),
+        merkle_leaf: lib_blockchain::Hash::default(),
+    };
+    let utxo_hash = lib_blockchain::types::hash::blake3_hash(
+        format!("welcome_bonus_utxo:{}", wallet_id_hex).as_bytes(),
+    );
+    blockchain.utxo_set.insert(utxo_hash, utxo_output);
+    info!(
+        "🎁 Welcome bonus: {} SOV credited to wallet {} (UTXO created)",
+        amount_atoms / SOV_ATOMIC_UNITS,
+        &wallet_id_hex[..16]
+    );
+}
 
 /// Information about an existing network discovered during startup
 #[derive(Debug, Clone)]
@@ -2931,6 +2971,14 @@ impl RuntimeOrchestrator {
         // ========================================================================
         info!("📝 Registering identity on blockchain...");
 
+        // The dev bootstrap bonus is Development-only; Testnet/Mainnet mint nothing.
+        let bootstrap_bonus = if self.config.environment == crate::config::Environment::Development
+        {
+            DEV_BOOTSTRAP_BONUS
+        } else {
+            0
+        };
+
         // Get pending identity from Phase 3
         if let Some(identity) = self.get_pending_identity_registration().await {
             // Prefer the global blockchain provider for registration.
@@ -2979,7 +3027,7 @@ impl RuntimeOrchestrator {
                     // Register wallets on blockchain
                     for (wallet_id, wallet) in &identity.wallet_manager.wallets {
                         let initial_balance = if format!("{:?}", wallet.wallet_type) == "Primary" {
-                            DEV_BOOTSTRAP_BONUS
+                            bootstrap_bonus
                         } else {
                             0
                         };
@@ -3027,42 +3075,13 @@ impl RuntimeOrchestrator {
                                     hex::encode(&tx_hash.as_bytes()[..8])
                                 );
 
-                                // Add welcome bonus for Primary wallets (new identity registration)
+                                // Add dev-bootstrap bonus for Primary wallets (Development only).
                                 if format!("{:?}", wallet.wallet_type) == "Primary" {
                                     let wallet_id_hex = hex::encode(&wallet_id.0);
-                                    let welcome_bonus = DEV_BOOTSTRAP_BONUS;
-
-                                    // Update wallet registry balance
-                                    blockchain_ref.update_wallet_shadow_initial_balance(
+                                    credit_dev_bootstrap_utxo(
+                                        blockchain_ref,
                                         &wallet_id_hex,
-                                        welcome_bonus,
-                                    );
-
-                                    // Create spendable UTXO for the welcome bonus
-                                    let utxo_output =
-                                        lib_blockchain::transaction::TransactionOutput {
-                                            commitment: lib_blockchain::types::hash::blake3_hash(
-                                                format!(
-                                                    "welcome_bonus_commitment_{}_{}",
-                                                    wallet_id_hex, welcome_bonus
-                                                )
-                                                .as_bytes(),
-                                            ),
-                                            note: lib_blockchain::types::hash::blake3_hash(
-                                                format!("welcome_bonus_note_{}", wallet_id_hex)
-                                                    .as_bytes(),
-                                            ),
-                                            recipient: lib_crypto::PublicKey::new([0u8; 2592]),
-                                            merkle_leaf: lib_blockchain::Hash::default(),
-                                        };
-                                    let utxo_hash = lib_blockchain::types::hash::blake3_hash(
-                                        format!("welcome_bonus_utxo:{}", wallet_id_hex).as_bytes(),
-                                    );
-                                    blockchain_ref.utxo_set.insert(utxo_hash, utxo_output);
-
-                                    info!(
-                                        "🎁 Welcome bonus: {} SOV recorded for wallet {} (UTXO created; TokenMint queued by backfill)",
-                                        DEV_BOOTSTRAP_BONUS_SOV, &wallet_id_hex[..16]
+                                        bootstrap_bonus,
                                     );
                                 }
                             }
@@ -3164,7 +3183,7 @@ impl RuntimeOrchestrator {
                                         if format!("{:?}", wallet.wallet_type) == "Primary" {
                                             let current = wallet.balance;
                                             if current == 0 {
-                                                DEV_BOOTSTRAP_BONUS
+                                                bootstrap_bonus
                                             } else {
                                                 current
                                             }
@@ -3221,7 +3240,9 @@ impl RuntimeOrchestrator {
 
                                             // Give welcome bonus to newly registered Primary wallets (like genesis)
                                             // Create actual UTXO so funds are spendable
-                                            if format!("{:?}", wallet.wallet_type) == "Primary" {
+                                            if format!("{:?}", wallet.wallet_type) == "Primary"
+                                                && bootstrap_bonus > 0
+                                            {
                                                 let wallet_id_hex = hex::encode(&wallet_id.0);
                                                 let welcome_bonus = DEV_BOOTSTRAP_BONUS;
 
@@ -3277,6 +3298,7 @@ impl RuntimeOrchestrator {
                                     // Wallet exists - check if it needs funding
                                     if wallet_entry.initial_balance == 0
                                         && format!("{:?}", wallet.wallet_type) == "Primary"
+                                        && bootstrap_bonus > 0
                                     {
                                         info!(
                                             "📝 Funding existing zero-balance Primary wallet: {}",
@@ -3328,7 +3350,7 @@ impl RuntimeOrchestrator {
                                         if format!("{:?}", wallet.wallet_type) == "Primary" {
                                             let current = wallet.balance;
                                             if current == 0 {
-                                                DEV_BOOTSTRAP_BONUS
+                                                bootstrap_bonus
                                             } else {
                                                 current
                                             }
@@ -3384,7 +3406,9 @@ impl RuntimeOrchestrator {
                                             );
 
                                             // Give welcome bonus to Primary wallets
-                                            if format!("{:?}", wallet.wallet_type) == "Primary" {
+                                            if format!("{:?}", wallet.wallet_type) == "Primary"
+                                                && bootstrap_bonus > 0
+                                            {
                                                 let welcome_bonus = DEV_BOOTSTRAP_BONUS;
 
                                                 // Update wallet registry balance

--- a/zhtp/src/runtime/mod.rs
+++ b/zhtp/src/runtime/mod.rs
@@ -10,7 +10,7 @@ use tokio::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
 use super::config::NodeConfig;
-use crate::api::handlers::constants::{SOV_WELCOME_BONUS, SOV_WELCOME_BONUS_SOV};
+use crate::api::handlers::constants::{DEV_BOOTSTRAP_BONUS, DEV_BOOTSTRAP_BONUS_SOV};
 use crate::runtime::node_identity::{
     derive_node_id, log_runtime_node_identity, resolve_device_name, set_runtime_node_identity,
     RuntimeNodeIdentity,
@@ -2979,7 +2979,7 @@ impl RuntimeOrchestrator {
                     // Register wallets on blockchain
                     for (wallet_id, wallet) in &identity.wallet_manager.wallets {
                         let initial_balance = if format!("{:?}", wallet.wallet_type) == "Primary" {
-                            SOV_WELCOME_BONUS
+                            DEV_BOOTSTRAP_BONUS
                         } else {
                             0
                         };
@@ -3030,7 +3030,7 @@ impl RuntimeOrchestrator {
                                 // Add welcome bonus for Primary wallets (new identity registration)
                                 if format!("{:?}", wallet.wallet_type) == "Primary" {
                                     let wallet_id_hex = hex::encode(&wallet_id.0);
-                                    let welcome_bonus = SOV_WELCOME_BONUS;
+                                    let welcome_bonus = DEV_BOOTSTRAP_BONUS;
 
                                     // Update wallet registry balance
                                     blockchain_ref.update_wallet_shadow_initial_balance(
@@ -3062,7 +3062,7 @@ impl RuntimeOrchestrator {
 
                                     info!(
                                         "🎁 Welcome bonus: {} SOV recorded for wallet {} (UTXO created; TokenMint queued by backfill)",
-                                        SOV_WELCOME_BONUS_SOV, &wallet_id_hex[..16]
+                                        DEV_BOOTSTRAP_BONUS_SOV, &wallet_id_hex[..16]
                                     );
                                 }
                             }
@@ -3164,7 +3164,7 @@ impl RuntimeOrchestrator {
                                         if format!("{:?}", wallet.wallet_type) == "Primary" {
                                             let current = wallet.balance;
                                             if current == 0 {
-                                                SOV_WELCOME_BONUS
+                                                DEV_BOOTSTRAP_BONUS
                                             } else {
                                                 current
                                             }
@@ -3223,7 +3223,7 @@ impl RuntimeOrchestrator {
                                             // Create actual UTXO so funds are spendable
                                             if format!("{:?}", wallet.wallet_type) == "Primary" {
                                                 let wallet_id_hex = hex::encode(&wallet_id.0);
-                                                let welcome_bonus = SOV_WELCOME_BONUS;
+                                                let welcome_bonus = DEV_BOOTSTRAP_BONUS;
 
                                                 // Update wallet registry balance
                                                 blockchain_ref
@@ -3254,7 +3254,7 @@ impl RuntimeOrchestrator {
                                                 blockchain_ref
                                                     .utxo_set
                                                     .insert(utxo_hash, utxo_output);
-                                                info!("🎁 Welcome bonus: {} SOV credited to wallet {} (UTXO created)", SOV_WELCOME_BONUS_SOV, &wallet_id_hex[..16]);
+                                                info!("🎁 Welcome bonus: {} SOV credited to wallet {} (UTXO created)", DEV_BOOTSTRAP_BONUS_SOV, &wallet_id_hex[..16]);
                                             }
                                         }
                                         Err(e) => {
@@ -3283,7 +3283,7 @@ impl RuntimeOrchestrator {
                                             &wallet_id_hex[..16]
                                         );
 
-                                        let welcome_bonus = SOV_WELCOME_BONUS;
+                                        let welcome_bonus = DEV_BOOTSTRAP_BONUS;
 
                                         // Update wallet registry
                                         blockchain_ref.update_wallet_shadow_initial_balance(
@@ -3315,7 +3315,7 @@ impl RuntimeOrchestrator {
                                         );
                                         blockchain_ref.utxo_set.insert(utxo_hash, utxo_output);
 
-                                        info!("🎁 Welcome bonus: {} SOV credited to wallet {} (UTXO created)", SOV_WELCOME_BONUS_SOV, &wallet_id_hex[..16]);
+                                        info!("🎁 Welcome bonus: {} SOV credited to wallet {} (UTXO created)", DEV_BOOTSTRAP_BONUS_SOV, &wallet_id_hex[..16]);
                                     }
                                 } else {
                                     // Wallet NOT in registry - register it now
@@ -3328,7 +3328,7 @@ impl RuntimeOrchestrator {
                                         if format!("{:?}", wallet.wallet_type) == "Primary" {
                                             let current = wallet.balance;
                                             if current == 0 {
-                                                SOV_WELCOME_BONUS
+                                                DEV_BOOTSTRAP_BONUS
                                             } else {
                                                 current
                                             }
@@ -3385,7 +3385,7 @@ impl RuntimeOrchestrator {
 
                                             // Give welcome bonus to Primary wallets
                                             if format!("{:?}", wallet.wallet_type) == "Primary" {
-                                                let welcome_bonus = SOV_WELCOME_BONUS;
+                                                let welcome_bonus = DEV_BOOTSTRAP_BONUS;
 
                                                 // Update wallet registry balance
                                                 blockchain_ref
@@ -3418,7 +3418,7 @@ impl RuntimeOrchestrator {
                                                     .insert(utxo_hash, utxo_output);
 
                                                 info!("🎁 Welcome bonus: {} SOV credited to wallet {} (UTXO created)",
-                                                    SOV_WELCOME_BONUS_SOV, &wallet_id_hex[..16]);
+                                                    DEV_BOOTSTRAP_BONUS_SOV, &wallet_id_hex[..16]);
                                             }
                                         }
                                         Err(e) => {
@@ -4902,7 +4902,7 @@ impl RuntimeOrchestrator {
         );
 
         for view in owned_outputs {
-            let utxo_amount = SOV_WELCOME_BONUS;
+            let utxo_amount = DEV_BOOTSTRAP_BONUS;
             wallet_utxos.push((view.legacy_hash, view.output_index, utxo_amount));
             info!(
                 "   Found UTXO: {}",

--- a/zhtp/src/runtime/services/genesis_funding.rs
+++ b/zhtp/src/runtime/services/genesis_funding.rs
@@ -1,4 +1,4 @@
-use crate::api::handlers::constants::{SOV_WELCOME_BONUS, SOV_WELCOME_BONUS_SOV};
+use crate::api::handlers::constants::{DEV_BOOTSTRAP_BONUS, DEV_BOOTSTRAP_BONUS_SOV};
 use anyhow::Result;
 use lib_blockchain::{
     integration::crypto_integration::{Signature, SignatureAlgorithm},
@@ -157,7 +157,7 @@ impl GenesisFundingService {
             let wallet_id_hex = hex::encode(&wallet_id.0[..8]);
             info!(
                 " Funding genesis user primary wallet: {} with {} SOV welcome bonus",
-                wallet_id_hex, SOV_WELCOME_BONUS_SOV
+                wallet_id_hex, DEV_BOOTSTRAP_BONUS_SOV
             );
 
             // CRITICAL: Get the FULL Dilithium5 public key from the identity's private data
@@ -207,7 +207,7 @@ impl GenesisFundingService {
                 created_at: 1730419200, // Genesis timestamp
                 registration_fee: 0,
                 capabilities: 0xFFFFFFFF,           // Full capabilities
-                initial_balance: SOV_WELCOME_BONUS, // 5,000 SOV welcome bonus (atomic units)
+                initial_balance: DEV_BOOTSTRAP_BONUS, // 5,000 SOV welcome bonus (atomic units)
             };
 
             blockchain.insert_wallet_shadow(hex::encode(&wallet_id.0), wallet_data);
@@ -237,7 +237,7 @@ impl GenesisFundingService {
                             anyhow::anyhow!("SOV token contract missing for genesis mint")
                         })?;
                     token
-                        .mint(&recipient_pk, SOV_WELCOME_BONUS as u128)
+                        .mint(&recipient_pk, DEV_BOOTSTRAP_BONUS as u128)
                         .map_err(|e| anyhow::anyhow!("failed to mint genesis wallet SOV: {e}"))?;
                     if let Some(store) = blockchain.get_store() {
                         let token_id = lib_blockchain::storage::TokenId::new(sov_token_id);
@@ -246,7 +246,7 @@ impl GenesisFundingService {
                             .force_set_token_balances(&[(
                                 token_id,
                                 addr,
-                                SOV_WELCOME_BONUS as u128,
+                                DEV_BOOTSTRAP_BONUS as u128,
                             )])
                             .map_err(|e| {
                                 anyhow::anyhow!("failed to persist genesis wallet SOV to sled: {e}")
@@ -257,7 +257,7 @@ impl GenesisFundingService {
 
             info!(
                 " Genesis user wallet funded and registered: {} SOV",
-                SOV_WELCOME_BONUS_SOV
+                DEV_BOOTSTRAP_BONUS_SOV
             );
             info!("   - Wallet ID: {}", hex::encode(&wallet_id.0));
             info!(

--- a/zhtp/src/server/mesh/identity_api.rs
+++ b/zhtp/src/server/mesh/identity_api.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
-use crate::api::handlers::constants::SOV_WELCOME_BONUS;
+use crate::api::handlers::constants::DEV_BOOTSTRAP_BONUS;
 use crate::session_manager::SessionManager;
 use lib_access_control::{Role, SecurityPrincipal};
 use lib_identity::IdentityManager;
@@ -1695,7 +1695,7 @@ fn register_wallet_on_blockchain(
                 .get("welcome_bonus")
                 .and_then(|wb| wb.get("bonus_amount"))
                 .and_then(|v| v.as_u64().map(|n| n as u128))
-                .unwrap_or(SOV_WELCOME_BONUS) // Default welcome bonus amount (atomic units)
+                .unwrap_or(DEV_BOOTSTRAP_BONUS) // Default welcome bonus amount (atomic units)
         } else {
             0 // Other wallets start with 0 balance
         };


### PR DESCRIPTION
## Summary

Rename `SOV_WELCOME_BONUS` → `DEV_BOOTSTRAP_BONUS` and `SOV_WELCOME_BONUS_SOV` → `DEV_BOOTSTRAP_BONUS_SOV` across lib-identity and zhtp. The old name read as "everyone gets 5,000 SOV"; after P1-1/P1-2 the only legitimate use is the Development bootstrap. Value (`5_000`) unchanged.

## Linked issues

Closes #2996
Refs #2993

## Architecture compliance

n/a

## Test plan

- [x] `grep -r SOV_WELCOME_BONUS` returns no results
- [x] `grep -r DEV_BOOTSTRAP_BONUS` shows only intended dev-bootstrap call sites
- [x] `cargo check -p zhtp` clean
- [x] `cargo test -p lib-blockchain --lib system_tx_signature` green (9 passed)

Note: `cargo test -p lib-identity` has 3 pre-existing failures in unrelated modules (`recovery_phrases`, `access_control`); this PR touches none of them.

## Risk and reversibility

Low blast radius — pure identifier rename, no value or logic change, no network restart needed. Reverts cleanly with a single commit revert.