### PR TITLE
feat(#3012): split governance_authority != kernel_address (deterministic kernel_address)

### DIFF
--- a/lib-blockchain/src/blockchain/wallets.rs
+++ b/lib-blockchain/src/blockchain/wallets.rs
@@ -62,7 +62,7 @@ impl Blockchain {
         };
 
         let kernel_authority = match &self.treasury_kernel {
-            Some(kernel) => kernel.governance_authority().clone(),
+            Some(kernel) => kernel.kernel_address().clone(),
             None => {
                 warn!("Cannot initialize welfare DAO tokens: Treasury Kernel not initialized");
                 return;
@@ -215,16 +215,30 @@ impl Blockchain {
         crate::contracts::utils::wallet_key_for_sov(*wallet_id)
     }
 
-    pub fn initialize_treasury_kernel(&mut self, kernel_authority: PublicKey) {
+    pub fn initialize_treasury_kernel(&mut self, governance_authority: PublicKey) {
         use crate::contracts::treasury_kernel::TreasuryKernel;
 
-        let governance_authority = kernel_authority.clone();
+        let kernel_address = Self::deterministic_kernel_address();
         self.treasury_kernel = Some(TreasuryKernel::new(
-            kernel_authority,
             governance_authority,
+            kernel_address,
             100,
         ));
         info!("Treasury Kernel initialized");
+    }
+
+    /// Derive the kernel's self-reference address deterministically (id-only).
+    ///
+    /// The kernel address is never signed externally — it is an internal
+    /// self-reference used to mint kernel-controlled tokens. Deriving it from a
+    /// fixed domain-separated label makes it identical across fresh nodes and
+    /// restarts, and non-signable (zeroed PQC key material, no private key).
+    pub fn deterministic_kernel_address() -> PublicKey {
+        PublicKey {
+            dilithium_pk: [0u8; 2592],
+            kyber_pk: [0u8; 1568],
+            key_id: crate::types::hash::blake3_hash(b"SOV_TREASURY_KERNEL_V1").as_array(),
+        }
     }
 
     fn is_kernel_controlled_token(&self, token: &crate::contracts::TokenContract) -> bool {
@@ -1108,5 +1122,41 @@ impl Blockchain {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn treasury_kernel_splits_governance_authority_from_kernel_address() {
+        let governance = PublicKey {
+            dilithium_pk: [7u8; 2592],
+            kyber_pk: [7u8; 1568],
+            key_id: [7u8; 32],
+        };
+
+        let mut blockchain = Blockchain::default();
+        blockchain.initialize_treasury_kernel(governance.clone());
+
+        let kernel = blockchain
+            .treasury_kernel
+            .as_ref()
+            .expect("kernel initialized");
+        assert_eq!(kernel.governance_authority(), &governance);
+        assert_ne!(
+            kernel.governance_authority().key_id,
+            kernel.kernel_address().key_id,
+            "governance_authority must differ from kernel_address"
+        );
+        assert_eq!(
+            kernel.kernel_address().key_id,
+            crate::types::hash::blake3_hash(b"SOV_TREASURY_KERNEL_V1").as_array()
+        );
+        assert_eq!(
+            Blockchain::deterministic_kernel_address().key_id,
+            kernel.kernel_address().key_id
+        );
     }
 }

--- a/lib-blockchain/tests/token_regression_tests.rs
+++ b/lib-blockchain/tests/token_regression_tests.rs
@@ -381,7 +381,7 @@ fn test_kernel_controlled_tokenmint_bypass_rejected() {
         1_000_000,
         test_pubkey(1),
     );
-    token.kernel_mint_authority = Some(kernel_authority.clone());
+    token.kernel_mint_authority = Some(Blockchain::deterministic_kernel_address());
     let token_id = token.token_id;
     blockchain.insert_token_contract(token_id, token);
 
@@ -412,7 +412,7 @@ fn test_kernel_controlled_tokenmint_via_kernel_authority_succeeds() {
         1_000_000,
         test_pubkey(1),
     );
-    token.kernel_mint_authority = Some(kernel_authority.clone());
+    token.kernel_mint_authority = Some(Blockchain::deterministic_kernel_address());
     let token_id = token.token_id;
     blockchain.insert_token_contract(token_id, token);
 


### PR DESCRIPTION
## Summary

Split the collapsed `governance_authority == kernel_address` in `initialize_treasury_kernel`. `kernel_address` is now derived deterministically (`blake3_hash(b"SOV_TREASURY_KERNEL_V1")`, zeroed PQC material, non-signable), while `governance_authority` remains the council/policy key. Welfare DAO tokens now use `kernel_address()` as their `kernel_mint_authority`.

## Linked issues

Closes #3012, Refs #3008

## Architecture compliance

n/a

## Test plan

- [x] Unit tests added/updated — `treasury_kernel_splits_governance_authority_from_kernel_address` asserts `governance_authority().key_id != kernel_address().key_id` and determinism
- [x] Integration tests updated — `token_regression_tests.rs` (2 kernel-mint tests use `Blockchain::deterministic_kernel_address()`)
- [x] `cargo check -p zhtp` clean
- [x] `cargo test -p lib-blockchain --test token_regression_tests` (27 passed) and `mint_authorization` (16 passed)

## Risk and reversibility

Consensus-critical: any node initialized after this change persists a deterministic `kernel_address` distinct from `governance_authority`. Blast radius is contained to treasury-kernel mint authorization and welfare token mint authority; the deterministic address is non-spoofable (signature is mandatory for `TokenMint`, and `validate_signature`'s `key_id ↔ public_key` binding rejects it). No coordinated network restart required; reversibility is a code-level revert. Legacy already-persisted kernels (old collapsed address) are out of scope.